### PR TITLE
Create a copy of ECF 1 guidance documentation for reference

### DIFF
--- a/documentation/ecf1_guidance/2022-cohort-closure-information-for-lead-providers.md
+++ b/documentation/ecf1_guidance/2022-cohort-closure-information-for-lead-providers.md
@@ -1,0 +1,123 @@
+
+# 2022 cohort closure: information for lead providers 
+
+Published: 21 March 2025
+
+Updated: 15 April 2025
+
+## Background 
+
+We’re closing the 2022 cohort at the end of July 2025. This means: 
+
+* lead providers will no longer be able to receive payments for training participants assigned to that cohort
+* we'll stop generating output fee statements for the 2022 cohort
+* we'll move partially trained early career teachers (ECTs) assigned to the 2022 contract to the 2024 cohort if there’s evidence they require training during the 2025/26 academic year 
+
+### How we’ll handle participants who haven’t completed their training by 31 July 
+
+| Training status   | Post-2022 cohort closure | 
+| -------------------- | ---------------------- | 
+| Partially trained ECTs | We'll move these ECTs to the 2024 cohort if there’s evidence they require training during the 2025/26 academic year | 
+| Partially trained mentors | We will not transfer mentors to the 2024 cohort because they’re not eligible for further training. We’ll mark them as `completed` and update their `mentor_funding_end_date` | 
+| ECTs and mentors with no `eligible`, `payable`, `paid`, `awaiting_clawback` or `clawed_back` declarations | We’ll archive these participants. Providers should retire their records. If they’re re-registered in the 2025/26 academic year, they’ll have new IDs | 
+
+## Moving ECTs to the 2024 cohort 
+
+For ECTs where there's evidence they require training during the 2025/26 academic year, we’ll start moving them to the 2024 cohort when registration opens in June. 
+
+We’ll have the following automatic triggers to move partially trained ECTs to the 2024 cohort: 
+
+* if they're registered as transferring into the school after June 2025
+* if the participant is still recorded as currently serving induction in the ‘Record inductions as an appropriate body’ service after mid-September 2025 
+
+These triggers will only take place if the induction tutor has set up their school’s 2025/26 programme. 
+
+Once the participant is in the 2024 cohort and the correct partnership is in place, providers will be able to continue getting their details over the API and declare for them in line with the 2024 milestones.  
+
+## Identifying ECTs who we've moved to the 2024 cohort  
+
+To help providers identify these ECTs in the API v3 test environment, there’s a field in the `GET participant` API endpoints called `cohort_changed_after_payments_frozen`. 
+
+For ECTs who’ve moved to the 2024 cohort, the field will have a `true` value in it. 
+
+When calling the `GET participant` endpoint, the ECT’s `cohort` value will be `2024`. When calling the `GET participant-declarations` endpoint, the ECT will have historical declarations in their original cohort. 
+
+Providers should use the `cohort_changed_after_payments_frozen` field to identify the ECT. 
+
+We’ll also assign these ECTs to the `ecf-extended-september` schedule. This allows providers to submit any required declarations for the 2025/26 academic year.    
+
+## Updating enrolment records 
+
+Once we’ve moved a participant to the 2024 cohort, the next time a provider retrieves participant details via the API they’ll notice the `cohort` field’s value will be `2024`.  
+
+Providers will need to update their enrolment records so that participants moved to the 2024 cohort are tagged correctly. 
+
+Provider CRMs will need to handle having declarations spanning across multiple cohorts if they keep these records. 
+
+Providers will also need to update the enrolment cohort to the latest one. 
+
+## Raising outstanding declarations 
+
+Where possible, providers should submit any outstanding declarations for participants currently in the 2022 cohort before registration for the 2025/26 academic year opens. 
+
+If the provider is the default for both the 2022 and 2024 cohorts, they can temporarily restore the participant to the 2022 cohort to make a declaration, then move them back to 2024 if needed.  
+
+If a declaration has already been made in 2024, they must:  
+
+1. Void it.
+2. Revert to 2022 and make the declaration there.
+3. Restore to 2024 and redeclare there. 
+
+Where this is not possible, providers must ask us via the Slack channels to move the participants between cohorts.  
+
+> Unlike when we closed the 2021 cohort, mentors who started training in 2022 will not be able to be moved between frozen cohorts. This is because they'll be marked as`completed.
+
+## Voiding declarations 
+
+Providers will no longer be able to void declarations previously paid in the 2022 cohort after 31 July 2025.  
+
+Contract management and assurance will carry out final checks and be in touch before the 2022 cohort is closed. 
+
+ECTs who are still in the 2022 cohort and have not been identified as continuing to train will also no longer be eligible to be declared for after the 31 July 2025. Providers will get a 422-error message asking them to contact us if they think this participant should be moved and declared for. 
+
+## Testing future declaration submissions in the 2024 cohort 
+
+For ECTs moved to the new cohort, providers will be able to continue to declare for them in line with the milestones of the 2024 call-off contracts. These will be agreed between providers and their DfE contract manager. 
+
+## Identifying a particpant's training needs 
+
+When providers receive a participant who has moved to the 2024 cohort, we recommend they focus on: 
+
+* understanding how much training the participant has left 
+* when they last engaged with training
+* where they were previously undertaking their training  
+
+Many of these participants will have experienced stop-start or interrupted training journeys, often due to deferrals or other changes.  
+
+There's no automated process to determine their continuation point or how much induction an ECT has left to serve, so it's important for providers to confirm this directly with the participant, the participant’s school or their appropriate body.  
+
+If there are nuances based on a participant's original cohort or schedule, and your approach may vary as a result, we'd welcome providers sharing this with us. This will help improve how we support similar cases in future. 
+
+## How to tell between 2022 and 2021 starters who’ve moved to the 2024 cohort 
+
+Providers can identify which cohort participants have moved from by taking the following steps:  
+
+1. Start by checking the `GET participants/ecf`endpoint for participants who’ve moved to the 2024 cohort after originally starting their training in 2021 or 2022. They’re identified by the `cohort_changed_after_payments_frozen` attribute being `true`.
+2. Then, using the `GET participant-declarations` or `GET participant-declarations/{id}` endpoint and filtering by `participant_id`, find the `statement_id`.
+3. Finally, call `GET statements/{id}`. The `cohort` field in the response shows which cohort each declaration was originally made in. 
+
+## Test data 
+
+We’ll set up dummy data/contracts and milestones in the test (sandbox) environment to support providers before registration opens.  
+
+Providers will be able to identify participants with the `cohort_changed_after_payments_frozen` field.  
+
+## Provider checklist 
+
+Ahead of the 2022 cohort closing, we recommend providers: 
+
+* check their CRM to make sure they can handle an enrolment in a new cohort with declarations spanning across 2022 and 2024
+* familiarise themselves with the `cohort_changed_after_payments_frozen` field in the `GET participant` endpoint response
+* check they can see historically submitted declarations made in a previous cohort in the `GET participant-declarations` endpoint when using the cohort filter
+* attempt some [future declarations](ecf/guidance.md#test-the-ability-to-submit-declarations-in-sandbox-ahead-of-time) and ensure they’re recorded and handled safely in their CRM
+* raise any outstanding declarations for the participants in the 2022 cohort before 31 July 2025 

--- a/documentation/ecf1_guidance/changes-for-the-2025-2026-academic-year.md
+++ b/documentation/ecf1_guidance/changes-for-the-2025-2026-academic-year.md
@@ -85,7 +85,7 @@ The introduction of the 2025 contracts requires updates to the API service.
 
 To help lead providers prepare for the opening of registration, we'll run a testing window throughout May 2025. 
 
-Refer to our [release notes](/release-notes.md) for all the relevant spec changes.
+Refer to our [release notes](release-notes.md) for all the relevant spec changes.
 
 ### Timelines 
 

--- a/documentation/ecf1_guidance/changes-for-the-2025-2026-academic-year.md
+++ b/documentation/ecf1_guidance/changes-for-the-2025-2026-academic-year.md
@@ -1,0 +1,222 @@
+
+# Changes for the 2025/26 academic year  
+
+Published: 25 February 2025
+
+Updated: 12 May 2025
+
+This is a summary of planned changes to API processes lead providers will see when early career teacher (ECT) and mentor registrations open (date to be confirmed). 
+
+We’ll update this section with any further details providers might need to help them test their endpoint integrations in the run up to registrations opening. 
+
+## Reduced declarations for mentors starting training in the 2025/26 academic year 
+
+We're removing the following declarations from the `POST participant-declarations` endpoint for mentors starting in the 2025/26 academic year:
+
+* `retained-1`
+* `retained-2`
+* `retained-3`
+* `retained-4`
+* `extended-1`
+* `extended-2`
+* `extended-3`
+
+This means there’ll be just 2 mentor declarations from the 2025/26 academic year onwards:  
+
+* `started`
+* `completed`
+
+>  Providers will need to update their integrations to support submitting 2 milestones only.
+>  Providers will see a 422-error message if they try to submit retained or extended declarations for a mentor who starts training in the 2025/26 academic year.
+
+## Evidence types for the 2025/26 academic year
+
+We'll be updating the `evidence_held` values lead providers will be able to use when they submit participant declarations for the 2025/26 academic year intake of ECTs and mentors.
+
+These values represent the evidence lead providers hold to show participants have met the retention criteria for the current milestone period. 
+
+For the 2025/26 academic year, every `declaration_type` will have its own `evidence_held` values (see tables). In previous years we’d applied the `training-event-attended`, `self-study-material-completed` and `other` values across all declaration types.
+
+### Declaration and evidence types for ECTs 
+
+| Declaration type   | Evidence held values |
+| -------------------- | ---------------------- |
+| `started`   |  <ul class="govuk-list govuk-list--bullet"><li>`training-event-attended`</li> <li>`self-study-material-completed`</li> <li>`other`</li> <li>`materials-engaged-with-offline` (new value)</li></ul> |
+| `retained-1` |  <ul class="govuk-list govuk-list--bullet"><li>`training-event-attended`</li> <li>`self-study-material-completed`</li> <li>`other`</li> <li>`materials-engaged-with-offline` (new value)</li></ul> |
+| `retained-2` |  <ul class="govuk-list govuk-list--bullet"><li>`75-percent-engagement-met` (new value)</li> <li>`75-percent-engagement-met-reduced-induction` (new value)</li></ul> |
+| `retained-3` |  <ul class="govuk-list govuk-list--bullet"><li>`training-event-attended`</li> <li>`self-study-material-completed`</li> <li>`other`</li> <li>`materials-engaged-with-offline` (new value)</li></ul> |
+| `retained-4` |  <ul class="govuk-list govuk-list--bullet"><li>`training-event-attended`</li> <li>`self-study-material-completed`</li> <li>`other`</li> <li>`materials-engaged-with-offline` (new value)</li></ul> |
+| `extended-1` |  <ul class="govuk-list govuk-list--bullet"><li>`training-event-attended`</li> <li>`self-study-material-completed`</li> <li>`other`</li> <li>`materials-engaged-with-offline` (new value)</li></ul> |
+| `extended-2` |  <ul class="govuk-list govuk-list--bullet"><li>`training-event-attended`</li> <li>`self-study-material-completed`</li> <li>`other`</li> <li>`materials-engaged-with-offline` (new value)</li></ul> |
+| `extended-3` |  <ul class="govuk-list govuk-list--bullet"><li>`training-event-attended`</li> <li>`self-study-material-completed`</li> <li>`other`</li> <li>`materials-engaged-with-offline` (new value)</li></ul> |
+| `completed` |  <ul class="govuk-list govuk-list--bullet"><li>`75-percent-engagement-met` (new value)</li> <li>`75-percent-engagement-met-reduced-induction` (new value)</li> <li> `one-term-induction` (new value) </li></ul>|
+
+### Declaration and evidence types for mentors 
+
+| Declaration type   | Evidence held values |
+| ------------- | ------------- |
+| `started`   |  <ul class="govuk-list govuk-list--bullet"><li>`training-event-attended`</li> <li>`self-study-material-completed`</li> <li>`other`</li> <li>`materials-engaged-with-offline` (new value)</li></ul> |
+| `completed` |  <ul class="govuk-list govuk-list--bullet"><li>`75-percent-engagement-met` (new value)</li> <li>`75-percent-engagement-met-reduced-induction` (new value)</li></ul> |
+
+> New evidence types are not compatible with previous cohorts. If providers try using a new evidence type for an older cohort declaration, it will not work and they’ll see a 422-error message.
+
+## Changes to induction programme types 
+
+We’ll be making the following changes to the `induction_programme_choice` field options in the `GET schools/ecf` and `GET schools/ecf/{id}` endpoints:
+
+* `core-induction-programme` and `diy` will change to `school-led`
+* `full-induction-programme` and `school-funded-full-induction-programme` will change to `provider-led`
+
+> These changes will apply across all cohorts. We’ll contact providers directly to ensure their integrations can support the new values.
+
+### Change to withdrawal reason value to reflect new programme types terminology 
+
+To align with the new programme types terminology, we’ll be changing one of the options in the `reason` field for the `PUT participants/ecf/{id}/withdraw` endpoint: 
+ 
+* `school-left-fip` will change to `switched-to-school-led`   
+
+As a result, we’ll update records across all cohorts that have previously used the `school-left-fip` value. This is not expected to affect how the endpoint functions. However, lead providers will need to update the options when submitting withdrawal requests to pass through the new value.  
+
+Records that have already been withdrawn using the old value will surface the new value and have a modified `updated_at` timestamp.  
+
+## API testing and integration
+
+The introduction of the 2025 contracts requires updates to the API service. 
+
+To help lead providers prepare for the opening of registration, we'll run a testing window throughout May 2025. 
+
+Refer to our [release notes](/release-notes.md) for all the relevant spec changes.
+
+### Timelines 
+
+As set out in the Model Call-off Contract, lead providers must complete testing by 1 June 2025. This is to ensure there’s enough time to resolve any urgent issues or integration challenges ahead of registration opening for the 2025/26 academic year on 30 June 2025. 
+
+#### Timeline overview 
+
+| Date | Activity |  
+| -------- | -------- | 
+| By 22 April | Test data added to test environment (sandbox) 
+| By 30 April | Test scenarios shared with lead providers |  
+| Throughout May | DfE product team will join digital check-ins | 
+| By 16 May | Providers should attempt all test scenarios | 
+| By 1 June | Deadline for providers to submit testing evidence | 
+| By 6 June | Deadline for providers to raise any issues or defects | 
+| By 13 June | DfE will have resolved any identified defects |  
+| 16 June | Soft launch of registration (for selected schools) |  
+| 30 June | Full registration opens |  
+
+### Affected API endpoints 
+
+These changes affect the following endpoints: 
+
+* `GET schools` – affected by induction type changes
+* `GET participants` and `PUT participants/ecf/{id}/withdraw` – includes new withdrawal reasons
+* `POST participant-declarations` – updated for mentor funding and evidence types
+* `GET participant-declarations` – updated for mentor funding and evidence types 
+
+### Support from DfE 
+
+During testing, we recommend lead providers: 
+
+* use existing Slack channels and check-in sessions to raise questions 
+* review all provided API documentation and guidance 
+
+We will: 
+
+* give timely access to technical support, including one to one sessions (contact digital engagement leads for more details)
+* monitor testing to anticipate provider needs 
+
+### Integration changes to consider 
+
+#### Evidence types 
+
+New values must be added to evidence types to meet 2025 policy requirements. Pay close attention to: 
+
+* `retained-2` declarations for ECTs
+* `completed` declarations for all participants 
+
+#### Mentor declarations 
+
+Providers will only be able to submit `started` and `completed` declarations for mentors who start training from June 2025 onwards. The API will return a 422 error if providers submit `retained` or `extended` declarations, as these are not accepted.
+
+#### School induction types 
+
+Language used in the `GET schools` endpoint will change. This is not expected to affect how the endpoint functions. However, lead providers should: 
+
+* resync with the API
+* review downstream systems for impacts 
+ 
+#### Withdrawal reasons 
+
+We’re adding a new value for participant withdrawals: `switched-to-school-led` 
+
+Providers must ensure their systems can both submit and process this new value. 
+
+### API integration testing 
+
+Lead providers must test to confirm: 
+
+* functionality has not been lost
+* all common journeys work as expected
+* their systems integrate correctly with the updated API 
+
+#### Testing areas 
+
+Providers will be expected to complete and provide evidence for the following: 
+
+##### Updated evidence types 
+
+Test declaration submissions using these values: 
+
+* `started` (ECTs and mentors)
+* `retained-1`, `retained-2`, `retained-3`, `retained-4` (ECTs only)
+* `completed` (ECTs and mentors)
+* `extended` (ECTs only) 
+
+##### Declarations
+
+Providers must demonstrate correct declaration submissions for both ECTs and mentors.
+
+##### Withdrawal scenarios 
+
+Test withdrawing a participant using the new reason: `switched-to-school-led` 
+
+##### Creating partnerships 
+
+This will not be tested directly. However, to submit declarations, a lead provider must first create a partnership between an eligible school and a delivery partner. 
+
+##### Full sync tests 
+
+Run full syncs on: 
+
+* `GET schools`
+* `GET participants`
+* `GET participant-declarations` 
+
+Providers must check that changes are accepted and that they remain within rate limits. 
+
+### Test data 
+
+We'll add test data to the sandbox by 22 April 2025. This will include: 
+
+* schools with different induction types for the 2024 and 2025 cohorts
+* assigned delivery partners for those cohorts
+* participants attached to each school 
+
+If providers need additional data or encounter issues, they should contact their digital engagement lead with detailed information. 
+
+### Deployment readiness checklist 
+
+Before the registration window opens, lead providers must confirm to us that: 
+
+* integrations have been reviewed and updated 
+* test scenarios have been completed and evidenced
+* full syncs using updated APIs are functioning correctly 
+
+We also welcome providers to share their test plans, feedback and concerns via the DfE Slack channel. 
+
+### Related links 
+
+[Test environment (sandbox)](https://sb.manage-training-for-early-career-teachers.education.gov.uk)
+
+[API guidance](https://manage-training-for-early-career-teachers.education.gov.uk/api-reference)

--- a/documentation/ecf1_guidance/ecf.md
+++ b/documentation/ecf1_guidance/ecf.md
@@ -3,18 +3,18 @@
 
 ## Contents
 
-* [Data definitions and states](ecf/definitions-and-states)
-* [Confirm, view and update partnerships](ecf/guidance/#confirm-view-and-update-partnerships)
-* [View and update participant data](ecf/guidance/#view-and-update-participant-data)
-* [Submit, view and void declarations](ecf/guidance/#submit-view-and-void-declarations)
-* [View financial statement payment dates](ecf/guidance/#view-financial-statement-payment-dates)
-* [Schedules and milestone dates ](ecf/schedules-and-milestone-dates)
+* [Data definitions and states](ecf/definitions-and-states.md)
+* [Confirm, view and update partnerships](ecf/guidance.md#confirm-view-and-update-partnerships)
+* [View and update participant data](ecf/guidance.md#view-and-update-participant-data)
+* [Submit, view and void declarations](ecf/guidance.md#submit-view-and-void-declarations)
+* [View financial statement payment dates](ecf/guidance.md#view-financial-statement-payment-dates)
+* [Schedules and milestone dates ](ecf/schedules-and-milestone-dates.md)
 
 ## Overview 
 
 Once integrated with the API, providers can view, submit and update data. The data enables providers to manage and deliver early career training programmes, and receive appropriate payment from DfE.
 
-<div class="govuk-inset-text">The following guidance has been written for lead providers who have integrated systems with API version 3.0.0. onwards. </div>
+> The following guidance has been written for lead providers who have integrated systems with API version 3.0.0. onwards.
 
 While this guidance focuses on `v3` endpoints, providers can view specifications for the API version their systems are integrated with:
 

--- a/documentation/ecf1_guidance/ecf.md
+++ b/documentation/ecf1_guidance/ecf.md
@@ -1,0 +1,23 @@
+
+# Manage early career training programmes
+
+## Contents
+
+* [Data definitions and states](ecf/definitions-and-states)
+* [Confirm, view and update partnerships](ecf/guidance/#confirm-view-and-update-partnerships)
+* [View and update participant data](ecf/guidance/#view-and-update-participant-data)
+* [Submit, view and void declarations](ecf/guidance/#submit-view-and-void-declarations)
+* [View financial statement payment dates](ecf/guidance/#view-financial-statement-payment-dates)
+* [Schedules and milestone dates ](ecf/schedules-and-milestone-dates)
+
+## Overview 
+
+Once integrated with the API, providers can view, submit and update data. The data enables providers to manage and deliver early career training programmes, and receive appropriate payment from DfE.
+
+<div class="govuk-inset-text">The following guidance has been written for lead providers who have integrated systems with API version 3.0.0. onwards. </div>
+
+While this guidance focuses on `v3` endpoints, providers can view specifications for the API version their systems are integrated with:
+
+* [Lead provider API - 1.0.0](reference-v1)
+* [Lead provider API - 2.0.0](reference-v2)
+* [Lead provider API - 3.0.0](reference-v3)

--- a/documentation/ecf1_guidance/ecf.md
+++ b/documentation/ecf1_guidance/ecf.md
@@ -18,6 +18,6 @@ Once integrated with the API, providers can view, submit and update data. The da
 
 While this guidance focuses on `v3` endpoints, providers can view specifications for the API version their systems are integrated with:
 
-* [Lead provider API - 1.0.0](reference-v1)
-* [Lead provider API - 2.0.0](reference-v2)
-* [Lead provider API - 3.0.0](reference-v3)
+* [Lead provider API - 1.0.0](reference-v1.md)
+* [Lead provider API - 2.0.0](reference-v2.md)
+* [Lead provider API - 3.0.0](reference-v3.md)

--- a/documentation/ecf1_guidance/ecf/definitions-and-states.md
+++ b/documentation/ecf1_guidance/ecf/definitions-and-states.md
@@ -1,0 +1,110 @@
+
+# Definitions and states
+
+## Key concepts
+
+| Concept      | Definition|
+| -------- | --------  |
+| `cohort`     | The grouping of participants who begin their induction or training in a given academic year under a given funding contract. For example, a participant who started their training in the 2024/25 academic year is assigned to the 2024 cohort. This is because funding for their training comes from the 2024/25 call-off contract. In most cases providers cannot change a participant’s cohort once they have started their training |
+| `course_identifier`      | The participant’s training as either an early career teacher (ECT) or mentor       |
+| `declaration`    | The notification submitted by providers via the API as the sole means for triggering output payments from DfE. Declarations are submitted where there is evidence of a participant’s engagement in training for a given milestone period      |
+| `participant`    | An early career teacher (ECT) or mentor registered for training      |
+| `partnership`     | The relationship created between schools, delivery partners and providers who work together to deliver early career training to participants      |
+| `schedule`     | The expected timeframe in which a participant will complete their early career training. Schedules include [defined milestone dates](ecf/schedules-and-milestone-dates) against which DfE validates the declarations submitted by providers      |
+| `statement`    | A record of output payments (based on declarations), service fees and any adjustments the DfE may pay lead providers at the end of a contractually agreed payment period. Statements sent to providers by DfE at the end of milestone periods can be used for invoicing purposes     |
+| `unfunded-mentor` | Mentors linked to a provider's ECTs but not eligible for funding through that provider. Typically, these mentors have either completed, or are currently doing, mentor training with a different lead provider than the one delivering training to the ECT they support |
+
+## API status values 
+
+The API uses status values to describe the current state of partnerships, participants, and declarations. 
+ 
+Each status tells providers what actions they can take through the API and what to expect from DfE. 
+
+### Partnership statuses  
+
+Partnership statuses are defined by the `status` attribute in partnership endpoint responses. 
+
+Providers must [confirm their partnerships with schools](ecf/guidance/#confirm-view-and-update-partnerships) for each cohort. Once a partnership has been established the `status` value will become `active` and providers will receive participant information via the API. 
+
+Schools can challenge existing partnerships at any time. Once a partnership `status` becomes `challenged`, providers will no longer be able to update partnership details. 
+
+| `status` | Definition | Action |
+| -------- | -------- | -------- |
+| `active`     | A partnership between a provider, school and delivery partner has been agreed and confirmed by the provider    | Providers can view, confirm and update `active` partnerships     |
+| `challenged`     | A partnership between a provider, school and delivery partner has been changed or dissolved by the school     | Providers can only view `challenged` partnerships    |
+
+<div class="govuk-inset-text"> The 2025 cohort will be the last to have challenge fields in partnership responses. From 2026, schools will make changes at an individual participant level (for example, moving an ECT to a different provider) rather than challenging a school-wide partnership.</div>
+
+[View more detailed specifications for the partnerships schema](reference-v3.html#schema-ecfpartnershipattributes)
+
+### Participant statuses 
+
+The API uses two different status fields to describe a participant’s journey in the participant endpoints: 
+
+* `training_status`, set by providers through the API. It determines what actions you can take, such as updating data or submitting declarations
+* `participant_status`, set by schools through the 'Register early career teachers’ service. It reflects the participant’s position in the school (for example, joining, leaving, or withdrawn). 
+
+Together, these statuses give both providers and schools a shared view of a participant’s training progress. 
+
+#### Training status field
+
+| `training_status` | Definition | Notes |
+|-------------------|-------------|--------|
+| `active` | Participant is currently in training | Update participant data and submit declarations |
+| `deferred` | Participant has paused training | Providers must notify DfE when the participant restarts |
+| `withdrawn` | Participant has left training | Cannot update participant data. Can only submit backdated declarations if `declaration_date` is before `withdrawal_date` |
+
+#### Participant status field
+
+| `participant_status` | Definition | Notes |
+|----------------------|-------------|--------|
+| `active` | Participant is currently training at the school | Matches the school’s latest confirmation |
+| `joining` | Participant is due to join the school | Will update to **active** once the join date is reached |
+| `leaving` | Participant is due to leave the school | Will update to **left** after the leaving date passes |
+| `left` | Participant has left the school | No longer associated with the school |
+| `withdrawn` | School has recorded that the participant has permanently left | May overlap with provider-recorded `training_status` |
+
+Example of how the two participant statuses can differ: 
+
+* a provider records a participant as `training_status = active` because they are still completing training
+* at the same time, the school records the participant as `participant_status = leaving`, with a leaving date set for the end of term. 
+
+In this case, the participant is still active in training, but their school has flagged that they are due to leave soon. Once the leaving date passes, the `participant_status` will update to `left`, while the provider will need to update the training record if the participant transfers or withdraws. 
+
+[View more detailed specifications for the ECF participant schema](reference-v3.html#schema-ecfparticipantattributes)
+
+## Declaration states
+
+Declaration states are defined by the `state` attribute.
+
+Providers must [submit declarations](ecf/guidance/#submit-view-and-void-declarations) to confirm a participant has engaged in training within a given milestone period. A declaration’s `state` value will reflect if and when DfE will pay providers for the training delivered.
+
+| state | Definition | Action |
+| -------- | -------- | -------- |
+| `submitted`     | A declaration associated with to a participant who has not yet been confirmed to be eligible for funding    | Providers can view and void `submitted` declarations    |
+| `eligible`     | A declaration associated with a participant who has been confirmed to be eligible for funding     | Providers can view and void `eligible` declarations    |
+| `ineligible`     | A declaration associated with 1) a participant who is not eligible for funding 2) a duplicate submission for a given participant    | Providers can view and void `ineligible` declarations     |
+| `payable`     | A declaration that has been approved and is ready for payment by DfE    | Providers can view and void `payable` declarations     |
+| `voided`     | A declaration that has been retracted by a provider    | Providers can **only** view `voided` declarations   |
+| `paid`     | A declaration that has been paid for by DfE    | Providers can view and void `paid` declarations     |
+| `awaiting_clawback`     | A `paid` declaration that has since been voided by a provider    | Providers can **only** view `awaiting_clawback` declarations     |
+| `clawed_back`     | An `awaiting_clawback` declaration that has since had its value deducted from payment by DfE to a provider     | Providers can **only** view `clawed_back` declarations     |
+
+[View more detailed specifications for the declaration schema](reference-v3.html#schema-participantdeclarationattributes)
+
+## IDs explained 
+
+We use various unique identifiers (IDs) in the endpoint requests and responses to help make the API reliable, efficient, and unambiguous.  
+
+| ID      | What the ID is for | 
+| -------- | -------- | 
+| `clawback_statement_id` | Identifies a clawback statement we’ve attached when funding paid to a lead provider needs to be returned due to overpayments or participant data changes (for example, someone withdraws from training or is found to be ineligible). Enables lead providers using the `declarations` endpoints  to identify which clawback statement a participant’s funding adjustment relates to and reconcile clawbacks against their monthly or cumulative funding reports | 
+| `declaration_id` | Created when providers submit a declaration. This ID can also be used to void a declaration. It’s shown as simply `id` at the top of successful responses in the `declarations` endpoints | 
+| `delivery_partner_id` | Identifies delivery partners. Used when providers form partnerships as part of the `POST partnerships` endpoint. It’s also listed in `GET participants/ecf` and `GET participants/ecf/{id}` responses in API v3 | 
+| `mentor_id` | Identifies individual ECT mentors within the API. This ID is used to link mentors to ECTs they’re supporting, and tracks their training status, funding eligibility, and contact information. The same `mentor_id` is used whether the mentor is funded or unfunded, including those trained by a different lead provider than the one supporting their ECT | 
+| `participant_id` | Identifies participants registered for training. This is used for declarations, changing schedules, notifying us of a change in circumstances related to their training as well as other endpoints to monitor training and progress | 
+| `participant_id_changes` | A record of changes where a participant’s ID has been updated, usually to fix a data issue like a duplicate or incorrect registration. In such cases, the `from_participant_id` field is the original ID that has been retired or replaced. The `to_participant_id` is the new ID that should now be used when referring to this participant | 
+| `partnership_id` | Identifies the partnership between schools, delivery partners and providers for a specific cohort who work together to deliver training to participants. It’s shown as simply `id` at the top of successful responses in the `partnership` endpoints | 
+| `statement_id` | Identifies a financial statement we've attached to a lead provider. It acts as a reference for each individual payment cycle or statement and allows lead providers to retrieve financial data using the `GET statements` endpoints | 
+| `school_id` | Identifies schools. Used when providers form partnerships as part of the `POST partnerships` endpoint | 
+| `training_record_id` | Identifies participants with multiple enrolments, such as an ECT who later becomes a mentor. Providers using the `participants` endpoints will see separate records for the same participant, each with a different `training_record_id` based on their role | 

--- a/documentation/ecf1_guidance/ecf/definitions-and-states.md
+++ b/documentation/ecf1_guidance/ecf/definitions-and-states.md
@@ -71,7 +71,7 @@ Example of how the two participant statuses can differ:
 
 In this case, the participant is still active in training, but their school has flagged that they are due to leave soon. Once the leaving date passes, the `participant_status` will update to `left`, while the provider will need to update the training record if the participant transfers or withdraws. 
 
-[View more detailed specifications for the ECF participant schema](../reference-v3.md#schema-ecfparticipantattributes)
+[View more detailed specifications for the ECF participant schema](../reference-v3.md#ecfparticipantattributes)
 
 ## Declaration states
 
@@ -90,7 +90,7 @@ Providers must [submit declarations](guidance.md#submit-view-and-void-declaratio
 | `awaiting_clawback`     | A `paid` declaration that has since been voided by a provider    | Providers can **only** view `awaiting_clawback` declarations     |
 | `clawed_back`     | An `awaiting_clawback` declaration that has since had its value deducted from payment by DfE to a provider     | Providers can **only** view `clawed_back` declarations     |
 
-[View more detailed specifications for the declaration schema](../reference-v3.md#schema-participantdeclarationattributes)
+[View more detailed specifications for the declaration schema](../reference-v3.md#participantdeclarationattributes)
 
 ## IDs explained 
 

--- a/documentation/ecf1_guidance/ecf/definitions-and-states.md
+++ b/documentation/ecf1_guidance/ecf/definitions-and-states.md
@@ -10,7 +10,7 @@
 | `declaration`    | The notification submitted by providers via the API as the sole means for triggering output payments from DfE. Declarations are submitted where there is evidence of a participant’s engagement in training for a given milestone period      |
 | `participant`    | An early career teacher (ECT) or mentor registered for training      |
 | `partnership`     | The relationship created between schools, delivery partners and providers who work together to deliver early career training to participants      |
-| `schedule`     | The expected timeframe in which a participant will complete their early career training. Schedules include [defined milestone dates](ecf/schedules-and-milestone-dates) against which DfE validates the declarations submitted by providers      |
+| `schedule`     | The expected timeframe in which a participant will complete their early career training. Schedules include [defined milestone dates](schedules-and-milestone-dates.md) against which DfE validates the declarations submitted by providers      |
 | `statement`    | A record of output payments (based on declarations), service fees and any adjustments the DfE may pay lead providers at the end of a contractually agreed payment period. Statements sent to providers by DfE at the end of milestone periods can be used for invoicing purposes     |
 | `unfunded-mentor` | Mentors linked to a provider's ECTs but not eligible for funding through that provider. Typically, these mentors have either completed, or are currently doing, mentor training with a different lead provider than the one delivering training to the ECT they support |
 
@@ -24,7 +24,7 @@ Each status tells providers what actions they can take through the API and what 
 
 Partnership statuses are defined by the `status` attribute in partnership endpoint responses. 
 
-Providers must [confirm their partnerships with schools](ecf/guidance/#confirm-view-and-update-partnerships) for each cohort. Once a partnership has been established the `status` value will become `active` and providers will receive participant information via the API. 
+Providers must [confirm their partnerships with schools](guidance.md#confirm-view-and-update-partnerships) for each cohort. Once a partnership has been established the `status` value will become `active` and providers will receive participant information via the API. 
 
 Schools can challenge existing partnerships at any time. Once a partnership `status` becomes `challenged`, providers will no longer be able to update partnership details. 
 
@@ -33,9 +33,9 @@ Schools can challenge existing partnerships at any time. Once a partnership `sta
 | `active`     | A partnership between a provider, school and delivery partner has been agreed and confirmed by the provider    | Providers can view, confirm and update `active` partnerships     |
 | `challenged`     | A partnership between a provider, school and delivery partner has been changed or dissolved by the school     | Providers can only view `challenged` partnerships    |
 
-<div class="govuk-inset-text"> The 2025 cohort will be the last to have challenge fields in partnership responses. From 2026, schools will make changes at an individual participant level (for example, moving an ECT to a different provider) rather than challenging a school-wide partnership.</div>
+> The 2025 cohort will be the last to have challenge fields in partnership responses. From 2026, schools will make changes at an individual participant level (for example, moving an ECT to a different provider) rather than challenging a school-wide partnership.
 
-[View more detailed specifications for the partnerships schema](reference-v3.html#schema-ecfpartnershipattributes)
+[View more detailed specifications for the partnerships schema](../reference-v3.md#ecfpartnershipattributes)
 
 ### Participant statuses 
 
@@ -71,13 +71,13 @@ Example of how the two participant statuses can differ:
 
 In this case, the participant is still active in training, but their school has flagged that they are due to leave soon. Once the leaving date passes, the `participant_status` will update to `left`, while the provider will need to update the training record if the participant transfers or withdraws. 
 
-[View more detailed specifications for the ECF participant schema](reference-v3.html#schema-ecfparticipantattributes)
+[View more detailed specifications for the ECF participant schema](../reference-v3.md#schema-ecfparticipantattributes)
 
 ## Declaration states
 
 Declaration states are defined by the `state` attribute.
 
-Providers must [submit declarations](ecf/guidance/#submit-view-and-void-declarations) to confirm a participant has engaged in training within a given milestone period. A declaration’s `state` value will reflect if and when DfE will pay providers for the training delivered.
+Providers must [submit declarations](guidance.md#submit-view-and-void-declarations) to confirm a participant has engaged in training within a given milestone period. A declaration’s `state` value will reflect if and when DfE will pay providers for the training delivered.
 
 | state | Definition | Action |
 | -------- | -------- | -------- |
@@ -90,7 +90,7 @@ Providers must [submit declarations](ecf/guidance/#submit-view-and-void-declarat
 | `awaiting_clawback`     | A `paid` declaration that has since been voided by a provider    | Providers can **only** view `awaiting_clawback` declarations     |
 | `clawed_back`     | An `awaiting_clawback` declaration that has since had its value deducted from payment by DfE to a provider     | Providers can **only** view `clawed_back` declarations     |
 
-[View more detailed specifications for the declaration schema](reference-v3.html#schema-participantdeclarationattributes)
+[View more detailed specifications for the declaration schema](../reference-v3.md#schema-participantdeclarationattributes)
 
 ## IDs explained 
 

--- a/documentation/ecf1_guidance/ecf/guidance.md
+++ b/documentation/ecf1_guidance/ecf/guidance.md
@@ -1,0 +1,1393 @@
+
+# Guidance
+
+The focus of the following guidance is on business logic only. Critical details which would be necessary for real-world usage have been left out. For example, [authentication](get-started#connect-to-the-API) is not detailed.
+
+> This guidance is written for API version 3.0.0, and therefore all endpoints reference `v3`. Providers should view specifications for the API version their systems are integrated as appropriate.
+
+## Overview of API requests
+
+### Registration and onboarding
+
+1. For a given cohort, providers confirm partnerships with schools via the API, including confirming who their delivery partners will be. **Note**, this only applies to providers integrated with API v3 onwards.
+2. School induction tutors register participants for training via the DfE online service.
+3. Providers view participant data via the API, using it to onboard participants to their learning management systems. Note, the API will not present any data for participants whose details have not yet been validated by DfE.
+
+### During training
+
+1. If necessary, providers will update the participant's training schedule via the API.
+2. Providers will train participants as per details set out in their contract.
+3. Providers will submit a `started` declaration via the API to notify DfE that training has begun.
+4. DfE will pay providers output payments for `started` declarations.
+5. Providers will check via the API to see whether any participants have transferred to or from schools they are in partnership with. **Note**, this only applies to providers integrated with API v3 onwards.
+6. Providers continue to train participants as per details set out in the contract.
+7. Providers will submit `retained` declarations via the API to notify DfE participants have continued in training for a given milestone.
+
+### Once training has been completed
+
+1. DfE will pay providers output payments for `retained` declarations.
+2. Providers complete training participants as per details set out in the contract.
+3. Providers will submit `completed` declarations via the API to notify DfE the participant has completed training.
+4. DfE will pay providers output payments for `completed` declarations.
+5. Providers view financial statements via the API.
+
+Changes can happen during training; some participants may not complete their training within the standard schedule, or at all. Providers must update relevant data using the API.
+
+## Confirm, view and update partnerships
+
+Partnerships are the relationships created between schools, delivery partners and providers who work together to deliver early career training programmes to participants.
+
+Providers must confirm to DfE whenever they agree to enter into new partnerships with a school and delivery partner to deliver training.
+
+> The partnerships endpoints are only available for systems integrated with API v3 onwards. They will not return data for API v1 or v2.
+
+### Before you start
+
+Use the `GET partnerships` endpoint to check if a partnership already exists for the school and cohort.
+
+Use the `GET schools` endpoint to check whether a school is already partnered with another lead provider.
+
+Submitting a duplicate partnership will return a 422 error.
+
+#### Understanding the `partnership_id`
+
+Every confirmed partnership has a unique identifier, returned as `id` in the `GET partnerships` response. This value identifies the specific relationship between the school, delivery partner, and lead provider for a single cohort.
+
+#### Default training assignment after partnership confirmation
+
+Once a partnership for a cohort is confirmed, any new participants registered for training at that school will be assigned to the ‘default’ training provision. For example, once a provider confirms their partnership for the 2024 cohort, any participants registered by the school's induction tutor will automatically default to training with the agreed provider and delivery partner.
+
+### Find schools delivering training in a given cohort
+
+```
+GET /api/v3/schools/ecf?filter[cohort]={year}
+```
+
+View details for schools providing training in a given cohort. Check details on the type of training programme schools have chosen to deliver, and whether they have confirmed partnerships in place.
+
+> The <code>cohort</code> filter must be included as a parameter. The API will reject requests which do not include the <code>cohort</code> filter.
+
+Providers can also filter results by school URN. For example, `GET /api/v3/schools/ecf?filter[cohort]=2024&filter[urn]=123456`.
+
+Successful requests will return a response body with school details.
+
+#### What the API will show
+
+The API will **only** show schools that are eligible for funded training programmes within a given cohort. For example, if schools are eligible for funding in the 2024 cohort, they will be visible via the API, and providers can go on to form partnerships with them.
+
+#### What the API will not show
+
+The API will **not** show schools that are ineligible for funding in a given cohort.
+
+If a school’s eligibility changes from one cohort to the next, results will default according to the latest school eligibility. For example, if a school was eligible for funding in the 2024 cohort but becomes ineligible for funding in 2025, the API will **not** show the school in the 2025 cohort.
+
+For more detailed information, see the `GET schools` [endpoint documentation](reference-v3#api-v3-schools-ecf-get).
+
+#### Example response body
+
+```
+{
+  "data": [
+    {
+      "id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+      "type": "school",
+      "attributes": {
+        "name": "School Example",
+        "urn": "123456",
+        "cohort": 2024,
+        "in_partnership": "false",
+        "induction_programme_choice": "not_yet_known",
+        "created_at": "2024-05-31T02:22:32.000Z",
+        "updated_at": "2024-05-31T02:22:32.000Z"
+      }
+    }
+  ]
+}
+```
+
+### View details for specific a school in a given cohort
+
+```
+GET /api/v3/schools/ecf/{id}?filter[cohort]={year}
+```
+
+Providers can view details for a specific school providing training in a given cohort. They can check details on the type of training programme the school has chosen to deliver, and whether they have a confirmed partnership in place.
+
+> The cohort filter must be included as a parameter. The API will reject requests which do not include the cohort filter.
+
+Successful requests will return a response body with school details.
+
+For more detailed information, view the `GET schools/ecf/{id}` [endpoint documentation](reference-v3#api-v3-schools-ecf-id-get).
+
+#### Example response body
+
+```
+{
+  "data": [
+    {
+      "id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+      "type": "school",
+      "attributes": {
+        "name": "School Example",
+        "urn": "123456",
+        "cohort": 2024,
+        "in_partnership": "false",
+        "induction_programme_choice": "not_yet_known",
+        "created_at": "2024-05-31T02:22:32.000Z",
+        "updated_at": "2024-05-31T02:22:32.000Z"
+      }
+    }
+  ]
+}
+```
+
+### Find delivery partner IDs
+
+```
+GET /api/v3/delivery-partners
+```
+
+We assign every delivery partner a unique ID. This `delivery_partner_id` is required when [confirming partnerships with a school and delivery partner](ecf/guidance#confirm-a-partnership-with-a-school-and-delivery-partner).
+
+Providers can also filter results by adding a cohort filter to the parameter. For example, `GET /api/v3/delivery-partners?filter[cohort]=2024`.
+
+Successful requests will return a response body including delivery partner details.
+
+For more detailed information, view the `GET delivery-partners` [endpoint documentation](reference-v3#api-v3-delivery-partners-get).
+
+#### Example response body
+
+```
+{
+  "data": [
+    {
+      "id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+      "type": "delivery-partner",
+      "attributes": {
+        "name": "Awesome Delivery Partner Ltd",
+        "cohort": [
+          "2023",
+          "2024"
+        ],
+        "created_at": "2024-05-31T02:22:32.000Z",
+        "updated_at": "2024-05-31T02:22:32.000Z"
+      }
+    }
+  ]
+}
+```
+
+### View details for a specific delivery partner
+
+```
+GET /api/v3/delivery-partners/{id}
+```
+
+View details for a specific delivery partner to check whether they've been registered to deliver training for a given cohort.
+
+Successful requests will return a response body with the delivery partner's details.
+
+For more detailed information, view the `GET delivery-partners/{id}` [endpoint documentation](reference-v3#api-v3-delivery-partners-id-get).
+
+#### Example response body
+
+```
+{
+  "data": [
+    {
+      "id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+      "type": "delivery-partner",
+      "attributes": {
+        "name": "Awesome Delivery Partner Ltd",
+        "cohort": [
+          "2023",
+          "2024"
+        ],
+        "created_at": "2024-05-31T02:22:32.000Z",
+        "updated_at": "2024-05-31T02:22:32.000Z"
+      }
+    }
+  ]
+}
+```
+
+### Confirm a partnership with a school and delivery partner
+
+```
+ POST /api/v3/partnerships/ecf
+```
+
+Request bodies must include the following data attributes:
+
+* `cohort`
+* `school_id`
+* `delivery_partner_id`
+
+Successful requests will return a response body with updates included.
+
+#### Do providers need to take any action to continue existing partnerships with schools from one cohort to the next?
+
+No, the API assumes schools intend to work with a given provider for consecutive cohorts. School induction tutors will be prompted to confirm existing partnerships with providers will continue into the upcoming cohort.
+
+#### What happens if schools have previous partnerships with other lead providers?
+
+For new providers to confirm partnerships with schools for an upcoming cohort, school induction tutors must first notify DfE that their schools will not continue their former partnerships with existing providers for the upcoming cohort. Until induction tutors have done this, any new partnerships with new providers will be rejected by the API.
+
+#### What if a school selected 'school-led' by mistake?
+
+If a school has mistakenly selected a `school-led` induction programme and intended to choose `provider-led`, lead providers can correct this using the `POST partnerships` endpoint. Providers must:
+
+* confirm with the school before submitting the change
+* provide both the school’s URN and the delivery partner’s ID
+
+For more detailed information, view the `POST partnerships`[endpoint documentation](reference-v3#api-v3-partnerships-ecf-post).
+
+#### Example request body
+
+```
+{
+  "data": {
+    "type": "ecf-partnership",
+    "attributes": {
+      "cohort": "2024",
+      "school_id": "24b61d1c-ad95-4000-aee0-afbdd542294a",
+      "delivery_partner_id": "db2fbf67-b7b7-454f-a1b7-0020411e2314"
+    }
+  }
+}
+```
+
+#### Example response body
+
+```
+{
+  "data": {
+    "id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+    "type": "partnership",
+    "attributes": {
+      "cohort": 2024,
+      "urn": "123456",
+      "school_id": "24b61d1c-ad95-4000-aee0-afbdd542294a",
+      "delivery_partner_id": "db2fbf67-b7b7-454f-a1b7-0020411e2314",
+      "delivery_partner_name": "Delivery Partner Example",
+      "status": "active",
+      "challenged_reason": null,
+      "challenged_at": null,
+      "induction_tutor_name": "John Doe",
+      "induction_tutor_email": "john.doe@example.com",
+      "updated_at": "2024-05-31T02:22:32.000Z",
+      "created_at": "2024-05-31T02:22:32.000Z"
+    }
+  }
+}
+```
+
+### View all details for all existing partnerships
+
+```
+GET /api/v3/partnerships/ecf
+```
+
+View details for all existing partnerships to check information is correct and whether any have had their status challenged by schools. [Find out more about partnership statuses.](ecf/definitions-and-states#partnership-states)
+
+Providers can also filter results by adding a cohort filter to the parameter. For example, `GET /api/v3/partnerships/ecf?filter[cohort]=2024`.
+
+For more detailed information, view the `GET partnerships/ecf` [endpoint documentation](reference-v3#api-v3-partnerships-ecf-get).
+
+#### Example response body
+
+```
+{
+  "data": [
+    {
+      "id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+      "type": "partnership",
+      "attributes": {
+        "cohort": 2024,
+        "urn": "123456",
+        "school_id": "dd4a11347-7308-4879-942a-c4a70ced400v",
+        "delivery_partner_id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+        "delivery_partner_name": "Delivery Partner Example",
+        "status": "challenged",
+        "challenged_reason": "mistake",
+        "challenged_at": "2024-05-31T02:22:32.000Z",
+        "induction_tutor_name": "John Doe",
+        "induction_tutor_email": "john.doe@example.com",
+        "updated_at": "2024-05-31T02:22:32.000Z",
+        "created_at": "2024-05-31T02:22:32.000Z"
+      }
+    }
+  ]
+}
+```
+
+### View details for a specific existing partnership
+
+```
+GET /api/v3/partnerships/ecf/{id}
+```
+
+View details for an existing partnership to check information is correct and whether the [partnership status](ecf/definitions-and-states/#partnership-states) has been challenged by the school.
+
+
+For more detailed information, view `GET/ partnerships/ecf/{id}` [endpoint documentation](reference-v3#api-v3-partnerships-ecf-id-get).
+
+#### Example response body
+
+```
+{
+  "data": [
+    {
+      "id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+      "type": "partnership",
+      "attributes": {
+        "cohort": 2024,
+        "urn": "123456",
+        "school_id": "dd4a11347-7308-4879-942a-c4a70ced400v",
+        "delivery_partner_id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+        "delivery_partner_name": "Delivery Partner Example",
+        "status": "challenged",
+        "challenged_reason": "mistake",
+        "challenged_at": "2024-05-31T02:22:32.000Z",
+        "induction_tutor_name": "John Doe",
+        "induction_tutor_email": "john.doe@example.com",
+        "updated_at": "2024-05-31T02:22:32.000Z",
+        "created_at": "2024-05-31T02:22:32.000Z"
+      }
+    }
+  ]
+}
+```
+
+### Update a partnership with a new delivery partner
+
+```
+ PUT /api/v3/partnerships/ecf/{id}
+```
+
+Update an existing partnership with new delivery partner details for a given cohort.
+
+Request bodies must include a new value for the `delivery_partner_id` attribute. If unsure, providers can [find delivery partner IDs](ecf/guidance#find-delivery-partner-ids).
+
+Providers can only update partnerships where the `status` attribute is `active`. Any requests to update `challenged` partnerships will return an error. If a partnership has been challenged and rejected, use `POST partnerships` to create a new partnership, rather than `PUT partnerships`.
+
+[Find out more about partnership statuses.](ecf/definitions-and-states#partnership-states)
+
+Successful requests will return a response body with updates included.
+
+For more detailed information see the specifications for this [update a partnership endpoint](reference-v3#api-v3-partnerships-ecf-id-put).
+
+#### Example request body
+
+```
+{
+  "data": {
+    "type": "ecf-partnership-update",
+    "attributes": {
+      "delivery_partner_id": "db2fbf67-b7b7-454f-a1b7-0020411e2314"
+    }
+  }
+}
+```
+
+### Partnerships troubleshooting
+
+#### Missing participants
+
+If participants are missing, check whether the partnership for the relevant school and cohort has been challenged.
+
+#### Viewing partnership statuses
+
+Use the `GET partnerships` endpoint to view the status of any active or challenged partnerships.
+
+#### Incorrect partnerships
+
+Providers should contact DfE if they believe a school is partnered incorrectly.
+
+#### Unexpected `updated_at` timestamps
+
+When a partnership is updated due to a terminology change (for example, `school-left-fip` to `switched-to-school-led`), the record will show:
+
+* the new withdrawal reason in the `GET` response
+* an updated `updated_at` timestamp, even if the partnership was originally withdrawn earlier
+
+#### Why providers may not receive data for every participant at a partnered school
+
+Not all participants at a given school will be registered to receive training through the default partnership. For example, if a participant begins training at School 1 (partnered with Provider A and Delivery Partner B) but later transfers to School 2 (partnered with Provider Y and Delivery Partner Z), they may choose to continue training with their original providers (A and B). In this case, Provider Y would not receive data for the participant.
+
+#### Why providers may receive data for participants at schools they’re not partnered with
+
+Providers may sometimes receive participant data for schools with which they do not have a current partnership. For example, a participant might start their training at School 1 (partnered with Provider Y and Delivery Partner Z) and later transfer to School 2. If they choose to stay with Provider Y and Delivery Partner Z after moving, Provider Y will continue to receive data about the participant, even though they are no longer partnered with the participant’s new school.
+
+## View and update participant data
+
+Providers can view data to find out whether participants:
+
+* have valid email addresses
+* have valid teacher reference numbers (TRN)
+* have achieved qualified teacher status (QTS)
+* are eligible for funding
+* have [transferred to or from a school you're partnered with](ecf/guidance#view-data-for-all-participants-who-have-transferred)
+* have (if they're ECTs) been assigned [unfunded mentors](ecf/guidance#view-all-unfunded-mentor-details)
+* have (if they're ECTs) completed their induction, according to the Database of Qualified Teachers
+
+Note, while participants can enter different email addresses when registering for each training course they apply for, providers will only see the email address associated with a given course registration. For example, a participant may complete their training with one associated email address, then register for an NPQ with a different email address, and go on to be an ECT mentor with a third email address. DfE will share the relevant email address with the relevant course provider.
+
+Providers can then update data to notify DfE that participants have:
+
+* [deferred training](ecf/guidance#notify-dfe-a-participant-has-taken-a-break-deferred-from-training )
+* [resumed training](ecf/guidance#notify-dfe-a-participant-has-resumed-training)
+* [withdrawn from training](ecf/guidance#notify-dfe-a-participant-has-withdrawn-from-training)
+* [changed their training schedule](ecf/guidance#notify-dfe-of-a-participant-39-s-training-schedule)
+
+### View all participant data
+
+```
+ GET /api/v{n}/participants/ecf
+```
+
+Note, providers can also filter results by adding `cohort` and `updated_since` filters to the parameter. For example: `GET /api/v{n}/participants/ecf?filter[cohort]=2024&filter[updated_since]=2020-11-13T11:21:55Z`
+
+An example response body is listed below.
+
+**Providers should note:**
+
+* DfE has [previously advised](release-notes#15-march-2023) of the possibility that participants may be registered as duplicates with multiple participant_ids. Where DfE identifies duplicates, it will fix the error by ‘retiring’ one of the participant IDs, then associating all records and data under the remaining ID
+* providers can check if a participant’s ID has changed using the `participant_id_changes` nested structure in the [ECFEnrolment](reference-v3#schema-ecfenrolment), which contains a `from_participant_id` and a `to_participant_id` string fields, as well a `changed_at` date value
+* DfE will close the funding contract for the 2021 cohort on 31 July 2024. Schools will start moving ECTs and mentors with partial declarations originally assigned to the 2021 cohort to the 2024 cohort from mid-June  
+
+For more detailed information, see the specifications for this [view multiple participants endpoint](reference-v3#api-v3-participants-ecf-get).
+
+#### Example response body:
+
+```
+{
+  "data": [
+    {
+      "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+      "type": "participant",
+      "attributes": {
+        "full_name": "Jane Smith",
+        "teacher_reference_number": "1234567",
+        "updated_at": "2024-05-31T02:22:32.000Z",
+        "ecf_enrolments": [
+          {
+            "training_record_id": "000a97ff-d2a9-4779-a397-9bfd9063072e",
+            "email": "jane.smith@some-school.example.com",
+            "mentor_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+            "school_urn": "106286",
+            "participant_type": "ect",
+            "cohort": "2024",
+            "training_status": "active",
+            "participant_status": "active",
+            "teacher_reference_number_validated": true,
+            "eligible_for_funding": true,
+            "pupil_premium_uplift": true,
+            "sparsity_uplift": true,
+            "schedule_identifier": "ecf-standard-january",
+            "delivery_partner_id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+            "withdrawal": null,
+            "deferral": null,
+            "created_at": "2024-05-31T02:22:32.000Z",
+            "induction_end_date": "2025-01-12",
+            "mentor_funding_end_date": "2024-04-19",
+            "cohort_changed_after_payments_frozen": false
+          }
+        ],
+        "participant_id_changes": [
+          {
+            "from_participant_id": "23dd8d66-e11f-4139-9001-86b4f9abcb02",
+            "to_participant_id": "db3a7848-7308-4879-942a-c4a70ced400a",
+            "changed_at": "2023-09-23T02:22:32.000Z",
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+### View a single participant's data
+
+```
+ GET /api/v{n}/participants/ecf/{id}
+```
+
+An example response body is listed below.
+
+**Providers should note:**
+
+* we’ve [previously advised](release-notes#15-march-2023) of the possibility that participants may be registered as duplicates with multiple `participant_ids`. Where we identify duplicates, we’ll fix the error by ‘retiring’ one of the participant IDs and then associating all records and data under the remaining ID. To date, when this has occurred, we’ve informed providers of changes via CSVs
+* they can check if a participant’s ID has changed using the `participant_id_changes` nested structure in the [ECFEnrolment](reference-v3#schema-ecfenrolment), which contains a `from_participant_id` and a `to_participant_id` string fields, as well a `changed_at` date value
+* if they cannot see a mentor as expected using this endpoint, it's probably because the mentor is not eligible for funding through them. In this case, providers should use the [GET /api/v3/unfunded-mentors/ecf/{id} endpoint](reference-v3#api-v3-unfunded-mentors-ecf-id-get) to retrieve the mentor’s details
+
+For more detailed information, see the specifications for the [view a single participant endpoint](reference-v3#api-v3-participants-ecf-id-get).
+
+#### Example response body:
+
+```
+{
+  "data": {
+    "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+    "type": "participant",
+    "attributes": {
+      "full_name": "Jane Smith",
+      "teacher_reference_number": "1234567",
+      "updated_at": "2024-05-31T02:22:32.000Z",
+      "ecf_enrolments": [
+        {
+          "training_record_id": "000a97ff-d2a9-4779-a397-9bfd9063072e",
+          "email": "jane.smith@some-school.example.com",
+          "mentor_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+          "school_urn": "106286",
+          "participant_type": "ect",
+          "cohort": "2024",
+          "training_status": "active",
+          "participant_status": "active",
+          "teacher_reference_number_validated": true,
+          "eligible_for_funding": true,
+          "pupil_premium_uplift": true,
+          "sparsity_uplift": true,
+          "schedule_identifier": "ecf-standard-january",
+          "delivery_partner_id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+          "withdrawal": null,
+          "deferral": null,
+          "created_at": "2024-05-31T02:22:32.000Z",
+          "induction_end_date": "2025-01-12",
+          "mentor_funding_end_date": "2024-04-19",
+          "cohort_changed_after_payments_frozen": false
+        }
+      ],
+      "participant_id_changes": [
+        {
+          "from_participant_id": "23dd8d66-e11f-4139-9001-86b4f9abcb02",
+          "to_participant_id": "db3a7848-7308-4879-942a-c4a70ced400a",
+          "changed_at": "2023-09-23T02:22:32.000Z",
+        }
+      ]
+    }
+  }
+}
+```
+
+### Retrieve multiple unfunded mentors 
+
+``` 
+GET /api/v3/unfunded-mentors/ecf 
+```  
+
+> Only available for systems integrated with API v3 onwards. It will not return data for API v1 or v2.
+ 
+Lead providers can use this endpoint to retrieve the names and email addresses of all mentors who are not eligible for funding through them but are assigned to their ECTs. Typically, these mentors have either completed, or are currently doing, mentor training with a different lead provider than the one delivering training to the ECT they support.
+
+For more detailed information, see the [‘Retrieve multiple unfunded mentors’ endpoint documentation](reference-v3#api-v3-unfunded-mentors-ecf-get). 
+
+#### Example response body:
+
+```
+{
+  "data": [
+    {
+      "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+      "type": "unfunded-mentor",
+      "attributes": {
+        "full_name": "Jane Smith",
+        "email": "jane.smith@some-school.example.com",
+        "teacher_reference_number": "1234567",
+        "created_at": "2024-05-31T02:22:32.000Z",
+        "updated_at": "2024-05-31T02:22:32.000Z"
+      }
+    }
+  ]
+}
+```
+
+### View details of a specific 'unfunded mentor'
+
+```
+ GET /api/v3/unfunded-mentors/ecf/{id}
+```
+
+> The following endpoint is only available for systems integrated with API v3 onwards. It will not return data for API v1 or v2.
+
+Lead providers can use this endpoint to retrieve the names and email addresses of individual mentors who are not eligible for funding through them but are assigned to their ECTs. Having these details will then enable providers to give these mentors access to the right learning platforms.
+
+For more detailed information, [see the ‘Get a single unfunded mentor’ endpoint documentation](reference-v3#api-v3-unfunded-mentors-ecf-id-get).
+
+#### Example response body:
+
+```
+{
+  "data": {
+    "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+    "type": "unfunded-mentor",
+    "attributes": {
+      "full_name": "Jane Smith",
+      "email": "jane.smith@some-school.example.com",
+      "teacher_reference_number": "1234567",
+      "created_at": "2024-05-31T02:22:32.000Z",
+      "updated_at": "2024-05-31T02:22:32.000Z"
+    }
+  }
+}
+```
+
+### Notify DfE a participant has taken a break (deferred) from training
+
+A participant can choose to take a break from training at any time if they plan to resume training at a later date. Providers must notify DfE of this via the API.
+
+```
+ PUT /api/v{n}/participants/ecf/{id}/defer
+```
+
+An example request body is listed below.
+
+Successful requests will return a response body including updates to the `training_status` attribute.
+
+For more detailed information, see the specifications for the [notify DfE that a participant is taking a break from their course endpoint](reference-v3#api-v3-participants-ecf-id-defer-put).
+
+#### Example request body:
+
+```
+{
+  "data": {
+    "type": "participant-defer",
+    "attributes": {
+      "reason": "career-break",
+      "course_identifier": "ecf-mentor"
+    }
+  }
+}
+```
+
+### Notify DfE a participant has resumed training
+
+A participant can choose to resume their training at any time if they had previously deferred. Providers must notify DfE of this via the API.
+
+```
+ PUT /api/v{n}/participants/ecf/{id}/resume
+```
+
+An example request body is listed below.
+
+Successful requests will return a response body including updates to the `training_status` attribute.
+
+For more detailed information see the specifications for this [notify DfE that a participant has resumed training endpoint](reference-v3#api-v3-participants-ecf-id-resume-put).
+
+#### Example request body:
+
+```
+{
+  "data": {
+    "type": "participant-resume",
+    "attributes": {
+      "course_identifier": "ecf-mentor"
+    }
+  }
+}
+```
+
+###  Notify DfE a participant has withdrawn from training
+
+A participant can choose to withdraw from training at any time. Providers must notify DfE of this via the API.
+
+```
+ PUT /api/v{n}/participants/ecf/{id}/withdraw
+```
+
+An example request body is listed below.
+
+Successful requests will return a response body including updates to the `training_status` attribute.
+
+For more detailed information see the specifications for this [notify DfE that a participant has withdrawn from training endpoint](reference-v3#api-v3-participants-ecf-id-withdraw-put).
+
+#### Providers should note:
+
+* DfE will **only** pay for participants who have had, at a minimum, a `started` declaration submitted against them
+* DfE will pay providers for declarations submitted where the `declaration_date` is before the date of the withdrawal
+
+Providers may see instances where a participant’s `training_status` and `participant_status` do not match. Providers are required to check the `participant_status` is accurate before notifying DFE that the participant has withdrawn from training with them altogether. **For example,** a participant has `"training_status": "active"` while their `"participant_status": "withdrawn"`. This would indicate an induction tutor has entered the DfE service to inform DfE that the participant has withdrawn from training at their school. However, the provider in partnership with that school has not yet withdrawn the participant via the API.  The participant’s `training_status` will remain `active` until the provider investigates (to see if the participant has withdrawn or has transferred to a new school) and notifies DfE a participant has withdrawn from training (`"training_status": "withdrawn"`).
+
+#### Example request body:
+
+```
+{
+  "data": {
+    "type": "participant-withdraw",
+    "attributes": {
+      "reason": "left-teaching-profession",
+      "course_identifier": "ecf-mentor"
+    }
+  }
+}
+```
+
+### Notify DfE of a participant's training schedule
+
+> All participants will be registered by default to a standard schedule starting in September. Providers must notify DfE of any other schedule.
+
+Participants can choose to follow standard or non-standard training schedules.
+
+```
+ PUT /api/v3/participants/ecf/{id}/change-schedule
+```
+
+An example request body is listed below.
+
+Successful requests will return a response body including updates to the `schedule_identifier` attribute.
+
+#### Providers should note:
+
+Milestone validation applies. The API will reject a schedule change if any previously submitted `eligible`, `payable` or `paid` declarations have a `declaration_date` which does not align with the new schedule’s milestone dates.
+
+Where this occurs, providers should:
+
+1. Void the existing declarations (where `declaration_date` does not align with the new schedule).
+2. Change the participant’s training schedule.
+3. Resubmit backdated declarations (where `declaration_date` aligns with the new schedule).
+
+For replacement mentors, view [guidance on updating a replacement mentor’s schedule.](ecf/guidance#update-a-replacement-mentor-s-schedule)
+
+For more detailed information see the specifications for this [notify that a participant has changed their training schedule endpoint](reference-v3#api-v3-participants-ecf-id-change-schedule-put).
+
+#### Example request body:
+
+```
+{
+  "data": {
+    "type": "participant-change-schedule",
+    "attributes": {
+      "schedule_identifier": "ecf-standard-january",
+      "course_identifier": "ecf-mentor",
+      "cohort": "2024"
+    }
+  }
+}
+```
+
+###  Update a replacement mentor’s schedule
+
+A new mentor can be assigned to an ECT part way through training.
+
+[Providers must notify DfE of replacement mentors by updating their training schedule.](ecf/guidance#notify-dfe-of-a-participant-39-s-training-schedule)
+
+Note, if a replacement mentor is already mentoring another ECT, and they replace a mentor for a second ECT, the first ECT takes precedence. In this instance, the provider should not change the mentor’s schedule.
+
+Providers must include a `schedule_identifier` reflecting when the replacement mentor starts.
+
+* `ecf-replacement-september`
+* `ecf-replacement-january`
+* `ecf-replacement-april`
+
+For API v3 onwards, a replacement mentor's schedule, and any associated declaration submissions, do not need to align with the ECT they are mentoring.
+
+Previously for API v1 and v2, a replacement mentor could start mentoring an ECT part way through their training. The provider had already submitted a `start` declaration for the previous mentor (in line with the ECT). If the provider were to submit a `retention-1` declaration for the ECT, then any declaration submitted for the new replacement mentor in the same milestone period would also have to be a retention-1 declaration. This is no longer the case for API v3.
+
+### Offboarding participants  
+
+There are 3 instances lead providers need to account for: 
+
+1. Transfers – when a participant has transferred and providers have finalised any outstanding declaration and offboarding processes, they should withdraw the participant using the `PUT participants/ecf/{id}/withdraw` endpoint. 
+2. Withdrawals – withdraw the participant as above. Any outstanding declarations can be backdated if they are on/before the withdrawal date.  
+3. Completions – when ECTs complete their induction the `induction_end_date` field will be populated on their profiles. Similarly, once providers have submitted a completed declaration for mentors, the `mentor_funding_end_date` field will be populated. Providers should backdate any declarations and remove these participants from their active training lists. Providers **do not have to** withdraw them. 
+
+## Participant transfers (v3 API-only) 
+ 
+In the v3 API, lead providers can: 
+ 
+* view transfer data as soon as schools report a move
+* see participant status updates based on reported joining and leaving dates
+* identify whether a participant is `joining`, `leaving`, `left`, or `active` depending on timing
+* retrieve details of transferred ECTs and mentors to maintain accurate records 
+
+Lead providers should update training statuses when a participant withdraws from their programme to ensure data accuracy. 
+
+### View data for all participants who have transferred 
+
+``` 
+GET /api/v3/participants/ecf/transfers 
+``` 
+
+Lead providers can use this endpoint to view data for participants who’ve transferred from and to schools they’re in partnership with. The data is updated whenever schools report a transfer. 
+
+View the [‘Retrieve multiple participant transfers’ endpoint documentation](reference-v3#api-v3-participants-ecf-transfers-get).
+
+### View data for a specific participant who has transferred  
+
+``` 
+GET /api/v3/participants/ecf/{id}/transfers 
+``` 
+
+Lead providers can use this endpoint to view data for individual participants who’ve transferred from and to schools they’re in partnership with.  
+
+View the [‘Get a single participant’s transfers’ endpoint documentation](reference-v3#api-v3-participants-ecf-id-transfers-get).
+
+### What providers will see in the API when a participant is transferring away from them  
+| Scenario | Participant status | Transfer response |
+| -------- | -----------------  | ----------------- |
+| **Before transfer** | Active      | N/A |
+| **Old school induction tutor reports leaver** | Leaving | Shows leaving details |
+| **New school induction tutor reports joiner** | Leaving | Shows leaving and joining details |
+| **After transfer** | Left | Shows leaving and joining details |
+
+### What providers will see in the API when a participant is transferring to them
+| Scenario | Participant status | Transfer response |
+| -------- | -----------------  | ----------------- |
+| **New school induction tutor reports joiner** | Joining | Shows leaving and joining details |
+| **After transfer** | Active | Shows leaving and joining details |
+
+### What providers will see in the API if a participant is staying with them after transferring schools 
+| Scenario | Participant status | Transfer response |
+| -------- | -----------------  | ----------------- |
+| **Before transfer** | Active | N/A |
+| **Old school induction tutor reports leaver** | Leaving | Shows leaving details |
+| **New school induction tutor reports joiner** | Joining (new school details shown) | Shows leaving and joining details |
+| **After transfer** | Active | Shows leaving and joining details |
+
+### Managing transfers between providers 
+ 
+Providers must [notify DfE when a participant withdraws](reference-v3#api-v3-participants-ecf-id-withdraw-put) from their training to ensure data accuracy. Once a participant transfers to a new provider and school induction tutors have confirmed the move, the original provider will see the `participant_status` as `left`. They should then update the participant’s `training_status` to `withdrawn`. The transfer record will also appear in `GET transfers` and `GET {id}/transfers` endpoint responses.
+
+### Why transfer data can appear incomplete 
+ 
+There can sometimes be a transfer data 'lag' because induction tutors enter information at different times. For example, if a participant is leaving one school but their new school hasn’t confirmed the transfer yet, only data from the departing school will be available via the API.  
+
+### How transfer dates between schools affect a participant’s status 
+
+A participant's joining and leaving dates are determined by when the outbound school reports them as leaving and the inbound school reports them as joining. This affects how their `status` appears for lead providers. 
+ 
+When a new school's induction tutor reports a participant joining before the previous school confirms their departure, the `leaving_date` remains `null` until the old school updates it. 
+
+### What to look for in the response bodies of transfer endpoints   
+
+Successful requests will return details including: 
+
+* participant IDs
+* the name of the provider a participant is transferring to or from
+* the unique reference number (URN) of the school a participant is transferring to or from
+* the type of transfer. For example, `new_school` or `new_provider`
+* a `status` field to show whether the transfer has already taken place or is in progress
+
+#### Example response body:
+
+```
+{
+  "data": [
+    {
+      "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+      "type": "participant-transfer",
+      "attributes": {
+        "updated_at": "2024-05-31T02:22:32.000Z",
+        "transfers": [
+          {
+            "training_record_id": "000a97ff-d2a9-4779-a397-9bfd9063072e",
+            "transfer_type": "new_provider",
+            "status": "complete",
+            "leaving": {
+              "school_urn": "123456",
+              "provider": "Old Institute",
+              "date": "2024-05-31"
+            },
+            "joining": {
+              "school_urn": "654321",
+              "provider": "New Institute",
+              "date": "2024-06-01"
+            },
+            "created_at": "2024-05-31T02:22:32.000Z"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+## Submit, view and void declarations
+
+### What are declarations?
+
+Declarations are formal submissions made by lead providers to confirm that a participant (an early career teacher or mentor) has engaged sufficiently with training during a specific period.
+
+### What declarations do
+
+Declarations:
+
+* inform DfE training has taken place
+* record participant progress across date milestones
+* trigger payments from DfE to lead providers
+
+Examples of declaration types include:
+
+* `started` – training began in a given period
+* `retained-1` / `retained-2` – participant continued training through subsequent milestones
+* `completed` – full programme finished
+* `extended` – when an ECT’s training continues beyond the standard schedule
+
+### How declarations are submitted
+
+Declarations are submitted via the API, using endpoints like `POST participant-declarations`.
+
+Each declaration includes:
+
+* participant ID
+* declaration type
+* declaration date (aligned with what’s outlined in the payment guidance)
+* type of evidence a lead provider holds to verify that a participant has engaged in training
+* lead provider and programme type details
+
+### Sample submission flow
+
+1. Participant attends training.
+2. Lead provider records training milestone.
+3. Lead provider submits declaration via API.
+4. API validates and links to relevant financial statement.
+5. Declaration triggers payment (if valid).
+
+### Can declarations be made after a cohort has closed in the service?
+
+No, providers cannot submit or void declarations after a cohort has closed.
+
+### What happens if providers submit duplicate declarations?
+
+Duplicate declarations cannot be submitted. If a duplicate is attempted, the API will return an error message.
+
+### What happens if a declaration gets stuck in a submitted state?
+
+#### Possible reasons for a declaration staying in submitted
+
+Participant or programme mismatch:
+
+* if a participant’s record has been withdrawn, transferred, or misaligned, the declaration may not be linked to a valid funding schedule
+
+System delay or sync issue:
+
+* occasionally, internal system syncing or financial statement generation may cause a delay
+
+#### What providers can do
+
+To solve the issue of declarations being stuck in a `submitted` state, providers should:
+
+1. Check the participant's status via `GET /participants/{id}`.
+2. Check the declaration details via `GET /participant-declarations/{id}`.
+3. Check for errors returned when it was submitted.
+4. Raise a query via their usual DfE support channel or digital engagement lead if it remains stuck for longer than expected (especially past the processing window).
+
+### How providers can test they're able to submit declarations
+
+`X-With-Server-Date` is a custom JSON header supported in the sandbox environment. It lets providers test their integrations and ensure they are able to submit declarations for future milestone dates.
+
+The `X-With-Server-Date` header lets providers simulate future dates, and therefore allows providers to test declaration submissions for future milestone dates.
+
+> It's only valid in the sandbox environment. Attempts to submit future declarations in the production environment (or without this header in sandbox) will be rejected as part of milestone validation.
+
+To test declaration submission functionality, include:
+
+* the header `X-With-Server-Date` as part of declaration submission request
+* the value of your chosen date in ISO8601 Date with time and Timezone (i.e. RFC3339 format). For example:
+
+```
+X-With-Server-Date: 2025-01-10T10:42:00Z
+```
+
+### Submit a declaration to notify DfE a participant has started training
+
+Notify the DfE that a participant has started training by submitting a `started` declaration in line with [milestone 1 dates](ecf/schedules-and-milestone-dates).
+
+```
+ POST /api/v3/participant-declarations
+```
+
+An example request body is listed below. Request bodies must include the necessary data attributes, including the `declaration_type` attribute with a `started` value.
+
+An example response body is listed below. Successful requests will return a response body with declaration data.
+
+Any attempts to submit duplicate declarations will return an error message.
+
+> Note, providers should store the returned participant declaration ID for management tasks.
+
+For more detailed information see the specifications for this [notify DfE that a participant has started training endpoint](reference-v3#api-v3-participant-declarations-post).
+
+#### Example request body:
+
+```
+{
+  "data": {
+    "type": "participant-declaration",
+    "attributes": {
+      "participant_id": "db3a7848-7308-4879-942a-c4a70ced400a",
+      "declaration_type": "started",
+      "declaration_date": "2024-05-31T02:21:32.000Z",
+      "course_identifier": "ecf-induction"
+    }
+  }
+}
+```
+
+#### Example response body:
+
+```
+{
+  "data": {
+    "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+    "type": "participant-declaration",
+    "attributes": {
+      "participant_id": "08d78829-f864-417f-8a30-cb7655714e28",
+      "declaration_type": "started",
+      "declaration_date": "2020-11-13T11:21:55Z",
+      "course_identifier": "ecf-induction",
+      "state": "eligible",
+      "updated_at": "2020-11-13T11:21:55Z",
+      "created_at": "2020-11-13T11:21:55Z",
+      "delivery_partner_id": "99ca2223-8c1f-4ac8-985d-a0672e97694e",
+      "statement_id": "99ca2223-8c1f-4ac8-985d-a0672e97694e",
+      "clawback_statement_id": null,
+      "ineligible_for_funding_reason": null,
+      "mentor_id": "907f61ed-5770-4d38-b22c-1a4265939378",
+      "uplift_paid": true,
+      "evidence_held": "other"
+    }
+  }
+}
+```
+
+### Submit a declaration to notify DfE a participant has been retained in training
+
+Notify DfE that a participant has reached a given retention point in their training by submitting a `retained` declaration in line with [milestone dates](ecf/schedules-and-milestone-dates).
+
+```
+POST /api/v{n}/participant-declarations
+```
+
+An example request body is listed below. Request bodies must include the necessary data attributes, including the appropriate `declaration_type` attribute value, for example `retained-1`.
+
+An example response body is listed below. Successful requests will return a response body with declaration data.
+
+Any attempts to submit duplicate declarations will return an error message.
+
+> Note, providers should store the returned participant declaration ID for management tasks.</div>
+
+For more detailed information see the specifications for this [notify DfE that a participant has been retained in training endpoint](reference-v3#api-v3-participant-declarations-post).
+
+#### Example request body:
+
+```
+{
+  “data”: {
+    “type”: “participant-declaration”,
+    “attributes”: {
+      “participant_id”: “db3a7848-7308-4879-942a-c4a70ced400a”,
+      “declaration_type”: “retained-1",
+      “declaration_date”: “2024-05-31T02:21:32.000Z”,
+      “course_identifier”: “ecf-induction”
+      “evidence_held”: “training-event-attended”
+    }
+  }
+}
+```
+
+#### Example response body:
+
+```
+{
+  “data”: {
+    “id”: “db3a7848-7308-4879-942a-c4a70ced400a”,
+    “type”: “participant-declaration”,
+    “attributes”: {
+      “participant_id”: “08d78829-f864-417f-8a30-cb7655714e28",
+      “declaration_type”: “retained-1",
+      “declaration_date”: “2024-05-31T02:21:32.000Z”,
+      “course_identifier”: “ecf-induction”,
+      “state”: “eligible”,
+      “updated_at”: “2020-11-13T11:21:55Z”,
+      “created_at”: “2020-11-13T11:21:55Z”,
+      “delivery_partner_id”: “99ca2223-8c1f-4ac8-985d-a0672e97694e”,
+      “statement_id”: “99ca2223-8c1f-4ac8-985d-a0672e97694e”,
+      “clawback_statement_id”: null,
+      “ineligible_for_funding_reason”: null,
+      “mentor_id”: “907f61ed-5770-4d38-b22c-1a4265939378",
+      “uplift_paid”: true,
+      “evidence_held”: “training-event-attended”
+    }
+  }
+}
+```
+
+### Submit a declaration to notify DfE a participant has completed training
+
+Notify the DfE that a participant has completed their training by submitting a `completed` declaration in line with [milestone dates](ecf/schedules-and-milestone-dates).
+
+```
+POST /api/v{n}/participant-declarations
+```
+
+An example request body is listed below. Request bodies must include the necessary data attributes, including the `declaration_type` attribute with a `completed` value.
+
+An example response body is listed below. Successful requests will return a response body with declaration data.
+
+Any attempts to submit duplicate declarations will return an error message.
+
+> Note, providers should store the returned participant declaration ID for future management tasks.
+
+For more detailed information see the specifications for this [notify DfE that a participant has completed training endpoint](reference-v3#api-v3-participant-declarations-post).
+
+#### Example request body:
+
+```
+{
+  “data”: {
+    “type”: “participant-declaration”,
+    “attributes”: {
+      “participant_id”: “db3a7848-7308-4879-942a-c4a70ced400a”,
+      “declaration_type”: “completed”,
+      “declaration_date”: “2024-05-31T02:21:32.000Z”,
+      “course_identifier”: “ecf-induction”
+      “evidence_held”: “self-study-material-completed”
+    }
+  }
+}
+```
+#### Example response body:
+
+```
+{
+  “data”: {
+    “id”: “db3a7848-7308-4879-942a-c4a70ced400a”,
+    “type”: “participant-declaration”,
+    “attributes”: {
+      “participant_id”: “08d78829-f864-417f-8a30-cb7655714e28",
+      “declaration_type”: “completed",
+      “declaration_date”: “2024-05-31T02:21:32.000Z”,
+      “course_identifier”: “ecf-induction”,
+      “state”: “eligible”,
+      “updated_at”: “2020-11-13T11:21:55Z”,
+      “created_at”: “2020-11-13T11:21:55Z”,
+      “delivery_partner_id”: “99ca2223-8c1f-4ac8-985d-a0672e97694e”,
+      “statement_id”: “99ca2223-8c1f-4ac8-985d-a0672e97694e”,
+      “clawback_statement_id”: null,
+      “ineligible_for_funding_reason”: null,
+      “mentor_id”: “907f61ed-5770-4d38-b22c-1a4265939378",
+      “uplift_paid”: true,
+      “evidence_held”: “self-study-material-completed”
+    }
+  }
+}
+```
+
+### View all previously submitted declarations
+
+View all declarations which have been submitted to date. Check submissions, identify if any are missing, and void or clawback those which have been submitted in error.
+
+```
+GET /api/v3/participant-declarations
+```
+
+Note, providers can also filter results by adding filters to the parameter. For example: `GET /api/v3/participant-declarations?filter[participant_id]=ab3a7848-1208-7679-942a-b4a70eed400a` or `GET /api/v3/participant-declarations?filter[cohort]=2024&filter[updated_since]=2020-11-13T11:21:55Z`
+
+An example response body is listed below.
+
+For more detailed information see the specifications for this [view all declarations endpoint.](reference-v3#api-v3-participant-declarations-get)
+
+#### Example response body:
+```
+{
+  "data": [
+    {
+      "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+      "type": "participant-declaration",
+      "attributes": {
+        "participant_id": "08d78829-f864-417f-8a30-cb7655714e28",
+        "declaration_type": "started",
+        "declaration_date": "2020-11-13T11:21:55Z",
+        "course_identifier": "ecf-induction",
+        "state": "eligible",
+        "updated_at": "2020-11-13T11:21:55Z",
+        "created_at": "2020-11-13T11:21:55Z",
+        "delivery_partner_id": "99ca2223-8c1f-4ac8-985d-a0672e97694e",
+        "statement_id": "99ca2223-8c1f-4ac8-985d-a0672e97694e",
+        "clawback_statement_id": null,
+        "ineligible_for_funding_reason": null,
+        "mentor_id": "907f61ed-5770-4d38-b22c-1a4265939378",
+        "uplift_paid": true,
+        "evidence_held": "other"
+      }
+    },
+    {
+      "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+      "type": "participant-declaration",
+      "attributes": {
+        "participant_id": "08d78829-f864-417f-8a30-cb7655714e28",
+        "declaration_type": "retained-1",
+        "declaration_date": "2020-11-13T11:21:55Z",
+        "course_identifier": "ecf-induction",
+        "state": "eligible",
+        "updated_at": "2020-11-13T11:21:55Z",
+        "created_at": "2020-11-13T11:21:55Z",
+        "delivery_partner_id": "99ca2223-8c1f-4ac8-985d-a0672e97694e",
+        "statement_id": "99ca2223-8c1f-4ac8-985d-a0672e97694e",
+        "clawback_statement_id": null,
+        "ineligible_for_funding_reason": null,
+        "mentor_id": "907f61ed-5770-4d38-b22c-1a4265939378",
+        "uplift_paid": true,
+        "evidence_held": "training-event-attended"
+      }
+    }
+  ]
+}
+```
+
+### View a specific previously submitted declaration
+
+View a specific declaration which has been previously submitted. Check declaration details and void or clawback those which have been submitted in error.
+
+```
+GET /api/v3/participant-declarations/{id}
+```
+
+An example response body is listed below.
+
+For more detailed information see the specifications for this [view specific declarations endpoint.](reference-v3#api-v3-participant-declarations-id-get)
+
+#### Example response body:
+
+```
+{
+  "data": {
+    "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+    "type": "participant-declaration",
+    "attributes": {
+      "participant_id": "08d78829-f864-417f-8a30-cb7655714e28",
+      "declaration_type": "started",
+      "declaration_date": "2020-11-13T11:21:55Z",
+      "course_identifier": "ecf-induction",
+      "state": "eligible",
+      "updated_at": "2020-11-13T11:21:55Z",
+      "created_at": "2020-11-13T11:21:55Z",
+      "delivery_partner_id": "99ca2223-8c1f-4ac8-985d-a0672e97694e",
+      "statement_id": "99ca2223-8c1f-4ac8-985d-a0672e97694e",
+      "clawback_statement_id": null,
+      "ineligible_for_funding_reason": null,
+      "mentor_id": "907f61ed-5770-4d38-b22c-1a4265939378",
+      "uplift_paid": true,
+      "evidence_held": "other"
+    }
+  }
+}
+```
+
+### Void or clawback a declaration
+
+Void specific declarations which have been submitted in error.
+
+```
+PUT /api/v3/participant-declarations/{id}/void
+```
+
+An example response body is listed below. Successful requests will return a response body including updates to the declaration `state`, which will become:
+
+* `voided` if it had been  `submitted`, `ineligible`, `eligible`, or `payable`
+* `awaiting_clawback` if it had been `paid`
+
+View more information on [declaration states.](ecf/definitions-and-states/#declaration-states)
+
+For more detailed information see the specifications for this [void declarations endpoint.](reference-v3#api-v3-participant-declarations-id-void-put)
+
+#### Example response body:
+
+```
+{
+  "data": {
+    "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+    "type": "participant-declaration",
+    "attributes": {
+      "participant_id": "08d78829-f864-417f-8a30-cb7655714e28",
+      "declaration_type": "started",
+      "declaration_date": "2020-11-13T11:21:55Z",
+      "course_identifier": "ecf-induction",
+      "state": "voided",
+      "updated_at": "2020-11-13T11:21:55Z",
+      "created_at": "2020-11-13T11:21:55Z",
+      "delivery_partner_id": "99ca2223-8c1f-4ac8-985d-a0672e97694e",
+      "statement_id": "99ca2223-8c1f-4ac8-985d-a0672e97694e",
+      "clawback_statement_id": null,
+      "ineligible_for_funding_reason": null,
+      "mentor_id": "907f61ed-5770-4d38-b22c-1a4265939378",
+      "uplift_paid": true,
+      "evidence_held": "other"
+    }
+  }
+}
+```
+
+## View financial statement payment dates
+
+> The following endpoints are only available for systems integrated with API v3 onwards. They will not return data for API v1 or v2.
+
+Providers can view up to date payment cut-off dates, upcoming payment dates, and check to see whether output payments have been made by DfE.
+
+### View all statement payment dates
+
+```
+GET /api/v3/statements
+```
+
+An example response body is listed below.
+
+For more detailed information see the specifications for this [view all statements endpoint.](reference-v3#api-v3-statements-get)
+
+#### Example response body:
+
+```
+{
+  "data": [
+    {
+      "id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+      "type": "statement",
+      "attributes": {
+        "month": "May",
+        "year": "2025",
+        "type": "ecf",
+        "cohort": "2024",
+        "cut_off_date": "2025-04-30",
+        "payment_date": "2025-05-25",
+        "paid": true
+        "created_at": "2024-05-31T02:22:32.000Z",
+        "updated_at": "2024-05-31T02:22:32.000Z"
+      }
+    }
+  ]
+}
+```
+
+### View specific statement payment dates
+
+```
+GET /api/v3/statements/{id}
+```
+
+Providers can find statement IDs within [previously submitted declaration](ecf/guidance/#view-a-specific-previously-submitted-declaration) response bodies.
+
+An example response body is listed below.
+
+For more detailed information see the specifications for this [view a specific statement endpoint.](reference-v3#api-v3-statements-id-get)
+
+#### Example response body:
+
+```
+{
+  "data": {
+    "id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+    "type": "statement",
+    "attributes": {
+      "month": "May",
+      "year": "2025",
+      "type": "ecf",
+      "cohort": "2024",
+      "cut_off_date": "2025-04-30",
+      "payment_date": "2025-05-25",
+      "paid": true,
+      "created_at": "2024-05-31T02:22:32.000Z",
+      "updated_at": "2024-05-31T02:22:32.000Z"
+    }
+  }
+}
+```

--- a/documentation/ecf1_guidance/ecf/guidance.md
+++ b/documentation/ecf1_guidance/ecf/guidance.md
@@ -1,7 +1,7 @@
 
 # Guidance
 
-The focus of the following guidance is on business logic only. Critical details which would be necessary for real-world usage have been left out. For example, [authentication](get-started#connect-to-the-API) is not detailed.
+The focus of the following guidance is on business logic only. Critical details which would be necessary for real-world usage have been left out. For example, [authentication](../get-started.md#connect-to-the-API) is not detailed.
 
 > This guidance is written for API version 3.0.0, and therefore all endpoints reference `v3`. Providers should view specifications for the API version their systems are integrated as appropriate.
 
@@ -81,7 +81,7 @@ The API will **not** show schools that are ineligible for funding in a given coh
 
 If a school’s eligibility changes from one cohort to the next, results will default according to the latest school eligibility. For example, if a school was eligible for funding in the 2024 cohort but becomes ineligible for funding in 2025, the API will **not** show the school in the 2025 cohort.
 
-For more detailed information, see the `GET schools` [endpoint documentation](reference-v3#api-v3-schools-ecf-get).
+For more detailed information, see the `GET schools` [endpoint documentation](../reference-v3.md#get-api-v3-schools-ecf).
 
 #### Example response body
 
@@ -117,7 +117,7 @@ Providers can view details for a specific school providing training in a given c
 
 Successful requests will return a response body with school details.
 
-For more detailed information, view the `GET schools/ecf/{id}` [endpoint documentation](reference-v3#api-v3-schools-ecf-id-get).
+For more detailed information, view the `GET schools/ecf/{id}` [endpoint documentation](../reference-v3.md#get-api-v3-schools-ecf-id).
 
 #### Example response body
 
@@ -147,13 +147,13 @@ For more detailed information, view the `GET schools/ecf/{id}` [endpoint documen
 GET /api/v3/delivery-partners
 ```
 
-We assign every delivery partner a unique ID. This `delivery_partner_id` is required when [confirming partnerships with a school and delivery partner](ecf/guidance#confirm-a-partnership-with-a-school-and-delivery-partner).
+We assign every delivery partner a unique ID. This `delivery_partner_id` is required when [confirming partnerships with a school and delivery partner](guidance.md#confirm-a-partnership-with-a-school-and-delivery-partner).
 
 Providers can also filter results by adding a cohort filter to the parameter. For example, `GET /api/v3/delivery-partners?filter[cohort]=2024`.
 
 Successful requests will return a response body including delivery partner details.
 
-For more detailed information, view the `GET delivery-partners` [endpoint documentation](reference-v3#api-v3-delivery-partners-get).
+For more detailed information, view the `GET delivery-partners` [endpoint documentation](../reference-v3.md#get-api-v3-delivery-partners).
 
 #### Example response body
 
@@ -187,7 +187,7 @@ View details for a specific delivery partner to check whether they've been regis
 
 Successful requests will return a response body with the delivery partner's details.
 
-For more detailed information, view the `GET delivery-partners/{id}` [endpoint documentation](reference-v3#api-v3-delivery-partners-id-get).
+For more detailed information, view the `GET delivery-partners/{id}` [endpoint documentation](../reference-v3.md#get-api-v3-delivery-partners-id-get).
 
 #### Example response body
 
@@ -240,7 +240,7 @@ If a school has mistakenly selected a `school-led` induction programme and inten
 * confirm with the school before submitting the change
 * provide both the school’s URN and the delivery partner’s ID
 
-For more detailed information, view the `POST partnerships`[endpoint documentation](reference-v3#api-v3-partnerships-ecf-post).
+For more detailed information, view the `POST partnerships`[endpoint documentation](../reference-v3.md#post-api-v3-partnerships-ecf).
 
 #### Example request body
 
@@ -288,11 +288,11 @@ For more detailed information, view the `POST partnerships`[endpoint documentati
 GET /api/v3/partnerships/ecf
 ```
 
-View details for all existing partnerships to check information is correct and whether any have had their status challenged by schools. [Find out more about partnership statuses.](ecf/definitions-and-states#partnership-states)
+View details for all existing partnerships to check information is correct and whether any have had their status challenged by schools. [Find out more about partnership statuses.](definitions-and-states.md#partnership-states)
 
 Providers can also filter results by adding a cohort filter to the parameter. For example, `GET /api/v3/partnerships/ecf?filter[cohort]=2024`.
 
-For more detailed information, view the `GET partnerships/ecf` [endpoint documentation](reference-v3#api-v3-partnerships-ecf-get).
+For more detailed information, view the `GET partnerships/ecf` [endpoint documentation](../reference-v3.md#get-api-v3-partnerships-ecf).
 
 #### Example response body
 
@@ -327,10 +327,10 @@ For more detailed information, view the `GET partnerships/ecf` [endpoint documen
 GET /api/v3/partnerships/ecf/{id}
 ```
 
-View details for an existing partnership to check information is correct and whether the [partnership status](ecf/definitions-and-states/#partnership-states) has been challenged by the school.
+View details for an existing partnership to check information is correct and whether the [partnership status](definitions-and-states.md#partnership-states) has been challenged by the school.
 
 
-For more detailed information, view `GET/ partnerships/ecf/{id}` [endpoint documentation](reference-v3#api-v3-partnerships-ecf-id-get).
+For more detailed information, view `GET/ partnerships/ecf/{id}` [endpoint documentation](../reference-v3.md#get-api-v3-partnerships-ecf-id).
 
 #### Example response body
 
@@ -367,15 +367,15 @@ For more detailed information, view `GET/ partnerships/ecf/{id}` [endpoint docum
 
 Update an existing partnership with new delivery partner details for a given cohort.
 
-Request bodies must include a new value for the `delivery_partner_id` attribute. If unsure, providers can [find delivery partner IDs](ecf/guidance#find-delivery-partner-ids).
+Request bodies must include a new value for the `delivery_partner_id` attribute. If unsure, providers can [find delivery partner IDs](#find-delivery-partner-ids).
 
 Providers can only update partnerships where the `status` attribute is `active`. Any requests to update `challenged` partnerships will return an error. If a partnership has been challenged and rejected, use `POST partnerships` to create a new partnership, rather than `PUT partnerships`.
 
-[Find out more about partnership statuses.](ecf/definitions-and-states#partnership-states)
+[Find out more about partnership statuses.](definitions-and-states#partnership-states.md)
 
 Successful requests will return a response body with updates included.
 
-For more detailed information see the specifications for this [update a partnership endpoint](reference-v3#api-v3-partnerships-ecf-id-put).
+For more detailed information see the specifications for this [update a partnership endpoint](../reference-v3.md#put-api-v3-partnerships-ecf-id).
 
 #### Example request body
 
@@ -427,18 +427,18 @@ Providers can view data to find out whether participants:
 * have valid teacher reference numbers (TRN)
 * have achieved qualified teacher status (QTS)
 * are eligible for funding
-* have [transferred to or from a school you're partnered with](ecf/guidance#view-data-for-all-participants-who-have-transferred)
-* have (if they're ECTs) been assigned [unfunded mentors](ecf/guidance#view-all-unfunded-mentor-details)
+* have [transferred to or from a school you're partnered with](#view-data-for-all-participants-who-have-transferred)
+* have (if they're ECTs) been assigned [unfunded mentors](#view-all-unfunded-mentor-details)
 * have (if they're ECTs) completed their induction, according to the Database of Qualified Teachers
 
 Note, while participants can enter different email addresses when registering for each training course they apply for, providers will only see the email address associated with a given course registration. For example, a participant may complete their training with one associated email address, then register for an NPQ with a different email address, and go on to be an ECT mentor with a third email address. DfE will share the relevant email address with the relevant course provider.
 
 Providers can then update data to notify DfE that participants have:
 
-* [deferred training](ecf/guidance#notify-dfe-a-participant-has-taken-a-break-deferred-from-training )
-* [resumed training](ecf/guidance#notify-dfe-a-participant-has-resumed-training)
-* [withdrawn from training](ecf/guidance#notify-dfe-a-participant-has-withdrawn-from-training)
-* [changed their training schedule](ecf/guidance#notify-dfe-of-a-participant-39-s-training-schedule)
+* [deferred training](#notify-dfe-a-participant-has-taken-a-break-deferred-from-training)
+* [resumed training](#notify-dfe-a-participant-has-resumed-training)
+* [withdrawn from training](#notify-dfe-a-participant-has-withdrawn-from-training)
+* [changed their training schedule](#notify-dfe-of-a-participant-39-s-training-schedule)
 
 ### View all participant data
 
@@ -452,11 +452,11 @@ An example response body is listed below.
 
 **Providers should note:**
 
-* DfE has [previously advised](release-notes#15-march-2023) of the possibility that participants may be registered as duplicates with multiple participant_ids. Where DfE identifies duplicates, it will fix the error by ‘retiring’ one of the participant IDs, then associating all records and data under the remaining ID
-* providers can check if a participant’s ID has changed using the `participant_id_changes` nested structure in the [ECFEnrolment](reference-v3#schema-ecfenrolment), which contains a `from_participant_id` and a `to_participant_id` string fields, as well a `changed_at` date value
+* DfE has [previously advised](../release-notes.md#15-march-2023) of the possibility that participants may be registered as duplicates with multiple participant_ids. Where DfE identifies duplicates, it will fix the error by ‘retiring’ one of the participant IDs, then associating all records and data under the remaining ID
+* providers can check if a participant’s ID has changed using the `participant_id_changes` nested structure in the [ECFEnrolment](../reference-v3.md#ecfenrolment), which contains a `from_participant_id` and a `to_participant_id` string fields, as well a `changed_at` date value
 * DfE will close the funding contract for the 2021 cohort on 31 July 2024. Schools will start moving ECTs and mentors with partial declarations originally assigned to the 2021 cohort to the 2024 cohort from mid-June  
 
-For more detailed information, see the specifications for this [view multiple participants endpoint](reference-v3#api-v3-participants-ecf-get).
+For more detailed information, see the specifications for this [view multiple participants endpoint](../reference-v3.md#get-api-v3-participants-ecf).
 
 #### Example response body:
 
@@ -517,11 +517,11 @@ An example response body is listed below.
 
 **Providers should note:**
 
-* we’ve [previously advised](release-notes#15-march-2023) of the possibility that participants may be registered as duplicates with multiple `participant_ids`. Where we identify duplicates, we’ll fix the error by ‘retiring’ one of the participant IDs and then associating all records and data under the remaining ID. To date, when this has occurred, we’ve informed providers of changes via CSVs
-* they can check if a participant’s ID has changed using the `participant_id_changes` nested structure in the [ECFEnrolment](reference-v3#schema-ecfenrolment), which contains a `from_participant_id` and a `to_participant_id` string fields, as well a `changed_at` date value
-* if they cannot see a mentor as expected using this endpoint, it's probably because the mentor is not eligible for funding through them. In this case, providers should use the [GET /api/v3/unfunded-mentors/ecf/{id} endpoint](reference-v3#api-v3-unfunded-mentors-ecf-id-get) to retrieve the mentor’s details
+* we’ve [previously advised](../release-notes.md#15-march-2023) of the possibility that participants may be registered as duplicates with multiple `participant_ids`. Where we identify duplicates, we’ll fix the error by ‘retiring’ one of the participant IDs and then associating all records and data under the remaining ID. To date, when this has occurred, we’ve informed providers of changes via CSVs
+* they can check if a participant’s ID has changed using the `participant_id_changes` nested structure in the [ECFEnrolment](../reference-v3.md#ecfenrolment), which contains a `from_participant_id` and a `to_participant_id` string fields, as well a `changed_at` date value
+* if they cannot see a mentor as expected using this endpoint, it's probably because the mentor is not eligible for funding through them. In this case, providers should use the [GET /api/v3/unfunded-mentors/ecf/{id} endpoint](../reference-v3.md#get-api-v3-unfunded-mentors-ecf-id) to retrieve the mentor’s details
 
-For more detailed information, see the specifications for the [view a single participant endpoint](reference-v3#api-v3-participants-ecf-id-get).
+For more detailed information, see the specifications for the [view a single participant endpoint](../reference-v3.md#get-api-v3-participants-ecf-id).
 
 #### Example response body:
 
@@ -580,7 +580,7 @@ GET /api/v3/unfunded-mentors/ecf
  
 Lead providers can use this endpoint to retrieve the names and email addresses of all mentors who are not eligible for funding through them but are assigned to their ECTs. Typically, these mentors have either completed, or are currently doing, mentor training with a different lead provider than the one delivering training to the ECT they support.
 
-For more detailed information, see the [‘Retrieve multiple unfunded mentors’ endpoint documentation](reference-v3#api-v3-unfunded-mentors-ecf-get). 
+For more detailed information, see the [‘Retrieve multiple unfunded mentors’ endpoint documentation](../reference-v3.md#get-api-v3-unfunded-mentors-ecf). 
 
 #### Example response body:
 
@@ -612,7 +612,7 @@ For more detailed information, see the [‘Retrieve multiple unfunded mentors’
 
 Lead providers can use this endpoint to retrieve the names and email addresses of individual mentors who are not eligible for funding through them but are assigned to their ECTs. Having these details will then enable providers to give these mentors access to the right learning platforms.
 
-For more detailed information, [see the ‘Get a single unfunded mentor’ endpoint documentation](reference-v3#api-v3-unfunded-mentors-ecf-id-get).
+For more detailed information, [see the ‘Get a single unfunded mentor’ endpoint documentation](../reference-v3.md#get-api-v3-unfunded-mentors-ecf-id).
 
 #### Example response body:
 
@@ -644,7 +644,7 @@ An example request body is listed below.
 
 Successful requests will return a response body including updates to the `training_status` attribute.
 
-For more detailed information, see the specifications for the [notify DfE that a participant is taking a break from their course endpoint](reference-v3#api-v3-participants-ecf-id-defer-put).
+For more detailed information, see the specifications for the [notify DfE that a participant is taking a break from their course endpoint](../reference-v3.md#put-api-v3-participants-ecf-id-defer).
 
 #### Example request body:
 
@@ -672,7 +672,7 @@ An example request body is listed below.
 
 Successful requests will return a response body including updates to the `training_status` attribute.
 
-For more detailed information see the specifications for this [notify DfE that a participant has resumed training endpoint](reference-v3#api-v3-participants-ecf-id-resume-put).
+For more detailed information see the specifications for this [notify DfE that a participant has resumed training endpoint](../reference-v3.md#put-api-v3-participants-ecf-id-resume).
 
 #### Example request body:
 
@@ -699,7 +699,7 @@ An example request body is listed below.
 
 Successful requests will return a response body including updates to the `training_status` attribute.
 
-For more detailed information see the specifications for this [notify DfE that a participant has withdrawn from training endpoint](reference-v3#api-v3-participants-ecf-id-withdraw-put).
+For more detailed information see the specifications for this [notify DfE that a participant has withdrawn from training endpoint](../reference-v3.md#put-api-v3-participants-ecf-id-withdraw).
 
 #### Providers should note:
 
@@ -746,9 +746,9 @@ Where this occurs, providers should:
 2. Change the participant’s training schedule.
 3. Resubmit backdated declarations (where `declaration_date` aligns with the new schedule).
 
-For replacement mentors, view [guidance on updating a replacement mentor’s schedule.](ecf/guidance#update-a-replacement-mentor-s-schedule)
+For replacement mentors, view [guidance on updating a replacement mentor’s schedule.](#update-a-replacement-mentor-s-schedule)
 
-For more detailed information see the specifications for this [notify that a participant has changed their training schedule endpoint](reference-v3#api-v3-participants-ecf-id-change-schedule-put).
+For more detailed information see the specifications for this [notify that a participant has changed their training schedule endpoint](../reference-v3.md#put-api-v3-participants-ecf-id-change-schedule).
 
 #### Example request body:
 
@@ -769,7 +769,7 @@ For more detailed information see the specifications for this [notify that a par
 
 A new mentor can be assigned to an ECT part way through training.
 
-[Providers must notify DfE of replacement mentors by updating their training schedule.](ecf/guidance#notify-dfe-of-a-participant-39-s-training-schedule)
+[Providers must notify DfE of replacement mentors by updating their training schedule.](#notify-dfe-of-a-participant-39-s-training-schedule)
 
 Note, if a replacement mentor is already mentoring another ECT, and they replace a mentor for a second ECT, the first ECT takes precedence. In this instance, the provider should not change the mentor’s schedule.
 
@@ -810,7 +810,7 @@ GET /api/v3/participants/ecf/transfers
 
 Lead providers can use this endpoint to view data for participants who’ve transferred from and to schools they’re in partnership with. The data is updated whenever schools report a transfer. 
 
-View the [‘Retrieve multiple participant transfers’ endpoint documentation](reference-v3#api-v3-participants-ecf-transfers-get).
+View the [‘Retrieve multiple participant transfers’ endpoint documentation](../reference-v3.md#get-api-v3-participants-ecf-transfers).
 
 ### View data for a specific participant who has transferred  
 
@@ -820,7 +820,7 @@ GET /api/v3/participants/ecf/{id}/transfers
 
 Lead providers can use this endpoint to view data for individual participants who’ve transferred from and to schools they’re in partnership with.  
 
-View the [‘Get a single participant’s transfers’ endpoint documentation](reference-v3#api-v3-participants-ecf-id-transfers-get).
+View the [‘Get a single participant’s transfers’ endpoint documentation](../reference-v3.md#get-api-v3-participants-ecf-id-transfers).
 
 ### What providers will see in the API when a participant is transferring away from them  
 | Scenario | Participant status | Transfer response |
@@ -846,7 +846,7 @@ View the [‘Get a single participant’s transfers’ endpoint documentation](r
 
 ### Managing transfers between providers 
  
-Providers must [notify DfE when a participant withdraws](reference-v3#api-v3-participants-ecf-id-withdraw-put) from their training to ensure data accuracy. Once a participant transfers to a new provider and school induction tutors have confirmed the move, the original provider will see the `participant_status` as `left`. They should then update the participant’s `training_status` to `withdrawn`. The transfer record will also appear in `GET transfers` and `GET {id}/transfers` endpoint responses.
+Providers must [notify DfE when a participant withdraws](../reference-v3.md#put-api-v3-participants-ecf-id-withdraw) from their training to ensure data accuracy. Once a participant transfers to a new provider and school induction tutors have confirmed the move, the original provider will see the `participant_status` as `left`. They should then update the participant’s `training_status` to `withdrawn`. The transfer record will also appear in `GET transfers` and `GET {id}/transfers` endpoint responses.
 
 ### Why transfer data can appear incomplete 
  
@@ -991,7 +991,7 @@ X-With-Server-Date: 2025-01-10T10:42:00Z
 
 ### Submit a declaration to notify DfE a participant has started training
 
-Notify the DfE that a participant has started training by submitting a `started` declaration in line with [milestone 1 dates](ecf/schedules-and-milestone-dates).
+Notify the DfE that a participant has started training by submitting a `started` declaration in line with [milestone 1 dates](schedules-and-milestone-dates.md).
 
 ```
  POST /api/v3/participant-declarations
@@ -1005,7 +1005,7 @@ Any attempts to submit duplicate declarations will return an error message.
 
 > Note, providers should store the returned participant declaration ID for management tasks.
 
-For more detailed information see the specifications for this [notify DfE that a participant has started training endpoint](reference-v3#api-v3-participant-declarations-post).
+For more detailed information see the specifications for this [notify DfE that a participant has started training endpoint](../reference-v3.md#post-api-v3-participant-declarations).
 
 #### Example request body:
 
@@ -1052,7 +1052,7 @@ For more detailed information see the specifications for this [notify DfE that a
 
 ### Submit a declaration to notify DfE a participant has been retained in training
 
-Notify DfE that a participant has reached a given retention point in their training by submitting a `retained` declaration in line with [milestone dates](ecf/schedules-and-milestone-dates).
+Notify DfE that a participant has reached a given retention point in their training by submitting a `retained` declaration in line with [milestone dates](schedules-and-milestone-dates.md).
 
 ```
 POST /api/v{n}/participant-declarations
@@ -1066,7 +1066,7 @@ Any attempts to submit duplicate declarations will return an error message.
 
 > Note, providers should store the returned participant declaration ID for management tasks.</div>
 
-For more detailed information see the specifications for this [notify DfE that a participant has been retained in training endpoint](reference-v3#api-v3-participant-declarations-post).
+For more detailed information see the specifications for this [notify DfE that a participant has been retained in training endpoint](../reference-v3.md#post-api-v3-participant-declarations).
 
 #### Example request body:
 
@@ -1114,7 +1114,7 @@ For more detailed information see the specifications for this [notify DfE that a
 
 ### Submit a declaration to notify DfE a participant has completed training
 
-Notify the DfE that a participant has completed their training by submitting a `completed` declaration in line with [milestone dates](ecf/schedules-and-milestone-dates).
+Notify the DfE that a participant has completed their training by submitting a `completed` declaration in line with [milestone dates](schedules-and-milestone-dates.md).
 
 ```
 POST /api/v{n}/participant-declarations
@@ -1128,7 +1128,7 @@ Any attempts to submit duplicate declarations will return an error message.
 
 > Note, providers should store the returned participant declaration ID for future management tasks.
 
-For more detailed information see the specifications for this [notify DfE that a participant has completed training endpoint](reference-v3#api-v3-participant-declarations-post).
+For more detailed information see the specifications for this [notify DfE that a participant has completed training endpoint](../reference-v3.md#post-api-v3-participant-declarations).
 
 #### Example request body:
 
@@ -1185,7 +1185,7 @@ Note, providers can also filter results by adding filters to the parameter. For 
 
 An example response body is listed below.
 
-For more detailed information see the specifications for this [view all declarations endpoint.](reference-v3#api-v3-participant-declarations-get)
+For more detailed information see the specifications for this [view all declarations endpoint.](../reference-v3.md#get-api-v3-participant-declarations)
 
 #### Example response body:
 ```
@@ -1245,7 +1245,7 @@ GET /api/v3/participant-declarations/{id}
 
 An example response body is listed below.
 
-For more detailed information see the specifications for this [view specific declarations endpoint.](reference-v3#api-v3-participant-declarations-id-get)
+For more detailed information see the specifications for this [view specific declarations endpoint.](../reference-v3.md#get-api-v3-participant-declarations-id)
 
 #### Example response body:
 
@@ -1287,9 +1287,9 @@ An example response body is listed below. Successful requests will return a resp
 * `voided` if it had been  `submitted`, `ineligible`, `eligible`, or `payable`
 * `awaiting_clawback` if it had been `paid`
 
-View more information on [declaration states.](ecf/definitions-and-states/#declaration-states)
+View more information on [declaration states.](definitions-and-states/#declaration-states.md)
 
-For more detailed information see the specifications for this [void declarations endpoint.](reference-v3#api-v3-participant-declarations-id-void-put)
+For more detailed information see the specifications for this [void declarations endpoint.](../reference-v3.md#put-api-v3-participant-declarations-id-void)
 
 #### Example response body:
 
@@ -1332,7 +1332,7 @@ GET /api/v3/statements
 
 An example response body is listed below.
 
-For more detailed information see the specifications for this [view all statements endpoint.](reference-v3#api-v3-statements-get)
+For more detailed information see the specifications for this [view all statements endpoint.](../reference-v3.md#get-api-v3-statements)
 
 #### Example response body:
 
@@ -1364,11 +1364,11 @@ For more detailed information see the specifications for this [view all statemen
 GET /api/v3/statements/{id}
 ```
 
-Providers can find statement IDs within [previously submitted declaration](ecf/guidance/#view-a-specific-previously-submitted-declaration) response bodies.
+Providers can find statement IDs within [previously submitted declaration](#view-a-specific-previously-submitted-declaration) response bodies.
 
 An example response body is listed below.
 
-For more detailed information see the specifications for this [view a specific statement endpoint.](reference-v3#api-v3-statements-id-get)
+For more detailed information see the specifications for this [view a specific statement endpoint.](../reference-v3.md#get-api-v3-statements-id)
 
 #### Example response body:
 

--- a/documentation/ecf1_guidance/ecf/schedules-and-milestone-dates.md
+++ b/documentation/ecf1_guidance/ecf/schedules-and-milestone-dates.md
@@ -1,0 +1,369 @@
+
+# Schedules and milestone dates
+
+This section explains the contractual retention periods in which lead providers must submit declarations to show training delivery and participant retention. 
+
+DfE pays providers based on agreed contractual schedules and training delivery criteria. Payments are proportional to the time providers support their participants. 
+
+<div class="govuk-warning-text"> 
+<span class="govuk-warning-text__icon" aria-hidden="true">!</span> 
+<strong class="govuk-warning-text__text"> 
+<span class="govuk-warning-text__assistive">Warning</span> 
+Providers must submit declarations before each milestone deadline to receive the related payment. 
+</strong> 
+</div> 
+
+Access to training materials should not be tied to a participant’s cohort or schedule.  
+
+## Key concepts
+
+| Concept      | Definition| 
+| -------- | --------  |
+| Schedule    | The expected timeframe in which a participant will complete their training, which determine the defined milestone dates      |
+| Standard schedule  | The default training schedule for participants completing a standard 2 year induction, starting in September, January or April  |
+| Extended schedule   | A non-standard training schedule for participants who expect to complete the induction over a period greater than 2 years. Examples include part-time ECTs, or ECTs whose induction period is extended by their appropriate body  |
+| Reduced schedule   | A non-standard training schedule for participants who expect to complete the induction over a period less than 2 years.  Examples include those with previous experience  |
+| Replacement schedule  | A non-standard training schedule for mentors that are replacing a previous mentor for an ECT that is part way through their training  |
+| Milestone   | Contractual retention periods during which providers must submit relevant declarations evidencing training delivery and participant retention     |
+| Milestone dates    | The deadline date a valid declaration can be made for a given milestone in order for DfE to be liable to make a payment the following month. Milestone dates are dependent on the participant’s schedule       |
+| Milestone period    | The period of time between the milestone start date and deadline date       |
+| Output payment    | The sum of money paid by DfE to providers per valid declaration     |
+| Payment date    | The date the DfE will make payment for valid declarations submitted by providers for a given milestone     |
+| Milestone validation    | The API's process to validate declarations submitted by providers for participants in standard training schedules        |
+
+
+## Standard schedules and dates
+
+A default 2 year induction training schedule covers 6 terms (3 in each academic year), and therefore has 6 milestones. 
+
+The payment model is such that for each of the 6 terms a provider is supporting a participant, DfE will pay the corresponding output payment according to valid declarations submitted.
+
+Declarations submitted for participants in standard schedules will be validated (accepted or rejected) against the 6 milestone dates. [View details on milestone validation for standard training schedules](ecf/schedules-and-milestone-dates/#validating-declarations-against-milestones).
+
+> Note, all participants will be registered by default to a standard schedule starting in September.
+
+Providers must [notify DfE if the participant is following any other standard or non-standard training schedule](ecf/guidance#notify-dfe-of-a-participant-39-s-training-schedule). Contact contract managers via email for additional support or information. 
+
+
+### Dates for standard schedule starting in September
+
+#### 2024 cohort
+
+Participants starting their training on or before 31 December 2024, and who are expected to complete their training over 2 academic years, should remain on the default schedule:
+
+```
+ "schedule_identifier": "ecf-standard-september"
+```
+
+| Milestone      | Start date     | Milestone date      | Declaration type    | Payment date      | 
+| -------- | --------  | -------- | --------  | -------- | 
+| Participant Start      | 1 Jun 2024     | 31 Dec 2024     | `started`    | 30 Nov 2024      | 
+| Retention Point 1      | 1 Jan 2025     | 31 Mar 2025      | `retained-1`    | 30 Apr 2025     | 
+| Retention Point 2      | 1 Apr 2025     | 31 Jul 2025      | `retained-2`    | 31 Aug 2025     | 
+| Retention Point 3      | 1 Aug 2025     | 31 Dec 2025      | `retained-3`    | 31 Jan 2026      | 
+| Retention Point 4      | 1 Jan 2026     | 31 Mar 2026      | `retained-4`    | 30 Apr 2026     | 
+| Participant Completion      | 1 Apr 2026     | 31 Jul 2026      | `completed`    | 31 Aug 2026      | 
+
+
+#### 2023 cohort
+
+Participants starting their training on or before 31 December 2023, and who are expected to complete their training over 2 academic years, should remain on the default schedule:
+
+```
+ "schedule_identifier": "ecf-standard-september"
+```
+
+| Milestone      | Start date     | Milestone date      | Declaration type    | Payment date      | 
+| -------- | --------  | -------- | --------  | -------- | 
+| Participant Start      | 1 Jun 2023     | 31 Dec 2023     | `started`    | 30 Nov 2023      | 
+| Retention Point 1      | 1 Jan 2024     | 31 Mar 2024      | `retained-1`    | 30 Apr 2024     | 
+| Retention Point 2      | 1 Apr 2024     | 31 Jul 2024      | `retained-2`    | 31 Aug 2024     | 
+| Retention Point 3      | 1 Aug 2024     | 31 Dec 2024      | `retained-3`    | 31 Jan 2025      | 
+| Retention Point 4      | 1 Jan 2025     | 31 Mar 2025      | `retained-4`    | 30 Apr 2025     | 
+| Participant Completion      | 1 Apr 2025     | 31 Jul 2025      | `completed`    | 31 Aug 2025      | 
+
+
+#### 2022 cohort
+
+Participants starting their training on or before 31 December 2022, and who are expected to complete their training over 2 academic years, should remain on the default schedule:
+
+```
+ "schedule_identifier": "ecf-standard-september"
+```
+
+| Milestone      | Start date     | Milestone date      | Declaration type    | Payment date      | 
+| -------- | --------  | -------- | --------  | -------- | 
+| Participant Start      | 1 Jun 2022     | 31 Dec 2022     | `started`    | 30 Nov 2022      | 
+| Retention Point 1      | 1 Jan 2023     | 31 Mar 2023      | `retained-1`    | 30 Apr 2023     | 
+| Retention Point 2      | 1 Apr 2023     | 31 Jul 2023      | `retained-2`    | 31 Aug 2023     | 
+| Retention Point 3      | 1 Aug 2023     | 31 Dec 2023      | `retained-3`    | 31 Jan 2024      | 
+| Retention Point 4      | 1 Jan 2024     | 31 Mar 2024      | `retained-4`    | 30 Apr 2024     | 
+| Participant Completion      | 1 Apr 2024     | 31 Jul 2024      | `completed`    | 31 Aug 2024      | 
+
+#### 2021 cohort
+
+Participants starting their training on or before 30 November 2021, and who are expected to complete their training over 2 academic years, should remain on the default schedule:
+
+```
+ "schedule_identifier": "ecf-standard-september"
+```
+
+| Milestone      | Start date     | Milestone date      | Declaration type    | Payment date      | 
+| -------- | --------  | -------- | --------  | -------- | 
+| Participant Start      | 1 Sep 2021    | 30 Nov 2021     | `started`    | 30 Nov 2021      | 
+| Retention Point 1      | 1 Sep 2021     | 31 Jan 2022      | `retained-1`    | 28 Feb 2022      | 
+| Retention Point 2      | 1 Feb 2022     | 30 Apr 2022      | `retained-2`    | 31 May 2022      | 
+| Retention Point 3      | 1 May 2022     | 30 Sep 2022      | `retained-3`    | 31 Oct 2022      | 
+| Retention Point 4      | 1 Oct 2022     | 31 Jan 2023      | `retained-4`    | 28 Feb 2023      | 
+| Participant Completion      | 1 Feb 2023     | 30 Apr 2023      | `completed`    | 31 May 2023      | 
+
+
+### Dates for standard schedule starting in January
+
+#### 2024 cohort
+
+Participants starting their training between 1 January and 31 March 2025, and who are expected to complete their training over 2 academic years, [should have their schedule updated](ecf/guidance#notify-dfe-of-a-participant-39-s-training-schedule) by providers to: 
+
+```
+ "schedule_identifier": "ecf-standard-january"
+```
+
+| Milestone      | Start date     | Milestone date      | Declaration type    | Payment date      | 
+| -------- | --------  | -------- | --------  | -------- | 
+| Participant Start      | 1 Jan 2025     | 31 Mar 2025      | `started`    | 30 Apr 2025      | 
+| Retention Point 1      | 1 Apr 2025    | 31 Jul 2025      | `retained-1`    | 31 Aug 2025      | 
+| Retention Point 2      | 1 Aug 2025     | 31 Dec 2025      | `retained-2`    | 31 Jan 2026      | 
+| Retention Point 3      | 1 Jan 2026     | 31 Mar 2026      | `retained-3`    | 30 Apr 2026      | 
+| Retention Point 4      | 1 Apr 2026     | 31 Jul 2026      | `retained-4`    | 31 Aug 2026      | 
+| Participant Completion      | 1 Aug 2026     | 31 Dec 2026      | `completed`    | 31 Jan 2027      | 
+
+#### 2023 cohort
+
+Participants starting their training between 1 January and 31 March 2024, and who are expected to complete their training over 2 academic years, [should have their schedule updated](ecf/guidance#notify-dfe-of-a-participant-39-s-training-schedule) by providers to: 
+
+```
+ "schedule_identifier": "ecf-standard-january"
+```
+
+| Milestone      | Start date     | Milestone date      | Declaration type    | Payment date      | 
+| -------- | --------  | -------- | --------  | -------- | 
+| Participant Start      | 1 Jan 2024     | 31 Mar 2024      | `started`    | 30 Apr 2024      | 
+| Retention Point 1      | 1 Apr 2024    | 31 Jul 2024      | `retained-1`    | 31 Aug 2024      | 
+| Retention Point 2      | 1 Aug 2024     | 31 Dec 2024      | `retained-2`    | 31 Jan 2025      | 
+| Retention Point 3      | 1 Jan 2025     | 31 Mar 2025      | `retained-3`    | 30 Apr 2025      | 
+| Retention Point 4      | 1 Apr 2025     | 31 Jul 2025      | `retained-4`    | 31 Aug 2025      | 
+| Participant Completion      | 1 Aug 2025     | 31 Dec 2025      | `completed`    | 31 Jan 2026      | 
+
+#### 2022 cohort
+
+Participants starting their training between 1 January and 31 March 2023, and who are expected to complete their training over 2 academic years, [should have their schedule updated](ecf/guidance#notify-dfe-of-a-participant-39-s-training-schedule) by providers to: 
+
+```
+ "schedule_identifier": "ecf-standard-january"
+```
+
+| Milestone      | Start date     | Milestone date      | Declaration type    | Payment date      | 
+| -------- | --------  | -------- | --------  | -------- | 
+| Participant Start      | 1 Jan 2023     | 31 Mar 2023      | `started`    | 30 Apr 2023      | 
+| Retention Point 1      | 1 Apr 2023    | 31 Jul 2023      | `retained-1`    | 31 Aug 2023      | 
+| Retention Point 2      | 1 Aug 2023     | 31 Dec 2023      | `retained-2`    | 31 Jan 2024      | 
+| Retention Point 3      | 1 Jan 2024     | 31 Mar 2024      | `retained-3`    | 30 Apr 2024      | 
+| Retention Point 4      | 1 Apr 2024     | 31 Jul 2024      | `retained-4`    | 31 Aug 2024      | 
+| Participant Completion      | 1 Aug 2024     | 31 Dec 2024      | `completed`    | 31 Jan 2025      | 
+
+#### 2021 cohort
+
+For participants starting their course on or before 1 December 2021, and who are expected to complete their training over 2 academic years, providers [should have their schedule updated](ecf/guidance#notify-dfe-of-a-participant-39-s-training-schedule) by providers to: 
+
+```
+ "schedule_identifier": "ecf-standard-january"
+```
+
+| Milestone      | Start date     | Milestone date      | Declaration type    | Payment date      | 
+| -------- | --------  | -------- | --------  | -------- | 
+| Participant Start      | 1 Dec 2021     | 31 Jan 2022      | `started`    | 28 Feb 2022      | 
+| Retention Point 1      | 1 Feb 2022     | 30 Apr 2022      | `retained-1`    | 31 May 2022      | 
+| Retention Point 2      | 1 May 2022     | 30 Sep 2022      | `retained-2`    | 31 Oct 2022      | 
+| Retention Point 3      | 1 Oct 2022     | 31 Jan 2023      | `retained-3`    | 28 Feb 2023      | 
+| Retention Point 4      | 1 Feb 2023     | 30 Apr 2023      | `retained-4`    | 31 May 2023      | 
+| Participant Completion      | 1 May 2023     | 31 Oct 2023      | `completed`    | 30 Nov 2023      | 
+
+
+### Dates for standard schedule starting in April
+
+#### 2024 cohort
+
+Participants starting their training between 1 April and 31 July 2025, and who are expected to complete their training over 2 academic years, [should have their schedule updated](ecf/guidance#notify-dfe-of-a-participant-39-s-training-schedule) by providers to: 
+
+```
+ "schedule_identifier": "ecf-standard-april"
+```
+
+| Milestone      | Start date     | Milestone date      | Declaration type    | Payment date      | 
+| -------- | --------  | -------- | --------  | -------- | 
+| Participant Start      | 1 Apr 2025     | 31 Jul 2025      | `started`    | 31 Aug 2025      | 
+| Retention Point 1      | 1 Aug 2025     | 31 Dec 2025     | `retained-1`    | 31 Jan 2026      | 
+| Retention Point 2      | 1 Jan 2026     | 31 Mar 2026      | `retained-2`    | 30 Apr 2026     | 
+| Retention Point 3      | 1 Apr 2026    | 31 Jul 2026      | `retained-3`    | 31 Aug 2026      | 
+| Retention Point 4      | 1 Aug 2026     | 31 Dec 2026      | `retained-4`    | 31 Jan 2027      | 
+| Participant Completion      | 1 Jan 2027     | 31 Mar 2027      | `completed`    | 30 Apr 2027      | 
+
+
+#### 2023 cohort
+
+Participants starting their training between 1 April and 31 July 2024, and who are expected to complete their training over 2 academic years, [should have their schedule updated](ecf/guidance#notify-dfe-of-a-participant-39-s-training-schedule) by providers to: 
+
+```
+ "schedule_identifier": "ecf-standard-april"
+```
+
+| Milestone      | Start date     | Milestone date      | Declaration type    | Payment date      | 
+| -------- | --------  | -------- | --------  | -------- | 
+| Participant Start      | 1 Apr 2024     | 31 Jul 2024      | `started`    | 31 Aug 2024      | 
+| Retention Point 1      | 1 Aug 2024     | 31 Dec 2024     | `retained-1`    | 31 Jan 2025      | 
+| Retention Point 2      | 1 Jan 2025     | 31 Mar 2025      | `retained-2`    | 30 Apr 2025     | 
+| Retention Point 3      | 1 Apr 2025    | 31 Jul 2025      | `retained-3`    | 31 Aug 2025      | 
+| Retention Point 4      | 1 Aug 2025     | 31 Dec 2025      | `retained-4`    | 31 Jan 2026      | 
+| Participant Completion      | 1 Jan 2026     | 31 Mar 2026      | `completed`    | 30 Apr 2026      | 
+
+#### 2022 cohort
+
+Participants starting their training between 1 April and 31 July 2023, and who are expected to complete their training over 2 academic years, [should have their schedule updated](ecf/guidance#notify-dfe-of-a-participant-39-s-training-schedule) by providers to: 
+
+```
+ "schedule_identifier": "ecf-standard-april"
+```
+
+| Milestone      | Start date     | Milestone date      | Declaration type    | Payment date      | 
+| -------- | --------  | -------- | --------  | -------- | 
+| Participant Start      | 1 Apr 2023     | 31 Jul 2023      | `started`    | 31 Aug 2023      | 
+| Retention Point 1      | 1 Aug 2023     | 31 Dec 2023     | `retained-1`    | 31 Jan 2024      | 
+| Retention Point 2      | 1 Jan 2024     | 31 Mar 2024      | `retained-2`    | 30 Apr 2024     | 
+| Retention Point 3      | 1 Apr 2024    | 31 Jul 2024      | `retained-3`    | 31 Aug 2024      | 
+| Retention Point 4      | 1 Aug 2024     | 31 Dec 2024      | `retained-4`    | 31 Jan 2025      | 
+| Participant Completion      | 1 Jan 2025     | 31 Mar 2025      | `completed`    | 30 Apr 2025      | 
+
+#### 2021 cohort
+
+For participants starting their course on or before 1 February 2022, and who are expected to complete their training over 2 academic years, providers [should have their schedule updated](ecf/guidance#notify-dfe-of-a-participant-39-s-training-schedule) by providers to: 
+
+```
+ "schedule_identifier": "ecf-standard-april"
+```
+
+| Milestone      | Start date     | Milestone date      | Declaration type    | Payment date      | 
+| -------- | --------  | -------- | --------  | -------- | 
+| Participant Start      | 1 Feb 2022     | 31 May 2022      | `started`    | 31 May 2022      | 
+| Retention Point 1      | 1 May 2022     | 30 Sep 2022      | `retained-1`    | 31 Oct 2022      | 
+| Retention Point 2      | 1 Oct 2022     | 31 Jan 2023      | `retained-2`    | 28 Feb 2023     | 
+| Retention Point 3      | 1 Feb 2023    | 30 Apr 2023      | `retained-3`    | 31 May 2023      | 
+| Retention Point 4      | 1 May 2023     | 31 Oct 2023      | `retained-4`    | 30 Nov 2023      | 
+| Participant Completion      | 1 Nov 2023     | 31 Jan 2024      | `completed`    | 28 Feb 2024      | 
+
+
+### Validating declarations against milestones
+
+Declarations submitted for participants on standard schedules are subject to milestone validation. 
+
+> Note, milestone validation does not apply to any non-standard schedules.
+
+The API will perform milestone validation to reject a declaration if:
+
+* it is not submitted for the correct milestone. For example, the API will reject a `retained-1` declaration if it is submitted during the `started` milestone period
+* it is submitted before or after the milestone date. For example, an `ecf-standard-september` schedule allows `started` declarations between 19 November to 30 November. A declaration submitted outside of these dates will be rejected, unless its `declaration_date` is backdated accordingly
+* it corresponds to a participant's [updated schedule](ecf/guidance#notify-dfe-of-a-participant-39-s-training-schedule), but the participant has previously submitted declarations corresponding to the former schedule (which have not yet been voided).
+
+## Non-standard schedules and dates
+
+A standard 2 year induction training schedule covers 6 terms (3 in each academic year), and therefore has 6 milestones. However, a participant can choose to follow a non-standard schedule: extended, reduced or replacement.  
+
+The payment model for non-standard schedules follows the same principles; DfE will pay the equivalent of 1 output payment (according to valid declarations submitted) for each of the 6 terms a provider is supporting a participant.
+
+Declarations submitted for participants in non-standard schedules do not need API milestone validation. 
+
+**Providers should note:**
+
+* all participants will be registered by default to a standard schedule starting in September
+* providers must [notify DfE if the participant is following any other standard or non-standard training schedule](ecf/guidance#notify-dfe-of-a-participant-39-s-training-schedule)
+* providers will need to evidence any declarations and why a participant is following a non-standard induction 
+
+### Extended schedules
+
+While the API will accept any declarations submitted after the first milestone start date (1 September, 1 January, 1 April each year), providers must submit declarations according to the terms outlined in the contract payment guidance. 
+
+Contact contract managers via email for more information on exact dates.
+
+Participants who expect to complete their training in more than 2 years, should have their [schedule updated](ecf/guidance#notify-dfe-of-a-participant-39-s-training-schedule) to one for the following: 
+
+```
+ "schedule_identifier": "ecf-extended-september"
+```
+
+```
+ "schedule_identifier": "ecf-extended-january"
+```
+
+```
+ "schedule_identifier": "ecf-extended-april"
+```
+Providers may submit extended declarations for ECTs on an extended schedule, providing they meet certain criteria.
+
+Qualifying ECTs will have had their induction extended as a result of having not yet met the Teachers’ standards, and need additional support to meet the standards. These ECTs must be placed onto one of the available [‘extended schedules’](ecf/schedules-and-milestone-dates#extended-schedules). 
+
+Providers may submit an extended declaration (subject to meeting the engagement criteria) for each extended term until the ECT has completed their induction, up to a maximum of 3 extensions. On completing induction, the provider should submit a completion declaration for the final term.
+
+Providers may submit extended declarations using the following values in the `declaration_type` field on the [participant declaration request body](reference-v3#schema-participantdeclarationrequest):
+
+* extended-1
+* extended-2
+* extended-3
+
+### Reduced schedules
+
+Reduced schedules apply to participants that expect to complete their training in less than 2 years.
+
+Providers should note:
+
+* providers may identify ECTs that have already completed their induction, and so need to be placed on a reduced schedule, via the API. We include details of the date an ECT completed their induction in the v3 [EcfParticipantAttributes](reference-v3#schema-ecfparticipantattributes)
+* while the API will accept any declarations submitted after the first milestone start date (1 September, 1 January, 1 April each year), providers must submit declarations according to the terms outlined in the contract payment guidance
+
+Contact contract managers via email for more information on exact dates.
+
+Participants who expect to complete their training in less than 2 years, should have their [schedule updated](ecf/guidance#notify-dfe-of-a-participant-39-s-training-schedule) to one for the following: 
+
+```
+ "schedule_identifier": "ecf-reduced-september"
+```
+
+```
+ "schedule_identifier": "ecf-reduced-january"
+```
+
+```
+ "schedule_identifier": "ecf-reduced-april"
+```
+
+### Replacement schedules 
+
+While the API will accept any declarations submitted after the first milestone start date (1 September, 1 January, 1 April each year), providers must submit declarations according to the terms outlined in the contract payment guidance. 
+
+Contact contract managers via email for more information on exact dates.
+
+#### Providers should note:
+
+* replacement schedules should only be used where a new mentor takes the place of a previous mentor (in supporting an ECT’s training), but where the new mentor is not also mentoring any other ECTs
+* replacement schedules should not be used if a mentor is already mentoring an ECT and takes on an additional role replacing a mentor for a second ECT. A mentor’s first ECT should take precedence in determining their schedule
+
+Mentors that are not already training ECTs and are replacing a mentor must be should have their [schedule updated](ecf/guidance#notify-dfe-of-a-participant-39-s-training-schedule) to one for the following: 
+
+```
+ "schedule_identifier": "ecf-replacement-september"
+```
+
+```
+ "schedule_identifier": "ecf-replacement-january"
+```
+
+```
+ "schedule_identifier": "ecf-replacement-april"
+```

--- a/documentation/ecf1_guidance/ecf/schedules-and-milestone-dates.md
+++ b/documentation/ecf1_guidance/ecf/schedules-and-milestone-dates.md
@@ -38,11 +38,11 @@ A default 2 year induction training schedule covers 6 terms (3 in each academic 
 
 The payment model is such that for each of the 6 terms a provider is supporting a participant, DfE will pay the corresponding output payment according to valid declarations submitted.
 
-Declarations submitted for participants in standard schedules will be validated (accepted or rejected) against the 6 milestone dates. [View details on milestone validation for standard training schedules](ecf/schedules-and-milestone-dates/#validating-declarations-against-milestones).
+Declarations submitted for participants in standard schedules will be validated (accepted or rejected) against the 6 milestone dates. [View details on milestone validation for standard training schedules](#validating-declarations-against-milestones).
 
 > Note, all participants will be registered by default to a standard schedule starting in September.
 
-Providers must [notify DfE if the participant is following any other standard or non-standard training schedule](ecf/guidance#notify-dfe-of-a-participant-39-s-training-schedule). Contact contract managers via email for additional support or information. 
+Providers must [notify DfE if the participant is following any other standard or non-standard training schedule](guidance.md#notify-dfe-of-a-participant-39-s-training-schedule). Contact contract managers via email for additional support or information. 
 
 
 ### Dates for standard schedule starting in September
@@ -122,7 +122,7 @@ Participants starting their training on or before 30 November 2021, and who are 
 
 #### 2024 cohort
 
-Participants starting their training between 1 January and 31 March 2025, and who are expected to complete their training over 2 academic years, [should have their schedule updated](ecf/guidance#notify-dfe-of-a-participant-39-s-training-schedule) by providers to: 
+Participants starting their training between 1 January and 31 March 2025, and who are expected to complete their training over 2 academic years, [should have their schedule updated](guidance.md#notify-dfe-of-a-participant-39-s-training-schedule) by providers to: 
 
 ```
  "schedule_identifier": "ecf-standard-january"
@@ -139,7 +139,7 @@ Participants starting their training between 1 January and 31 March 2025, and wh
 
 #### 2023 cohort
 
-Participants starting their training between 1 January and 31 March 2024, and who are expected to complete their training over 2 academic years, [should have their schedule updated](ecf/guidance#notify-dfe-of-a-participant-39-s-training-schedule) by providers to: 
+Participants starting their training between 1 January and 31 March 2024, and who are expected to complete their training over 2 academic years, [should have their schedule updated](guidance.md#notify-dfe-of-a-participant-39-s-training-schedule) by providers to: 
 
 ```
  "schedule_identifier": "ecf-standard-january"
@@ -156,7 +156,7 @@ Participants starting their training between 1 January and 31 March 2024, and wh
 
 #### 2022 cohort
 
-Participants starting their training between 1 January and 31 March 2023, and who are expected to complete their training over 2 academic years, [should have their schedule updated](ecf/guidance#notify-dfe-of-a-participant-39-s-training-schedule) by providers to: 
+Participants starting their training between 1 January and 31 March 2023, and who are expected to complete their training over 2 academic years, [should have their schedule updated](guidance.md#notify-dfe-of-a-participant-39-s-training-schedule) by providers to: 
 
 ```
  "schedule_identifier": "ecf-standard-january"
@@ -173,7 +173,7 @@ Participants starting their training between 1 January and 31 March 2023, and wh
 
 #### 2021 cohort
 
-For participants starting their course on or before 1 December 2021, and who are expected to complete their training over 2 academic years, providers [should have their schedule updated](ecf/guidance#notify-dfe-of-a-participant-39-s-training-schedule) by providers to: 
+For participants starting their course on or before 1 December 2021, and who are expected to complete their training over 2 academic years, providers [should have their schedule updated](guidance.md#notify-dfe-of-a-participant-39-s-training-schedule) by providers to: 
 
 ```
  "schedule_identifier": "ecf-standard-january"
@@ -193,7 +193,7 @@ For participants starting their course on or before 1 December 2021, and who are
 
 #### 2024 cohort
 
-Participants starting their training between 1 April and 31 July 2025, and who are expected to complete their training over 2 academic years, [should have their schedule updated](ecf/guidance#notify-dfe-of-a-participant-39-s-training-schedule) by providers to: 
+Participants starting their training between 1 April and 31 July 2025, and who are expected to complete their training over 2 academic years, [should have their schedule updated](guidance.md#notify-dfe-of-a-participant-39-s-training-schedule) by providers to: 
 
 ```
  "schedule_identifier": "ecf-standard-april"
@@ -211,7 +211,7 @@ Participants starting their training between 1 April and 31 July 2025, and who a
 
 #### 2023 cohort
 
-Participants starting their training between 1 April and 31 July 2024, and who are expected to complete their training over 2 academic years, [should have their schedule updated](ecf/guidance#notify-dfe-of-a-participant-39-s-training-schedule) by providers to: 
+Participants starting their training between 1 April and 31 July 2024, and who are expected to complete their training over 2 academic years, [should have their schedule updated](guidance.md#notify-dfe-of-a-participant-39-s-training-schedule) by providers to: 
 
 ```
  "schedule_identifier": "ecf-standard-april"
@@ -228,7 +228,7 @@ Participants starting their training between 1 April and 31 July 2024, and who a
 
 #### 2022 cohort
 
-Participants starting their training between 1 April and 31 July 2023, and who are expected to complete their training over 2 academic years, [should have their schedule updated](ecf/guidance#notify-dfe-of-a-participant-39-s-training-schedule) by providers to: 
+Participants starting their training between 1 April and 31 July 2023, and who are expected to complete their training over 2 academic years, [should have their schedule updated](guidance.md#notify-dfe-of-a-participant-39-s-training-schedule) by providers to: 
 
 ```
  "schedule_identifier": "ecf-standard-april"
@@ -245,7 +245,7 @@ Participants starting their training between 1 April and 31 July 2023, and who a
 
 #### 2021 cohort
 
-For participants starting their course on or before 1 February 2022, and who are expected to complete their training over 2 academic years, providers [should have their schedule updated](ecf/guidance#notify-dfe-of-a-participant-39-s-training-schedule) by providers to: 
+For participants starting their course on or before 1 February 2022, and who are expected to complete their training over 2 academic years, providers [should have their schedule updated](guidance.md#notify-dfe-of-a-participant-39-s-training-schedule) by providers to: 
 
 ```
  "schedule_identifier": "ecf-standard-april"
@@ -271,7 +271,7 @@ The API will perform milestone validation to reject a declaration if:
 
 * it is not submitted for the correct milestone. For example, the API will reject a `retained-1` declaration if it is submitted during the `started` milestone period
 * it is submitted before or after the milestone date. For example, an `ecf-standard-september` schedule allows `started` declarations between 19 November to 30 November. A declaration submitted outside of these dates will be rejected, unless its `declaration_date` is backdated accordingly
-* it corresponds to a participant's [updated schedule](ecf/guidance#notify-dfe-of-a-participant-39-s-training-schedule), but the participant has previously submitted declarations corresponding to the former schedule (which have not yet been voided).
+* it corresponds to a participant's [updated schedule](guidance.md#notify-dfe-of-a-participant-39-s-training-schedule), but the participant has previously submitted declarations corresponding to the former schedule (which have not yet been voided).
 
 ## Non-standard schedules and dates
 
@@ -284,7 +284,7 @@ Declarations submitted for participants in non-standard schedules do not need AP
 **Providers should note:**
 
 * all participants will be registered by default to a standard schedule starting in September
-* providers must [notify DfE if the participant is following any other standard or non-standard training schedule](ecf/guidance#notify-dfe-of-a-participant-39-s-training-schedule)
+* providers must [notify DfE if the participant is following any other standard or non-standard training schedule](guidance.md#notify-dfe-of-a-participant-39-s-training-schedule)
 * providers will need to evidence any declarations and why a participant is following a non-standard induction 
 
 ### Extended schedules
@@ -293,7 +293,7 @@ While the API will accept any declarations submitted after the first milestone s
 
 Contact contract managers via email for more information on exact dates.
 
-Participants who expect to complete their training in more than 2 years, should have their [schedule updated](ecf/guidance#notify-dfe-of-a-participant-39-s-training-schedule) to one for the following: 
+Participants who expect to complete their training in more than 2 years, should have their [schedule updated](guidance.md#notify-dfe-of-a-participant-39-s-training-schedule) to one for the following: 
 
 ```
  "schedule_identifier": "ecf-extended-september"
@@ -308,11 +308,11 @@ Participants who expect to complete their training in more than 2 years, should 
 ```
 Providers may submit extended declarations for ECTs on an extended schedule, providing they meet certain criteria.
 
-Qualifying ECTs will have had their induction extended as a result of having not yet met the Teachers’ standards, and need additional support to meet the standards. These ECTs must be placed onto one of the available [‘extended schedules’](ecf/schedules-and-milestone-dates#extended-schedules). 
+Qualifying ECTs will have had their induction extended as a result of having not yet met the Teachers’ standards, and need additional support to meet the standards. These ECTs must be placed onto one of the available [‘extended schedules’](schedules-and-milestone-dates.md#extended-schedules). 
 
 Providers may submit an extended declaration (subject to meeting the engagement criteria) for each extended term until the ECT has completed their induction, up to a maximum of 3 extensions. On completing induction, the provider should submit a completion declaration for the final term.
 
-Providers may submit extended declarations using the following values in the `declaration_type` field on the [participant declaration request body](reference-v3#schema-participantdeclarationrequest):
+Providers may submit extended declarations using the following values in the `declaration_type` field on the [participant declaration request body](../reference-v3.md#participantdeclarationrequest):
 
 * extended-1
 * extended-2
@@ -324,12 +324,12 @@ Reduced schedules apply to participants that expect to complete their training i
 
 Providers should note:
 
-* providers may identify ECTs that have already completed their induction, and so need to be placed on a reduced schedule, via the API. We include details of the date an ECT completed their induction in the v3 [EcfParticipantAttributes](reference-v3#schema-ecfparticipantattributes)
+* providers may identify ECTs that have already completed their induction, and so need to be placed on a reduced schedule, via the API. We include details of the date an ECT completed their induction in the v3 [EcfParticipantAttributes](../reference-v3.md#ecfparticipantattributes)
 * while the API will accept any declarations submitted after the first milestone start date (1 September, 1 January, 1 April each year), providers must submit declarations according to the terms outlined in the contract payment guidance
 
 Contact contract managers via email for more information on exact dates.
 
-Participants who expect to complete their training in less than 2 years, should have their [schedule updated](ecf/guidance#notify-dfe-of-a-participant-39-s-training-schedule) to one for the following: 
+Participants who expect to complete their training in less than 2 years, should have their [schedule updated](guidance.md#notify-dfe-of-a-participant-39-s-training-schedule) to one for the following: 
 
 ```
  "schedule_identifier": "ecf-reduced-september"
@@ -354,7 +354,7 @@ Contact contract managers via email for more information on exact dates.
 * replacement schedules should only be used where a new mentor takes the place of a previous mentor (in supporting an ECT’s training), but where the new mentor is not also mentoring any other ECTs
 * replacement schedules should not be used if a mentor is already mentoring an ECT and takes on an additional role replacing a mentor for a second ECT. A mentor’s first ECT should take precedence in determining their schedule
 
-Mentors that are not already training ECTs and are replacing a mentor must be should have their [schedule updated](ecf/guidance#notify-dfe-of-a-participant-39-s-training-schedule) to one for the following: 
+Mentors that are not already training ECTs and are replacing a mentor must be should have their [schedule updated](guidance.md#notify-dfe-of-a-participant-39-s-training-schedule) to one for the following: 
 
 ```
  "schedule_identifier": "ecf-replacement-september"

--- a/documentation/ecf1_guidance/get-started.md
+++ b/documentation/ecf1_guidance/get-started.md
@@ -1,0 +1,121 @@
+
+# Get started
+
+## Connect to the API
+
+Connect to the API by integrating local provider CRM systems with it.
+
+A unique authentication token is needed to connect to the API.
+
+Each token is associated with a single provider and will give providers access to appropriate CPD participant data. 
+
+Authentication tokens do not expire.
+
+### Request an authentication token
+
+Providers must [contact us](help.md) to request a token for production and sandbox environments.
+
+DfE will send a unique authentication token via secure email.
+
+<div class="govuk-warning-text">
+  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+  <strong class="govuk-warning-text__text">
+    <span class="govuk-warning-text__assistive">Warning</span>
+    Providers must not share tokens in publicly accessible documents or repositories.
+  </strong>
+</div>
+
+### How to use an authentication token
+
+Include an authentication token in all requests to the API by adding an `Authorization` request header (not as part of the URL) in the following format: 
+
+```
+Authorization: Bearer {token}
+```
+
+Unauthenticated requests will receive an `UnauthorizedResponse` with a `401` error code.
+
+### Access YAML format API specs
+
+Provider development teams can also access the OpenAPI spec in YAML formats: 
+
+* [View the OpenAPI v1.0.0. spec](/lead-providers/api-docs/v1/api_spec.yml)
+* [View the OpenAPI v2.0.0. spec](/lead-providers/api-docs/v2/api_spec.yml)
+* [View the OpenAPI v3.0.0. spec](/lead-providers/api-docs/v3/api_spec.yml)
+
+Providers can use API testing tools such as [Postman](https://www.postman.com/) to make test API calls. Providers can import the API as a collection by using Postman's import feature and copying in the YAML URL of the API spec.
+
+## Production and sandbox environments
+
+The API is available via production (live) and sandbox (testing) environments.
+
+### Production environment
+
+The production environment is the live environment which processes real data.  
+
+> Do not perform testing in the production environment as real participant and payment data may be affected.
+
+```
+API v1: 
+https://manage-training-for-early-career-teachers.education.gov.uk/api/v1
+```
+
+```
+API v2:
+https://manage-training-for-early-career-teachers.education.gov.uk/api/v2
+```
+
+```
+API v3: 
+https://manage-training-for-early-career-teachers.education.gov.uk/api/v3
+```
+
+### Sandbox environment
+
+The sandbox environment is used to test API integrations without affecting real data. 
+
+```
+API v1: 
+https://sb.manage-training-for-early-career-teachers.education.gov.uk/api/v1
+```
+
+```
+API v2:
+https://sb.manage-training-for-early-career-teachers.education.gov.uk/api/v2
+```
+
+```
+API v3: 
+https://sb.manage-training-for-early-career-teachers.education.gov.uk/api/v3
+```
+
+<div class="govuk-inset-text"> Note, there are some custom API headers that can only be used in the sandbox. </div>
+
+[Test the ability to submit declarations in the sandbox ahead of time](ecf/guidance/#test-the-ability-to-submit-declarations-in-sandbox-ahead-of-time)
+
+## Rate limits
+
+Providers are limited to 1,000 requests per 5 minutes when using the API in the production environment. If the limit is exceeded, providers will see `429` HTTP status codes.
+
+This limit on requests for each authentication key is calculated on a rolling basis. 
+
+## Syncing data best practice
+
+### Performing a full sync once a week
+
+We recommend you sync all records in the API weekly without using the `updated_since` filters. DfE can coordinate ‘windows’ for providers to do this when the service has a low background load. Contact us if you need further details.
+
+### Regular polling
+
+To ensure you never miss any declarations, participants, transfers or unfunded mentors, we recommend making regular poll requests to the relevant `GET endpoints` several times daily. Use the `updated_since` filter and the default pagination of [100] records per page.
+
+Continue this until the API response is empty.
+
+### Polling windows
+
+Always poll 2 windows back from your last successful update request. This guarantees that all participant data is captured. For example:
+
+* at 3:15pm enter the following request - `/api/v3/participants/ecf?filter[updated_since]=2025-01-28T13:15:00Z`
+* at 4:15pm enter the following request - `/api/v3/participants/ecf?filter[updated_since]=2025-01-28T14:15:00Z`
+
+Try polling randomly rather than on the hour to prevent system overload.

--- a/documentation/ecf1_guidance/get-started.md
+++ b/documentation/ecf1_guidance/get-started.md
@@ -91,7 +91,7 @@ https://sb.manage-training-for-early-career-teachers.education.gov.uk/api/v3
 
 <div class="govuk-inset-text"> Note, there are some custom API headers that can only be used in the sandbox. </div>
 
-[Test the ability to submit declarations in the sandbox ahead of time](ecf/guidance.md#test-the-ability-to-submit-declarations-in-sandbox-ahead-of-time)
+[Test the ability to submit declarations in the sandbox ahead of time](ecf/guidance.md#how-providers-can-test-theyre-able-to-submit-declarations)
 
 ## Rate limits
 

--- a/documentation/ecf1_guidance/get-started.md
+++ b/documentation/ecf1_guidance/get-started.md
@@ -91,7 +91,7 @@ https://sb.manage-training-for-early-career-teachers.education.gov.uk/api/v3
 
 <div class="govuk-inset-text"> Note, there are some custom API headers that can only be used in the sandbox. </div>
 
-[Test the ability to submit declarations in the sandbox ahead of time](ecf/guidance/#test-the-ability-to-submit-declarations-in-sandbox-ahead-of-time)
+[Test the ability to submit declarations in the sandbox ahead of time](ecf/guidance.md#test-the-ability-to-submit-declarations-in-sandbox-ahead-of-time)
 
 ## Rate limits
 

--- a/documentation/ecf1_guidance/help.md
+++ b/documentation/ecf1_guidance/help.md
@@ -1,0 +1,10 @@
+---
+title: Get help
+weight: 9
+---
+
+# Get help
+
+If you have any questions or suggestions email us at [continuing-professional-development@digital.education.gov.uk](mailto:continuing-professional-development@digital.education.gov.uk)
+
+We’ll try to get back to you within two working days.

--- a/documentation/ecf1_guidance/help.md
+++ b/documentation/ecf1_guidance/help.md
@@ -1,7 +1,3 @@
----
-title: Get help
-weight: 9
----
 
 # Get help
 

--- a/documentation/ecf1_guidance/index.md
+++ b/documentation/ecf1_guidance/index.md
@@ -1,5 +1,6 @@
-[!IMPORTANT]
-This is a copy of the legacy ECF1 API Guidance
+> [!IMPORTANT]
+> This is a copy of the legacy ECF1 API Guidance
+
 
 # About the API
 

--- a/documentation/ecf1_guidance/index.md
+++ b/documentation/ecf1_guidance/index.md
@@ -1,0 +1,17 @@
+# About the API
+
+Lead providers must use this API to view, submit and update participant data so they receive accurate payments from Department for Education (DfE) for their early career training programme.
+
+Once a participant has been registered to the service by their school, data associated with them becomes available to lead providers via the API.
+
+## API versions and updates
+
+We regularly make improvements and add new functionality to the API. View our [release notes](release-notes.md) to find out about the latest updates.
+
+If we change the API so it’s no longer able to work with older data or functionality, we’ll publish a new version. This is specified in the `URL /api/v{n}/`. For example, `/api/v1/` or `/api/v2/` and so on. We recommend lead providers use the latest version of the API.
+
+When we publish a new API version, only one previous version will remain supported. For example, when a `v4` is released, `v2` will be discontinued.
+
+Note, there's an exception to this rule for `v3`. We're supporting `v1` for an extended period while we work with providers on transition plans.
+
+When we make non-breaking updates (sometimes referred to as backwards compatible updates), we will not re-version the API. An example of a non-breaking change would be when we introduce a new attribute without removing an existing one. 

--- a/documentation/ecf1_guidance/index.md
+++ b/documentation/ecf1_guidance/index.md
@@ -1,3 +1,6 @@
+[!IMPORTANT]
+This is a copy of the legacy ECF1 API Guidance
+
 # About the API
 
 Lead providers must use this API to view, submit and update participant data so they receive accurate payments from Department for Education (DfE) for their early career training programme.

--- a/documentation/ecf1_guidance/reference-v1.md
+++ b/documentation/ecf1_guidance/reference-v1.md
@@ -26,8 +26,8 @@ The lead provider API for DfE’s manage teacher CPD service
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine participant declarations to return.<br/>This consumes a [ListFilterDeclarations](listfilterdeclarations) schema.<br/> | participant\_id=ab3a7848-1208-7679-942a-b4a70eed400a&updated\_since=2020-11-13T11:21:55Z | 
-| page | query | object | false | Pagination options to navigate through the list of participant declarations.<br/>This consumes a [Pagination](pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| filter | query | object | false | Refine participant declarations to return.<br/>This consumes a [ListFilterDeclarations](#schema-listfilterdeclarations) schema.<br/> | participant\_id=ab3a7848-1208-7679-942a-b4a70eed400a&updated\_since=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of participant declarations.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
 
 
 ### Responses
@@ -35,14 +35,14 @@ The lead provider API for DfE’s manage teacher CPD service
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A list of participant declarations<br/>This response returns a [MultipleParticipantDeclarationsResponse](multipleparticipantdeclarationsresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
+| 200 | A list of participant declarations<br/>This response returns a [MultipleParticipantDeclarationsResponse](#schema-multipleparticipantdeclarationsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A list of participant declarations
-This response returns a [MultipleParticipantDeclarationsResponse](multipleparticipantdeclarationsresponse) schema.
+This response returns a [MultipleParticipantDeclarationsResponse](#schema-multipleparticipantdeclarationsresponse) schema.
 
 ```
 {
@@ -74,7 +74,7 @@ This response returns a [MultipleParticipantDeclarationsResponse](multiplepartic
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
 
 ```
 {
@@ -97,23 +97,23 @@ This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 ### Request body
 
 
-This consumes a [ParticipantDeclarationRequest](participantdeclarationrequest) schema.
+This consumes a [ParticipantDeclarationRequest](#schema-participantdeclarationrequest) schema.
 
 ### Responses
 
 
 | Status | Description |
 | ---- | ---- |
-| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](singleparticipantdeclarationresponse) schema.<br/> | 
-| 422 | Bad or Missing parameter<br/>This response returns a [ErrorResponse](errorresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
-| 400 | Bad Request<br/>This response returns a [BadRequestResponse](badrequestresponse) schema.<br/> | 
+| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.<br/> | 
+| 422 | Bad or Missing parameter<br/>This response returns a [ErrorResponse](#schema-errorresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 400 | Bad Request<br/>This response returns a [BadRequestResponse](#schema-badrequestresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - Successful
-This response returns a [SingleParticipantDeclarationResponse](singleparticipantdeclarationresponse) schema.
+This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.
 
 ```
 {
@@ -136,7 +136,7 @@ This response returns a [SingleParticipantDeclarationResponse](singleparticipant
 ```
 
 422 - Bad or Missing parameter
-This response returns a [ErrorResponse](errorresponse) schema.
+This response returns a [ErrorResponse](#schema-errorresponse) schema.
 
 ```
 {
@@ -150,7 +150,7 @@ This response returns a [ErrorResponse](errorresponse) schema.
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
 
 ```
 {
@@ -159,7 +159,7 @@ This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 ```
 
 400 - Bad Request
-This response returns a [BadRequestResponse](badrequestresponse) schema.
+This response returns a [BadRequestResponse](#schema-badrequestresponse) schema.
 
 ```
 {
@@ -184,16 +184,16 @@ This response returns a [BadRequestResponse](badrequestresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A CSV file of participant declarations<br/>This response returns a [MultipleParticipantDeclarationsCsvResponse](multipleparticipantdeclarationscsvresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
+| 200 | A CSV file of participant declarations<br/>This response returns a [MultipleParticipantDeclarationsCsvResponse](#schema-multipleparticipantdeclarationscsvresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A CSV file of participant declarations
-This response returns a [MultipleParticipantDeclarationsCsvResponse](multipleparticipantdeclarationscsvresponse) schema.
+This response returns a [MultipleParticipantDeclarationsCsvResponse](#schema-multipleparticipantdeclarationscsvresponse) schema.
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
 
 ---
 
@@ -219,15 +219,15 @@ This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A single participant declaration<br/>This response returns a [SingleParticipantDeclarationResponse](singleparticipantdeclarationresponse) schema.<br/> | 
-| 404 | Not found<br/>This response returns a [NotFoundResponse](notfoundresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
+| 200 | A single participant declaration<br/>This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.<br/> | 
+| 404 | Not found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A single participant declaration
-This response returns a [SingleParticipantDeclarationResponse](singleparticipantdeclarationresponse) schema.
+This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.
 
 ```
 {
@@ -250,7 +250,7 @@ This response returns a [SingleParticipantDeclarationResponse](singleparticipant
 ```
 
 404 - Not found
-This response returns a [NotFoundResponse](notfoundresponse) schema.
+This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 
 ```
 {
@@ -259,7 +259,7 @@ This response returns a [NotFoundResponse](notfoundresponse) schema.
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
 
 ```
 {
@@ -292,13 +292,13 @@ This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](singleparticipantdeclarationresponse) schema.<br/> | 
+| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - Successful
-This response returns a [SingleParticipantDeclarationResponse](singleparticipantdeclarationresponse) schema.
+This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.
 
 ```
 {
@@ -337,8 +337,8 @@ This response returns a [SingleParticipantDeclarationResponse](singleparticipant
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine ECF participants to return.<br/>This consumes a [ParticipantListFilter](participantlistfilter) schema.<br/> | filter[cohort]=2022&filter[updated\_since]=2020-11-13T11:21:55Z | 
-| page | query | object | false | Pagination options to navigate through the list of ECF participants.<br/>This consumes a [Pagination](pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| filter | query | object | false | Refine ECF participants to return.<br/>This consumes a [ParticipantListFilter](#schema-participantlistfilter) schema.<br/> | filter[cohort]=2022&filter[updated\_since]=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of ECF participants.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
 
 
 ### Responses
@@ -346,14 +346,14 @@ This response returns a [SingleParticipantDeclarationResponse](singleparticipant
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A list of ECF participants<br/>This response returns a [MultipleECFParticipantsResponse](multipleecfparticipantsresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
+| 200 | A list of ECF participants<br/>This response returns a [MultipleECFParticipantsResponse](#schema-multipleecfparticipantsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A list of ECF participants
-This response returns a [MultipleECFParticipantsResponse](multipleecfparticipantsresponse) schema.
+This response returns a [MultipleECFParticipantsResponse](#schema-multipleecfparticipantsresponse) schema.
 
 ```
 {
@@ -422,7 +422,7 @@ This response returns a [MultipleECFParticipantsResponse](multipleecfparticipant
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
 
 ```
 {
@@ -447,7 +447,7 @@ This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine ECF participants to return.<br/>This consumes a [ParticipantListFilter](participantlistfilter) schema.<br/> | updated\_since=2020-11-13T11:21:55Z | 
+| filter | query | object | false | Refine ECF participants to return.<br/>This consumes a [ParticipantListFilter](#schema-participantlistfilter) schema.<br/> | updated\_since=2020-11-13T11:21:55Z | 
 
 
 ### Responses
@@ -455,16 +455,16 @@ This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A CSV file of ECF participants<br/>This response returns a [MultipleECFParticipantsCsvResponse](multipleecfparticipantscsvresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
+| 200 | A CSV file of ECF participants<br/>This response returns a [MultipleECFParticipantsCsvResponse](#schema-multipleecfparticipantscsvresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A CSV file of ECF participants
-This response returns a [MultipleECFParticipantsCsvResponse](multipleecfparticipantscsvresponse) schema.
+This response returns a [MultipleECFParticipantsCsvResponse](#schema-multipleecfparticipantscsvresponse) schema.
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
 
 ---
 
@@ -490,14 +490,14 @@ This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A single ECF participant<br/>This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
+| 200 | A single ECF participant<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A single ECF participant
-This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
 
 ```
 {
@@ -527,7 +527,7 @@ This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
 
 ```
 {
@@ -558,7 +558,7 @@ This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 ### Request body
 
 
-This consumes a [ECFParticipantDeferRequest](ecfparticipantdeferrequest) schema.
+This consumes a [ECFParticipantDeferRequest](#schema-ecfparticipantdeferrequest) schema.
 
 ### Request example
 
@@ -581,13 +581,13 @@ This consumes a [ECFParticipantDeferRequest](ecfparticipantdeferrequest) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant being deferred<br/>This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.<br/> | 
+| 200 | The ECF participant being deferred<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant being deferred
-This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
 
 ```
 {
@@ -639,7 +639,7 @@ This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
 ### Request body
 
 
-This consumes a [ECFParticipantResumeRequest](ecfparticipantresumerequest) schema.
+This consumes a [ECFParticipantResumeRequest](#schema-ecfparticipantresumerequest) schema.
 
 ### Request example
 
@@ -661,13 +661,13 @@ This consumes a [ECFParticipantResumeRequest](ecfparticipantresumerequest) schem
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant being resumed<br/>This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.<br/> | 
+| 200 | The ECF participant being resumed<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant being resumed
-This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
 
 ```
 {
@@ -719,7 +719,7 @@ This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
 ### Request body
 
 
-This consumes a [ECFParticipantWithdrawRequest](ecfparticipantwithdrawrequest) schema.
+This consumes a [ECFParticipantWithdrawRequest](#schema-ecfparticipantwithdrawrequest) schema.
 
 ### Request example
 
@@ -742,13 +742,13 @@ This consumes a [ECFParticipantWithdrawRequest](ecfparticipantwithdrawrequest) s
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant being withdrawn<br/>This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.<br/> | 
+| 200 | The ECF participant being withdrawn<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant being withdrawn
-This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
 
 ```
 {
@@ -800,7 +800,7 @@ This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
 ### Request body
 
 
-This consumes a [ECFParticipantDeferRequest](ecfparticipantdeferrequest) schema.
+This consumes a [ECFParticipantDeferRequest](#schema-ecfparticipantdeferrequest) schema.
 
 ### Request example
 
@@ -823,13 +823,13 @@ This consumes a [ECFParticipantDeferRequest](ecfparticipantdeferrequest) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant being deferred<br/>This response returns a [ECFParticipantDeferResponse](ecfparticipantdeferresponse) schema.<br/> | 
+| 200 | The ECF participant being deferred<br/>This response returns a [ECFParticipantDeferResponse](#schema-ecfparticipantdeferresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant being deferred
-This response returns a [ECFParticipantDeferResponse](ecfparticipantdeferresponse) schema.
+This response returns a [ECFParticipantDeferResponse](#schema-ecfparticipantdeferresponse) schema.
 
 ```
 {
@@ -880,7 +880,7 @@ This response returns a [ECFParticipantDeferResponse](ecfparticipantdeferrespons
 ### Request body
 
 
-This consumes a [ECFParticipantResumeRequest](ecfparticipantresumerequest) schema.
+This consumes a [ECFParticipantResumeRequest](#schema-ecfparticipantresumerequest) schema.
 
 ### Request example
 
@@ -902,13 +902,13 @@ This consumes a [ECFParticipantResumeRequest](ecfparticipantresumerequest) schem
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant being resumed<br/>This response returns a [ECFParticipantResumeResponse](ecfparticipantresumeresponse) schema.<br/> | 
+| 200 | The ECF participant being resumed<br/>This response returns a [ECFParticipantResumeResponse](#schema-ecfparticipantresumeresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant being resumed
-This response returns a [ECFParticipantResumeResponse](ecfparticipantresumeresponse) schema.
+This response returns a [ECFParticipantResumeResponse](#schema-ecfparticipantresumeresponse) schema.
 
 ```
 {
@@ -959,7 +959,7 @@ This response returns a [ECFParticipantResumeResponse](ecfparticipantresumerespo
 ### Request body
 
 
-This consumes a [ECFParticipantWithdrawRequest](ecfparticipantwithdrawrequest) schema.
+This consumes a [ECFParticipantWithdrawRequest](#schema-ecfparticipantwithdrawrequest) schema.
 
 ### Request example
 
@@ -982,13 +982,13 @@ This consumes a [ECFParticipantWithdrawRequest](ecfparticipantwithdrawrequest) s
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant being withdrawn<br/>This response returns a [ECFParticipantWithdrawResponse](ecfparticipantwithdrawresponse) schema.<br/> | 
+| 200 | The ECF participant being withdrawn<br/>This response returns a [ECFParticipantWithdrawResponse](#schema-ecfparticipantwithdrawresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant being withdrawn
-This response returns a [ECFParticipantWithdrawResponse](ecfparticipantwithdrawresponse) schema.
+This response returns a [ECFParticipantWithdrawResponse](#schema-ecfparticipantwithdrawresponse) schema.
 
 ```
 {
@@ -1039,7 +1039,7 @@ This response returns a [ECFParticipantWithdrawResponse](ecfparticipantwithdrawr
 ### Request body
 
 
-This consumes a [ECFParticipantChangeScheduleRequest](ecfparticipantchangeschedulerequest) schema.
+This consumes a [ECFParticipantChangeScheduleRequest](#schema-ecfparticipantchangeschedulerequest) schema.
 
 ### Request example
 
@@ -1063,13 +1063,13 @@ This consumes a [ECFParticipantChangeScheduleRequest](ecfparticipantchangeschedu
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant changing schedule<br/>This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.<br/> | 
+| 200 | The ECF participant changing schedule<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant changing schedule
-This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
 
 ```
 {
@@ -1121,7 +1121,7 @@ This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
 ### Request body
 
 
-This consumes a [ECFParticipantChangeScheduleRequest](ecfparticipantchangeschedulerequest) schema.
+This consumes a [ECFParticipantChangeScheduleRequest](#schema-ecfparticipantchangeschedulerequest) schema.
 
 ### Request example
 
@@ -1145,13 +1145,13 @@ This consumes a [ECFParticipantChangeScheduleRequest](ecfparticipantchangeschedu
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant changing schedule<br/>This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.<br/> | 
+| 200 | The ECF participant changing schedule<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant changing schedule
-This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
 
 ```
 {
@@ -1231,7 +1231,7 @@ The details of a participant
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantAttributes](ecfparticipantattributes) schema. | 
+| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantAttributes](#schema-ecfparticipantattributes) schema. | 
 
 
 ### ECFParticipantAttributes
@@ -1267,7 +1267,7 @@ An ECF participant change schedule action
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | true | The data type<br/>Possible values:<br/><ul><li>participant-change-schedule</li></ul> | 
-| attributes | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeScheduleAttributes](ecfparticipantchangescheduleattributes) schema. | 
+| attributes | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeScheduleAttributes](#schema-ecfparticipantchangescheduleattributes) schema. | 
 
 
 #### Example
@@ -1315,7 +1315,7 @@ The change schedule request for a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeSchedule](ecfparticipantchangeschedule) schema. | 
+| data | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeSchedule](#schema-ecfparticipantchangeschedule) schema. | 
 
 
 #### Example
@@ -1509,7 +1509,7 @@ The details of a participant deferral request
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | true | The data type<br/>Possible values:<br/><ul><li>participant-defer</li></ul> | 
-| attributes | object | true | An ECF participant deferral action<br/>It conforms to [ECFParticipantDeferAttributes](ecfparticipantdeferattributes) schema. | 
+| attributes | object | true | An ECF participant deferral action<br/>It conforms to [ECFParticipantDeferAttributes](#schema-ecfparticipantdeferattributes) schema. | 
 
 
 ### ECFParticipantDeferAttributes
@@ -1565,7 +1565,7 @@ The deferral request for a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | The details of a participant deferral request<br/>It conforms to [ECFParticipantDefer](ecfparticipantdefer) schema. | 
+| data | object | true | The details of a participant deferral request<br/>It conforms to [ECFParticipantDefer](#schema-ecfparticipantdefer) schema. | 
 
 
 #### Example
@@ -1591,7 +1591,7 @@ An ECF Participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantDeferResponseData](ecfparticipantdeferresponsedata) schema. | 
+| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantDeferResponseData](#schema-ecfparticipantdeferresponsedata) schema. | 
 
 
 ### ECFParticipantDeferResponseData
@@ -1603,7 +1603,7 @@ The details of a participant
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantDeferAttributesResponse](ecfparticipantdeferattributesresponse) schema. | 
+| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantDeferAttributesResponse](#schema-ecfparticipantdeferattributesresponse) schema. | 
 
 
 ### ECFParticipantResponse
@@ -1613,7 +1613,7 @@ An ECF Participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | The details of a participant<br/>It conforms to [ECFParticipant](ecfparticipant) schema. | 
+| data | object | true | The details of a participant<br/>It conforms to [ECFParticipant](#schema-ecfparticipant) schema. | 
 
 
 ### ECFParticipantResume
@@ -1624,7 +1624,7 @@ An ECF participant resume action
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | true | The data type<br/>Possible values:<br/><ul><li>participant-resume</li></ul> | 
-| attributes | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResumeAttributes](ecfparticipantresumeattributes) schema. | 
+| attributes | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResumeAttributes](#schema-ecfparticipantresumeattributes) schema. | 
 
 
 ### ECFParticipantResumeAttributes
@@ -1678,7 +1678,7 @@ The resume request for a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResume](ecfparticipantresume) schema. | 
+| data | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResume](#schema-ecfparticipantresume) schema. | 
 
 
 #### Example
@@ -1703,7 +1703,7 @@ An ECF Participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantResumeResponseData](ecfparticipantresumeresponsedata) schema. | 
+| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantResumeResponseData](#schema-ecfparticipantresumeresponsedata) schema. | 
 
 
 ### ECFParticipantResumeResponseData
@@ -1715,7 +1715,7 @@ The details of a participant
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantResumeAttributesResponse](ecfparticipantresumeattributesresponse) schema. | 
+| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantResumeAttributesResponse](#schema-ecfparticipantresumeattributesresponse) schema. | 
 
 
 ### ECFParticipantRetainedDeclaration
@@ -1726,7 +1726,7 @@ An ECF participant retained declaration request body
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | object | false | The request data<br/>Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | true | An ECF participant retained declaration<br/>It conforms to [ECFParticipantRetainedDeclarationAttributes](ecfparticipantretaineddeclarationattributes) schema. | 
+| attributes | object | true | An ECF participant retained declaration<br/>It conforms to [ECFParticipantRetainedDeclarationAttributes](#schema-ecfparticipantretaineddeclarationattributes) schema. | 
 
 
 ### ECFParticipantRetainedDeclarationAttributes
@@ -1765,7 +1765,7 @@ A participant started declaration request body
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | object | false | The request data<br/>Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | true | An ECF started and completed participant declaration<br/>It conforms to [ECFParticipantStartedDeclarationAttributes](ecfparticipantstarteddeclarationattributes) schema. | 
+| attributes | object | true | An ECF started and completed participant declaration<br/>It conforms to [ECFParticipantStartedDeclarationAttributes](#schema-ecfparticipantstarteddeclarationattributes) schema. | 
 
 
 ### ECFParticipantStartedDeclarationAttributes
@@ -1802,7 +1802,7 @@ An ECF participant withdrawal action
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | The data type<br/>Possible values:<br/><ul><li>participant-withdraw</li></ul> | 
-| attributes | object | false | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdrawAttributes](ecfparticipantwithdrawattributes) schema. | 
+| attributes | object | false | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdrawAttributes](#schema-ecfparticipantwithdrawattributes) schema. | 
 
 
 ### ECFParticipantWithdrawAttributes
@@ -1860,7 +1860,7 @@ The details of a participant
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantWithdrawAttributesResponse](ecfparticipantwithdrawattributesresponse) schema. | 
+| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantWithdrawAttributesResponse](#schema-ecfparticipantwithdrawattributesresponse) schema. | 
 
 
 ### ECFParticipantWithdrawRequest
@@ -1870,7 +1870,7 @@ The withdrawal request for a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdraw](ecfparticipantwithdraw) schema. | 
+| data | object | true | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdraw](#schema-ecfparticipantwithdraw) schema. | 
 
 
 #### Example
@@ -1896,7 +1896,7 @@ An ECF Participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantWithdrawDataResponse](ecfparticipantwithdrawdataresponse) schema. | 
+| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantWithdrawDataResponse](#schema-ecfparticipantwithdrawdataresponse) schema. | 
 
 
 ### Error
@@ -1917,7 +1917,7 @@ A list of errors
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| error | array | false | It conforms to [Error](error) schema. | 
+| error | array | false | It conforms to [Error](#schema-error) schema. | 
 
 
 ### ListFilter
@@ -1949,7 +1949,7 @@ A list of ECF participants in the Comma Separated Value (CSV) format
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ECFParticipantCsvRow](ecfparticipantcsvrow) schema. | 
+| data | array | true | It conforms to [ECFParticipantCsvRow](#schema-ecfparticipantcsvrow) schema. | 
 
 
 ### MultipleECFParticipantsResponse
@@ -1959,7 +1959,7 @@ A list of ECF participants
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ECFParticipant](ecfparticipant) schema. | 
+| data | array | true | It conforms to [ECFParticipant](#schema-ecfparticipant) schema. | 
 
 
 ### MultipleParticipantDeclarationsCsvResponse
@@ -1969,7 +1969,7 @@ A list of participant declarations in the Comma Separated Value (CSV) format
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ParticipantDeclarationCsvRow](participantdeclarationcsvrow) schema. | 
+| data | array | true | It conforms to [ParticipantDeclarationCsvRow](#schema-participantdeclarationcsvrow) schema. | 
 
 
 ### MultipleParticipantDeclarationsResponse
@@ -1979,7 +1979,7 @@ A list of participant declarations
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ParticipantDeclarationResponse](participantdeclarationresponse) schema. | 
+| data | array | true | It conforms to [ParticipantDeclarationResponse](#schema-participantdeclarationresponse) schema. | 
 
 
 ### NotFoundResponse
@@ -2075,7 +2075,7 @@ A participant declaration data request for ECT participants from cohort 2025 onw
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024ECTStartedAttributesRequest](ecfparticipantdeclarationpost2024ectstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTRetainedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectretainedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectcompletedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTExtendedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectextendedattributesrequest) </li></ul> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024ECTStartedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTRetainedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectretainedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectcompletedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTExtendedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectextendedattributesrequest) </li></ul> | 
 
 
 ### ParticipantDeclarationPost2024MentorDataRequest
@@ -2086,7 +2086,7 @@ A participant declaration data request for mentor participants from cohort 2025 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024MentorStartedAttributesRequest](ecfparticipantdeclarationpost2024mentorstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024MentorCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorcompletedattributesrequest) </li></ul> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024MentorStartedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024MentorCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorcompletedattributesrequest) </li></ul> | 
 
 
 ### ParticipantDeclarationPre2025DataRequest
@@ -2097,7 +2097,7 @@ A participant declaration data request for participants in cohort 2024 and previ
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPre2025StartedAttributesRequest](ecfparticipantdeclarationpre2025startedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025RetainedAttributesRequest](#schema-ecfparticipantdeclarationpre2025retainedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025CompletedAttributesRequest](#schema-ecfparticipantdeclarationpre2025completedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025ExtendedAttributesRequest](#schema-ecfparticipantdeclarationpre2025extendedattributesrequest) </li></ul> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPre2025StartedAttributesRequest](#schema-ecfparticipantdeclarationpre2025startedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025RetainedAttributesRequest](#schema-ecfparticipantdeclarationpre2025retainedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025CompletedAttributesRequest](#schema-ecfparticipantdeclarationpre2025completedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025ExtendedAttributesRequest](#schema-ecfparticipantdeclarationpre2025extendedattributesrequest) </li></ul> | 
 
 
 ### ParticipantDeclarationRequest
@@ -2107,7 +2107,7 @@ An participant declaration request
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | This conforms to any of the following schemas:<br/><ul><li> [ParticipantDeclarationPre2025DataRequest](participantdeclarationpre2025datarequest) </li><li> [ParticipantDeclarationPost2024ECTDataRequest](#schema-participantdeclarationpost2024ectdatarequest) </li><li> [ParticipantDeclarationPost2024MentorDataRequest](#schema-participantdeclarationpost2024mentordatarequest) </li></ul> | 
+| data | object | true | This conforms to any of the following schemas:<br/><ul><li> [ParticipantDeclarationPre2025DataRequest](#schema-participantdeclarationpre2025datarequest) </li><li> [ParticipantDeclarationPost2024ECTDataRequest](#schema-participantdeclarationpost2024ectdatarequest) </li><li> [ParticipantDeclarationPost2024MentorDataRequest](#schema-participantdeclarationpost2024mentordatarequest) </li></ul> | 
 
 
 ### ParticipantDeclarationResponse
@@ -2119,7 +2119,7 @@ A participant declaration response
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant declaration record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with a participant declaration response<br/>It conforms to [ParticipantDeclarationAttributes](participantdeclarationattributes) schema. | 
+| attributes | object | true | The data attributes associated with a participant declaration response<br/>It conforms to [ParticipantDeclarationAttributes](#schema-participantdeclarationattributes) schema. | 
 
 
 ### ParticipantListFilter
@@ -2140,7 +2140,7 @@ A confirmation that the participant declaration has been recorded successfully
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | A participant declaration response<br/>It conforms to [ParticipantDeclarationResponse](participantdeclarationresponse) schema. | 
+| data | object | true | A participant declaration response<br/>It conforms to [ParticipantDeclarationResponse](#schema-participantdeclarationresponse) schema. | 
 
 
 ### UnauthorisedResponse

--- a/documentation/ecf1_guidance/reference-v1.md
+++ b/documentation/ecf1_guidance/reference-v1.md
@@ -13,10 +13,7 @@ The lead provider API for DfE’s manage teacher CPD service
  [/](/) 
  **Production** 
  [https://manage-training-for-early-career-teachers.education.gov.uk](https://manage-training-for-early-career-teachers.education.gov.uk) 
-## GET
-    
-    
-      /api/v1/participant-declarations
+## GET /api/v1/participant-declarations
 
 
  _List all participant declarations_ 
@@ -86,10 +83,7 @@ This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 ---
 
 
-## POST
-    
-    
-      /api/v1/participant-declarations
+## POST /api/v1/participant-declarations
 
 
  _Declare a participant has reached a milestone. Idempotent endpoint - submitting exact copy of a request will return the same response body as submitting it the first time._ 
@@ -171,10 +165,7 @@ This response returns a [BadRequestResponse](#badrequestresponse) schema.
 ---
 
 
-## GET
-    
-    
-      /api/v1/participant-declarations.csv
+## GET /api/v1/participant-declarations.csv
 
 
  _Retrieve all participant declarations in CSV format_ 
@@ -198,10 +189,7 @@ This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 ---
 
 
-## GET
-    
-    
-      /api/v1/participant-declarations/{id}
+## GET /api/v1/participant-declarations/{id}
 
 
  _Get single participant declaration_ 
@@ -271,10 +259,7 @@ This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 ---
 
 
-## PUT
-    
-    
-      /api/v1/participant-declarations/{id}/void
+## PUT /api/v1/participant-declarations/{id}/void
 
 
  _Void a declaration - it will not be soft-deleted_ 
@@ -324,10 +309,7 @@ This response returns a [SingleParticipantDeclarationResponse](#singleparticipan
 ---
 
 
-## GET
-    
-    
-      /api/v1/participants/ecf
+## GET /api/v1/participants/ecf
 
 
  _Retrieve multiple participants, replaces /api/v1/participants_ 
@@ -434,10 +416,7 @@ This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 ---
 
 
-## GET
-    
-    
-      /api/v1/participants/ecf.csv
+## GET /api/v1/participants/ecf.csv
 
 
  _Retrieve all participants in CSV format, replaces /api/v1/participants.csv_ 
@@ -469,10 +448,7 @@ This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 ---
 
 
-## GET
-    
-    
-      /api/v1/participants/ecf/{id}
+## GET /api/v1/participants/ecf/{id}
 
 
  _Get a single ECF participant_ 
@@ -539,10 +515,7 @@ This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 ---
 
 
-## PUT
-    
-    
-      /api/v1/participants/{id}/defer
+## PUT /api/v1/participants/{id}/defer
 
 
  _Notify that an ECF participant is taking a break from their course_ 
@@ -620,10 +593,7 @@ This response returns a [ECFParticipantResponse](#ecfparticipantresponse) schema
 ---
 
 
-## PUT
-    
-    
-      /api/v1/participants/{id}/resume
+## PUT /api/v1/participants/{id}/resume
 
 
  _Notify that an ECF participant is resuming their course_ 
@@ -700,10 +670,7 @@ This response returns a [ECFParticipantResponse](#ecfparticipantresponse) schema
 ---
 
 
-## PUT
-    
-    
-      /api/v1/participants/{id}/withdraw
+## PUT /api/v1/participants/{id}/withdraw
 
 
  _Notify that an ECF participant has withdrawn from their course_ 
@@ -781,10 +748,7 @@ This response returns a [ECFParticipantResponse](#ecfparticipantresponse) schema
 ---
 
 
-## PUT
-    
-    
-      /api/v1/participants/ecf/{id}/defer
+## PUT /api/v1/participants/ecf/{id}/defer
 
 
  _Notify that an ECF participant is taking a break from their course_ 
@@ -861,10 +825,7 @@ This response returns a [ECFParticipantDeferResponse](#ecfparticipantdeferrespon
 ---
 
 
-## PUT
-    
-    
-      /api/v1/participants/ecf/{id}/resume
+## PUT /api/v1/participants/ecf/{id}/resume
 
 
  _Notify that an ECF participant is resuming their course_ 
@@ -940,10 +901,7 @@ This response returns a [ECFParticipantResumeResponse](#ecfparticipantresumeresp
 ---
 
 
-## PUT
-    
-    
-      /api/v1/participants/ecf/{id}/withdraw
+## PUT /api/v1/participants/ecf/{id}/withdraw
 
 
  _Notify that an ECF participant has withdrawn from their course_ 
@@ -1020,10 +978,7 @@ This response returns a [ECFParticipantWithdrawResponse](#ecfparticipantwithdraw
 ---
 
 
-## PUT
-    
-    
-      /api/v1/participants/{id}/change-schedule
+## PUT /api/v1/participants/{id}/change-schedule
 
 
  _Notify that an ECF participant is changing training schedule_ 
@@ -1102,10 +1057,7 @@ This response returns a [ECFParticipantResponse](#ecfparticipantresponse) schema
 ---
 
 
-## PUT
-    
-    
-      /api/v1/participants/ecf/{id}/change-schedule
+## PUT /api/v1/participants/ecf/{id}/change-schedule
 
 
  _Notify that an ECF participant is changing training schedule_ 

--- a/documentation/ecf1_guidance/reference-v1.md
+++ b/documentation/ecf1_guidance/reference-v1.md
@@ -1,0 +1,2154 @@
+
+# Lead provider API - 1.0.0
+
+
+The lead provider API for DfE’s manage teacher CPD service
+
+## Base URLs
+
+
+ **Sandbox** 
+ [https://sb.manage-training-for-early-career-teachers.education.gov.uk](https://sb.manage-training-for-early-career-teachers.education.gov.uk) 
+ **Current environment** 
+ [/](/) 
+ **Production** 
+ [https://manage-training-for-early-career-teachers.education.gov.uk](https://manage-training-for-early-career-teachers.education.gov.uk) 
+## GET
+    
+    
+      /api/v1/participant-declarations
+
+
+ _List all participant declarations_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| filter | query | object | false | Refine participant declarations to return.<br/>This consumes a [ListFilterDeclarations](#schema-listfilterdeclarations) schema.<br/> | participant\_id=ab3a7848-1208-7679-942a-b4a70eed400a&updated\_since=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of participant declarations.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | A list of participant declarations<br/>This response returns a [MultipleParticipantDeclarationsResponse](#schema-multipleparticipantdeclarationsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - A list of participant declarations
+This response returns a [MultipleParticipantDeclarationsResponse](#schema-multipleparticipantdeclarationsresponse) schema.
+
+```
+{
+  "data": [
+    {
+      "id": "01017c12-354b-4b2d-b621-3531ab729c43",
+      "type": "participant-declaration",
+      "attributes": {
+        "participant_id": "db3a7848-7308-4879-942a-c4a70ced400a",
+        "declaration_type": "started",
+        "declaration_date": "2021-05-31T02:21:32.000Z",
+        "course_identifier": "ecf-mentor",
+        "eligible_for_payment": false
+      }
+    },
+    {
+      "id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+      "type": "participant-declaration",
+      "attributes": {
+        "participant_id": "ab3a7848-7308-4879-942a-c4a70ced400a",
+        "declaration_type": "started",
+        "declaration_date": "2021-05-31T02:21:32.000Z",
+        "course_identifier": "ecf-mentor",
+        "eligible_for_payment": true
+      }
+    }
+  ]
+}
+```
+
+401 - Unauthorized
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+
+```
+{
+  "error": "HTTP Token: Access denied"
+}
+```
+
+
+---
+
+
+## POST
+    
+    
+      /api/v1/participant-declarations
+
+
+ _Declare a participant has reached a milestone. Idempotent endpoint - submitting exact copy of a request will return the same response body as submitting it the first time._ 
+
+### Request body
+
+
+This consumes a [ParticipantDeclarationRequest](#schema-participantdeclarationrequest) schema.
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.<br/> | 
+| 422 | Bad or Missing parameter<br/>This response returns a [ErrorResponse](#schema-errorresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 400 | Bad Request<br/>This response returns a [BadRequestResponse](#schema-badrequestresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - Successful
+This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.
+
+```
+{
+  "data": {
+    "id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+    "type": "participant-declaration",
+    "attributes": {
+      "participant_id": "db3a7848-7308-4879-942a-c4a70ced400a",
+      "declaration_type": "started",
+      "declaration_date": "2021-05-31T02:21:32.000Z",
+      "course_identifier": "ecf-induction",
+      "eligible_for_payment": true,
+      "voided": true,
+      "state": "submitted",
+      "updated_at": "2021-05-31T02:22:32.000Z",
+      "has_passed": true
+    }
+  }
+}
+```
+
+422 - Bad or Missing parameter
+This response returns a [ErrorResponse](#schema-errorresponse) schema.
+
+```
+{
+  "error": [
+    {
+      "title": "string",
+      "detail": "string"
+    }
+  ]
+}
+```
+
+401 - Unauthorized
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+
+```
+{
+  "error": "HTTP Token: Access denied"
+}
+```
+
+400 - Bad Request
+This response returns a [BadRequestResponse](#schema-badrequestresponse) schema.
+
+```
+{
+  "bad_request": "string"
+}
+```
+
+
+---
+
+
+## GET
+    
+    
+      /api/v1/participant-declarations.csv
+
+
+ _Retrieve all participant declarations in CSV format_ 
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | A CSV file of participant declarations<br/>This response returns a [MultipleParticipantDeclarationsCsvResponse](#schema-multipleparticipantdeclarationscsvresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - A CSV file of participant declarations
+This response returns a [MultipleParticipantDeclarationsCsvResponse](#schema-multipleparticipantdeclarationscsvresponse) schema.
+401 - Unauthorized
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+
+---
+
+
+## GET
+    
+    
+      /api/v1/participant-declarations/{id}
+
+
+ _Get single participant declaration_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| id | path | string | true | The ID of the participant declaration ID<br/> | 9ed4612b-f8bd-44d9-b296-38ab103fadd2 | 
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | A single participant declaration<br/>This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.<br/> | 
+| 404 | Not found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - A single participant declaration
+This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.
+
+```
+{
+  "data": {
+    "id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+    "type": "participant-declaration",
+    "attributes": {
+      "participant_id": "db3a7848-7308-4879-942a-c4a70ced400a",
+      "declaration_type": "started",
+      "declaration_date": "2021-05-31T02:21:32.000Z",
+      "course_identifier": "ecf-induction",
+      "eligible_for_payment": true,
+      "voided": true,
+      "state": "submitted",
+      "updated_at": "2021-05-31T02:22:32.000Z",
+      "has_passed": true
+    }
+  }
+}
+```
+
+404 - Not found
+This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
+
+```
+{
+  "error": "Resource not found"
+}
+```
+
+401 - Unauthorized
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+
+```
+{
+  "error": "HTTP Token: Access denied"
+}
+```
+
+
+---
+
+
+## PUT
+    
+    
+      /api/v1/participant-declarations/{id}/void
+
+
+ _Void a declaration - it will not be soft-deleted_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| id | path | string | true | The ID of the declaration to void<br/> | 28c461ee-ffc0-4e56-96bd-788579a0ed75 | 
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - Successful
+This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.
+
+```
+{
+  "data": {
+    "id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+    "type": "participant-declaration",
+    "attributes": {
+      "participant_id": "db3a7848-7308-4879-942a-c4a70ced400a",
+      "declaration_type": "started",
+      "declaration_date": "2021-05-31T02:21:32.000Z",
+      "course_identifier": "ecf-induction",
+      "eligible_for_payment": true,
+      "voided": true,
+      "state": "submitted",
+      "updated_at": "2021-05-31T02:22:32.000Z",
+      "has_passed": true
+    }
+  }
+}
+```
+
+
+---
+
+
+## GET
+    
+    
+      /api/v1/participants/ecf
+
+
+ _Retrieve multiple participants, replaces /api/v1/participants_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| filter | query | object | false | Refine ECF participants to return.<br/>This consumes a [ParticipantListFilter](#schema-participantlistfilter) schema.<br/> | filter[cohort]=2022&filter[updated\_since]=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of ECF participants.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | A list of ECF participants<br/>This response returns a [MultipleECFParticipantsResponse](#schema-multipleecfparticipantsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - A list of ECF participants
+This response returns a [MultipleECFParticipantsResponse](#schema-multipleecfparticipantsresponse) schema.
+
+```
+{
+  "data": [
+    {
+      "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+      "type": "participant",
+      "attributes": {
+        "email": "jane.smith@some-school.example.com",
+        "full_name": "Jane Smith",
+        "mentor_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+        "school_urn": "106286",
+        "participant_type": "ect",
+        "cohort": "2021",
+        "status": "active",
+        "teacher_reference_number": "0012345",
+        "teacher_reference_number_validated": true,
+        "eligible_for_funding": true,
+        "pupil_premium_uplift": false,
+        "sparsity_uplift": true,
+        "training_status": "active",
+        "updated_at": "2021-05-31T02:22:32.000Z"
+      }
+    },
+    {
+      "id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+      "type": "participant",
+      "attributes": {
+        "email": "martin.jones@some-school.example.com",
+        "full_name": "Martin jones",
+        "school_urn": "106286",
+        "participant_type": "mentor",
+        "cohort": "2021",
+        "status": "active",
+        "teacher_reference_number": null,
+        "teacher_reference_number_validated": false,
+        "eligible_for_funding": null,
+        "pupil_premium_uplift": true,
+        "sparsity_uplift": false,
+        "training_status": "deferred",
+        "updated_at": "2021-05-31T02:22:32.000Z"
+      }
+    },
+    {
+      "id": "eb475531-bf08-48ae-b0ef-c2ff5e5bdef0",
+      "type": "participant",
+      "attributes": {
+        "email": "null,",
+        "full_name": null,
+        "mentor_id": null,
+        "school_urn": null,
+        "participant_type": null,
+        "cohort": null,
+        "status": "withdrawn",
+        "teacher_reference_number": null,
+        "teacher_reference_number_validated": null,
+        "eligible_for_funding": null,
+        "pupil_premium_uplift": null,
+        "sparsity_uplift": null,
+        "training_status": "withdrawn",
+        "updated_at": "2021-05-31T02:22:32.000Z"
+      }
+    }
+  ]
+}
+```
+
+401 - Unauthorized
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+
+```
+{
+  "error": "HTTP Token: Access denied"
+}
+```
+
+
+---
+
+
+## GET
+    
+    
+      /api/v1/participants/ecf.csv
+
+
+ _Retrieve all participants in CSV format, replaces /api/v1/participants.csv_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| filter | query | object | false | Refine ECF participants to return.<br/>This consumes a [ParticipantListFilter](#schema-participantlistfilter) schema.<br/> | updated\_since=2020-11-13T11:21:55Z | 
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | A CSV file of ECF participants<br/>This response returns a [MultipleECFParticipantsCsvResponse](#schema-multipleecfparticipantscsvresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - A CSV file of ECF participants
+This response returns a [MultipleECFParticipantsCsvResponse](#schema-multipleecfparticipantscsvresponse) schema.
+401 - Unauthorized
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+
+---
+
+
+## GET
+    
+    
+      /api/v1/participants/ecf/{id}
+
+
+ _Get a single ECF participant_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| id | path | string | true | The ID of the ECF participant.<br/> | 28c461ee-ffc0-4e56-96bd-788579a0ed75 | 
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | A single ECF participant<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - A single ECF participant
+This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+
+```
+{
+  "data": {
+    "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+    "type": "participant",
+    "attributes": {
+      "email": "jane.smith@some-school.example.com",
+      "full_name": "Jane Smith",
+      "mentor_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+      "school_urn": "106286",
+      "participant_type": "ect",
+      "cohort": "2021",
+      "status": "active",
+      "teacher_reference_number": "1234567",
+      "teacher_reference_number_validated": true,
+      "eligible_for_funding": true,
+      "pupil_premium_uplift": true,
+      "sparsity_uplift": true,
+      "training_status": "active",
+      "training_record_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+      "schedule_identifier": "ecf-standard-january",
+      "updated_at": "2021-05-31T02:22:32.000Z"
+    }
+  }
+}
+```
+
+401 - Unauthorized
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+
+```
+{
+  "error": "HTTP Token: Access denied"
+}
+```
+
+
+---
+
+
+## PUT
+    
+    
+      /api/v1/participants/{id}/defer
+
+
+ _Notify that an ECF participant is taking a break from their course_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| id | path | string | true | The ID of the participant to defer<br/> | 28c461ee-ffc0-4e56-96bd-788579a0ed75 | 
+
+
+### Request body
+
+
+This consumes a [ECFParticipantDeferRequest](#schema-ecfparticipantdeferrequest) schema.
+
+### Request example
+
+
+```
+{
+  "data": {
+    "type": "participant-defer",
+    "attributes": {
+      "reason": "career-break",
+      "course_identifier": "ecf-mentor"
+    }
+  }
+}
+```
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | The ECF participant being deferred<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - The ECF participant being deferred
+This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+
+```
+{
+  "data": {
+    "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+    "type": "participant",
+    "attributes": {
+      "email": "jane.smith@some-school.example.com",
+      "full_name": "Jane Smith",
+      "mentor_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+      "school_urn": "106286",
+      "participant_type": "ect",
+      "cohort": "2021",
+      "status": "active",
+      "teacher_reference_number": "1234567",
+      "teacher_reference_number_validated": true,
+      "eligible_for_funding": true,
+      "pupil_premium_uplift": true,
+      "sparsity_uplift": true,
+      "training_status": "active",
+      "training_record_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+      "schedule_identifier": "ecf-standard-january",
+      "updated_at": "2021-05-31T02:22:32.000Z"
+    }
+  }
+}
+```
+
+
+---
+
+
+## PUT
+    
+    
+      /api/v1/participants/{id}/resume
+
+
+ _Notify that an ECF participant is resuming their course_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| id | path | string | true | The ID of the participant to resume<br/> | 28c461ee-ffc0-4e56-96bd-788579a0ed75 | 
+
+
+### Request body
+
+
+This consumes a [ECFParticipantResumeRequest](#schema-ecfparticipantresumerequest) schema.
+
+### Request example
+
+
+```
+{
+  "data": {
+    "type": "participant-resume",
+    "attributes": {
+      "course_identifier": "ecf-mentor"
+    }
+  }
+}
+```
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | The ECF participant being resumed<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - The ECF participant being resumed
+This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+
+```
+{
+  "data": {
+    "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+    "type": "participant",
+    "attributes": {
+      "email": "jane.smith@some-school.example.com",
+      "full_name": "Jane Smith",
+      "mentor_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+      "school_urn": "106286",
+      "participant_type": "ect",
+      "cohort": "2021",
+      "status": "active",
+      "teacher_reference_number": "1234567",
+      "teacher_reference_number_validated": true,
+      "eligible_for_funding": true,
+      "pupil_premium_uplift": true,
+      "sparsity_uplift": true,
+      "training_status": "active",
+      "training_record_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+      "schedule_identifier": "ecf-standard-january",
+      "updated_at": "2021-05-31T02:22:32.000Z"
+    }
+  }
+}
+```
+
+
+---
+
+
+## PUT
+    
+    
+      /api/v1/participants/{id}/withdraw
+
+
+ _Notify that an ECF participant has withdrawn from their course_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| id | path | string | true | The ID of the participant to withdraw<br/> | 28c461ee-ffc0-4e56-96bd-788579a0ed75 | 
+
+
+### Request body
+
+
+This consumes a [ECFParticipantWithdrawRequest](#schema-ecfparticipantwithdrawrequest) schema.
+
+### Request example
+
+
+```
+{
+  "data": {
+    "type": "participant-withdraw",
+    "attributes": {
+      "reason": "left-teaching-profession",
+      "course_identifier": "ecf-mentor"
+    }
+  }
+}
+```
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | The ECF participant being withdrawn<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - The ECF participant being withdrawn
+This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+
+```
+{
+  "data": {
+    "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+    "type": "participant",
+    "attributes": {
+      "email": "jane.smith@some-school.example.com",
+      "full_name": "Jane Smith",
+      "mentor_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+      "school_urn": "106286",
+      "participant_type": "ect",
+      "cohort": "2021",
+      "status": "active",
+      "teacher_reference_number": "1234567",
+      "teacher_reference_number_validated": true,
+      "eligible_for_funding": true,
+      "pupil_premium_uplift": true,
+      "sparsity_uplift": true,
+      "training_status": "active",
+      "training_record_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+      "schedule_identifier": "ecf-standard-january",
+      "updated_at": "2021-05-31T02:22:32.000Z"
+    }
+  }
+}
+```
+
+
+---
+
+
+## PUT
+    
+    
+      /api/v1/participants/ecf/{id}/defer
+
+
+ _Notify that an ECF participant is taking a break from their course_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| id | path | string | true | The ID of the participant to defer<br/> | 28c461ee-ffc0-4e56-96bd-788579a0ed75 | 
+
+
+### Request body
+
+
+This consumes a [ECFParticipantDeferRequest](#schema-ecfparticipantdeferrequest) schema.
+
+### Request example
+
+
+```
+{
+  "data": {
+    "type": "participant-defer",
+    "attributes": {
+      "reason": "career-break",
+      "course_identifier": "ecf-mentor"
+    }
+  }
+}
+```
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | The ECF participant being deferred<br/>This response returns a [ECFParticipantDeferResponse](#schema-ecfparticipantdeferresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - The ECF participant being deferred
+This response returns a [ECFParticipantDeferResponse](#schema-ecfparticipantdeferresponse) schema.
+
+```
+{
+  "data": {
+    "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+    "type": "participant",
+    "attributes": {
+      "email": "jane.smith@some-school.example.com",
+      "full_name": "Jane Smith",
+      "mentor_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+      "school_urn": "106286",
+      "participant_type": "ect",
+      "cohort": "2021",
+      "status": "active",
+      "teacher_reference_number": "1234567",
+      "teacher_reference_number_validated": true,
+      "eligible_for_funding": true,
+      "pupil_premium_uplift": true,
+      "sparsity_uplift": true,
+      "training_status": "deferred",
+      "schedule_identifier": "ecf-standard-january",
+      "updated_at": "2021-05-31T02:22:32.000Z"
+    }
+  }
+}
+```
+
+
+---
+
+
+## PUT
+    
+    
+      /api/v1/participants/ecf/{id}/resume
+
+
+ _Notify that an ECF participant is resuming their course_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| id | path | string | true | The ID of the participant to resume<br/> | 28c461ee-ffc0-4e56-96bd-788579a0ed75 | 
+
+
+### Request body
+
+
+This consumes a [ECFParticipantResumeRequest](#schema-ecfparticipantresumerequest) schema.
+
+### Request example
+
+
+```
+{
+  "data": {
+    "type": "participant-resume",
+    "attributes": {
+      "course_identifier": "ecf-mentor"
+    }
+  }
+}
+```
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | The ECF participant being resumed<br/>This response returns a [ECFParticipantResumeResponse](#schema-ecfparticipantresumeresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - The ECF participant being resumed
+This response returns a [ECFParticipantResumeResponse](#schema-ecfparticipantresumeresponse) schema.
+
+```
+{
+  "data": {
+    "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+    "type": "participant",
+    "attributes": {
+      "email": "jane.smith@some-school.example.com",
+      "full_name": "Jane Smith",
+      "mentor_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+      "school_urn": "106286",
+      "participant_type": "ect",
+      "cohort": "2021",
+      "status": "active",
+      "teacher_reference_number": "1234567",
+      "teacher_reference_number_validated": true,
+      "eligible_for_funding": true,
+      "pupil_premium_uplift": true,
+      "sparsity_uplift": true,
+      "training_status": "active",
+      "schedule_identifier": "ecf-standard-january",
+      "updated_at": "2021-05-31T02:22:32.000Z"
+    }
+  }
+}
+```
+
+
+---
+
+
+## PUT
+    
+    
+      /api/v1/participants/ecf/{id}/withdraw
+
+
+ _Notify that an ECF participant has withdrawn from their course_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| id | path | string | true | The ID of the participant to withdraw<br/> | 28c461ee-ffc0-4e56-96bd-788579a0ed75 | 
+
+
+### Request body
+
+
+This consumes a [ECFParticipantWithdrawRequest](#schema-ecfparticipantwithdrawrequest) schema.
+
+### Request example
+
+
+```
+{
+  "data": {
+    "type": "participant-withdraw",
+    "attributes": {
+      "reason": "left-teaching-profession",
+      "course_identifier": "ecf-mentor"
+    }
+  }
+}
+```
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | The ECF participant being withdrawn<br/>This response returns a [ECFParticipantWithdrawResponse](#schema-ecfparticipantwithdrawresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - The ECF participant being withdrawn
+This response returns a [ECFParticipantWithdrawResponse](#schema-ecfparticipantwithdrawresponse) schema.
+
+```
+{
+  "data": {
+    "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+    "type": "participant",
+    "attributes": {
+      "email": "jane.smith@some-school.example.com",
+      "full_name": "Jane Smith",
+      "mentor_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+      "school_urn": "106286",
+      "participant_type": "ect",
+      "cohort": "2021",
+      "status": "active",
+      "teacher_reference_number": "1234567",
+      "teacher_reference_number_validated": true,
+      "eligible_for_funding": true,
+      "pupil_premium_uplift": true,
+      "sparsity_uplift": true,
+      "training_status": "withdrawn",
+      "schedule_identifier": "ecf-standard-january",
+      "updated_at": "2021-05-31T02:22:32.000Z"
+    }
+  }
+}
+```
+
+
+---
+
+
+## PUT
+    
+    
+      /api/v1/participants/{id}/change-schedule
+
+
+ _Notify that an ECF participant is changing training schedule_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| id | path | string | true | The ID of the participant<br/> | 28c461ee-ffc0-4e56-96bd-788579a0ed75 | 
+
+
+### Request body
+
+
+This consumes a [ECFParticipantChangeScheduleRequest](#schema-ecfparticipantchangeschedulerequest) schema.
+
+### Request example
+
+
+```
+{
+  "data": {
+    "type": "participant-change-schedule",
+    "attributes": {
+      "schedule_identifier": "ecf-standard-january",
+      "course_identifier": "ecf-mentor",
+      "cohort": "2021"
+    }
+  }
+}
+```
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | The ECF participant changing schedule<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - The ECF participant changing schedule
+This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+
+```
+{
+  "data": {
+    "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+    "type": "participant",
+    "attributes": {
+      "email": "jane.smith@some-school.example.com",
+      "full_name": "Jane Smith",
+      "mentor_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+      "school_urn": "106286",
+      "participant_type": "ect",
+      "cohort": "2021",
+      "status": "active",
+      "teacher_reference_number": "1234567",
+      "teacher_reference_number_validated": true,
+      "eligible_for_funding": true,
+      "pupil_premium_uplift": true,
+      "sparsity_uplift": true,
+      "training_status": "active",
+      "training_record_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+      "schedule_identifier": "ecf-standard-january",
+      "updated_at": "2021-05-31T02:22:32.000Z"
+    }
+  }
+}
+```
+
+
+---
+
+
+## PUT
+    
+    
+      /api/v1/participants/ecf/{id}/change-schedule
+
+
+ _Notify that an ECF participant is changing training schedule_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| id | path | string | true | The ID of the participant<br/> | 28c461ee-ffc0-4e56-96bd-788579a0ed75 | 
+
+
+### Request body
+
+
+This consumes a [ECFParticipantChangeScheduleRequest](#schema-ecfparticipantchangeschedulerequest) schema.
+
+### Request example
+
+
+```
+{
+  "data": {
+    "type": "participant-change-schedule",
+    "attributes": {
+      "schedule_identifier": "ecf-standard-january",
+      "course_identifier": "ecf-mentor",
+      "cohort": "2021"
+    }
+  }
+}
+```
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | The ECF participant changing schedule<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - The ECF participant changing schedule
+This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+
+```
+{
+  "data": {
+    "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+    "type": "participant",
+    "attributes": {
+      "email": "jane.smith@some-school.example.com",
+      "full_name": "Jane Smith",
+      "mentor_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+      "school_urn": "106286",
+      "participant_type": "ect",
+      "cohort": "2021",
+      "status": "active",
+      "teacher_reference_number": "1234567",
+      "teacher_reference_number_validated": true,
+      "eligible_for_funding": true,
+      "pupil_premium_uplift": true,
+      "sparsity_uplift": true,
+      "training_status": "active",
+      "training_record_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+      "schedule_identifier": "ecf-standard-january",
+      "updated_at": "2021-05-31T02:22:32.000Z"
+    }
+  }
+}
+```
+
+
+---
+
+
+## Schemas
+
+
+### BadOrMissingParametersResponse
+
+
+Request was missing data or contained invalid data
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| bad\_or\_missing\_parameters | array | true | An error message for each bad or missing attribute describing the problems<br/> | 
+
+
+### BadRequestResponse
+
+
+Bad Request
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| bad\_request | string | false | An error message for bad request<br/> | 
+
+
+#### Example
+
+
+```
+{
+  "errors": [
+    {
+      "title": "Bad request",
+      "detail": "correct json data structure required. See API docs for reference"
+    }
+  ]
+}
+```
+
+
+### ECFParticipant
+
+
+The details of a participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| id | string | true | The unique identifier of the participant record<br/> | 
+| type | string | true | The data type<br/> | 
+| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantAttributes](#schema-ecfparticipantattributes) schema. | 
+
+
+### ECFParticipantAttributes
+
+
+The data attributes associated with an ECF participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| email | string | true | The email address registered for this ECF participant<br/> | 
+| full\_name | string | true | The full name of this ECF participant<br/> | 
+| mentor\_id | string | false | The unique identifier of this ECF participants mentor<br/> | 
+| school\_urn | string | true | The Unique Reference Number (URN) of the school that submitted this ECF participant<br/> | 
+| participant\_type | string | true | The type of ECF participant this record refers to<br/>Possible values:<br/><br/> - ect<br/> - mentor<br/><br/> | 
+| cohort | string | true | Indicates which call-off contract funds this participant’s training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year.<br/> | 
+| status | string | true | The status of this ECF participant record<br/>Possible values:<br/><br/> - active<br/> - withdrawn<br/><br/> | 
+| teacher\_reference\_number | string | false | The Teacher Reference Number (TRN) for this ECF participant<br/> | 
+| teacher\_reference\_number\_validated | boolean | false | Indicates whether the Teacher Reference Number (TRN) has been validated<br/> | 
+| eligible\_for\_funding | boolean | false | Indicates whether this participant is eligible to receive DfE funded induction<br/> | 
+| pupil\_premium\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to pupil premium<br/> | 
+| sparsity\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to sparsity<br/> | 
+| training\_status | string | true | The training status of the ECF participant<br/>Possible values:<br/><br/> - active<br/> - deferred<br/> - withdrawn<br/><br/> | 
+| training\_record\_id | string | true | The unique identifier of the participant training record<br/> | 
+| schedule\_identifier | string | true | The schedule of the ECF participant<br/>Possible values:<br/><br/> - ecf-standard-september<br/> - ecf-standard-january<br/> - ecf-standard-april<br/> - ecf-reduced-september<br/> - ecf-reduced-january<br/> - ecf-reduced-april<br/> - ecf-extended-september<br/> - ecf-extended-january<br/> - ecf-extended-april<br/> - ecf-replacement-september<br/> - ecf-replacement-january<br/> - ecf-replacement-april<br/><br/> | 
+| updated\_at | string | true | The date the ECF participant was last updated<br/> | 
+
+
+### ECFParticipantChangeSchedule
+
+
+An ECF participant change schedule action
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| type | string | true | The data type<br/>Possible values:<br/><br/> - participant-change-schedule<br/><br/> | 
+| attributes | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeScheduleAttributes](#schema-ecfparticipantchangescheduleattributes) schema. | 
+
+
+#### Example
+
+
+```
+{
+  "type": "participant-change-schedule",
+  "attributes": {
+    "schedule_identifier": "ecf-standard-january",
+    "course_identifier": "ecf-mentor"
+  }
+}
+```
+
+
+### ECFParticipantChangeScheduleAttributes
+
+
+An ECF participant change schedule action
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| schedule\_identifier | string | true | The new schedule of the participant<br/>Possible values:<br/><br/> - ecf-standard-september<br/> - ecf-standard-january<br/> - ecf-standard-april<br/> - ecf-reduced-september<br/> - ecf-reduced-january<br/> - ecf-reduced-april<br/> - ecf-extended-september<br/> - ecf-extended-january<br/> - ecf-extended-april<br/> - ecf-replacement-september<br/> - ecf-replacement-january<br/> - ecf-replacement-april<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| cohort | string | false | Providers may not change the current value for ECF participants. Indicates which call-off contract funds this participant’s training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year.<br/> | 
+
+
+#### Example
+
+
+```
+{
+  "schedule_identifier": "ecf-standard-january",
+  "course_identifier": "ecf-mentor",
+  "cohort": "2021"
+}
+```
+
+
+### ECFParticipantChangeScheduleRequest
+
+
+The change schedule request for a participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeSchedule](#schema-ecfparticipantchangeschedule) schema. | 
+
+
+#### Example
+
+
+```
+{
+  "data": {
+    "type": "participant-change-schedule",
+    "attributes": {
+      "schedule_identifier": "ecf-standard-january",
+      "course_identifier": "ecf-mentor",
+      "cohort": "2021"
+    }
+  }
+}
+```
+
+
+### ECFParticipantCsvRow
+
+
+The details of an ECF participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| id | string | true | The unique identifier of the ECF participant record<br/> | 
+| type | string | true | The data type<br/>Possible values:<br/><br/> - participant<br/><br/> | 
+| email | string | true | The email registered for this ECF participant<br/> | 
+| full\_name | string | true | The full name of the ECF participant<br/> | 
+| mentor\_id | string | false | The unique identifier of the ECF participants mentor<br/> | 
+| school\_urn | string | true | The Unique Reference Number (URN) of the school the submitted this ECF participant<br/> | 
+| participant\_type | string | true | The type of ECF Participant this record refers to either ECT or Mentor<br/>Possible values:<br/><br/> - ect<br/> - mentor<br/><br/> | 
+| cohort | string | true | Indicates which call-off contract funds this participant’s training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year.<br/> | 
+| status | string | true | The status of the ECF Participant record<br/>Possible values:<br/><br/> - active<br/> - withdrawn<br/><br/> | 
+| teacher\_reference\_number | string | false | The Teacher Reference Number (TRN) for this ECF participant<br/> | 
+| teacher\_reference\_number\_validated | boolean | false | Indicates whether the Teacher Reference Number (TRN) has been validated<br/> | 
+| eligible\_for\_funding | boolean | false | Indicates whether this participant is eligible to receive DfE funded induction<br/> | 
+| pupil\_premium\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to pupil premium<br/> | 
+| sparsity\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to sparsity<br/> | 
+| training\_status | string | true | The training status of the ECF Participant<br/>Possible values:<br/><br/> - active<br/> - deferred<br/> - withdrawn<br/><br/> | 
+| training\_record\_id | string | true | The unique identifier of the participant training record<br/> | 
+| schedule\_identifier | string | true | The schedule of the ECF participant<br/>Possible values:<br/><br/> - ecf-standard-september<br/> - ecf-standard-january<br/> - ecf-standard-april<br/> - ecf-reduced-september<br/> - ecf-reduced-january<br/> - ecf-reduced-april<br/> - ecf-extended-september<br/> - ecf-extended-january<br/> - ecf-extended-april<br/> - ecf-replacement-september<br/> - ecf-replacement-january<br/> - ecf-replacement-april<br/><br/> | 
+| updated\_at | string | true | The date the ECF participant was last updated<br/> | 
+
+
+### ECFParticipantDeclarationPost2024ECTCompletedAttributesRequest
+
+
+An ECF completed participant declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique ID of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - completed<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/><br/> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - 75-percent-engagement-met<br/> - 75-percent-engagement-met-reduced-induction<br/> - one-term-induction<br/><br/> | 
+
+
+### ECFParticipantDeclarationPost2024ECTExtendedAttributesRequest
+
+
+An ECF extended participant declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique ID of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - extended-1<br/> - extended-2<br/> - extended-3<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/><br/> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - materials-engaged-with-offline<br/> - other<br/><br/> | 
+
+
+### ECFParticipantDeclarationPost2024ECTRetainedAttributesRequest
+
+
+An ECF participant retained declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique ID of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - retained-1<br/> - retained-2<br/> - retained-3<br/> - retained-4<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/><br/> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period. For retained-2 declarations, providers will need to confirm if the engagement threshold has been reached and only accept either the ‘75-percent-engagement-met’ or ‘75-percent-engagement-met-reduced-induction’ values.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - materials-engaged-with-offline<br/> - other<br/> - 75-percent-engagement-met<br/> - 75-percent-engagement-met-reduced-induction<br/><br/> | 
+
+
+### ECFParticipantDeclarationPost2024ECTStartedAttributesRequest
+
+
+An ECF started participant declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique ID of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - started<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/><br/> | 
+| evidence\_held | string | false | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - materials-engaged-with-offline<br/> - other<br/><br/> | 
+
+
+### ECFParticipantDeclarationPost2024MentorCompletedAttributesRequest
+
+
+An ECF completed participant declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique ID of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - completed<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-mentor<br/><br/> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - 75-percent-engagement-met<br/> - 75-percent-engagement-met-reduced-induction<br/><br/> | 
+
+
+### ECFParticipantDeclarationPost2024MentorStartedAttributesRequest
+
+
+An ECF started participant declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique ID of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - started<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-mentor<br/><br/> | 
+| evidence\_held | string | false | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - materials-engaged-with-offline<br/> - other<br/><br/> | 
+
+
+### ECFParticipantDeclarationPre2025CompletedAttributesRequest
+
+
+An ECF completed participant declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique ID of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - completed<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - other<br/><br/> | 
+
+
+### ECFParticipantDeclarationPre2025ExtendedAttributesRequest
+
+
+An ECF extended participant declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique ID of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - extended-1<br/> - extended-2<br/> - extended-3<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - other<br/><br/> | 
+
+
+### ECFParticipantDeclarationPre2025RetainedAttributesRequest
+
+
+An ECF participant retained declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique ID of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - retained-1<br/> - retained-2<br/> - retained-3<br/> - retained-4<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - other<br/><br/> | 
+
+
+### ECFParticipantDeclarationPre2025StartedAttributesRequest
+
+
+An ECF started participant declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique ID of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - started<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+
+
+### ECFParticipantDefer
+
+
+The details of a participant deferral request
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| type | string | true | The data type<br/>Possible values:<br/><br/> - participant-defer<br/><br/> | 
+| attributes | object | true | An ECF participant deferral action<br/>It conforms to [ECFParticipantDeferAttributes](#schema-ecfparticipantdeferattributes) schema. | 
+
+
+### ECFParticipantDeferAttributes
+
+
+An ECF participant deferral action
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| reason | string | true | The reason for the deferral<br/>Possible values:<br/><br/> - bereavement<br/> - long-term-sickness<br/> - parental-leave<br/> - career-break<br/> - other<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+
+
+#### Example
+
+
+```
+{
+  "reason": "career-break",
+  "course_identifier": "ecf-mentor"
+}
+```
+
+
+### ECFParticipantDeferAttributesResponse
+
+
+The data attributes associated with an ECF participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| email | string | true | The email address registered for this ECF participant<br/> | 
+| full\_name | string | true | The full name of this ECF participant<br/> | 
+| mentor\_id | string | false | The unique identifier of this ECF participants mentor<br/> | 
+| school\_urn | string | true | The Unique Reference Number (URN) of the school that submitted this ECF participant<br/> | 
+| participant\_type | string | true | The type of ECF participant this record refers to<br/>Possible values:<br/><br/> - ect<br/> - mentor<br/><br/> | 
+| cohort | string | true | Indicates which call-off contract funds this participant’s training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year.<br/> | 
+| status | string | true | The status of this ECF participant record<br/>Possible values:<br/><br/> - active<br/> - withdrawn<br/><br/> | 
+| teacher\_reference\_number | string | false | The Teacher Reference Number (TRN) for this ECF participant<br/> | 
+| teacher\_reference\_number\_validated | boolean | false | Indicates whether the Teacher Reference Number (TRN) has been validated<br/> | 
+| eligible\_for\_funding | boolean | false | Indicates whether this participant is eligible to receive DfE funded induction<br/> | 
+| pupil\_premium\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to pupil premium<br/> | 
+| sparsity\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to sparsity<br/> | 
+| training\_status | string | true | The training status of the ECF participant<br/>Possible values:<br/><br/> - active<br/> - deferred<br/> - withdrawn<br/><br/> | 
+| schedule\_identifier | string | true | The schedule of the ECF participant<br/>Possible values:<br/><br/> - ecf-standard-september<br/> - ecf-standard-january<br/> - ecf-standard-april<br/> - ecf-reduced-september<br/> - ecf-reduced-january<br/> - ecf-reduced-april<br/> - ecf-extended-september<br/> - ecf-extended-january<br/> - ecf-extended-april<br/> - ecf-replacement-september<br/> - ecf-replacement-january<br/> - ecf-replacement-april<br/><br/> | 
+| updated\_at | string | true | The date the ECF participant was last updated<br/> | 
+
+
+### ECFParticipantDeferRequest
+
+
+The deferral request for a participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | object | true | The details of a participant deferral request<br/>It conforms to [ECFParticipantDefer](#schema-ecfparticipantdefer) schema. | 
+
+
+#### Example
+
+
+```
+{
+  "data": {
+    "type": "participant-defer",
+    "attributes": {
+      "reason": "career-break",
+      "course_identifier": "ecf-mentor"
+    }
+  }
+}
+```
+
+
+### ECFParticipantDeferResponse
+
+
+An ECF Participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantDeferResponseData](#schema-ecfparticipantdeferresponsedata) schema. | 
+
+
+### ECFParticipantDeferResponseData
+
+
+The details of a participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| id | string | true | The unique identifier of the participant record<br/> | 
+| type | string | true | The data type<br/> | 
+| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantDeferAttributesResponse](#schema-ecfparticipantdeferattributesresponse) schema. | 
+
+
+### ECFParticipantResponse
+
+
+An ECF Participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | object | true | The details of a participant<br/>It conforms to [ECFParticipant](#schema-ecfparticipant) schema. | 
+
+
+### ECFParticipantResume
+
+
+An ECF participant resume action
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| type | string | true | The data type<br/>Possible values:<br/><br/> - participant-resume<br/><br/> | 
+| attributes | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResumeAttributes](#schema-ecfparticipantresumeattributes) schema. | 
+
+
+### ECFParticipantResumeAttributes
+
+
+An ECF participant resume action
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+
+
+#### Example
+
+
+```
+{
+  "course_identifier": "ecf-mentor"
+}
+```
+
+
+### ECFParticipantResumeAttributesResponse
+
+
+The data attributes associated with an ECF participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| email | string | true | The email address registered for this ECF participant<br/> | 
+| full\_name | string | true | The full name of this ECF participant<br/> | 
+| mentor\_id | string | false | The unique identifier of this ECF participants mentor<br/> | 
+| school\_urn | string | true | The Unique Reference Number (URN) of the school that submitted this ECF participant<br/> | 
+| participant\_type | string | true | The type of ECF participant this record refers to<br/>Possible values:<br/><br/> - ect<br/> - mentor<br/><br/> | 
+| cohort | string | true | Indicates which call-off contract funds this participant’s training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year.<br/> | 
+| status | string | true | The status of this ECF participant record<br/>Possible values:<br/><br/> - active<br/> - withdrawn<br/><br/> | 
+| teacher\_reference\_number | string | false | The Teacher Reference Number (TRN) for this ECF participant<br/> | 
+| teacher\_reference\_number\_validated | boolean | false | Indicates whether the Teacher Reference Number (TRN) has been validated<br/> | 
+| eligible\_for\_funding | boolean | false | Indicates whether this participant is eligible to receive DfE funded induction<br/> | 
+| pupil\_premium\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to pupil premium<br/> | 
+| sparsity\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to sparsity<br/> | 
+| training\_status | string | true | The training status of the ECF participant<br/>Possible values:<br/><br/> - active<br/> - deferred<br/> - withdrawn<br/><br/> | 
+| schedule\_identifier | string | true | The schedule of the ECF participant<br/>Possible values:<br/><br/> - ecf-standard-september<br/> - ecf-standard-january<br/> - ecf-standard-april<br/> - ecf-reduced-september<br/> - ecf-reduced-january<br/> - ecf-reduced-april<br/> - ecf-extended-september<br/> - ecf-extended-january<br/> - ecf-extended-april<br/> - ecf-replacement-september<br/> - ecf-replacement-january<br/> - ecf-replacement-april<br/><br/> | 
+| updated\_at | string | true | The date the ECF participant was last updated<br/> | 
+
+
+### ECFParticipantResumeRequest
+
+
+The resume request for a participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResume](#schema-ecfparticipantresume) schema. | 
+
+
+#### Example
+
+
+```
+{
+  "data": {
+    "type": "participant-resume",
+    "attributes": {
+      "course_identifier": "ecf-mentor"
+    }
+  }
+}
+```
+
+
+### ECFParticipantResumeResponse
+
+
+An ECF Participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantResumeResponseData](#schema-ecfparticipantresumeresponsedata) schema. | 
+
+
+### ECFParticipantResumeResponseData
+
+
+The details of a participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| id | string | true | The unique identifier of the participant record<br/> | 
+| type | string | true | The data type<br/> | 
+| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantResumeAttributesResponse](#schema-ecfparticipantresumeattributesresponse) schema. | 
+
+
+### ECFParticipantRetainedDeclaration
+
+
+An ECF participant retained declaration request body
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| type | object | false | The request data<br/>Possible values:<br/><br/> - participant-declaration<br/><br/> | 
+| attributes | object | true | An ECF participant retained declaration<br/>It conforms to [ECFParticipantRetainedDeclarationAttributes](#schema-ecfparticipantretaineddeclarationattributes) schema. | 
+
+
+### ECFParticipantRetainedDeclarationAttributes
+
+
+An ECF participant retained declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique id of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - retained-1<br/> - retained-2<br/> - retained-3<br/> - retained-4<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - other<br/><br/> | 
+
+
+#### Example
+
+
+```
+{
+  "participant_id": "db3a7848-7308-4879-942a-c4a70ced400a",
+  "declaration_type": "retained-1",
+  "declaration_date": "2021-05-31T02:21:32.000Z",
+  "course_identifier": "ecf-induction",
+  "evidence_held": "training-event-attended"
+}
+```
+
+
+### ECFParticipantStartedDeclaration
+
+
+A participant started declaration request body
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| type | object | false | The request data<br/>Possible values:<br/><br/> - participant-declaration<br/><br/> | 
+| attributes | object | true | An ECF started and completed participant declaration<br/>It conforms to [ECFParticipantStartedDeclarationAttributes](#schema-ecfparticipantstarteddeclarationattributes) schema. | 
+
+
+### ECFParticipantStartedDeclarationAttributes
+
+
+An ECF started and completed participant declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique id of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - started<br/> - completed<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+
+
+#### Example
+
+
+```
+{
+  "participant_id": "db3a7848-7308-4879-942a-c4a70ced400a",
+  "declaration_type": "started",
+  "declaration_date": "2021-05-31T02:21:32.000Z",
+  "course_identifier": "ecf-mentor"
+}
+```
+
+
+### ECFParticipantWithdraw
+
+
+An ECF participant withdrawal action
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| type | string | false | The data type<br/>Possible values:<br/><br/> - participant-withdraw<br/><br/> | 
+| attributes | object | false | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdrawAttributes](#schema-ecfparticipantwithdrawattributes) schema. | 
+
+
+### ECFParticipantWithdrawAttributes
+
+
+An ECF participant withdrawal action
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| reason | string | true | The reason for the withdrawal<br/>Possible values:<br/><br/> - left-teaching-profession<br/> - moved-school<br/> - mentor-no-longer-being-mentor<br/> - switched-to-school-led<br/> - other<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+
+
+#### Example
+
+
+```
+{
+  "reason": "left-teaching-profession",
+  "course_identifier": "ecf-mentor"
+}
+```
+
+
+### ECFParticipantWithdrawAttributesResponse
+
+
+The data attributes associated with an ECF participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| email | string | true | The email address registered for this ECF participant<br/> | 
+| full\_name | string | true | The full name of this ECF participant<br/> | 
+| mentor\_id | string | false | The unique identifier of this ECF participants mentor<br/> | 
+| school\_urn | string | true | The Unique Reference Number (URN) of the school that submitted this ECF participant<br/> | 
+| participant\_type | string | true | The type of ECF participant this record refers to<br/>Possible values:<br/><br/> - ect<br/> - mentor<br/><br/> | 
+| cohort | string | true | Indicates which call-off contract funds this participant’s training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year.<br/> | 
+| status | string | true | The status of this ECF participant record<br/>Possible values:<br/><br/> - active<br/> - withdrawn<br/><br/> | 
+| teacher\_reference\_number | string | false | The Teacher Reference Number (TRN) for this ECF participant<br/> | 
+| teacher\_reference\_number\_validated | boolean | false | Indicates whether the Teacher Reference Number (TRN) has been validated<br/> | 
+| eligible\_for\_funding | boolean | false | Indicates whether this participant is eligible to receive DfE funded induction<br/> | 
+| pupil\_premium\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to pupil premium<br/> | 
+| sparsity\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to sparsity<br/> | 
+| training\_status | string | true | The training status of the ECF participant<br/>Possible values:<br/><br/> - active<br/> - deferred<br/> - withdrawn<br/><br/> | 
+| schedule\_identifier | string | true | The schedule of the ECF participant<br/>Possible values:<br/><br/> - ecf-standard-september<br/> - ecf-standard-january<br/> - ecf-standard-april<br/> - ecf-reduced-september<br/> - ecf-reduced-january<br/> - ecf-reduced-april<br/> - ecf-extended-september<br/> - ecf-extended-january<br/> - ecf-extended-april<br/> - ecf-replacement-september<br/> - ecf-replacement-january<br/> - ecf-replacement-april<br/><br/> | 
+| updated\_at | string | true | The date the ECF participant was last updated<br/> | 
+
+
+### ECFParticipantWithdrawDataResponse
+
+
+The details of a participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| id | string | true | The unique identifier of the participant record<br/> | 
+| type | string | true | The data type<br/> | 
+| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantWithdrawAttributesResponse](#schema-ecfparticipantwithdrawattributesresponse) schema. | 
+
+
+### ECFParticipantWithdrawRequest
+
+
+The withdrawal request for a participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | object | true | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdraw](#schema-ecfparticipantwithdraw) schema. | 
+
+
+#### Example
+
+
+```
+{
+  "data": {
+    "type": "participant-withdraw",
+    "attributes": {
+      "reason": "left-teaching-profession",
+      "course_identifier": "ecf-mentor"
+    }
+  }
+}
+```
+
+
+### ECFParticipantWithdrawResponse
+
+
+An ECF Participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantWithdrawDataResponse](#schema-ecfparticipantwithdrawdataresponse) schema. | 
+
+
+### Error
+
+
+An single error element
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| title | string | false | A title of the error<br/> | 
+| detail | string | false | Additional details of the error<br/> | 
+
+
+### ErrorResponse
+
+
+A list of errors
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| error | array | false | It conforms to [Error](#schema-error) schema. | 
+
+
+### ListFilter
+
+
+Filter a list of records to return more specific results
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| updated\_since | string | false | Return only records that have been updated since this date and time (ISO 8601 date format)<br/> | 
+| created\_since | string | false | Return only records that have been created since this date and time (ISO 8601 date format)<br/> | 
+
+
+### ListFilterDeclarations
+
+
+Filter a list of declarations records to return more specific results
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| updated\_since | string | false | Return only records that have been updated since this date and time (ISO 8601 date format)<br/> | 
+| participant\_id | string | false | The unique id of the participant<br/> | 
+
+
+### MultipleECFParticipantsCsvResponse
+
+
+A list of ECF participants in the Comma Separated Value (CSV) format
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | array | true | It conforms to [ECFParticipantCsvRow](#schema-ecfparticipantcsvrow) schema. | 
+
+
+### MultipleECFParticipantsResponse
+
+
+A list of ECF participants
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | array | true | It conforms to [ECFParticipant](#schema-ecfparticipant) schema. | 
+
+
+### MultipleParticipantDeclarationsCsvResponse
+
+
+A list of participant declarations in the Comma Separated Value (CSV) format
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | array | true | It conforms to [ParticipantDeclarationCsvRow](#schema-participantdeclarationcsvrow) schema. | 
+
+
+### MultipleParticipantDeclarationsResponse
+
+
+A list of participant declarations
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | array | true | It conforms to [ParticipantDeclarationResponse](#schema-participantdeclarationresponse) schema. | 
+
+
+### NotFoundResponse
+
+
+The requested resource was not found
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| error | string | false |  | 
+
+
+### Pagination
+
+
+This schema used to paginate through a collection.
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| page | integer | false | The page number to paginate to in the collection. If no value is specified it defaults to the first page.<br/> | 
+| per\_page | integer | false | The number items to display on a page. Defaults to 100. Maximum is 3000, if the value is greater that the maximum allowed it will fallback to 3000.<br/> | 
+
+
+### ParticipantDeclaration
+
+
+A participant declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | object | true | It conforms to [] schema. | 
+
+
+#### Example
+
+
+```
+{
+  "data": {
+    "type": "participant-declaration",
+    "attributes": {
+      "participant_id": "db3a7848-7308-4879-942a-c4a70ced400a",
+      "declaration_type": "started",
+      "declaration_date": "2021-05-31T02:21:32.000Z",
+      "course_identifier": "ecf-mentor"
+    }
+  }
+}
+```
+
+
+### ParticipantDeclarationAttributes
+
+
+The data attributes associated with a participant declaration response
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique id of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - started<br/> - retained-1<br/> - retained-2<br/> - retained-3<br/> - retained-4<br/> - completed<br/> - extended-1<br/> - extended-2<br/> - extended-3<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| eligible\_for\_payment | boolean | true | [Deprecated - use state instead] Indicates whether this declaration would be eligible for funding from the DfE<br/> | 
+| voided | boolean | true | [Deprecated - use state instead] Indicates whether this declaration has been voided<br/> | 
+| state | string | true | Indicates the state of this payment declaration<br/>Possible values:<br/><br/> - submitted<br/> - eligible<br/> - payable<br/> - paid<br/> - voided<br/> - ineligible<br/> - awaiting-clawback<br/> - clawed-back<br/><br/> | 
+| updated\_at | string | true | The date the declaration was last updated<br/> | 
+| has\_passed | boolean | false | Whether the participant has failed or passed<br/> | 
+
+
+### ParticipantDeclarationCsvRow
+
+
+The details of a participant declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| id | string | true | The unique identifier of the participant declaration record<br/> | 
+| participant\_id | string | true | The unique identifier of the participant record the declaration refers to<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - started<br/> - retained-1<br/> - retained-2<br/> - retained-3<br/> - retained-4<br/> - completed<br/> - extended-1<br/> - extended-2<br/> - extended-3<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| eligible\_for\_payment | boolean | true | [Deprecated - use state instead] Indicates whether this declaration would be eligible for funding from the DfE<br/> | 
+| voided | boolean | true | [Deprecated - use state instead] Indicates whether this declaration has been voided<br/> | 
+| state | string | false | Indicates the state of this payment declaration<br/> | 
+| updated\_at | string | true | The date the declaration was last updated<br/> | 
+
+
+### ParticipantDeclarationPost2024ECTDataRequest
+
+
+A participant declaration data request for ECT participants from cohort 2025 onwards
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| type | string | false | Possible values:<br/><br/> - participant-declaration<br/><br/> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><br/> -  [ECFParticipantDeclarationPost2024ECTStartedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectstartedattributesrequest) <br/> -  [ECFParticipantDeclarationPost2024ECTRetainedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectretainedattributesrequest) <br/> -  [ECFParticipantDeclarationPost2024ECTCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectcompletedattributesrequest) <br/> -  [ECFParticipantDeclarationPost2024ECTExtendedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectextendedattributesrequest) <br/><br/> | 
+
+
+### ParticipantDeclarationPost2024MentorDataRequest
+
+
+A participant declaration data request for mentor participants from cohort 2025 onwards
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| type | string | false | Possible values:<br/><br/> - participant-declaration<br/><br/> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><br/> -  [ECFParticipantDeclarationPost2024MentorStartedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorstartedattributesrequest) <br/> -  [ECFParticipantDeclarationPost2024MentorCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorcompletedattributesrequest) <br/><br/> | 
+
+
+### ParticipantDeclarationPre2025DataRequest
+
+
+A participant declaration data request for participants in cohort 2024 and previous years
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| type | string | false | Possible values:<br/><br/> - participant-declaration<br/><br/> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><br/> -  [ECFParticipantDeclarationPre2025StartedAttributesRequest](#schema-ecfparticipantdeclarationpre2025startedattributesrequest) <br/> -  [ECFParticipantDeclarationPre2025RetainedAttributesRequest](#schema-ecfparticipantdeclarationpre2025retainedattributesrequest) <br/> -  [ECFParticipantDeclarationPre2025CompletedAttributesRequest](#schema-ecfparticipantdeclarationpre2025completedattributesrequest) <br/> -  [ECFParticipantDeclarationPre2025ExtendedAttributesRequest](#schema-ecfparticipantdeclarationpre2025extendedattributesrequest) <br/><br/> | 
+
+
+### ParticipantDeclarationRequest
+
+
+An participant declaration request
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | object | true | This conforms to any of the following schemas:<br/><br/> -  [ParticipantDeclarationPre2025DataRequest](#schema-participantdeclarationpre2025datarequest) <br/> -  [ParticipantDeclarationPost2024ECTDataRequest](#schema-participantdeclarationpost2024ectdatarequest) <br/> -  [ParticipantDeclarationPost2024MentorDataRequest](#schema-participantdeclarationpost2024mentordatarequest) <br/><br/> | 
+
+
+### ParticipantDeclarationResponse
+
+
+A participant declaration response
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| id | string | true | The unique identifier of the participant declaration record<br/> | 
+| type | string | true | The data type<br/> | 
+| attributes | object | true | The data attributes associated with a participant declaration response<br/>It conforms to [ParticipantDeclarationAttributes](#schema-participantdeclarationattributes) schema. | 
+
+
+### ParticipantListFilter
+
+
+Filter a list of records to return more specific results
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| updated\_since | string | false | Return only records that have been updated since this date and time (ISO 8601 date format)<br/> | 
+| cohort | string | false | Return only records for the given cohort<br/> | 
+
+
+### SingleParticipantDeclarationResponse
+
+
+A confirmation that the participant declaration has been recorded successfully
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | object | true | A participant declaration response<br/>It conforms to [ParticipantDeclarationResponse](#schema-participantdeclarationresponse) schema. | 
+
+
+### UnauthorisedResponse
+
+
+Authorization information is missing or invalid
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| error | string | false |  | 
+

--- a/documentation/ecf1_guidance/reference-v1.md
+++ b/documentation/ecf1_guidance/reference-v1.md
@@ -1245,17 +1245,17 @@ The data attributes associated with an ECF participant
 | full\_name | string | true | The full name of this ECF participant<br/> | 
 | mentor\_id | string | false | The unique identifier of this ECF participants mentor<br/> | 
 | school\_urn | string | true | The Unique Reference Number (URN) of the school that submitted this ECF participant<br/> | 
-| participant\_type | string | true | The type of ECF participant this record refers to<br/>Possible values:<br/><br/> * ect<br/> * mentor<br/><br/> | 
+| participant\_type | string | true | The type of ECF participant this record refers to<br/>Possible values:<br/><ul><li>ect</li><li>mentor</li></ul> | 
 | cohort | string | true | Indicates which call-off contract funds this participant’s training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year.<br/> | 
-| status | string | true | The status of this ECF participant record<br/>Possible values:<br/><br/> * active<br/> * withdrawn<br/><br/> | 
+| status | string | true | The status of this ECF participant record<br/>Possible values:<br/><ul><li>active</li><li>withdrawn</li></ul> | 
 | teacher\_reference\_number | string | false | The Teacher Reference Number (TRN) for this ECF participant<br/> | 
 | teacher\_reference\_number\_validated | boolean | false | Indicates whether the Teacher Reference Number (TRN) has been validated<br/> | 
 | eligible\_for\_funding | boolean | false | Indicates whether this participant is eligible to receive DfE funded induction<br/> | 
 | pupil\_premium\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to pupil premium<br/> | 
 | sparsity\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to sparsity<br/> | 
-| training\_status | string | true | The training status of the ECF participant<br/>Possible values:<br/><br/> * active<br/> * deferred<br/> * withdrawn<br/><br/> | 
+| training\_status | string | true | The training status of the ECF participant<br/>Possible values:<br/><ul><li>active</li><li>deferred</li><li>withdrawn</li></ul> | 
 | training\_record\_id | string | true | The unique identifier of the participant training record<br/> | 
-| schedule\_identifier | string | true | The schedule of the ECF participant<br/>Possible values:<br/><br/> - ecf-standard-september<br/> * ecf-standard-january<br/> * ecf-standard-april<br/> * ecf-reduced-september<br/> * ecf-reduced-january<br/> * ecf-reduced-april<br/> * ecf-extended-september<br/> * ecf-extended-january<br/> * ecf-extended-april<br/> * ecf-replacement-september<br/> * ecf-replacement-january<br/> * ecf-replacement-april<br/><br/> | 
+| schedule\_identifier | string | true | The schedule of the ECF participant<br/>Possible values:<br/><ul><li>ecf-standard-september</li><li>ecf-standard-january</li><li>ecf-standard-april</li><li>ecf-reduced-september</li><li>ecf-reduced-january</li><li>ecf-reduced-april</li><li>ecf-extended-september</li><li>ecf-extended-january</li><li>ecf-extended-april</li><li>ecf-replacement-september</li><li>ecf-replacement-january</li><li>ecf-replacement-april</li></ul> | 
 | updated\_at | string | true | The date the ECF participant was last updated<br/> | 
 
 
@@ -1266,7 +1266,7 @@ An ECF participant change schedule action
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| type | string | true | The data type<br/>Possible values:<br/><br/> - participant-change-schedule<br/><br/> | 
+| type | string | true | The data type<br/>Possible values:<br/><ul><li>participant-change-schedule</li></ul> | 
 | attributes | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeScheduleAttributes](#schema-ecfparticipantchangescheduleattributes) schema. | 
 
 
@@ -1291,8 +1291,8 @@ An ECF participant change schedule action
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| schedule\_identifier | string | true | The new schedule of the participant<br/>Possible values:<br/><br/> - ecf-standard-september<br/> - ecf-standard-january<br/> - ecf-standard-april<br/> - ecf-reduced-september<br/> - ecf-reduced-january<br/> - ecf-reduced-april<br/> - ecf-extended-september<br/> - ecf-extended-january<br/> - ecf-extended-april<br/> - ecf-replacement-september<br/> - ecf-replacement-january<br/> - ecf-replacement-april<br/><br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| schedule\_identifier | string | true | The new schedule of the participant<br/>Possible values:<br/><ul><li>ecf-standard-september</li><li>ecf-standard-january</li><li>ecf-standard-april</li><li>ecf-reduced-september</li><li>ecf-reduced-january</li><li>ecf-reduced-april</li><li>ecf-extended-september</li><li>ecf-extended-january</li><li>ecf-extended-april</li><li>ecf-replacement-september</li><li>ecf-replacement-january</li><li>ecf-replacement-april</li></ul> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li><li>ecf-mentor</li></ul> | 
 | cohort | string | false | Providers may not change the current value for ECF participants. Indicates which call-off contract funds this participant’s training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year.<br/> | 
 
 
@@ -1343,22 +1343,22 @@ The details of an ECF participant
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the ECF participant record<br/> | 
-| type | string | true | The data type<br/>Possible values:<br/><br/> - participant<br/><br/> | 
+| type | string | true | The data type<br/>Possible values:<br/><ul><li>participant</li></ul> | 
 | email | string | true | The email registered for this ECF participant<br/> | 
 | full\_name | string | true | The full name of the ECF participant<br/> | 
 | mentor\_id | string | false | The unique identifier of the ECF participants mentor<br/> | 
 | school\_urn | string | true | The Unique Reference Number (URN) of the school the submitted this ECF participant<br/> | 
-| participant\_type | string | true | The type of ECF Participant this record refers to either ECT or Mentor<br/>Possible values:<br/><br/> - ect<br/> - mentor<br/><br/> | 
+| participant\_type | string | true | The type of ECF Participant this record refers to either ECT or Mentor<br/>Possible values:<br/><ul><li>ect</li><li>mentor</li></ul> | 
 | cohort | string | true | Indicates which call-off contract funds this participant’s training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year.<br/> | 
-| status | string | true | The status of the ECF Participant record<br/>Possible values:<br/><br/> - active<br/> - withdrawn<br/><br/> | 
+| status | string | true | The status of the ECF Participant record<br/>Possible values:<br/><ul><li>active</li><li>withdrawn</li></ul> | 
 | teacher\_reference\_number | string | false | The Teacher Reference Number (TRN) for this ECF participant<br/> | 
 | teacher\_reference\_number\_validated | boolean | false | Indicates whether the Teacher Reference Number (TRN) has been validated<br/> | 
 | eligible\_for\_funding | boolean | false | Indicates whether this participant is eligible to receive DfE funded induction<br/> | 
 | pupil\_premium\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to pupil premium<br/> | 
 | sparsity\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to sparsity<br/> | 
-| training\_status | string | true | The training status of the ECF Participant<br/>Possible values:<br/><br/> - active<br/> - deferred<br/> - withdrawn<br/><br/> | 
+| training\_status | string | true | The training status of the ECF Participant<br/>Possible values:<br/><ul><li>active</li><li>deferred</li><li>withdrawn</li></ul> | 
 | training\_record\_id | string | true | The unique identifier of the participant training record<br/> | 
-| schedule\_identifier | string | true | The schedule of the ECF participant<br/>Possible values:<br/><br/> - ecf-standard-september<br/> - ecf-standard-january<br/> - ecf-standard-april<br/> - ecf-reduced-september<br/> - ecf-reduced-january<br/> - ecf-reduced-april<br/> - ecf-extended-september<br/> - ecf-extended-january<br/> - ecf-extended-april<br/> - ecf-replacement-september<br/> - ecf-replacement-january<br/> - ecf-replacement-april<br/><br/> | 
+| schedule\_identifier | string | true | The schedule of the ECF participant<br/>Possible values:<br/><ul><li>ecf-standard-september</li><li>ecf-standard-january</li><li>ecf-standard-april</li><li>ecf-reduced-september</li><li>ecf-reduced-january</li><li>ecf-reduced-april</li><li>ecf-extended-september</li><li>ecf-extended-january</li><li>ecf-extended-april</li><li>ecf-replacement-september</li><li>ecf-replacement-january</li><li>ecf-replacement-april</li></ul> | 
 | updated\_at | string | true | The date the ECF participant was last updated<br/> | 
 
 
@@ -1370,10 +1370,10 @@ An ECF completed participant declaration
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique ID of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - completed<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>completed</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/><br/> | 
-| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - 75-percent-engagement-met<br/> - 75-percent-engagement-met-reduced-induction<br/> - one-term-induction<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li></ul> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><ul><li>75-percent-engagement-met</li><li>75-percent-engagement-met-reduced-induction</li><li>one-term-induction</li></ul> | 
 
 
 ### ECFParticipantDeclarationPost2024ECTExtendedAttributesRequest
@@ -1384,10 +1384,10 @@ An ECF extended participant declaration
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique ID of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - extended-1<br/> - extended-2<br/> - extended-3<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>extended-1</li><li>extended-2</li><li>extended-3</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/><br/> | 
-| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - materials-engaged-with-offline<br/> - other<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li></ul> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><ul><li>training-event-attended</li><li>self-study-material-completed</li><li>materials-engaged-with-offline</li><li>other</li></ul> | 
 
 
 ### ECFParticipantDeclarationPost2024ECTRetainedAttributesRequest
@@ -1398,10 +1398,10 @@ An ECF participant retained declaration
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique ID of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - retained-1<br/> - retained-2<br/> - retained-3<br/> - retained-4<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>retained-1</li><li>retained-2</li><li>retained-3</li><li>retained-4</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/><br/> | 
-| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period. For retained-2 declarations, providers will need to confirm if the engagement threshold has been reached and only accept either the ‘75-percent-engagement-met’ or ‘75-percent-engagement-met-reduced-induction’ values.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - materials-engaged-with-offline<br/> - other<br/> - 75-percent-engagement-met<br/> - 75-percent-engagement-met-reduced-induction<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li></ul> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period. For retained-2 declarations, providers will need to confirm if the engagement threshold has been reached and only accept either the ‘75-percent-engagement-met’ or ‘75-percent-engagement-met-reduced-induction’ values.<br/>Possible values:<br/><ul><li>training-event-attended</li><li>self-study-material-completed</li><li>materials-engaged-with-offline</li><li>other</li><li>75-percent-engagement-met</li><li>75-percent-engagement-met-reduced-induction</li></ul> | 
 
 
 ### ECFParticipantDeclarationPost2024ECTStartedAttributesRequest
@@ -1412,10 +1412,10 @@ An ECF started participant declaration
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique ID of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - started<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>started</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/><br/> | 
-| evidence\_held | string | false | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - materials-engaged-with-offline<br/> - other<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li></ul> | 
+| evidence\_held | string | false | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><ul><li>training-event-attended</li><li>self-study-material-completed</li><li>materials-engaged-with-offline</li><li>other</li></ul> | 
 
 
 ### ECFParticipantDeclarationPost2024MentorCompletedAttributesRequest
@@ -1426,10 +1426,10 @@ An ECF completed participant declaration
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique ID of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - completed<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>completed</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-mentor<br/><br/> | 
-| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - 75-percent-engagement-met<br/> - 75-percent-engagement-met-reduced-induction<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-mentor</li></ul> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><ul><li>75-percent-engagement-met</li><li>75-percent-engagement-met-reduced-induction</li></ul> | 
 
 
 ### ECFParticipantDeclarationPost2024MentorStartedAttributesRequest
@@ -1440,10 +1440,10 @@ An ECF started participant declaration
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique ID of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - started<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>started</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-mentor<br/><br/> | 
-| evidence\_held | string | false | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - materials-engaged-with-offline<br/> - other<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-mentor</li></ul> | 
+| evidence\_held | string | false | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><ul><li>training-event-attended</li><li>self-study-material-completed</li><li>materials-engaged-with-offline</li><li>other</li></ul> | 
 
 
 ### ECFParticipantDeclarationPre2025CompletedAttributesRequest
@@ -1454,10 +1454,10 @@ An ECF completed participant declaration
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique ID of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - completed<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>completed</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
-| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - other<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li><li>ecf-mentor</li></ul> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><ul><li>training-event-attended</li><li>self-study-material-completed</li><li>other</li></ul> | 
 
 
 ### ECFParticipantDeclarationPre2025ExtendedAttributesRequest
@@ -1468,10 +1468,10 @@ An ECF extended participant declaration
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique ID of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - extended-1<br/> - extended-2<br/> - extended-3<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>extended-1</li><li>extended-2</li><li>extended-3</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
-| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - other<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li><li>ecf-mentor</li></ul> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><ul><li>training-event-attended</li><li>self-study-material-completed</li><li>other</li></ul> | 
 
 
 ### ECFParticipantDeclarationPre2025RetainedAttributesRequest
@@ -1482,10 +1482,10 @@ An ECF participant retained declaration
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique ID of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - retained-1<br/> - retained-2<br/> - retained-3<br/> - retained-4<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>retained-1</li><li>retained-2</li><li>retained-3</li><li>retained-4</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
-| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - other<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li><li>ecf-mentor</li></ul> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><ul><li>training-event-attended</li><li>self-study-material-completed</li><li>other</li></ul> | 
 
 
 ### ECFParticipantDeclarationPre2025StartedAttributesRequest
@@ -1496,9 +1496,9 @@ An ECF started participant declaration
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique ID of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - started<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>started</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li><li>ecf-mentor</li></ul> | 
 
 
 ### ECFParticipantDefer
@@ -1508,7 +1508,7 @@ The details of a participant deferral request
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| type | string | true | The data type<br/>Possible values:<br/><br/> - participant-defer<br/><br/> | 
+| type | string | true | The data type<br/>Possible values:<br/><ul><li>participant-defer</li></ul> | 
 | attributes | object | true | An ECF participant deferral action<br/>It conforms to [ECFParticipantDeferAttributes](#schema-ecfparticipantdeferattributes) schema. | 
 
 
@@ -1519,8 +1519,8 @@ An ECF participant deferral action
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| reason | string | true | The reason for the deferral<br/>Possible values:<br/><br/> - bereavement<br/> - long-term-sickness<br/> - parental-leave<br/> - career-break<br/> - other<br/><br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| reason | string | true | The reason for the deferral<br/>Possible values:<br/><ul><li>bereavement</li><li>long-term-sickness</li><li>parental-leave</li><li>career-break</li><li>other</li></ul> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li><li>ecf-mentor</li></ul> | 
 
 
 #### Example
@@ -1545,16 +1545,16 @@ The data attributes associated with an ECF participant
 | full\_name | string | true | The full name of this ECF participant<br/> | 
 | mentor\_id | string | false | The unique identifier of this ECF participants mentor<br/> | 
 | school\_urn | string | true | The Unique Reference Number (URN) of the school that submitted this ECF participant<br/> | 
-| participant\_type | string | true | The type of ECF participant this record refers to<br/>Possible values:<br/><br/> - ect<br/> - mentor<br/><br/> | 
+| participant\_type | string | true | The type of ECF participant this record refers to<br/>Possible values:<br/><ul><li>ect</li><li>mentor</li></ul> | 
 | cohort | string | true | Indicates which call-off contract funds this participant’s training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year.<br/> | 
-| status | string | true | The status of this ECF participant record<br/>Possible values:<br/><br/> - active<br/> - withdrawn<br/><br/> | 
+| status | string | true | The status of this ECF participant record<br/>Possible values:<br/><ul><li>active</li><li>withdrawn</li></ul> | 
 | teacher\_reference\_number | string | false | The Teacher Reference Number (TRN) for this ECF participant<br/> | 
 | teacher\_reference\_number\_validated | boolean | false | Indicates whether the Teacher Reference Number (TRN) has been validated<br/> | 
 | eligible\_for\_funding | boolean | false | Indicates whether this participant is eligible to receive DfE funded induction<br/> | 
 | pupil\_premium\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to pupil premium<br/> | 
 | sparsity\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to sparsity<br/> | 
-| training\_status | string | true | The training status of the ECF participant<br/>Possible values:<br/><br/> - active<br/> - deferred<br/> - withdrawn<br/><br/> | 
-| schedule\_identifier | string | true | The schedule of the ECF participant<br/>Possible values:<br/><br/> - ecf-standard-september<br/> - ecf-standard-january<br/> - ecf-standard-april<br/> - ecf-reduced-september<br/> - ecf-reduced-january<br/> - ecf-reduced-april<br/> - ecf-extended-september<br/> - ecf-extended-january<br/> - ecf-extended-april<br/> - ecf-replacement-september<br/> - ecf-replacement-january<br/> - ecf-replacement-april<br/><br/> | 
+| training\_status | string | true | The training status of the ECF participant<br/>Possible values:<br/><ul><li>active</li><li>deferred</li><li>withdrawn</li></ul> | 
+| schedule\_identifier | string | true | The schedule of the ECF participant<br/>Possible values:<br/><ul><li>ecf-standard-september</li><li>ecf-standard-january</li><li>ecf-standard-april</li><li>ecf-reduced-september</li><li>ecf-reduced-january</li><li>ecf-reduced-april</li><li>ecf-extended-september</li><li>ecf-extended-january</li><li>ecf-extended-april</li><li>ecf-replacement-september</li><li>ecf-replacement-january</li><li>ecf-replacement-april</li></ul> | 
 | updated\_at | string | true | The date the ECF participant was last updated<br/> | 
 
 
@@ -1623,7 +1623,7 @@ An ECF participant resume action
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| type | string | true | The data type<br/>Possible values:<br/><br/> - participant-resume<br/><br/> | 
+| type | string | true | The data type<br/>Possible values:<br/><ul><li>participant-resume</li></ul> | 
 | attributes | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResumeAttributes](#schema-ecfparticipantresumeattributes) schema. | 
 
 
@@ -1634,7 +1634,7 @@ An ECF participant resume action
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li><li>ecf-mentor</li></ul> | 
 
 
 #### Example
@@ -1658,16 +1658,16 @@ The data attributes associated with an ECF participant
 | full\_name | string | true | The full name of this ECF participant<br/> | 
 | mentor\_id | string | false | The unique identifier of this ECF participants mentor<br/> | 
 | school\_urn | string | true | The Unique Reference Number (URN) of the school that submitted this ECF participant<br/> | 
-| participant\_type | string | true | The type of ECF participant this record refers to<br/>Possible values:<br/><br/> - ect<br/> - mentor<br/><br/> | 
+| participant\_type | string | true | The type of ECF participant this record refers to<br/>Possible values:<br/><ul><li>ect</li><li>mentor</li></ul> | 
 | cohort | string | true | Indicates which call-off contract funds this participant’s training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year.<br/> | 
-| status | string | true | The status of this ECF participant record<br/>Possible values:<br/><br/> - active<br/> - withdrawn<br/><br/> | 
+| status | string | true | The status of this ECF participant record<br/>Possible values:<br/><ul><li>active</li><li>withdrawn</li></ul> | 
 | teacher\_reference\_number | string | false | The Teacher Reference Number (TRN) for this ECF participant<br/> | 
 | teacher\_reference\_number\_validated | boolean | false | Indicates whether the Teacher Reference Number (TRN) has been validated<br/> | 
 | eligible\_for\_funding | boolean | false | Indicates whether this participant is eligible to receive DfE funded induction<br/> | 
 | pupil\_premium\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to pupil premium<br/> | 
 | sparsity\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to sparsity<br/> | 
-| training\_status | string | true | The training status of the ECF participant<br/>Possible values:<br/><br/> - active<br/> - deferred<br/> - withdrawn<br/><br/> | 
-| schedule\_identifier | string | true | The schedule of the ECF participant<br/>Possible values:<br/><br/> - ecf-standard-september<br/> - ecf-standard-january<br/> - ecf-standard-april<br/> - ecf-reduced-september<br/> - ecf-reduced-january<br/> - ecf-reduced-april<br/> - ecf-extended-september<br/> - ecf-extended-january<br/> - ecf-extended-april<br/> - ecf-replacement-september<br/> - ecf-replacement-january<br/> - ecf-replacement-april<br/><br/> | 
+| training\_status | string | true | The training status of the ECF participant<br/>Possible values:<br/><ul><li>active</li><li>deferred</li><li>withdrawn</li></ul> | 
+| schedule\_identifier | string | true | The schedule of the ECF participant<br/>Possible values:<br/><ul><li>ecf-standard-september</li><li>ecf-standard-january</li><li>ecf-standard-april</li><li>ecf-reduced-september</li><li>ecf-reduced-january</li><li>ecf-reduced-april</li><li>ecf-extended-september</li><li>ecf-extended-january</li><li>ecf-extended-april</li><li>ecf-replacement-september</li><li>ecf-replacement-january</li><li>ecf-replacement-april</li></ul> | 
 | updated\_at | string | true | The date the ECF participant was last updated<br/> | 
 
 
@@ -1725,7 +1725,7 @@ An ECF participant retained declaration request body
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| type | object | false | The request data<br/>Possible values:<br/><br/> - participant-declaration<br/><br/> | 
+| type | object | false | The request data<br/>Possible values:<br/><ul><li>participant-declaration</li></ul> | 
 | attributes | object | true | An ECF participant retained declaration<br/>It conforms to [ECFParticipantRetainedDeclarationAttributes](#schema-ecfparticipantretaineddeclarationattributes) schema. | 
 
 
@@ -1737,10 +1737,10 @@ An ECF participant retained declaration
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique id of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - retained-1<br/> - retained-2<br/> - retained-3<br/> - retained-4<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>retained-1</li><li>retained-2</li><li>retained-3</li><li>retained-4</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
-| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - other<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li><li>ecf-mentor</li></ul> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><ul><li>training-event-attended</li><li>self-study-material-completed</li><li>other</li></ul> | 
 
 
 #### Example
@@ -1764,7 +1764,7 @@ A participant started declaration request body
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| type | object | false | The request data<br/>Possible values:<br/><br/> - participant-declaration<br/><br/> | 
+| type | object | false | The request data<br/>Possible values:<br/><ul><li>participant-declaration</li></ul> | 
 | attributes | object | true | An ECF started and completed participant declaration<br/>It conforms to [ECFParticipantStartedDeclarationAttributes](#schema-ecfparticipantstarteddeclarationattributes) schema. | 
 
 
@@ -1776,9 +1776,9 @@ An ECF started and completed participant declaration
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique id of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - started<br/> - completed<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>started</li><li>completed</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li><li>ecf-mentor</li></ul> | 
 
 
 #### Example
@@ -1801,7 +1801,7 @@ An ECF participant withdrawal action
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| type | string | false | The data type<br/>Possible values:<br/><br/> - participant-withdraw<br/><br/> | 
+| type | string | false | The data type<br/>Possible values:<br/><ul><li>participant-withdraw</li></ul> | 
 | attributes | object | false | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdrawAttributes](#schema-ecfparticipantwithdrawattributes) schema. | 
 
 
@@ -1812,8 +1812,8 @@ An ECF participant withdrawal action
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| reason | string | true | The reason for the withdrawal<br/>Possible values:<br/><br/> - left-teaching-profession<br/> - moved-school<br/> - mentor-no-longer-being-mentor<br/> - switched-to-school-led<br/> - other<br/><br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| reason | string | true | The reason for the withdrawal<br/>Possible values:<br/><ul><li>left-teaching-profession</li><li>moved-school</li><li>mentor-no-longer-being-mentor</li><li>switched-to-school-led</li><li>other</li></ul> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li><li>ecf-mentor</li></ul> | 
 
 
 #### Example
@@ -1838,16 +1838,16 @@ The data attributes associated with an ECF participant
 | full\_name | string | true | The full name of this ECF participant<br/> | 
 | mentor\_id | string | false | The unique identifier of this ECF participants mentor<br/> | 
 | school\_urn | string | true | The Unique Reference Number (URN) of the school that submitted this ECF participant<br/> | 
-| participant\_type | string | true | The type of ECF participant this record refers to<br/>Possible values:<br/><br/> - ect<br/> - mentor<br/><br/> | 
+| participant\_type | string | true | The type of ECF participant this record refers to<br/>Possible values:<br/><ul><li>ect</li><li>mentor</li></ul> | 
 | cohort | string | true | Indicates which call-off contract funds this participant’s training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year.<br/> | 
-| status | string | true | The status of this ECF participant record<br/>Possible values:<br/><br/> - active<br/> - withdrawn<br/><br/> | 
+| status | string | true | The status of this ECF participant record<br/>Possible values:<br/><ul><li>active</li><li>withdrawn</li></ul> | 
 | teacher\_reference\_number | string | false | The Teacher Reference Number (TRN) for this ECF participant<br/> | 
 | teacher\_reference\_number\_validated | boolean | false | Indicates whether the Teacher Reference Number (TRN) has been validated<br/> | 
 | eligible\_for\_funding | boolean | false | Indicates whether this participant is eligible to receive DfE funded induction<br/> | 
 | pupil\_premium\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to pupil premium<br/> | 
 | sparsity\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to sparsity<br/> | 
-| training\_status | string | true | The training status of the ECF participant<br/>Possible values:<br/><br/> - active<br/> - deferred<br/> - withdrawn<br/><br/> | 
-| schedule\_identifier | string | true | The schedule of the ECF participant<br/>Possible values:<br/><br/> - ecf-standard-september<br/> - ecf-standard-january<br/> - ecf-standard-april<br/> - ecf-reduced-september<br/> - ecf-reduced-january<br/> - ecf-reduced-april<br/> - ecf-extended-september<br/> - ecf-extended-january<br/> - ecf-extended-april<br/> - ecf-replacement-september<br/> - ecf-replacement-january<br/> - ecf-replacement-april<br/><br/> | 
+| training\_status | string | true | The training status of the ECF participant<br/>Possible values:<br/><ul><li>active</li><li>deferred</li><li>withdrawn</li></ul> | 
+| schedule\_identifier | string | true | The schedule of the ECF participant<br/>Possible values:<br/><ul><li>ecf-standard-september</li><li>ecf-standard-january</li><li>ecf-standard-april</li><li>ecf-reduced-september</li><li>ecf-reduced-january</li><li>ecf-reduced-april</li><li>ecf-extended-september</li><li>ecf-extended-january</li><li>ecf-extended-april</li><li>ecf-replacement-september</li><li>ecf-replacement-january</li><li>ecf-replacement-april</li></ul> | 
 | updated\_at | string | true | The date the ECF participant was last updated<br/> | 
 
 
@@ -2039,12 +2039,12 @@ The data attributes associated with a participant declaration response
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique id of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - started<br/> - retained-1<br/> - retained-2<br/> - retained-3<br/> - retained-4<br/> - completed<br/> - extended-1<br/> - extended-2<br/> - extended-3<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>started</li><li>retained-1</li><li>retained-2</li><li>retained-3</li><li>retained-4</li><li>completed</li><li>extended-1</li><li>extended-2</li><li>extended-3</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li><li>ecf-mentor</li></ul> | 
 | eligible\_for\_payment | boolean | true | [Deprecated - use state instead] Indicates whether this declaration would be eligible for funding from the DfE<br/> | 
 | voided | boolean | true | [Deprecated - use state instead] Indicates whether this declaration has been voided<br/> | 
-| state | string | true | Indicates the state of this payment declaration<br/>Possible values:<br/><br/> - submitted<br/> - eligible<br/> - payable<br/> - paid<br/> - voided<br/> - ineligible<br/> - awaiting-clawback<br/> - clawed-back<br/><br/> | 
+| state | string | true | Indicates the state of this payment declaration<br/>Possible values:<br/><ul><li>submitted</li><li>eligible</li><li>payable</li><li>paid</li><li>voided</li><li>ineligible</li><li>awaiting-clawback</li><li>clawed-back</li></ul> | 
 | updated\_at | string | true | The date the declaration was last updated<br/> | 
 | has\_passed | boolean | false | Whether the participant has failed or passed<br/> | 
 
@@ -2058,9 +2058,9 @@ The details of a participant declaration
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant declaration record<br/> | 
 | participant\_id | string | true | The unique identifier of the participant record the declaration refers to<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - started<br/> - retained-1<br/> - retained-2<br/> - retained-3<br/> - retained-4<br/> - completed<br/> - extended-1<br/> - extended-2<br/> - extended-3<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>started</li><li>retained-1</li><li>retained-2</li><li>retained-3</li><li>retained-4</li><li>completed</li><li>extended-1</li><li>extended-2</li><li>extended-3</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li><li>ecf-mentor</li></ul> | 
 | eligible\_for\_payment | boolean | true | [Deprecated - use state instead] Indicates whether this declaration would be eligible for funding from the DfE<br/> | 
 | voided | boolean | true | [Deprecated - use state instead] Indicates whether this declaration has been voided<br/> | 
 | state | string | false | Indicates the state of this payment declaration<br/> | 
@@ -2074,8 +2074,8 @@ A participant declaration data request for ECT participants from cohort 2025 onw
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| type | string | false | Possible values:<br/><br/> - participant-declaration<br/><br/> | 
-| attributes | object | false | This conforms to any of the following schemas:<br/><br/> -  [ECFParticipantDeclarationPost2024ECTStartedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectstartedattributesrequest) <br/> -  [ECFParticipantDeclarationPost2024ECTRetainedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectretainedattributesrequest) <br/> -  [ECFParticipantDeclarationPost2024ECTCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectcompletedattributesrequest) <br/> -  [ECFParticipantDeclarationPost2024ECTExtendedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectextendedattributesrequest) <br/><br/> | 
+| type | string | false | Possible values:<br/><ul><li>participant-declaration</li></ul> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024ECTStartedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTRetainedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectretainedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectcompletedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTExtendedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectextendedattributesrequest) </li></ul> | 
 
 
 ### ParticipantDeclarationPost2024MentorDataRequest
@@ -2085,8 +2085,8 @@ A participant declaration data request for mentor participants from cohort 2025 
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| type | string | false | Possible values:<br/><br/> - participant-declaration<br/><br/> | 
-| attributes | object | false | This conforms to any of the following schemas:<br/><br/> -  [ECFParticipantDeclarationPost2024MentorStartedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorstartedattributesrequest) <br/> -  [ECFParticipantDeclarationPost2024MentorCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorcompletedattributesrequest) <br/><br/> | 
+| type | string | false | Possible values:<br/><ul><li>participant-declaration</li></ul> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024MentorStartedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024MentorCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorcompletedattributesrequest) </li></ul> | 
 
 
 ### ParticipantDeclarationPre2025DataRequest
@@ -2096,8 +2096,8 @@ A participant declaration data request for participants in cohort 2024 and previ
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| type | string | false | Possible values:<br/><br/> - participant-declaration<br/><br/> | 
-| attributes | object | false | This conforms to any of the following schemas:<br/><br/> -  [ECFParticipantDeclarationPre2025StartedAttributesRequest](#schema-ecfparticipantdeclarationpre2025startedattributesrequest) <br/> -  [ECFParticipantDeclarationPre2025RetainedAttributesRequest](#schema-ecfparticipantdeclarationpre2025retainedattributesrequest) <br/> -  [ECFParticipantDeclarationPre2025CompletedAttributesRequest](#schema-ecfparticipantdeclarationpre2025completedattributesrequest) <br/> -  [ECFParticipantDeclarationPre2025ExtendedAttributesRequest](#schema-ecfparticipantdeclarationpre2025extendedattributesrequest) <br/><br/> | 
+| type | string | false | Possible values:<br/><ul><li>participant-declaration</li></ul> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPre2025StartedAttributesRequest](#schema-ecfparticipantdeclarationpre2025startedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025RetainedAttributesRequest](#schema-ecfparticipantdeclarationpre2025retainedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025CompletedAttributesRequest](#schema-ecfparticipantdeclarationpre2025completedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025ExtendedAttributesRequest](#schema-ecfparticipantdeclarationpre2025extendedattributesrequest) </li></ul> | 
 
 
 ### ParticipantDeclarationRequest
@@ -2107,7 +2107,7 @@ An participant declaration request
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | This conforms to any of the following schemas:<br/><br/> -  [ParticipantDeclarationPre2025DataRequest](#schema-participantdeclarationpre2025datarequest) <br/> -  [ParticipantDeclarationPost2024ECTDataRequest](#schema-participantdeclarationpost2024ectdatarequest) <br/> -  [ParticipantDeclarationPost2024MentorDataRequest](#schema-participantdeclarationpost2024mentordatarequest) <br/><br/> | 
+| data | object | true | This conforms to any of the following schemas:<br/><ul><li> [ParticipantDeclarationPre2025DataRequest](#schema-participantdeclarationpre2025datarequest) </li><li> [ParticipantDeclarationPost2024ECTDataRequest](#schema-participantdeclarationpost2024ectdatarequest) </li><li> [ParticipantDeclarationPost2024MentorDataRequest](#schema-participantdeclarationpost2024mentordatarequest) </li></ul> | 
 
 
 ### ParticipantDeclarationResponse

--- a/documentation/ecf1_guidance/reference-v1.md
+++ b/documentation/ecf1_guidance/reference-v1.md
@@ -26,8 +26,8 @@ The lead provider API for DfE’s manage teacher CPD service
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine participant declarations to return.<br/>This consumes a [ListFilterDeclarations](#schema-listfilterdeclarations) schema.<br/> | participant\_id=ab3a7848-1208-7679-942a-b4a70eed400a&updated\_since=2020-11-13T11:21:55Z | 
-| page | query | object | false | Pagination options to navigate through the list of participant declarations.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| filter | query | object | false | Refine participant declarations to return.<br/>This consumes a [ListFilterDeclarations](listfilterdeclarations) schema.<br/> | participant\_id=ab3a7848-1208-7679-942a-b4a70eed400a&updated\_since=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of participant declarations.<br/>This consumes a [Pagination](pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
 
 
 ### Responses
@@ -35,14 +35,14 @@ The lead provider API for DfE’s manage teacher CPD service
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A list of participant declarations<br/>This response returns a [MultipleParticipantDeclarationsResponse](#schema-multipleparticipantdeclarationsresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A list of participant declarations<br/>This response returns a [MultipleParticipantDeclarationsResponse](multipleparticipantdeclarationsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A list of participant declarations
-This response returns a [MultipleParticipantDeclarationsResponse](#schema-multipleparticipantdeclarationsresponse) schema.
+This response returns a [MultipleParticipantDeclarationsResponse](multipleparticipantdeclarationsresponse) schema.
 
 ```
 {
@@ -74,7 +74,7 @@ This response returns a [MultipleParticipantDeclarationsResponse](#schema-multip
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 ```
 {
@@ -97,23 +97,23 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ### Request body
 
 
-This consumes a [ParticipantDeclarationRequest](#schema-participantdeclarationrequest) schema.
+This consumes a [ParticipantDeclarationRequest](participantdeclarationrequest) schema.
 
 ### Responses
 
 
 | Status | Description |
 | ---- | ---- |
-| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.<br/> | 
-| 422 | Bad or Missing parameter<br/>This response returns a [ErrorResponse](#schema-errorresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
-| 400 | Bad Request<br/>This response returns a [BadRequestResponse](#schema-badrequestresponse) schema.<br/> | 
+| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](singleparticipantdeclarationresponse) schema.<br/> | 
+| 422 | Bad or Missing parameter<br/>This response returns a [ErrorResponse](errorresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
+| 400 | Bad Request<br/>This response returns a [BadRequestResponse](badrequestresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - Successful
-This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.
+This response returns a [SingleParticipantDeclarationResponse](singleparticipantdeclarationresponse) schema.
 
 ```
 {
@@ -136,7 +136,7 @@ This response returns a [SingleParticipantDeclarationResponse](#schema-singlepar
 ```
 
 422 - Bad or Missing parameter
-This response returns a [ErrorResponse](#schema-errorresponse) schema.
+This response returns a [ErrorResponse](errorresponse) schema.
 
 ```
 {
@@ -150,7 +150,7 @@ This response returns a [ErrorResponse](#schema-errorresponse) schema.
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 ```
 {
@@ -159,7 +159,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ```
 
 400 - Bad Request
-This response returns a [BadRequestResponse](#schema-badrequestresponse) schema.
+This response returns a [BadRequestResponse](badrequestresponse) schema.
 
 ```
 {
@@ -184,16 +184,16 @@ This response returns a [BadRequestResponse](#schema-badrequestresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A CSV file of participant declarations<br/>This response returns a [MultipleParticipantDeclarationsCsvResponse](#schema-multipleparticipantdeclarationscsvresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A CSV file of participant declarations<br/>This response returns a [MultipleParticipantDeclarationsCsvResponse](multipleparticipantdeclarationscsvresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A CSV file of participant declarations
-This response returns a [MultipleParticipantDeclarationsCsvResponse](#schema-multipleparticipantdeclarationscsvresponse) schema.
+This response returns a [MultipleParticipantDeclarationsCsvResponse](multipleparticipantdeclarationscsvresponse) schema.
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 ---
 
@@ -219,15 +219,15 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A single participant declaration<br/>This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.<br/> | 
-| 404 | Not found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A single participant declaration<br/>This response returns a [SingleParticipantDeclarationResponse](singleparticipantdeclarationresponse) schema.<br/> | 
+| 404 | Not found<br/>This response returns a [NotFoundResponse](notfoundresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A single participant declaration
-This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.
+This response returns a [SingleParticipantDeclarationResponse](singleparticipantdeclarationresponse) schema.
 
 ```
 {
@@ -250,7 +250,7 @@ This response returns a [SingleParticipantDeclarationResponse](#schema-singlepar
 ```
 
 404 - Not found
-This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
+This response returns a [NotFoundResponse](notfoundresponse) schema.
 
 ```
 {
@@ -259,7 +259,7 @@ This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 ```
 {
@@ -292,13 +292,13 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 
 | Status | Description |
 | ---- | ---- |
-| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.<br/> | 
+| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](singleparticipantdeclarationresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - Successful
-This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.
+This response returns a [SingleParticipantDeclarationResponse](singleparticipantdeclarationresponse) schema.
 
 ```
 {
@@ -337,8 +337,8 @@ This response returns a [SingleParticipantDeclarationResponse](#schema-singlepar
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine ECF participants to return.<br/>This consumes a [ParticipantListFilter](#schema-participantlistfilter) schema.<br/> | filter[cohort]=2022&filter[updated\_since]=2020-11-13T11:21:55Z | 
-| page | query | object | false | Pagination options to navigate through the list of ECF participants.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| filter | query | object | false | Refine ECF participants to return.<br/>This consumes a [ParticipantListFilter](participantlistfilter) schema.<br/> | filter[cohort]=2022&filter[updated\_since]=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of ECF participants.<br/>This consumes a [Pagination](pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
 
 
 ### Responses
@@ -346,14 +346,14 @@ This response returns a [SingleParticipantDeclarationResponse](#schema-singlepar
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A list of ECF participants<br/>This response returns a [MultipleECFParticipantsResponse](#schema-multipleecfparticipantsresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A list of ECF participants<br/>This response returns a [MultipleECFParticipantsResponse](multipleecfparticipantsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A list of ECF participants
-This response returns a [MultipleECFParticipantsResponse](#schema-multipleecfparticipantsresponse) schema.
+This response returns a [MultipleECFParticipantsResponse](multipleecfparticipantsresponse) schema.
 
 ```
 {
@@ -422,7 +422,7 @@ This response returns a [MultipleECFParticipantsResponse](#schema-multipleecfpar
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 ```
 {
@@ -447,7 +447,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine ECF participants to return.<br/>This consumes a [ParticipantListFilter](#schema-participantlistfilter) schema.<br/> | updated\_since=2020-11-13T11:21:55Z | 
+| filter | query | object | false | Refine ECF participants to return.<br/>This consumes a [ParticipantListFilter](participantlistfilter) schema.<br/> | updated\_since=2020-11-13T11:21:55Z | 
 
 
 ### Responses
@@ -455,16 +455,16 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A CSV file of ECF participants<br/>This response returns a [MultipleECFParticipantsCsvResponse](#schema-multipleecfparticipantscsvresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A CSV file of ECF participants<br/>This response returns a [MultipleECFParticipantsCsvResponse](multipleecfparticipantscsvresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A CSV file of ECF participants
-This response returns a [MultipleECFParticipantsCsvResponse](#schema-multipleecfparticipantscsvresponse) schema.
+This response returns a [MultipleECFParticipantsCsvResponse](multipleecfparticipantscsvresponse) schema.
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 ---
 
@@ -490,14 +490,14 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A single ECF participant<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A single ECF participant<br/>This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A single ECF participant
-This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
 
 ```
 {
@@ -527,7 +527,7 @@ This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse)
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 ```
 {
@@ -558,7 +558,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ### Request body
 
 
-This consumes a [ECFParticipantDeferRequest](#schema-ecfparticipantdeferrequest) schema.
+This consumes a [ECFParticipantDeferRequest](ecfparticipantdeferrequest) schema.
 
 ### Request example
 
@@ -581,13 +581,13 @@ This consumes a [ECFParticipantDeferRequest](#schema-ecfparticipantdeferrequest)
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant being deferred<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
+| 200 | The ECF participant being deferred<br/>This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant being deferred
-This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
 
 ```
 {
@@ -639,7 +639,7 @@ This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse)
 ### Request body
 
 
-This consumes a [ECFParticipantResumeRequest](#schema-ecfparticipantresumerequest) schema.
+This consumes a [ECFParticipantResumeRequest](ecfparticipantresumerequest) schema.
 
 ### Request example
 
@@ -661,13 +661,13 @@ This consumes a [ECFParticipantResumeRequest](#schema-ecfparticipantresumereques
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant being resumed<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
+| 200 | The ECF participant being resumed<br/>This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant being resumed
-This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
 
 ```
 {
@@ -719,7 +719,7 @@ This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse)
 ### Request body
 
 
-This consumes a [ECFParticipantWithdrawRequest](#schema-ecfparticipantwithdrawrequest) schema.
+This consumes a [ECFParticipantWithdrawRequest](ecfparticipantwithdrawrequest) schema.
 
 ### Request example
 
@@ -742,13 +742,13 @@ This consumes a [ECFParticipantWithdrawRequest](#schema-ecfparticipantwithdrawre
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant being withdrawn<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
+| 200 | The ECF participant being withdrawn<br/>This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant being withdrawn
-This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
 
 ```
 {
@@ -800,7 +800,7 @@ This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse)
 ### Request body
 
 
-This consumes a [ECFParticipantDeferRequest](#schema-ecfparticipantdeferrequest) schema.
+This consumes a [ECFParticipantDeferRequest](ecfparticipantdeferrequest) schema.
 
 ### Request example
 
@@ -823,13 +823,13 @@ This consumes a [ECFParticipantDeferRequest](#schema-ecfparticipantdeferrequest)
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant being deferred<br/>This response returns a [ECFParticipantDeferResponse](#schema-ecfparticipantdeferresponse) schema.<br/> | 
+| 200 | The ECF participant being deferred<br/>This response returns a [ECFParticipantDeferResponse](ecfparticipantdeferresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant being deferred
-This response returns a [ECFParticipantDeferResponse](#schema-ecfparticipantdeferresponse) schema.
+This response returns a [ECFParticipantDeferResponse](ecfparticipantdeferresponse) schema.
 
 ```
 {
@@ -880,7 +880,7 @@ This response returns a [ECFParticipantDeferResponse](#schema-ecfparticipantdefe
 ### Request body
 
 
-This consumes a [ECFParticipantResumeRequest](#schema-ecfparticipantresumerequest) schema.
+This consumes a [ECFParticipantResumeRequest](ecfparticipantresumerequest) schema.
 
 ### Request example
 
@@ -902,13 +902,13 @@ This consumes a [ECFParticipantResumeRequest](#schema-ecfparticipantresumereques
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant being resumed<br/>This response returns a [ECFParticipantResumeResponse](#schema-ecfparticipantresumeresponse) schema.<br/> | 
+| 200 | The ECF participant being resumed<br/>This response returns a [ECFParticipantResumeResponse](ecfparticipantresumeresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant being resumed
-This response returns a [ECFParticipantResumeResponse](#schema-ecfparticipantresumeresponse) schema.
+This response returns a [ECFParticipantResumeResponse](ecfparticipantresumeresponse) schema.
 
 ```
 {
@@ -959,7 +959,7 @@ This response returns a [ECFParticipantResumeResponse](#schema-ecfparticipantres
 ### Request body
 
 
-This consumes a [ECFParticipantWithdrawRequest](#schema-ecfparticipantwithdrawrequest) schema.
+This consumes a [ECFParticipantWithdrawRequest](ecfparticipantwithdrawrequest) schema.
 
 ### Request example
 
@@ -982,13 +982,13 @@ This consumes a [ECFParticipantWithdrawRequest](#schema-ecfparticipantwithdrawre
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant being withdrawn<br/>This response returns a [ECFParticipantWithdrawResponse](#schema-ecfparticipantwithdrawresponse) schema.<br/> | 
+| 200 | The ECF participant being withdrawn<br/>This response returns a [ECFParticipantWithdrawResponse](ecfparticipantwithdrawresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant being withdrawn
-This response returns a [ECFParticipantWithdrawResponse](#schema-ecfparticipantwithdrawresponse) schema.
+This response returns a [ECFParticipantWithdrawResponse](ecfparticipantwithdrawresponse) schema.
 
 ```
 {
@@ -1039,7 +1039,7 @@ This response returns a [ECFParticipantWithdrawResponse](#schema-ecfparticipantw
 ### Request body
 
 
-This consumes a [ECFParticipantChangeScheduleRequest](#schema-ecfparticipantchangeschedulerequest) schema.
+This consumes a [ECFParticipantChangeScheduleRequest](ecfparticipantchangeschedulerequest) schema.
 
 ### Request example
 
@@ -1063,13 +1063,13 @@ This consumes a [ECFParticipantChangeScheduleRequest](#schema-ecfparticipantchan
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant changing schedule<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
+| 200 | The ECF participant changing schedule<br/>This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant changing schedule
-This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
 
 ```
 {
@@ -1121,7 +1121,7 @@ This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse)
 ### Request body
 
 
-This consumes a [ECFParticipantChangeScheduleRequest](#schema-ecfparticipantchangeschedulerequest) schema.
+This consumes a [ECFParticipantChangeScheduleRequest](ecfparticipantchangeschedulerequest) schema.
 
 ### Request example
 
@@ -1145,13 +1145,13 @@ This consumes a [ECFParticipantChangeScheduleRequest](#schema-ecfparticipantchan
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant changing schedule<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
+| 200 | The ECF participant changing schedule<br/>This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant changing schedule
-This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
 
 ```
 {
@@ -1231,7 +1231,7 @@ The details of a participant
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantAttributes](#schema-ecfparticipantattributes) schema. | 
+| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantAttributes](ecfparticipantattributes) schema. | 
 
 
 ### ECFParticipantAttributes
@@ -1267,7 +1267,7 @@ An ECF participant change schedule action
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | true | The data type<br/>Possible values:<br/><ul><li>participant-change-schedule</li></ul> | 
-| attributes | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeScheduleAttributes](#schema-ecfparticipantchangescheduleattributes) schema. | 
+| attributes | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeScheduleAttributes](ecfparticipantchangescheduleattributes) schema. | 
 
 
 #### Example
@@ -1315,7 +1315,7 @@ The change schedule request for a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeSchedule](#schema-ecfparticipantchangeschedule) schema. | 
+| data | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeSchedule](ecfparticipantchangeschedule) schema. | 
 
 
 #### Example
@@ -1509,7 +1509,7 @@ The details of a participant deferral request
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | true | The data type<br/>Possible values:<br/><ul><li>participant-defer</li></ul> | 
-| attributes | object | true | An ECF participant deferral action<br/>It conforms to [ECFParticipantDeferAttributes](#schema-ecfparticipantdeferattributes) schema. | 
+| attributes | object | true | An ECF participant deferral action<br/>It conforms to [ECFParticipantDeferAttributes](ecfparticipantdeferattributes) schema. | 
 
 
 ### ECFParticipantDeferAttributes
@@ -1565,7 +1565,7 @@ The deferral request for a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | The details of a participant deferral request<br/>It conforms to [ECFParticipantDefer](#schema-ecfparticipantdefer) schema. | 
+| data | object | true | The details of a participant deferral request<br/>It conforms to [ECFParticipantDefer](ecfparticipantdefer) schema. | 
 
 
 #### Example
@@ -1591,7 +1591,7 @@ An ECF Participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantDeferResponseData](#schema-ecfparticipantdeferresponsedata) schema. | 
+| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantDeferResponseData](ecfparticipantdeferresponsedata) schema. | 
 
 
 ### ECFParticipantDeferResponseData
@@ -1603,7 +1603,7 @@ The details of a participant
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantDeferAttributesResponse](#schema-ecfparticipantdeferattributesresponse) schema. | 
+| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantDeferAttributesResponse](ecfparticipantdeferattributesresponse) schema. | 
 
 
 ### ECFParticipantResponse
@@ -1613,7 +1613,7 @@ An ECF Participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | The details of a participant<br/>It conforms to [ECFParticipant](#schema-ecfparticipant) schema. | 
+| data | object | true | The details of a participant<br/>It conforms to [ECFParticipant](ecfparticipant) schema. | 
 
 
 ### ECFParticipantResume
@@ -1624,7 +1624,7 @@ An ECF participant resume action
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | true | The data type<br/>Possible values:<br/><ul><li>participant-resume</li></ul> | 
-| attributes | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResumeAttributes](#schema-ecfparticipantresumeattributes) schema. | 
+| attributes | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResumeAttributes](ecfparticipantresumeattributes) schema. | 
 
 
 ### ECFParticipantResumeAttributes
@@ -1678,7 +1678,7 @@ The resume request for a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResume](#schema-ecfparticipantresume) schema. | 
+| data | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResume](ecfparticipantresume) schema. | 
 
 
 #### Example
@@ -1703,7 +1703,7 @@ An ECF Participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantResumeResponseData](#schema-ecfparticipantresumeresponsedata) schema. | 
+| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantResumeResponseData](ecfparticipantresumeresponsedata) schema. | 
 
 
 ### ECFParticipantResumeResponseData
@@ -1715,7 +1715,7 @@ The details of a participant
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantResumeAttributesResponse](#schema-ecfparticipantresumeattributesresponse) schema. | 
+| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantResumeAttributesResponse](ecfparticipantresumeattributesresponse) schema. | 
 
 
 ### ECFParticipantRetainedDeclaration
@@ -1726,7 +1726,7 @@ An ECF participant retained declaration request body
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | object | false | The request data<br/>Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | true | An ECF participant retained declaration<br/>It conforms to [ECFParticipantRetainedDeclarationAttributes](#schema-ecfparticipantretaineddeclarationattributes) schema. | 
+| attributes | object | true | An ECF participant retained declaration<br/>It conforms to [ECFParticipantRetainedDeclarationAttributes](ecfparticipantretaineddeclarationattributes) schema. | 
 
 
 ### ECFParticipantRetainedDeclarationAttributes
@@ -1765,7 +1765,7 @@ A participant started declaration request body
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | object | false | The request data<br/>Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | true | An ECF started and completed participant declaration<br/>It conforms to [ECFParticipantStartedDeclarationAttributes](#schema-ecfparticipantstarteddeclarationattributes) schema. | 
+| attributes | object | true | An ECF started and completed participant declaration<br/>It conforms to [ECFParticipantStartedDeclarationAttributes](ecfparticipantstarteddeclarationattributes) schema. | 
 
 
 ### ECFParticipantStartedDeclarationAttributes
@@ -1802,7 +1802,7 @@ An ECF participant withdrawal action
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | The data type<br/>Possible values:<br/><ul><li>participant-withdraw</li></ul> | 
-| attributes | object | false | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdrawAttributes](#schema-ecfparticipantwithdrawattributes) schema. | 
+| attributes | object | false | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdrawAttributes](ecfparticipantwithdrawattributes) schema. | 
 
 
 ### ECFParticipantWithdrawAttributes
@@ -1860,7 +1860,7 @@ The details of a participant
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantWithdrawAttributesResponse](#schema-ecfparticipantwithdrawattributesresponse) schema. | 
+| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantWithdrawAttributesResponse](ecfparticipantwithdrawattributesresponse) schema. | 
 
 
 ### ECFParticipantWithdrawRequest
@@ -1870,7 +1870,7 @@ The withdrawal request for a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdraw](#schema-ecfparticipantwithdraw) schema. | 
+| data | object | true | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdraw](ecfparticipantwithdraw) schema. | 
 
 
 #### Example
@@ -1896,7 +1896,7 @@ An ECF Participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantWithdrawDataResponse](#schema-ecfparticipantwithdrawdataresponse) schema. | 
+| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantWithdrawDataResponse](ecfparticipantwithdrawdataresponse) schema. | 
 
 
 ### Error
@@ -1917,7 +1917,7 @@ A list of errors
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| error | array | false | It conforms to [Error](#schema-error) schema. | 
+| error | array | false | It conforms to [Error](error) schema. | 
 
 
 ### ListFilter
@@ -1949,7 +1949,7 @@ A list of ECF participants in the Comma Separated Value (CSV) format
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ECFParticipantCsvRow](#schema-ecfparticipantcsvrow) schema. | 
+| data | array | true | It conforms to [ECFParticipantCsvRow](ecfparticipantcsvrow) schema. | 
 
 
 ### MultipleECFParticipantsResponse
@@ -1959,7 +1959,7 @@ A list of ECF participants
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ECFParticipant](#schema-ecfparticipant) schema. | 
+| data | array | true | It conforms to [ECFParticipant](ecfparticipant) schema. | 
 
 
 ### MultipleParticipantDeclarationsCsvResponse
@@ -1969,7 +1969,7 @@ A list of participant declarations in the Comma Separated Value (CSV) format
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ParticipantDeclarationCsvRow](#schema-participantdeclarationcsvrow) schema. | 
+| data | array | true | It conforms to [ParticipantDeclarationCsvRow](participantdeclarationcsvrow) schema. | 
 
 
 ### MultipleParticipantDeclarationsResponse
@@ -1979,7 +1979,7 @@ A list of participant declarations
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ParticipantDeclarationResponse](#schema-participantdeclarationresponse) schema. | 
+| data | array | true | It conforms to [ParticipantDeclarationResponse](participantdeclarationresponse) schema. | 
 
 
 ### NotFoundResponse
@@ -2075,7 +2075,7 @@ A participant declaration data request for ECT participants from cohort 2025 onw
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024ECTStartedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTRetainedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectretainedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectcompletedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTExtendedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectextendedattributesrequest) </li></ul> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024ECTStartedAttributesRequest](ecfparticipantdeclarationpost2024ectstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTRetainedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectretainedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectcompletedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTExtendedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectextendedattributesrequest) </li></ul> | 
 
 
 ### ParticipantDeclarationPost2024MentorDataRequest
@@ -2086,7 +2086,7 @@ A participant declaration data request for mentor participants from cohort 2025 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024MentorStartedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024MentorCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorcompletedattributesrequest) </li></ul> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024MentorStartedAttributesRequest](ecfparticipantdeclarationpost2024mentorstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024MentorCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorcompletedattributesrequest) </li></ul> | 
 
 
 ### ParticipantDeclarationPre2025DataRequest
@@ -2097,7 +2097,7 @@ A participant declaration data request for participants in cohort 2024 and previ
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPre2025StartedAttributesRequest](#schema-ecfparticipantdeclarationpre2025startedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025RetainedAttributesRequest](#schema-ecfparticipantdeclarationpre2025retainedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025CompletedAttributesRequest](#schema-ecfparticipantdeclarationpre2025completedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025ExtendedAttributesRequest](#schema-ecfparticipantdeclarationpre2025extendedattributesrequest) </li></ul> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPre2025StartedAttributesRequest](ecfparticipantdeclarationpre2025startedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025RetainedAttributesRequest](#schema-ecfparticipantdeclarationpre2025retainedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025CompletedAttributesRequest](#schema-ecfparticipantdeclarationpre2025completedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025ExtendedAttributesRequest](#schema-ecfparticipantdeclarationpre2025extendedattributesrequest) </li></ul> | 
 
 
 ### ParticipantDeclarationRequest
@@ -2107,7 +2107,7 @@ An participant declaration request
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | This conforms to any of the following schemas:<br/><ul><li> [ParticipantDeclarationPre2025DataRequest](#schema-participantdeclarationpre2025datarequest) </li><li> [ParticipantDeclarationPost2024ECTDataRequest](#schema-participantdeclarationpost2024ectdatarequest) </li><li> [ParticipantDeclarationPost2024MentorDataRequest](#schema-participantdeclarationpost2024mentordatarequest) </li></ul> | 
+| data | object | true | This conforms to any of the following schemas:<br/><ul><li> [ParticipantDeclarationPre2025DataRequest](participantdeclarationpre2025datarequest) </li><li> [ParticipantDeclarationPost2024ECTDataRequest](#schema-participantdeclarationpost2024ectdatarequest) </li><li> [ParticipantDeclarationPost2024MentorDataRequest](#schema-participantdeclarationpost2024mentordatarequest) </li></ul> | 
 
 
 ### ParticipantDeclarationResponse
@@ -2119,7 +2119,7 @@ A participant declaration response
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant declaration record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with a participant declaration response<br/>It conforms to [ParticipantDeclarationAttributes](#schema-participantdeclarationattributes) schema. | 
+| attributes | object | true | The data attributes associated with a participant declaration response<br/>It conforms to [ParticipantDeclarationAttributes](participantdeclarationattributes) schema. | 
 
 
 ### ParticipantListFilter
@@ -2140,7 +2140,7 @@ A confirmation that the participant declaration has been recorded successfully
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | A participant declaration response<br/>It conforms to [ParticipantDeclarationResponse](#schema-participantdeclarationresponse) schema. | 
+| data | object | true | A participant declaration response<br/>It conforms to [ParticipantDeclarationResponse](participantdeclarationresponse) schema. | 
 
 
 ### UnauthorisedResponse

--- a/documentation/ecf1_guidance/reference-v1.md
+++ b/documentation/ecf1_guidance/reference-v1.md
@@ -26,8 +26,8 @@ The lead provider API for DfE’s manage teacher CPD service
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine participant declarations to return.<br/>This consumes a [ListFilterDeclarations](#schema-listfilterdeclarations) schema.<br/> | participant\_id=ab3a7848-1208-7679-942a-b4a70eed400a&updated\_since=2020-11-13T11:21:55Z | 
-| page | query | object | false | Pagination options to navigate through the list of participant declarations.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| filter | query | object | false | Refine participant declarations to return.<br/>This consumes a [ListFilterDeclarations](#listfilterdeclarations) schema.<br/> | participant\_id=ab3a7848-1208-7679-942a-b4a70eed400a&updated\_since=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of participant declarations.<br/>This consumes a [Pagination](#pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
 
 
 ### Responses
@@ -35,14 +35,14 @@ The lead provider API for DfE’s manage teacher CPD service
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A list of participant declarations<br/>This response returns a [MultipleParticipantDeclarationsResponse](#schema-multipleparticipantdeclarationsresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A list of participant declarations<br/>This response returns a [MultipleParticipantDeclarationsResponse](#multipleparticipantdeclarationsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A list of participant declarations
-This response returns a [MultipleParticipantDeclarationsResponse](#schema-multipleparticipantdeclarationsresponse) schema.
+This response returns a [MultipleParticipantDeclarationsResponse](#multipleparticipantdeclarationsresponse) schema.
 
 ```
 {
@@ -74,7 +74,7 @@ This response returns a [MultipleParticipantDeclarationsResponse](#schema-multip
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 
 ```
 {
@@ -97,23 +97,23 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ### Request body
 
 
-This consumes a [ParticipantDeclarationRequest](#schema-participantdeclarationrequest) schema.
+This consumes a [ParticipantDeclarationRequest](#participantdeclarationrequest) schema.
 
 ### Responses
 
 
 | Status | Description |
 | ---- | ---- |
-| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.<br/> | 
-| 422 | Bad or Missing parameter<br/>This response returns a [ErrorResponse](#schema-errorresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
-| 400 | Bad Request<br/>This response returns a [BadRequestResponse](#schema-badrequestresponse) schema.<br/> | 
+| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](#singleparticipantdeclarationresponse) schema.<br/> | 
+| 422 | Bad or Missing parameter<br/>This response returns a [ErrorResponse](#errorresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.<br/> | 
+| 400 | Bad Request<br/>This response returns a [BadRequestResponse](#badrequestresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - Successful
-This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.
+This response returns a [SingleParticipantDeclarationResponse](#singleparticipantdeclarationresponse) schema.
 
 ```
 {
@@ -136,7 +136,7 @@ This response returns a [SingleParticipantDeclarationResponse](#schema-singlepar
 ```
 
 422 - Bad or Missing parameter
-This response returns a [ErrorResponse](#schema-errorresponse) schema.
+This response returns a [ErrorResponse](#errorresponse) schema.
 
 ```
 {
@@ -150,7 +150,7 @@ This response returns a [ErrorResponse](#schema-errorresponse) schema.
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 
 ```
 {
@@ -159,7 +159,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ```
 
 400 - Bad Request
-This response returns a [BadRequestResponse](#schema-badrequestresponse) schema.
+This response returns a [BadRequestResponse](#badrequestresponse) schema.
 
 ```
 {
@@ -184,16 +184,16 @@ This response returns a [BadRequestResponse](#schema-badrequestresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A CSV file of participant declarations<br/>This response returns a [MultipleParticipantDeclarationsCsvResponse](#schema-multipleparticipantdeclarationscsvresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A CSV file of participant declarations<br/>This response returns a [MultipleParticipantDeclarationsCsvResponse](#multipleparticipantdeclarationscsvresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A CSV file of participant declarations
-This response returns a [MultipleParticipantDeclarationsCsvResponse](#schema-multipleparticipantdeclarationscsvresponse) schema.
+This response returns a [MultipleParticipantDeclarationsCsvResponse](#multipleparticipantdeclarationscsvresponse) schema.
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 
 ---
 
@@ -219,15 +219,15 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A single participant declaration<br/>This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.<br/> | 
-| 404 | Not found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A single participant declaration<br/>This response returns a [SingleParticipantDeclarationResponse](#singleparticipantdeclarationresponse) schema.<br/> | 
+| 404 | Not found<br/>This response returns a [NotFoundResponse](#notfoundresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A single participant declaration
-This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.
+This response returns a [SingleParticipantDeclarationResponse](#singleparticipantdeclarationresponse) schema.
 
 ```
 {
@@ -250,7 +250,7 @@ This response returns a [SingleParticipantDeclarationResponse](#schema-singlepar
 ```
 
 404 - Not found
-This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
+This response returns a [NotFoundResponse](#notfoundresponse) schema.
 
 ```
 {
@@ -259,7 +259,7 @@ This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 
 ```
 {
@@ -292,13 +292,13 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 
 | Status | Description |
 | ---- | ---- |
-| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.<br/> | 
+| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](#singleparticipantdeclarationresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - Successful
-This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.
+This response returns a [SingleParticipantDeclarationResponse](#singleparticipantdeclarationresponse) schema.
 
 ```
 {
@@ -337,8 +337,8 @@ This response returns a [SingleParticipantDeclarationResponse](#schema-singlepar
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine ECF participants to return.<br/>This consumes a [ParticipantListFilter](#schema-participantlistfilter) schema.<br/> | filter[cohort]=2022&filter[updated\_since]=2020-11-13T11:21:55Z | 
-| page | query | object | false | Pagination options to navigate through the list of ECF participants.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| filter | query | object | false | Refine ECF participants to return.<br/>This consumes a [ParticipantListFilter](#participantlistfilter) schema.<br/> | filter[cohort]=2022&filter[updated\_since]=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of ECF participants.<br/>This consumes a [Pagination](#pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
 
 
 ### Responses
@@ -346,14 +346,14 @@ This response returns a [SingleParticipantDeclarationResponse](#schema-singlepar
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A list of ECF participants<br/>This response returns a [MultipleECFParticipantsResponse](#schema-multipleecfparticipantsresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A list of ECF participants<br/>This response returns a [MultipleECFParticipantsResponse](#multipleecfparticipantsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A list of ECF participants
-This response returns a [MultipleECFParticipantsResponse](#schema-multipleecfparticipantsresponse) schema.
+This response returns a [MultipleECFParticipantsResponse](#multipleecfparticipantsresponse) schema.
 
 ```
 {
@@ -422,7 +422,7 @@ This response returns a [MultipleECFParticipantsResponse](#schema-multipleecfpar
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 
 ```
 {
@@ -447,7 +447,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine ECF participants to return.<br/>This consumes a [ParticipantListFilter](#schema-participantlistfilter) schema.<br/> | updated\_since=2020-11-13T11:21:55Z | 
+| filter | query | object | false | Refine ECF participants to return.<br/>This consumes a [ParticipantListFilter](#participantlistfilter) schema.<br/> | updated\_since=2020-11-13T11:21:55Z | 
 
 
 ### Responses
@@ -455,16 +455,16 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A CSV file of ECF participants<br/>This response returns a [MultipleECFParticipantsCsvResponse](#schema-multipleecfparticipantscsvresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A CSV file of ECF participants<br/>This response returns a [MultipleECFParticipantsCsvResponse](#multipleecfparticipantscsvresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A CSV file of ECF participants
-This response returns a [MultipleECFParticipantsCsvResponse](#schema-multipleecfparticipantscsvresponse) schema.
+This response returns a [MultipleECFParticipantsCsvResponse](#multipleecfparticipantscsvresponse) schema.
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 
 ---
 
@@ -490,14 +490,14 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A single ECF participant<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A single ECF participant<br/>This response returns a [ECFParticipantResponse](#ecfparticipantresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A single ECF participant
-This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](#ecfparticipantresponse) schema.
 
 ```
 {
@@ -527,7 +527,7 @@ This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse)
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 
 ```
 {
@@ -558,7 +558,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ### Request body
 
 
-This consumes a [ECFParticipantDeferRequest](#schema-ecfparticipantdeferrequest) schema.
+This consumes a [ECFParticipantDeferRequest](#ecfparticipantdeferrequest) schema.
 
 ### Request example
 
@@ -581,13 +581,13 @@ This consumes a [ECFParticipantDeferRequest](#schema-ecfparticipantdeferrequest)
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant being deferred<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
+| 200 | The ECF participant being deferred<br/>This response returns a [ECFParticipantResponse](#ecfparticipantresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant being deferred
-This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](#ecfparticipantresponse) schema.
 
 ```
 {
@@ -639,7 +639,7 @@ This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse)
 ### Request body
 
 
-This consumes a [ECFParticipantResumeRequest](#schema-ecfparticipantresumerequest) schema.
+This consumes a [ECFParticipantResumeRequest](#ecfparticipantresumerequest) schema.
 
 ### Request example
 
@@ -661,13 +661,13 @@ This consumes a [ECFParticipantResumeRequest](#schema-ecfparticipantresumereques
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant being resumed<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
+| 200 | The ECF participant being resumed<br/>This response returns a [ECFParticipantResponse](#ecfparticipantresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant being resumed
-This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](#ecfparticipantresponse) schema.
 
 ```
 {
@@ -719,7 +719,7 @@ This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse)
 ### Request body
 
 
-This consumes a [ECFParticipantWithdrawRequest](#schema-ecfparticipantwithdrawrequest) schema.
+This consumes a [ECFParticipantWithdrawRequest](#ecfparticipantwithdrawrequest) schema.
 
 ### Request example
 
@@ -742,13 +742,13 @@ This consumes a [ECFParticipantWithdrawRequest](#schema-ecfparticipantwithdrawre
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant being withdrawn<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
+| 200 | The ECF participant being withdrawn<br/>This response returns a [ECFParticipantResponse](#ecfparticipantresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant being withdrawn
-This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](#ecfparticipantresponse) schema.
 
 ```
 {
@@ -800,7 +800,7 @@ This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse)
 ### Request body
 
 
-This consumes a [ECFParticipantDeferRequest](#schema-ecfparticipantdeferrequest) schema.
+This consumes a [ECFParticipantDeferRequest](#ecfparticipantdeferrequest) schema.
 
 ### Request example
 
@@ -823,13 +823,13 @@ This consumes a [ECFParticipantDeferRequest](#schema-ecfparticipantdeferrequest)
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant being deferred<br/>This response returns a [ECFParticipantDeferResponse](#schema-ecfparticipantdeferresponse) schema.<br/> | 
+| 200 | The ECF participant being deferred<br/>This response returns a [ECFParticipantDeferResponse](#ecfparticipantdeferresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant being deferred
-This response returns a [ECFParticipantDeferResponse](#schema-ecfparticipantdeferresponse) schema.
+This response returns a [ECFParticipantDeferResponse](#ecfparticipantdeferresponse) schema.
 
 ```
 {
@@ -880,7 +880,7 @@ This response returns a [ECFParticipantDeferResponse](#schema-ecfparticipantdefe
 ### Request body
 
 
-This consumes a [ECFParticipantResumeRequest](#schema-ecfparticipantresumerequest) schema.
+This consumes a [ECFParticipantResumeRequest](#ecfparticipantresumerequest) schema.
 
 ### Request example
 
@@ -902,13 +902,13 @@ This consumes a [ECFParticipantResumeRequest](#schema-ecfparticipantresumereques
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant being resumed<br/>This response returns a [ECFParticipantResumeResponse](#schema-ecfparticipantresumeresponse) schema.<br/> | 
+| 200 | The ECF participant being resumed<br/>This response returns a [ECFParticipantResumeResponse](#ecfparticipantresumeresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant being resumed
-This response returns a [ECFParticipantResumeResponse](#schema-ecfparticipantresumeresponse) schema.
+This response returns a [ECFParticipantResumeResponse](#ecfparticipantresumeresponse) schema.
 
 ```
 {
@@ -959,7 +959,7 @@ This response returns a [ECFParticipantResumeResponse](#schema-ecfparticipantres
 ### Request body
 
 
-This consumes a [ECFParticipantWithdrawRequest](#schema-ecfparticipantwithdrawrequest) schema.
+This consumes a [ECFParticipantWithdrawRequest](#ecfparticipantwithdrawrequest) schema.
 
 ### Request example
 
@@ -982,13 +982,13 @@ This consumes a [ECFParticipantWithdrawRequest](#schema-ecfparticipantwithdrawre
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant being withdrawn<br/>This response returns a [ECFParticipantWithdrawResponse](#schema-ecfparticipantwithdrawresponse) schema.<br/> | 
+| 200 | The ECF participant being withdrawn<br/>This response returns a [ECFParticipantWithdrawResponse](#ecfparticipantwithdrawresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant being withdrawn
-This response returns a [ECFParticipantWithdrawResponse](#schema-ecfparticipantwithdrawresponse) schema.
+This response returns a [ECFParticipantWithdrawResponse](#ecfparticipantwithdrawresponse) schema.
 
 ```
 {
@@ -1039,7 +1039,7 @@ This response returns a [ECFParticipantWithdrawResponse](#schema-ecfparticipantw
 ### Request body
 
 
-This consumes a [ECFParticipantChangeScheduleRequest](#schema-ecfparticipantchangeschedulerequest) schema.
+This consumes a [ECFParticipantChangeScheduleRequest](#ecfparticipantchangeschedulerequest) schema.
 
 ### Request example
 
@@ -1063,13 +1063,13 @@ This consumes a [ECFParticipantChangeScheduleRequest](#schema-ecfparticipantchan
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant changing schedule<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
+| 200 | The ECF participant changing schedule<br/>This response returns a [ECFParticipantResponse](#ecfparticipantresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant changing schedule
-This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](#ecfparticipantresponse) schema.
 
 ```
 {
@@ -1121,7 +1121,7 @@ This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse)
 ### Request body
 
 
-This consumes a [ECFParticipantChangeScheduleRequest](#schema-ecfparticipantchangeschedulerequest) schema.
+This consumes a [ECFParticipantChangeScheduleRequest](#ecfparticipantchangeschedulerequest) schema.
 
 ### Request example
 
@@ -1145,13 +1145,13 @@ This consumes a [ECFParticipantChangeScheduleRequest](#schema-ecfparticipantchan
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant changing schedule<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
+| 200 | The ECF participant changing schedule<br/>This response returns a [ECFParticipantResponse](#ecfparticipantresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant changing schedule
-This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](#ecfparticipantresponse) schema.
 
 ```
 {
@@ -1231,7 +1231,7 @@ The details of a participant
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantAttributes](#schema-ecfparticipantattributes) schema. | 
+| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantAttributes](#ecfparticipantattributes) schema. | 
 
 
 ### ECFParticipantAttributes
@@ -1267,7 +1267,7 @@ An ECF participant change schedule action
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | true | The data type<br/>Possible values:<br/><ul><li>participant-change-schedule</li></ul> | 
-| attributes | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeScheduleAttributes](#schema-ecfparticipantchangescheduleattributes) schema. | 
+| attributes | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeScheduleAttributes](#ecfparticipantchangescheduleattributes) schema. | 
 
 
 #### Example
@@ -1315,7 +1315,7 @@ The change schedule request for a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeSchedule](#schema-ecfparticipantchangeschedule) schema. | 
+| data | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeSchedule](#ecfparticipantchangeschedule) schema. | 
 
 
 #### Example
@@ -1509,7 +1509,7 @@ The details of a participant deferral request
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | true | The data type<br/>Possible values:<br/><ul><li>participant-defer</li></ul> | 
-| attributes | object | true | An ECF participant deferral action<br/>It conforms to [ECFParticipantDeferAttributes](#schema-ecfparticipantdeferattributes) schema. | 
+| attributes | object | true | An ECF participant deferral action<br/>It conforms to [ECFParticipantDeferAttributes](#ecfparticipantdeferattributes) schema. | 
 
 
 ### ECFParticipantDeferAttributes
@@ -1565,7 +1565,7 @@ The deferral request for a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | The details of a participant deferral request<br/>It conforms to [ECFParticipantDefer](#schema-ecfparticipantdefer) schema. | 
+| data | object | true | The details of a participant deferral request<br/>It conforms to [ECFParticipantDefer](#ecfparticipantdefer) schema. | 
 
 
 #### Example
@@ -1591,7 +1591,7 @@ An ECF Participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantDeferResponseData](#schema-ecfparticipantdeferresponsedata) schema. | 
+| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantDeferResponseData](#ecfparticipantdeferresponsedata) schema. | 
 
 
 ### ECFParticipantDeferResponseData
@@ -1603,7 +1603,7 @@ The details of a participant
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantDeferAttributesResponse](#schema-ecfparticipantdeferattributesresponse) schema. | 
+| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantDeferAttributesResponse](#ecfparticipantdeferattributesresponse) schema. | 
 
 
 ### ECFParticipantResponse
@@ -1613,7 +1613,7 @@ An ECF Participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | The details of a participant<br/>It conforms to [ECFParticipant](#schema-ecfparticipant) schema. | 
+| data | object | true | The details of a participant<br/>It conforms to [ECFParticipant](#ecfparticipant) schema. | 
 
 
 ### ECFParticipantResume
@@ -1624,7 +1624,7 @@ An ECF participant resume action
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | true | The data type<br/>Possible values:<br/><ul><li>participant-resume</li></ul> | 
-| attributes | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResumeAttributes](#schema-ecfparticipantresumeattributes) schema. | 
+| attributes | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResumeAttributes](#ecfparticipantresumeattributes) schema. | 
 
 
 ### ECFParticipantResumeAttributes
@@ -1678,7 +1678,7 @@ The resume request for a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResume](#schema-ecfparticipantresume) schema. | 
+| data | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResume](#ecfparticipantresume) schema. | 
 
 
 #### Example
@@ -1703,7 +1703,7 @@ An ECF Participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantResumeResponseData](#schema-ecfparticipantresumeresponsedata) schema. | 
+| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantResumeResponseData](#ecfparticipantresumeresponsedata) schema. | 
 
 
 ### ECFParticipantResumeResponseData
@@ -1715,7 +1715,7 @@ The details of a participant
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantResumeAttributesResponse](#schema-ecfparticipantresumeattributesresponse) schema. | 
+| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantResumeAttributesResponse](#ecfparticipantresumeattributesresponse) schema. | 
 
 
 ### ECFParticipantRetainedDeclaration
@@ -1726,7 +1726,7 @@ An ECF participant retained declaration request body
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | object | false | The request data<br/>Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | true | An ECF participant retained declaration<br/>It conforms to [ECFParticipantRetainedDeclarationAttributes](#schema-ecfparticipantretaineddeclarationattributes) schema. | 
+| attributes | object | true | An ECF participant retained declaration<br/>It conforms to [ECFParticipantRetainedDeclarationAttributes](#ecfparticipantretaineddeclarationattributes) schema. | 
 
 
 ### ECFParticipantRetainedDeclarationAttributes
@@ -1765,7 +1765,7 @@ A participant started declaration request body
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | object | false | The request data<br/>Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | true | An ECF started and completed participant declaration<br/>It conforms to [ECFParticipantStartedDeclarationAttributes](#schema-ecfparticipantstarteddeclarationattributes) schema. | 
+| attributes | object | true | An ECF started and completed participant declaration<br/>It conforms to [ECFParticipantStartedDeclarationAttributes](#ecfparticipantstarteddeclarationattributes) schema. | 
 
 
 ### ECFParticipantStartedDeclarationAttributes
@@ -1802,7 +1802,7 @@ An ECF participant withdrawal action
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | The data type<br/>Possible values:<br/><ul><li>participant-withdraw</li></ul> | 
-| attributes | object | false | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdrawAttributes](#schema-ecfparticipantwithdrawattributes) schema. | 
+| attributes | object | false | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdrawAttributes](#ecfparticipantwithdrawattributes) schema. | 
 
 
 ### ECFParticipantWithdrawAttributes
@@ -1860,7 +1860,7 @@ The details of a participant
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantWithdrawAttributesResponse](#schema-ecfparticipantwithdrawattributesresponse) schema. | 
+| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantWithdrawAttributesResponse](#ecfparticipantwithdrawattributesresponse) schema. | 
 
 
 ### ECFParticipantWithdrawRequest
@@ -1870,7 +1870,7 @@ The withdrawal request for a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdraw](#schema-ecfparticipantwithdraw) schema. | 
+| data | object | true | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdraw](#ecfparticipantwithdraw) schema. | 
 
 
 #### Example
@@ -1896,7 +1896,7 @@ An ECF Participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantWithdrawDataResponse](#schema-ecfparticipantwithdrawdataresponse) schema. | 
+| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantWithdrawDataResponse](#ecfparticipantwithdrawdataresponse) schema. | 
 
 
 ### Error
@@ -1917,7 +1917,7 @@ A list of errors
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| error | array | false | It conforms to [Error](#schema-error) schema. | 
+| error | array | false | It conforms to [Error](#error) schema. | 
 
 
 ### ListFilter
@@ -1949,7 +1949,7 @@ A list of ECF participants in the Comma Separated Value (CSV) format
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ECFParticipantCsvRow](#schema-ecfparticipantcsvrow) schema. | 
+| data | array | true | It conforms to [ECFParticipantCsvRow](#ecfparticipantcsvrow) schema. | 
 
 
 ### MultipleECFParticipantsResponse
@@ -1959,7 +1959,7 @@ A list of ECF participants
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ECFParticipant](#schema-ecfparticipant) schema. | 
+| data | array | true | It conforms to [ECFParticipant](#ecfparticipant) schema. | 
 
 
 ### MultipleParticipantDeclarationsCsvResponse
@@ -1969,7 +1969,7 @@ A list of participant declarations in the Comma Separated Value (CSV) format
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ParticipantDeclarationCsvRow](#schema-participantdeclarationcsvrow) schema. | 
+| data | array | true | It conforms to [ParticipantDeclarationCsvRow](#participantdeclarationcsvrow) schema. | 
 
 
 ### MultipleParticipantDeclarationsResponse
@@ -1979,7 +1979,7 @@ A list of participant declarations
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ParticipantDeclarationResponse](#schema-participantdeclarationresponse) schema. | 
+| data | array | true | It conforms to [ParticipantDeclarationResponse](#participantdeclarationresponse) schema. | 
 
 
 ### NotFoundResponse
@@ -2075,7 +2075,7 @@ A participant declaration data request for ECT participants from cohort 2025 onw
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024ECTStartedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTRetainedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectretainedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectcompletedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTExtendedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectextendedattributesrequest) </li></ul> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024ECTStartedAttributesRequest](#ecfparticipantdeclarationpost2024ectstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTRetainedAttributesRequest](#ecfparticipantdeclarationpost2024ectretainedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTCompletedAttributesRequest](#ecfparticipantdeclarationpost2024ectcompletedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTExtendedAttributesRequest](#ecfparticipantdeclarationpost2024ectextendedattributesrequest) </li></ul> | 
 
 
 ### ParticipantDeclarationPost2024MentorDataRequest
@@ -2086,7 +2086,7 @@ A participant declaration data request for mentor participants from cohort 2025 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024MentorStartedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024MentorCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorcompletedattributesrequest) </li></ul> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024MentorStartedAttributesRequest](#ecfparticipantdeclarationpost2024mentorstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024MentorCompletedAttributesRequest](#ecfparticipantdeclarationpost2024mentorcompletedattributesrequest) </li></ul> | 
 
 
 ### ParticipantDeclarationPre2025DataRequest
@@ -2097,7 +2097,7 @@ A participant declaration data request for participants in cohort 2024 and previ
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPre2025StartedAttributesRequest](#schema-ecfparticipantdeclarationpre2025startedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025RetainedAttributesRequest](#schema-ecfparticipantdeclarationpre2025retainedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025CompletedAttributesRequest](#schema-ecfparticipantdeclarationpre2025completedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025ExtendedAttributesRequest](#schema-ecfparticipantdeclarationpre2025extendedattributesrequest) </li></ul> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPre2025StartedAttributesRequest](#ecfparticipantdeclarationpre2025startedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025RetainedAttributesRequest](#ecfparticipantdeclarationpre2025retainedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025CompletedAttributesRequest](#ecfparticipantdeclarationpre2025completedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025ExtendedAttributesRequest](#ecfparticipantdeclarationpre2025extendedattributesrequest) </li></ul> | 
 
 
 ### ParticipantDeclarationRequest
@@ -2107,7 +2107,7 @@ An participant declaration request
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | This conforms to any of the following schemas:<br/><ul><li> [ParticipantDeclarationPre2025DataRequest](#schema-participantdeclarationpre2025datarequest) </li><li> [ParticipantDeclarationPost2024ECTDataRequest](#schema-participantdeclarationpost2024ectdatarequest) </li><li> [ParticipantDeclarationPost2024MentorDataRequest](#schema-participantdeclarationpost2024mentordatarequest) </li></ul> | 
+| data | object | true | This conforms to any of the following schemas:<br/><ul><li> [ParticipantDeclarationPre2025DataRequest](#participantdeclarationpre2025datarequest) </li><li> [ParticipantDeclarationPost2024ECTDataRequest](#participantdeclarationpost2024ectdatarequest) </li><li> [ParticipantDeclarationPost2024MentorDataRequest](#participantdeclarationpost2024mentordatarequest) </li></ul> | 
 
 
 ### ParticipantDeclarationResponse
@@ -2119,7 +2119,7 @@ A participant declaration response
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant declaration record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with a participant declaration response<br/>It conforms to [ParticipantDeclarationAttributes](#schema-participantdeclarationattributes) schema. | 
+| attributes | object | true | The data attributes associated with a participant declaration response<br/>It conforms to [ParticipantDeclarationAttributes](#participantdeclarationattributes) schema. | 
 
 
 ### ParticipantListFilter
@@ -2140,7 +2140,7 @@ A confirmation that the participant declaration has been recorded successfully
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | A participant declaration response<br/>It conforms to [ParticipantDeclarationResponse](#schema-participantdeclarationresponse) schema. | 
+| data | object | true | A participant declaration response<br/>It conforms to [ParticipantDeclarationResponse](#participantdeclarationresponse) schema. | 
 
 
 ### UnauthorisedResponse

--- a/documentation/ecf1_guidance/reference-v1.md
+++ b/documentation/ecf1_guidance/reference-v1.md
@@ -1245,17 +1245,17 @@ The data attributes associated with an ECF participant
 | full\_name | string | true | The full name of this ECF participant<br/> | 
 | mentor\_id | string | false | The unique identifier of this ECF participants mentor<br/> | 
 | school\_urn | string | true | The Unique Reference Number (URN) of the school that submitted this ECF participant<br/> | 
-| participant\_type | string | true | The type of ECF participant this record refers to<br/>Possible values:<br/><br/> - ect<br/> - mentor<br/><br/> | 
+| participant\_type | string | true | The type of ECF participant this record refers to<br/>Possible values:<br/><br/> * ect<br/> * mentor<br/><br/> | 
 | cohort | string | true | Indicates which call-off contract funds this participant’s training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year.<br/> | 
-| status | string | true | The status of this ECF participant record<br/>Possible values:<br/><br/> - active<br/> - withdrawn<br/><br/> | 
+| status | string | true | The status of this ECF participant record<br/>Possible values:<br/><br/> * active<br/> * withdrawn<br/><br/> | 
 | teacher\_reference\_number | string | false | The Teacher Reference Number (TRN) for this ECF participant<br/> | 
 | teacher\_reference\_number\_validated | boolean | false | Indicates whether the Teacher Reference Number (TRN) has been validated<br/> | 
 | eligible\_for\_funding | boolean | false | Indicates whether this participant is eligible to receive DfE funded induction<br/> | 
 | pupil\_premium\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to pupil premium<br/> | 
 | sparsity\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to sparsity<br/> | 
-| training\_status | string | true | The training status of the ECF participant<br/>Possible values:<br/><br/> - active<br/> - deferred<br/> - withdrawn<br/><br/> | 
+| training\_status | string | true | The training status of the ECF participant<br/>Possible values:<br/><br/> * active<br/> * deferred<br/> * withdrawn<br/><br/> | 
 | training\_record\_id | string | true | The unique identifier of the participant training record<br/> | 
-| schedule\_identifier | string | true | The schedule of the ECF participant<br/>Possible values:<br/><br/> - ecf-standard-september<br/> - ecf-standard-january<br/> - ecf-standard-april<br/> - ecf-reduced-september<br/> - ecf-reduced-january<br/> - ecf-reduced-april<br/> - ecf-extended-september<br/> - ecf-extended-january<br/> - ecf-extended-april<br/> - ecf-replacement-september<br/> - ecf-replacement-january<br/> - ecf-replacement-april<br/><br/> | 
+| schedule\_identifier | string | true | The schedule of the ECF participant<br/>Possible values:<br/><br/> - ecf-standard-september<br/> * ecf-standard-january<br/> * ecf-standard-april<br/> * ecf-reduced-september<br/> * ecf-reduced-january<br/> * ecf-reduced-april<br/> * ecf-extended-september<br/> * ecf-extended-january<br/> * ecf-extended-april<br/> * ecf-replacement-september<br/> * ecf-replacement-january<br/> * ecf-replacement-april<br/><br/> | 
 | updated\_at | string | true | The date the ECF participant was last updated<br/> | 
 
 

--- a/documentation/ecf1_guidance/reference-v2.md
+++ b/documentation/ecf1_guidance/reference-v2.md
@@ -26,8 +26,8 @@ The lead provider API for DfE’s manage teacher CPD service
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine participant declarations to return.<br/>This consumes a [ListFilterDeclarations](#schema-listfilterdeclarations) schema.<br/> | participant\_id=ab3a7848-1208-7679-942a-b4a70eed400a&updated\_since=2020-11-13T11:21:55Z | 
-| page | query | object | false | Pagination options to navigate through the list of participant declarations.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| filter | query | object | false | Refine participant declarations to return.<br/>This consumes a [ListFilterDeclarations](#listfilterdeclarations) schema.<br/> | participant\_id=ab3a7848-1208-7679-942a-b4a70eed400a&updated\_since=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of participant declarations.<br/>This consumes a [Pagination](#pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
 
 
 ### Responses
@@ -35,14 +35,14 @@ The lead provider API for DfE’s manage teacher CPD service
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A list of participant declarations<br/>This response returns a [MultipleParticipantDeclarationsResponse](#schema-multipleparticipantdeclarationsresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A list of participant declarations<br/>This response returns a [MultipleParticipantDeclarationsResponse](#multipleparticipantdeclarationsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A list of participant declarations
-This response returns a [MultipleParticipantDeclarationsResponse](#schema-multipleparticipantdeclarationsresponse) schema.
+This response returns a [MultipleParticipantDeclarationsResponse](#multipleparticipantdeclarationsresponse) schema.
 
 ```
 {
@@ -72,7 +72,7 @@ This response returns a [MultipleParticipantDeclarationsResponse](#schema-multip
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 
 ```
 {
@@ -95,23 +95,23 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ### Request body
 
 
-This consumes a [ParticipantDeclarationRequest](#schema-participantdeclarationrequest) schema.
+This consumes a [ParticipantDeclarationRequest](#participantdeclarationrequest) schema.
 
 ### Responses
 
 
 | Status | Description |
 | ---- | ---- |
-| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.<br/> | 
-| 422 | Bad or Missing parameter<br/>This response returns a [ErrorResponse](#schema-errorresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
-| 400 | Bad Request<br/>This response returns a [BadRequestResponse](#schema-badrequestresponse) schema.<br/> | 
+| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](#singleparticipantdeclarationresponse) schema.<br/> | 
+| 422 | Bad or Missing parameter<br/>This response returns a [ErrorResponse](#errorresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.<br/> | 
+| 400 | Bad Request<br/>This response returns a [BadRequestResponse](#badrequestresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - Successful
-This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.
+This response returns a [SingleParticipantDeclarationResponse](#singleparticipantdeclarationresponse) schema.
 
 ```
 {
@@ -132,7 +132,7 @@ This response returns a [SingleParticipantDeclarationResponse](#schema-singlepar
 ```
 
 422 - Bad or Missing parameter
-This response returns a [ErrorResponse](#schema-errorresponse) schema.
+This response returns a [ErrorResponse](#errorresponse) schema.
 
 ```
 {
@@ -146,7 +146,7 @@ This response returns a [ErrorResponse](#schema-errorresponse) schema.
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 
 ```
 {
@@ -155,7 +155,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ```
 
 400 - Bad Request
-This response returns a [BadRequestResponse](#schema-badrequestresponse) schema.
+This response returns a [BadRequestResponse](#badrequestresponse) schema.
 
 ```
 {
@@ -180,16 +180,16 @@ This response returns a [BadRequestResponse](#schema-badrequestresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A CSV file of participant declarations<br/>This response returns a [MultipleParticipantDeclarationsCsvResponse](#schema-multipleparticipantdeclarationscsvresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A CSV file of participant declarations<br/>This response returns a [MultipleParticipantDeclarationsCsvResponse](#multipleparticipantdeclarationscsvresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A CSV file of participant declarations
-This response returns a [MultipleParticipantDeclarationsCsvResponse](#schema-multipleparticipantdeclarationscsvresponse) schema.
+This response returns a [MultipleParticipantDeclarationsCsvResponse](#multipleparticipantdeclarationscsvresponse) schema.
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 
 ---
 
@@ -215,15 +215,15 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A single participant declaration<br/>This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.<br/> | 
-| 404 | Not found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A single participant declaration<br/>This response returns a [SingleParticipantDeclarationResponse](#singleparticipantdeclarationresponse) schema.<br/> | 
+| 404 | Not found<br/>This response returns a [NotFoundResponse](#notfoundresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A single participant declaration
-This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.
+This response returns a [SingleParticipantDeclarationResponse](#singleparticipantdeclarationresponse) schema.
 
 ```
 {
@@ -244,7 +244,7 @@ This response returns a [SingleParticipantDeclarationResponse](#schema-singlepar
 ```
 
 404 - Not found
-This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
+This response returns a [NotFoundResponse](#notfoundresponse) schema.
 
 ```
 {
@@ -253,7 +253,7 @@ This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 
 ```
 {
@@ -286,13 +286,13 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 
 | Status | Description |
 | ---- | ---- |
-| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.<br/> | 
+| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](#singleparticipantdeclarationresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - Successful
-This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.
+This response returns a [SingleParticipantDeclarationResponse](#singleparticipantdeclarationresponse) schema.
 
 ```
 {
@@ -329,8 +329,8 @@ This response returns a [SingleParticipantDeclarationResponse](#schema-singlepar
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine ECF participants to return.<br/>This consumes a [ListFilter](#schema-listfilter) schema.<br/> | filter[cohort]=2022&filter[updated\_since]=2020-11-13T11:21:55Z | 
-| page | query | object | false | Pagination options to navigate through the list of ECF participants.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| filter | query | object | false | Refine ECF participants to return.<br/>This consumes a [ListFilter](#listfilter) schema.<br/> | filter[cohort]=2022&filter[updated\_since]=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of ECF participants.<br/>This consumes a [Pagination](#pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
 
 
 ### Responses
@@ -338,14 +338,14 @@ This response returns a [SingleParticipantDeclarationResponse](#schema-singlepar
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A list of ECF participants<br/>This response returns a [MultipleECFParticipantsResponse](#schema-multipleecfparticipantsresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A list of ECF participants<br/>This response returns a [MultipleECFParticipantsResponse](#multipleecfparticipantsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A list of ECF participants
-This response returns a [MultipleECFParticipantsResponse](#schema-multipleecfparticipantsresponse) schema.
+This response returns a [MultipleECFParticipantsResponse](#multipleecfparticipantsresponse) schema.
 
 ```
 {
@@ -414,7 +414,7 @@ This response returns a [MultipleECFParticipantsResponse](#schema-multipleecfpar
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 
 ```
 {
@@ -439,7 +439,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine ECF participants to return.<br/>This consumes a [ListFilter](#schema-listfilter) schema.<br/> | updated\_since=2020-11-13T11:21:55Z | 
+| filter | query | object | false | Refine ECF participants to return.<br/>This consumes a [ListFilter](#listfilter) schema.<br/> | updated\_since=2020-11-13T11:21:55Z | 
 
 
 ### Responses
@@ -447,16 +447,16 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A CSV file of ECF participants<br/>This response returns a [MultipleECFParticipantsCsvResponse](#schema-multipleecfparticipantscsvresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A CSV file of ECF participants<br/>This response returns a [MultipleECFParticipantsCsvResponse](#multipleecfparticipantscsvresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A CSV file of ECF participants
-This response returns a [MultipleECFParticipantsCsvResponse](#schema-multipleecfparticipantscsvresponse) schema.
+This response returns a [MultipleECFParticipantsCsvResponse](#multipleecfparticipantscsvresponse) schema.
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 
 ---
 
@@ -482,14 +482,14 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A single ECF participant<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A single ECF participant<br/>This response returns a [ECFParticipantResponse](#ecfparticipantresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A single ECF participant
-This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](#ecfparticipantresponse) schema.
 
 ```
 {
@@ -519,7 +519,7 @@ This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse)
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 
 ```
 {
@@ -550,7 +550,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ### Request body
 
 
-This consumes a [ECFParticipantDeferRequest](#schema-ecfparticipantdeferrequest) schema.
+This consumes a [ECFParticipantDeferRequest](#ecfparticipantdeferrequest) schema.
 
 ### Request example
 
@@ -573,13 +573,13 @@ This consumes a [ECFParticipantDeferRequest](#schema-ecfparticipantdeferrequest)
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant being deferred<br/>This response returns a [ECFParticipantDeferResponse](#schema-ecfparticipantdeferresponse) schema.<br/> | 
+| 200 | The ECF participant being deferred<br/>This response returns a [ECFParticipantDeferResponse](#ecfparticipantdeferresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant being deferred
-This response returns a [ECFParticipantDeferResponse](#schema-ecfparticipantdeferresponse) schema.
+This response returns a [ECFParticipantDeferResponse](#ecfparticipantdeferresponse) schema.
 
 ```
 {
@@ -630,7 +630,7 @@ This response returns a [ECFParticipantDeferResponse](#schema-ecfparticipantdefe
 ### Request body
 
 
-This consumes a [ECFParticipantResumeRequest](#schema-ecfparticipantresumerequest) schema.
+This consumes a [ECFParticipantResumeRequest](#ecfparticipantresumerequest) schema.
 
 ### Request example
 
@@ -652,13 +652,13 @@ This consumes a [ECFParticipantResumeRequest](#schema-ecfparticipantresumereques
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant being resumed<br/>This response returns a [ECFParticipantResumeResponse](#schema-ecfparticipantresumeresponse) schema.<br/> | 
+| 200 | The ECF participant being resumed<br/>This response returns a [ECFParticipantResumeResponse](#ecfparticipantresumeresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant being resumed
-This response returns a [ECFParticipantResumeResponse](#schema-ecfparticipantresumeresponse) schema.
+This response returns a [ECFParticipantResumeResponse](#ecfparticipantresumeresponse) schema.
 
 ```
 {
@@ -709,7 +709,7 @@ This response returns a [ECFParticipantResumeResponse](#schema-ecfparticipantres
 ### Request body
 
 
-This consumes a [ECFParticipantWithdrawRequest](#schema-ecfparticipantwithdrawrequest) schema.
+This consumes a [ECFParticipantWithdrawRequest](#ecfparticipantwithdrawrequest) schema.
 
 ### Request example
 
@@ -732,13 +732,13 @@ This consumes a [ECFParticipantWithdrawRequest](#schema-ecfparticipantwithdrawre
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant being withdrawn<br/>This response returns a [ECFParticipantWithdrawResponse](#schema-ecfparticipantwithdrawresponse) schema.<br/> | 
+| 200 | The ECF participant being withdrawn<br/>This response returns a [ECFParticipantWithdrawResponse](#ecfparticipantwithdrawresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant being withdrawn
-This response returns a [ECFParticipantWithdrawResponse](#schema-ecfparticipantwithdrawresponse) schema.
+This response returns a [ECFParticipantWithdrawResponse](#ecfparticipantwithdrawresponse) schema.
 
 ```
 {
@@ -789,7 +789,7 @@ This response returns a [ECFParticipantWithdrawResponse](#schema-ecfparticipantw
 ### Request body
 
 
-This consumes a [ECFParticipantChangeScheduleRequest](#schema-ecfparticipantchangeschedulerequest) schema.
+This consumes a [ECFParticipantChangeScheduleRequest](#ecfparticipantchangeschedulerequest) schema.
 
 ### Request example
 
@@ -813,13 +813,13 @@ This consumes a [ECFParticipantChangeScheduleRequest](#schema-ecfparticipantchan
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant changing schedule<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
+| 200 | The ECF participant changing schedule<br/>This response returns a [ECFParticipantResponse](#ecfparticipantresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant changing schedule
-This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](#ecfparticipantresponse) schema.
 
 ```
 {
@@ -899,7 +899,7 @@ The details of a participant
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantAttributes](#schema-ecfparticipantattributes) schema. | 
+| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantAttributes](#ecfparticipantattributes) schema. | 
 
 
 ### ECFParticipantAttributes
@@ -935,7 +935,7 @@ An ECF participant change schedule action
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | true | The data type<br/>Possible values:<br/><ul><li>participant-change-schedule</li></ul> | 
-| attributes | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeScheduleAttributes](#schema-ecfparticipantchangescheduleattributes) schema. | 
+| attributes | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeScheduleAttributes](#ecfparticipantchangescheduleattributes) schema. | 
 
 
 #### Example
@@ -983,7 +983,7 @@ The change schedule request for a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeSchedule](#schema-ecfparticipantchangeschedule) schema. | 
+| data | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeSchedule](#ecfparticipantchangeschedule) schema. | 
 
 
 #### Example
@@ -1177,7 +1177,7 @@ The details of a participant deferral request
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | true | The data type<br/>Possible values:<br/><ul><li>participant-defer</li></ul> | 
-| attributes | object | true | An ECF participant deferral action<br/>It conforms to [ECFParticipantDeferAttributes](#schema-ecfparticipantdeferattributes) schema. | 
+| attributes | object | true | An ECF participant deferral action<br/>It conforms to [ECFParticipantDeferAttributes](#ecfparticipantdeferattributes) schema. | 
 
 
 ### ECFParticipantDeferAttributes
@@ -1233,7 +1233,7 @@ The deferral request for a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | The details of a participant deferral request<br/>It conforms to [ECFParticipantDefer](#schema-ecfparticipantdefer) schema. | 
+| data | object | true | The details of a participant deferral request<br/>It conforms to [ECFParticipantDefer](#ecfparticipantdefer) schema. | 
 
 
 #### Example
@@ -1259,7 +1259,7 @@ An ECF Participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantDeferResponseData](#schema-ecfparticipantdeferresponsedata) schema. | 
+| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantDeferResponseData](#ecfparticipantdeferresponsedata) schema. | 
 
 
 ### ECFParticipantDeferResponseData
@@ -1271,7 +1271,7 @@ The details of a participant
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantDeferAttributesResponse](#schema-ecfparticipantdeferattributesresponse) schema. | 
+| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantDeferAttributesResponse](#ecfparticipantdeferattributesresponse) schema. | 
 
 
 ### ECFParticipantResponse
@@ -1281,7 +1281,7 @@ An ECF Participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | The details of a participant<br/>It conforms to [ECFParticipant](#schema-ecfparticipant) schema. | 
+| data | object | true | The details of a participant<br/>It conforms to [ECFParticipant](#ecfparticipant) schema. | 
 
 
 ### ECFParticipantResume
@@ -1292,7 +1292,7 @@ An ECF participant resume action
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | true | The data type<br/>Possible values:<br/><ul><li>participant-resume</li></ul> | 
-| attributes | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResumeAttributes](#schema-ecfparticipantresumeattributes) schema. | 
+| attributes | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResumeAttributes](#ecfparticipantresumeattributes) schema. | 
 
 
 ### ECFParticipantResumeAttributes
@@ -1346,7 +1346,7 @@ The resume request for a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResume](#schema-ecfparticipantresume) schema. | 
+| data | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResume](#ecfparticipantresume) schema. | 
 
 
 #### Example
@@ -1371,7 +1371,7 @@ An ECF Participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantResumeResponseData](#schema-ecfparticipantresumeresponsedata) schema. | 
+| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantResumeResponseData](#ecfparticipantresumeresponsedata) schema. | 
 
 
 ### ECFParticipantResumeResponseData
@@ -1383,7 +1383,7 @@ The details of a participant
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantResumeAttributesResponse](#schema-ecfparticipantresumeattributesresponse) schema. | 
+| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantResumeAttributesResponse](#ecfparticipantresumeattributesresponse) schema. | 
 
 
 ### ECFParticipantRetainedDeclaration
@@ -1394,7 +1394,7 @@ An ECF participant retained declaration request body
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | object | false | The request data<br/>Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | true | An ECF participant retained declaration<br/>It conforms to [ECFParticipantRetainedDeclarationAttributes](#schema-ecfparticipantretaineddeclarationattributes) schema. | 
+| attributes | object | true | An ECF participant retained declaration<br/>It conforms to [ECFParticipantRetainedDeclarationAttributes](#ecfparticipantretaineddeclarationattributes) schema. | 
 
 
 ### ECFParticipantRetainedDeclarationAttributes
@@ -1433,7 +1433,7 @@ A participant started declaration request body
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | object | false | The request data<br/>Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | true | An ECF started and completed participant declaration<br/>It conforms to [ECFParticipantStartedDeclarationAttributes](#schema-ecfparticipantstarteddeclarationattributes) schema. | 
+| attributes | object | true | An ECF started and completed participant declaration<br/>It conforms to [ECFParticipantStartedDeclarationAttributes](#ecfparticipantstarteddeclarationattributes) schema. | 
 
 
 ### ECFParticipantStartedDeclarationAttributes
@@ -1470,7 +1470,7 @@ An ECF participant withdrawal action
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | The data type<br/>Possible values:<br/><ul><li>participant-withdraw</li></ul> | 
-| attributes | object | false | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdrawAttributes](#schema-ecfparticipantwithdrawattributes) schema. | 
+| attributes | object | false | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdrawAttributes](#ecfparticipantwithdrawattributes) schema. | 
 
 
 ### ECFParticipantWithdrawAttributes
@@ -1528,7 +1528,7 @@ The details of a participant
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantWithdrawAttributesResponse](#schema-ecfparticipantwithdrawattributesresponse) schema. | 
+| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantWithdrawAttributesResponse](#ecfparticipantwithdrawattributesresponse) schema. | 
 
 
 ### ECFParticipantWithdrawRequest
@@ -1538,7 +1538,7 @@ The withdrawal request for a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdraw](#schema-ecfparticipantwithdraw) schema. | 
+| data | object | true | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdraw](#ecfparticipantwithdraw) schema. | 
 
 
 #### Example
@@ -1564,7 +1564,7 @@ An ECF Participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantWithdrawDataResponse](#schema-ecfparticipantwithdrawdataresponse) schema. | 
+| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantWithdrawDataResponse](#ecfparticipantwithdrawdataresponse) schema. | 
 
 
 ### Error
@@ -1585,7 +1585,7 @@ A list of errors
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| error | array | false | It conforms to [Error](#schema-error) schema. | 
+| error | array | false | It conforms to [Error](#error) schema. | 
 
 
 ### ListFilter
@@ -1616,7 +1616,7 @@ A list of ECF participants in the Comma Separated Value (CSV) format
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ECFParticipantCsvRow](#schema-ecfparticipantcsvrow) schema. | 
+| data | array | true | It conforms to [ECFParticipantCsvRow](#ecfparticipantcsvrow) schema. | 
 
 
 ### MultipleECFParticipantsResponse
@@ -1626,7 +1626,7 @@ A list of ECF participants
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ECFParticipant](#schema-ecfparticipant) schema. | 
+| data | array | true | It conforms to [ECFParticipant](#ecfparticipant) schema. | 
 
 
 ### MultipleParticipantDeclarationsCsvResponse
@@ -1636,7 +1636,7 @@ A list of participant declarations in the Comma Separated Value (CSV) format
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ParticipantDeclarationCsvRow](#schema-participantdeclarationcsvrow) schema. | 
+| data | array | true | It conforms to [ParticipantDeclarationCsvRow](#participantdeclarationcsvrow) schema. | 
 
 
 ### MultipleParticipantDeclarationsResponse
@@ -1646,7 +1646,7 @@ A list of participant declarations
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ParticipantDeclarationResponse](#schema-participantdeclarationresponse) schema. | 
+| data | array | true | It conforms to [ParticipantDeclarationResponse](#participantdeclarationresponse) schema. | 
 
 
 ### NotFoundResponse
@@ -1710,7 +1710,7 @@ A participant declaration data request for ECT participants from cohort 2025 onw
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024ECTStartedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTRetainedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectretainedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectcompletedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTExtendedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectextendedattributesrequest) </li></ul> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024ECTStartedAttributesRequest](#ecfparticipantdeclarationpost2024ectstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTRetainedAttributesRequest](#ecfparticipantdeclarationpost2024ectretainedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTCompletedAttributesRequest](#ecfparticipantdeclarationpost2024ectcompletedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTExtendedAttributesRequest](#ecfparticipantdeclarationpost2024ectextendedattributesrequest) </li></ul> | 
 
 
 ### ParticipantDeclarationPost2024MentorDataRequest
@@ -1721,7 +1721,7 @@ A participant declaration data request for mentor participants from cohort 2025 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024MentorStartedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024MentorCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorcompletedattributesrequest) </li></ul> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024MentorStartedAttributesRequest](#ecfparticipantdeclarationpost2024mentorstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024MentorCompletedAttributesRequest](#ecfparticipantdeclarationpost2024mentorcompletedattributesrequest) </li></ul> | 
 
 
 ### ParticipantDeclarationPre2025DataRequest
@@ -1732,7 +1732,7 @@ A participant declaration data request for participants in cohort 2024 and previ
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPre2025StartedAttributesRequest](#schema-ecfparticipantdeclarationpre2025startedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025RetainedAttributesRequest](#schema-ecfparticipantdeclarationpre2025retainedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025CompletedAttributesRequest](#schema-ecfparticipantdeclarationpre2025completedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025ExtendedAttributesRequest](#schema-ecfparticipantdeclarationpre2025extendedattributesrequest) </li></ul> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPre2025StartedAttributesRequest](#ecfparticipantdeclarationpre2025startedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025RetainedAttributesRequest](#ecfparticipantdeclarationpre2025retainedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025CompletedAttributesRequest](#ecfparticipantdeclarationpre2025completedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025ExtendedAttributesRequest](#ecfparticipantdeclarationpre2025extendedattributesrequest) </li></ul> | 
 
 
 ### ParticipantDeclarationRequest
@@ -1742,7 +1742,7 @@ An participant declaration request
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | This conforms to any of the following schemas:<br/><ul><li> [ParticipantDeclarationPre2025DataRequest](#schema-participantdeclarationpre2025datarequest) </li><li> [ParticipantDeclarationPost2024ECTDataRequest](#schema-participantdeclarationpost2024ectdatarequest) </li><li> [ParticipantDeclarationPost2024MentorDataRequest](#schema-participantdeclarationpost2024mentordatarequest) </li></ul> | 
+| data | object | true | This conforms to any of the following schemas:<br/><ul><li> [ParticipantDeclarationPre2025DataRequest](#participantdeclarationpre2025datarequest) </li><li> [ParticipantDeclarationPost2024ECTDataRequest](#participantdeclarationpost2024ectdatarequest) </li><li> [ParticipantDeclarationPost2024MentorDataRequest](#participantdeclarationpost2024mentordatarequest) </li></ul> | 
 
 
 ### ParticipantDeclarationResponse
@@ -1754,7 +1754,7 @@ A participant declaration response
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant declaration record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with a participant declaration response<br/>It conforms to [ParticipantDeclarationAttributes](#schema-participantdeclarationattributes) schema. | 
+| attributes | object | true | The data attributes associated with a participant declaration response<br/>It conforms to [ParticipantDeclarationAttributes](#participantdeclarationattributes) schema. | 
 
 
 ### ParticipantListFilter
@@ -1775,7 +1775,7 @@ A confirmation that the participant declaration has been recorded successfully
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | A participant declaration response<br/>It conforms to [ParticipantDeclarationResponse](#schema-participantdeclarationresponse) schema. | 
+| data | object | true | A participant declaration response<br/>It conforms to [ParticipantDeclarationResponse](#participantdeclarationresponse) schema. | 
 
 
 ### UnauthorisedResponse

--- a/documentation/ecf1_guidance/reference-v2.md
+++ b/documentation/ecf1_guidance/reference-v2.md
@@ -1,0 +1,1789 @@
+
+# Lead provider API - 2.0.0
+
+
+The lead provider API for DfE’s manage teacher CPD service
+
+## Base URLs
+
+
+ **Sandbox** 
+ [https://sb.manage-training-for-early-career-teachers.education.gov.uk](https://sb.manage-training-for-early-career-teachers.education.gov.uk) 
+ **Current environment** 
+ [/](/) 
+ **Production** 
+ [https://manage-training-for-early-career-teachers.education.gov.uk](https://manage-training-for-early-career-teachers.education.gov.uk) 
+## GET
+    
+    
+      /api/v2/participant-declarations
+
+
+ _List all participant declarations_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| filter | query | object | false | Refine participant declarations to return.<br/>This consumes a [ListFilterDeclarations](#schema-listfilterdeclarations) schema.<br/> | participant\_id=ab3a7848-1208-7679-942a-b4a70eed400a&updated\_since=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of participant declarations.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | A list of participant declarations<br/>This response returns a [MultipleParticipantDeclarationsResponse](#schema-multipleparticipantdeclarationsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - A list of participant declarations
+This response returns a [MultipleParticipantDeclarationsResponse](#schema-multipleparticipantdeclarationsresponse) schema.
+
+```
+{
+  "data": [
+    {
+      "id": "01017c12-354b-4b2d-b621-3531ab729c43",
+      "type": "participant-declaration",
+      "attributes": {
+        "participant_id": "db3a7848-7308-4879-942a-c4a70ced400a",
+        "declaration_type": "started",
+        "declaration_date": "2021-05-31T02:21:32.000Z",
+        "course_identifier": "ecf-mentor"
+      }
+    },
+    {
+      "id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+      "type": "participant-declaration",
+      "attributes": {
+        "participant_id": "ab3a7848-7308-4879-942a-c4a70ced400a",
+        "declaration_type": "started",
+        "declaration_date": "2021-05-31T02:21:32.000Z",
+        "course_identifier": "ecf-mentor"
+      }
+    }
+  ]
+}
+```
+
+401 - Unauthorized
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+
+```
+{
+  "error": "HTTP Token: Access denied"
+}
+```
+
+
+---
+
+
+## POST
+    
+    
+      /api/v2/participant-declarations
+
+
+ _Declare a participant has reached a milestone. Idempotent endpoint - submitting exact copy of a request will return the same response body as submitting it the first time._ 
+
+### Request body
+
+
+This consumes a [ParticipantDeclarationRequest](#schema-participantdeclarationrequest) schema.
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.<br/> | 
+| 422 | Bad or Missing parameter<br/>This response returns a [ErrorResponse](#schema-errorresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 400 | Bad Request<br/>This response returns a [BadRequestResponse](#schema-badrequestresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - Successful
+This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.
+
+```
+{
+  "data": {
+    "id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+    "type": "participant-declaration",
+    "attributes": {
+      "participant_id": "db3a7848-7308-4879-942a-c4a70ced400a",
+      "declaration_type": "started",
+      "declaration_date": "2021-05-31T02:21:32.000Z",
+      "course_identifier": "ecf-induction",
+      "state": "submitted",
+      "updated_at": "2021-05-31T02:22:32.000Z",
+      "has_passed": true
+    }
+  }
+}
+```
+
+422 - Bad or Missing parameter
+This response returns a [ErrorResponse](#schema-errorresponse) schema.
+
+```
+{
+  "error": [
+    {
+      "title": "string",
+      "detail": "string"
+    }
+  ]
+}
+```
+
+401 - Unauthorized
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+
+```
+{
+  "error": "HTTP Token: Access denied"
+}
+```
+
+400 - Bad Request
+This response returns a [BadRequestResponse](#schema-badrequestresponse) schema.
+
+```
+{
+  "bad_request": "string"
+}
+```
+
+
+---
+
+
+## GET
+    
+    
+      /api/v2/participant-declarations.csv
+
+
+ _Retrieve all participant declarations in CSV format_ 
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | A CSV file of participant declarations<br/>This response returns a [MultipleParticipantDeclarationsCsvResponse](#schema-multipleparticipantdeclarationscsvresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - A CSV file of participant declarations
+This response returns a [MultipleParticipantDeclarationsCsvResponse](#schema-multipleparticipantdeclarationscsvresponse) schema.
+401 - Unauthorized
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+
+---
+
+
+## GET
+    
+    
+      /api/v2/participant-declarations/{id}
+
+
+ _Get single participant declaration_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| id | path | string | true | The ID of the participant declaration ID<br/> | 9ed4612b-f8bd-44d9-b296-38ab103fadd2 | 
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | A single participant declaration<br/>This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.<br/> | 
+| 404 | Not found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - A single participant declaration
+This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.
+
+```
+{
+  "data": {
+    "id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+    "type": "participant-declaration",
+    "attributes": {
+      "participant_id": "db3a7848-7308-4879-942a-c4a70ced400a",
+      "declaration_type": "started",
+      "declaration_date": "2021-05-31T02:21:32.000Z",
+      "course_identifier": "ecf-induction",
+      "state": "submitted",
+      "updated_at": "2021-05-31T02:22:32.000Z",
+      "has_passed": true
+    }
+  }
+}
+```
+
+404 - Not found
+This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
+
+```
+{
+  "error": "Resource not found"
+}
+```
+
+401 - Unauthorized
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+
+```
+{
+  "error": "HTTP Token: Access denied"
+}
+```
+
+
+---
+
+
+## PUT
+    
+    
+      /api/v2/participant-declarations/{id}/void
+
+
+ _Void a declaration - it will not be soft-deleted_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| id | path | string | true | The ID of the declaration to void<br/> | 28c461ee-ffc0-4e56-96bd-788579a0ed75 | 
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - Successful
+This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.
+
+```
+{
+  "data": {
+    "id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+    "type": "participant-declaration",
+    "attributes": {
+      "participant_id": "db3a7848-7308-4879-942a-c4a70ced400a",
+      "declaration_type": "started",
+      "declaration_date": "2021-05-31T02:21:32.000Z",
+      "course_identifier": "ecf-induction",
+      "state": "submitted",
+      "updated_at": "2021-05-31T02:22:32.000Z",
+      "has_passed": true
+    }
+  }
+}
+```
+
+
+---
+
+
+## GET
+    
+    
+      /api/v2/participants/ecf
+
+
+ _Retrieve multiple participants, replaces /api/v2/participants_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| filter | query | object | false | Refine ECF participants to return.<br/>This consumes a [ListFilter](#schema-listfilter) schema.<br/> | filter[cohort]=2022&filter[updated\_since]=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of ECF participants.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | A list of ECF participants<br/>This response returns a [MultipleECFParticipantsResponse](#schema-multipleecfparticipantsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - A list of ECF participants
+This response returns a [MultipleECFParticipantsResponse](#schema-multipleecfparticipantsresponse) schema.
+
+```
+{
+  "data": [
+    {
+      "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+      "type": "participant",
+      "attributes": {
+        "email": "jane.smith@some-school.example.com",
+        "full_name": "Jane Smith",
+        "mentor_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+        "school_urn": "106286",
+        "participant_type": "ect",
+        "cohort": "2021",
+        "status": "active",
+        "teacher_reference_number": "0012345",
+        "teacher_reference_number_validated": true,
+        "eligible_for_funding": true,
+        "pupil_premium_uplift": false,
+        "sparsity_uplift": true,
+        "training_status": "active",
+        "updated_at": "2021-05-31T02:22:32.000Z"
+      }
+    },
+    {
+      "id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+      "type": "participant",
+      "attributes": {
+        "email": "martin.jones@some-school.example.com",
+        "full_name": "Martin jones",
+        "school_urn": "106286",
+        "participant_type": "mentor",
+        "cohort": "2021",
+        "status": "active",
+        "teacher_reference_number": null,
+        "teacher_reference_number_validated": false,
+        "eligible_for_funding": null,
+        "pupil_premium_uplift": true,
+        "sparsity_uplift": false,
+        "training_status": "deferred",
+        "updated_at": "2021-05-31T02:22:32.000Z"
+      }
+    },
+    {
+      "id": "eb475531-bf08-48ae-b0ef-c2ff5e5bdef0",
+      "type": "participant",
+      "attributes": {
+        "email": "null,",
+        "full_name": null,
+        "mentor_id": null,
+        "school_urn": null,
+        "participant_type": null,
+        "cohort": null,
+        "status": "withdrawn",
+        "teacher_reference_number": null,
+        "teacher_reference_number_validated": null,
+        "eligible_for_funding": null,
+        "pupil_premium_uplift": null,
+        "sparsity_uplift": null,
+        "training_status": "withdrawn",
+        "updated_at": "2021-05-31T02:22:32.000Z"
+      }
+    }
+  ]
+}
+```
+
+401 - Unauthorized
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+
+```
+{
+  "error": "HTTP Token: Access denied"
+}
+```
+
+
+---
+
+
+## GET
+    
+    
+      /api/v2/participants/ecf.csv
+
+
+ _Retrieve all participants in CSV format, replaces /api/v2/participants.csv_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| filter | query | object | false | Refine ECF participants to return.<br/>This consumes a [ListFilter](#schema-listfilter) schema.<br/> | updated\_since=2020-11-13T11:21:55Z | 
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | A CSV file of ECF participants<br/>This response returns a [MultipleECFParticipantsCsvResponse](#schema-multipleecfparticipantscsvresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - A CSV file of ECF participants
+This response returns a [MultipleECFParticipantsCsvResponse](#schema-multipleecfparticipantscsvresponse) schema.
+401 - Unauthorized
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+
+---
+
+
+## GET
+    
+    
+      /api/v2/participants/ecf/{id}
+
+
+ _Get a single ECF participant_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| id | path | string | true | The ID of the ECF participant.<br/> | 28c461ee-ffc0-4e56-96bd-788579a0ed75 | 
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | A single ECF participant<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - A single ECF participant
+This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+
+```
+{
+  "data": {
+    "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+    "type": "participant",
+    "attributes": {
+      "email": "jane.smith@some-school.example.com",
+      "full_name": "Jane Smith",
+      "mentor_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+      "school_urn": "106286",
+      "participant_type": "ect",
+      "cohort": "2021",
+      "status": "active",
+      "teacher_reference_number": "1234567",
+      "teacher_reference_number_validated": true,
+      "eligible_for_funding": true,
+      "pupil_premium_uplift": true,
+      "sparsity_uplift": true,
+      "training_status": "active",
+      "training_record_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+      "schedule_identifier": "ecf-standard-january",
+      "updated_at": "2021-05-31T02:22:32.000Z"
+    }
+  }
+}
+```
+
+401 - Unauthorized
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+
+```
+{
+  "error": "HTTP Token: Access denied"
+}
+```
+
+
+---
+
+
+## PUT
+    
+    
+      /api/v2/participants/ecf/{id}/defer
+
+
+ _Notify that an ECF participant is taking a break from their course_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| id | path | string | true | The ID of the participant to defer<br/> | 28c461ee-ffc0-4e56-96bd-788579a0ed75 | 
+
+
+### Request body
+
+
+This consumes a [ECFParticipantDeferRequest](#schema-ecfparticipantdeferrequest) schema.
+
+### Request example
+
+
+```
+{
+  "data": {
+    "type": "participant-defer",
+    "attributes": {
+      "reason": "career-break",
+      "course_identifier": "ecf-mentor"
+    }
+  }
+}
+```
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | The ECF participant being deferred<br/>This response returns a [ECFParticipantDeferResponse](#schema-ecfparticipantdeferresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - The ECF participant being deferred
+This response returns a [ECFParticipantDeferResponse](#schema-ecfparticipantdeferresponse) schema.
+
+```
+{
+  "data": {
+    "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+    "type": "participant",
+    "attributes": {
+      "email": "jane.smith@some-school.example.com",
+      "full_name": "Jane Smith",
+      "mentor_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+      "school_urn": "106286",
+      "participant_type": "ect",
+      "cohort": "2021",
+      "status": "active",
+      "teacher_reference_number": "1234567",
+      "teacher_reference_number_validated": true,
+      "eligible_for_funding": true,
+      "pupil_premium_uplift": true,
+      "sparsity_uplift": true,
+      "training_status": "deferred",
+      "schedule_identifier": "ecf-standard-january",
+      "updated_at": "2021-05-31T02:22:32.000Z"
+    }
+  }
+}
+```
+
+
+---
+
+
+## PUT
+    
+    
+      /api/v2/participants/ecf/{id}/resume
+
+
+ _Notify that an ECF participant is resuming their course_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| id | path | string | true | The ID of the participant to resume<br/> | 28c461ee-ffc0-4e56-96bd-788579a0ed75 | 
+
+
+### Request body
+
+
+This consumes a [ECFParticipantResumeRequest](#schema-ecfparticipantresumerequest) schema.
+
+### Request example
+
+
+```
+{
+  "data": {
+    "type": "participant-resume",
+    "attributes": {
+      "course_identifier": "ecf-mentor"
+    }
+  }
+}
+```
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | The ECF participant being resumed<br/>This response returns a [ECFParticipantResumeResponse](#schema-ecfparticipantresumeresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - The ECF participant being resumed
+This response returns a [ECFParticipantResumeResponse](#schema-ecfparticipantresumeresponse) schema.
+
+```
+{
+  "data": {
+    "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+    "type": "participant",
+    "attributes": {
+      "email": "jane.smith@some-school.example.com",
+      "full_name": "Jane Smith",
+      "mentor_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+      "school_urn": "106286",
+      "participant_type": "ect",
+      "cohort": "2021",
+      "status": "active",
+      "teacher_reference_number": "1234567",
+      "teacher_reference_number_validated": true,
+      "eligible_for_funding": true,
+      "pupil_premium_uplift": true,
+      "sparsity_uplift": true,
+      "training_status": "active",
+      "schedule_identifier": "ecf-standard-january",
+      "updated_at": "2021-05-31T02:22:32.000Z"
+    }
+  }
+}
+```
+
+
+---
+
+
+## PUT
+    
+    
+      /api/v2/participants/ecf/{id}/withdraw
+
+
+ _Notify that an ECF participant has withdrawn from their course_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| id | path | string | true | The ID of the participant to withdraw<br/> | 28c461ee-ffc0-4e56-96bd-788579a0ed75 | 
+
+
+### Request body
+
+
+This consumes a [ECFParticipantWithdrawRequest](#schema-ecfparticipantwithdrawrequest) schema.
+
+### Request example
+
+
+```
+{
+  "data": {
+    "type": "participant-withdraw",
+    "attributes": {
+      "reason": "left-teaching-profession",
+      "course_identifier": "ecf-mentor"
+    }
+  }
+}
+```
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | The ECF participant being withdrawn<br/>This response returns a [ECFParticipantWithdrawResponse](#schema-ecfparticipantwithdrawresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - The ECF participant being withdrawn
+This response returns a [ECFParticipantWithdrawResponse](#schema-ecfparticipantwithdrawresponse) schema.
+
+```
+{
+  "data": {
+    "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+    "type": "participant",
+    "attributes": {
+      "email": "jane.smith@some-school.example.com",
+      "full_name": "Jane Smith",
+      "mentor_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+      "school_urn": "106286",
+      "participant_type": "ect",
+      "cohort": "2021",
+      "status": "active",
+      "teacher_reference_number": "1234567",
+      "teacher_reference_number_validated": true,
+      "eligible_for_funding": true,
+      "pupil_premium_uplift": true,
+      "sparsity_uplift": true,
+      "training_status": "withdrawn",
+      "schedule_identifier": "ecf-standard-january",
+      "updated_at": "2021-05-31T02:22:32.000Z"
+    }
+  }
+}
+```
+
+
+---
+
+
+## PUT
+    
+    
+      /api/v2/participants/ecf/{id}/change-schedule
+
+
+ _Notify that an ECF participant is changing training schedule_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| id | path | string | true | The ID of the participant<br/> | 28c461ee-ffc0-4e56-96bd-788579a0ed75 | 
+
+
+### Request body
+
+
+This consumes a [ECFParticipantChangeScheduleRequest](#schema-ecfparticipantchangeschedulerequest) schema.
+
+### Request example
+
+
+```
+{
+  "data": {
+    "type": "participant-change-schedule",
+    "attributes": {
+      "schedule_identifier": "ecf-standard-january",
+      "course_identifier": "ecf-mentor",
+      "cohort": "2021"
+    }
+  }
+}
+```
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | The ECF participant changing schedule<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - The ECF participant changing schedule
+This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+
+```
+{
+  "data": {
+    "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+    "type": "participant",
+    "attributes": {
+      "email": "jane.smith@some-school.example.com",
+      "full_name": "Jane Smith",
+      "mentor_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+      "school_urn": "106286",
+      "participant_type": "ect",
+      "cohort": "2021",
+      "status": "active",
+      "teacher_reference_number": "1234567",
+      "teacher_reference_number_validated": true,
+      "eligible_for_funding": true,
+      "pupil_premium_uplift": true,
+      "sparsity_uplift": true,
+      "training_status": "active",
+      "training_record_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+      "schedule_identifier": "ecf-standard-january",
+      "updated_at": "2021-05-31T02:22:32.000Z"
+    }
+  }
+}
+```
+
+
+---
+
+
+## Schemas
+
+
+### BadOrMissingParametersResponse
+
+
+Request was missing data or contained invalid data
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| bad\_or\_missing\_parameters | array | true | An error message for each bad or missing attribute describing the problems<br/> | 
+
+
+### BadRequestResponse
+
+
+Bad Request
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| bad\_request | string | false | An error message for bad request<br/> | 
+
+
+#### Example
+
+
+```
+{
+  "errors": [
+    {
+      "title": "Bad request",
+      "detail": "correct json data structure required. See API docs for reference"
+    }
+  ]
+}
+```
+
+
+### ECFParticipant
+
+
+The details of a participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| id | string | true | The unique identifier of the participant record<br/> | 
+| type | string | true | The data type<br/> | 
+| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantAttributes](#schema-ecfparticipantattributes) schema. | 
+
+
+### ECFParticipantAttributes
+
+
+The data attributes associated with an ECF participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| email | string | true | The email address registered for this ECF participant<br/> | 
+| full\_name | string | true | The full name of this ECF participant<br/> | 
+| mentor\_id | string | false | The unique identifier of this ECF participants mentor<br/> | 
+| school\_urn | string | true | The Unique Reference Number (URN) of the school that submitted this ECF participant<br/> | 
+| participant\_type | string | true | The type of ECF participant this record refers to<br/>Possible values:<br/><br/> - ect<br/> - mentor<br/><br/> | 
+| cohort | string | true | Indicates which call-off contract funds this participant’s training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year.<br/> | 
+| status | string | true | The status of this ECF participant record<br/>Possible values:<br/><br/> - active<br/> - withdrawn<br/><br/> | 
+| teacher\_reference\_number | string | false | The Teacher Reference Number (TRN) for this ECF participant<br/> | 
+| teacher\_reference\_number\_validated | boolean | false | Indicates whether the Teacher Reference Number (TRN) has been validated<br/> | 
+| eligible\_for\_funding | boolean | false | Indicates whether this participant is eligible to receive DfE funded induction<br/> | 
+| pupil\_premium\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to pupil premium<br/> | 
+| sparsity\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to sparsity<br/> | 
+| training\_status | string | true | The training status of the ECF participant<br/>Possible values:<br/><br/> - active<br/> - deferred<br/> - withdrawn<br/><br/> | 
+| training\_record\_id | string | true | The unique identifier of the participant training record<br/> | 
+| schedule\_identifier | string | true | The schedule of the ECF participant<br/>Possible values:<br/><br/> - ecf-standard-september<br/> - ecf-standard-january<br/> - ecf-standard-april<br/> - ecf-reduced-september<br/> - ecf-reduced-january<br/> - ecf-reduced-april<br/> - ecf-extended-september<br/> - ecf-extended-january<br/> - ecf-extended-april<br/> - ecf-replacement-september<br/> - ecf-replacement-january<br/> - ecf-replacement-april<br/><br/> | 
+| updated\_at | string | true | The date the ECF participant was last updated<br/> | 
+
+
+### ECFParticipantChangeSchedule
+
+
+An ECF participant change schedule action
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| type | string | true | The data type<br/>Possible values:<br/><br/> - participant-change-schedule<br/><br/> | 
+| attributes | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeScheduleAttributes](#schema-ecfparticipantchangescheduleattributes) schema. | 
+
+
+#### Example
+
+
+```
+{
+  "type": "participant-change-schedule",
+  "attributes": {
+    "schedule_identifier": "ecf-standard-january",
+    "course_identifier": "ecf-mentor"
+  }
+}
+```
+
+
+### ECFParticipantChangeScheduleAttributes
+
+
+An ECF participant change schedule action
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| schedule\_identifier | string | true | The new schedule of the participant<br/>Possible values:<br/><br/> - ecf-standard-september<br/> - ecf-standard-january<br/> - ecf-standard-april<br/> - ecf-reduced-september<br/> - ecf-reduced-january<br/> - ecf-reduced-april<br/> - ecf-extended-september<br/> - ecf-extended-january<br/> - ecf-extended-april<br/> - ecf-replacement-september<br/> - ecf-replacement-january<br/> - ecf-replacement-april<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| cohort | string | false | Providers may not change the current value for ECF participants. Indicates which call-off contract funds this participant’s training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year.<br/> | 
+
+
+#### Example
+
+
+```
+{
+  "schedule_identifier": "ecf-standard-january",
+  "course_identifier": "ecf-mentor",
+  "cohort": "2021"
+}
+```
+
+
+### ECFParticipantChangeScheduleRequest
+
+
+The change schedule request for a participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeSchedule](#schema-ecfparticipantchangeschedule) schema. | 
+
+
+#### Example
+
+
+```
+{
+  "data": {
+    "type": "participant-change-schedule",
+    "attributes": {
+      "schedule_identifier": "ecf-standard-january",
+      "course_identifier": "ecf-mentor",
+      "cohort": "2021"
+    }
+  }
+}
+```
+
+
+### ECFParticipantCsvRow
+
+
+The details of an ECF participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| id | string | true | The unique identifier of the ECF participant record<br/> | 
+| type | string | true | The data type<br/>Possible values:<br/><br/> - participant<br/><br/> | 
+| email | string | true | The email registered for this ECF participant<br/> | 
+| full\_name | string | true | The full name of the ECF participant<br/> | 
+| mentor\_id | string | false | The unique identifier of the ECF participants mentor<br/> | 
+| school\_urn | string | true | The Unique Reference Number (URN) of the school the submitted this ECF participant<br/> | 
+| participant\_type | string | true | The type of ECF Participant this record refers to either ECT or Mentor<br/>Possible values:<br/><br/> - ect<br/> - mentor<br/><br/> | 
+| cohort | string | true | Indicates which call-off contract funds this participant’s training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year.<br/> | 
+| status | string | true | The status of the ECF Participant record<br/>Possible values:<br/><br/> - active<br/> - withdrawn<br/><br/> | 
+| teacher\_reference\_number | string | false | The Teacher Reference Number (TRN) for this ECF participant<br/> | 
+| teacher\_reference\_number\_validated | boolean | false | Indicates whether the Teacher Reference Number (TRN) has been validated<br/> | 
+| eligible\_for\_funding | boolean | false | Indicates whether this participant is eligible to receive DfE funded induction<br/> | 
+| pupil\_premium\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to pupil premium<br/> | 
+| sparsity\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to sparsity<br/> | 
+| training\_status | string | true | The training status of the ECF Participant<br/>Possible values:<br/><br/> - active<br/> - deferred<br/> - withdrawn<br/><br/> | 
+| training\_record\_id | string | true | The unique identifier of the participant training record<br/> | 
+| schedule\_identifier | string | true | The schedule of the ECF participant<br/>Possible values:<br/><br/> - ecf-standard-september<br/> - ecf-standard-january<br/> - ecf-standard-april<br/> - ecf-reduced-september<br/> - ecf-reduced-january<br/> - ecf-reduced-april<br/> - ecf-extended-september<br/> - ecf-extended-january<br/> - ecf-extended-april<br/> - ecf-replacement-september<br/> - ecf-replacement-january<br/> - ecf-replacement-april<br/><br/> | 
+| updated\_at | string | true | The date the ECF participant was last updated<br/> | 
+
+
+### ECFParticipantDeclarationPost2024ECTCompletedAttributesRequest
+
+
+An ECF completed participant declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique ID of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - completed<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/><br/> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - 75-percent-engagement-met<br/> - 75-percent-engagement-met-reduced-induction<br/> - one-term-induction<br/><br/> | 
+
+
+### ECFParticipantDeclarationPost2024ECTExtendedAttributesRequest
+
+
+An ECF extended participant declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique ID of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - extended-1<br/> - extended-2<br/> - extended-3<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/><br/> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - materials-engaged-with-offline<br/> - other<br/><br/> | 
+
+
+### ECFParticipantDeclarationPost2024ECTRetainedAttributesRequest
+
+
+An ECF participant retained declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique ID of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - retained-1<br/> - retained-2<br/> - retained-3<br/> - retained-4<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/><br/> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period. For retained-2 declarations, providers will need to confirm if the engagement threshold has been reached and only accept either the ‘75-percent-engagement-met’ or ‘75-percent-engagement-met-reduced-induction’ values.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - materials-engaged-with-offline<br/> - other<br/> - 75-percent-engagement-met<br/> - 75-percent-engagement-met-reduced-induction<br/><br/> | 
+
+
+### ECFParticipantDeclarationPost2024ECTStartedAttributesRequest
+
+
+An ECF started participant declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique ID of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - started<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/><br/> | 
+| evidence\_held | string | false | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - materials-engaged-with-offline<br/> - other<br/><br/> | 
+
+
+### ECFParticipantDeclarationPost2024MentorCompletedAttributesRequest
+
+
+An ECF completed participant declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique ID of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - completed<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-mentor<br/><br/> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - 75-percent-engagement-met<br/> - 75-percent-engagement-met-reduced-induction<br/><br/> | 
+
+
+### ECFParticipantDeclarationPost2024MentorStartedAttributesRequest
+
+
+An ECF started participant declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique ID of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - started<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-mentor<br/><br/> | 
+| evidence\_held | string | false | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - materials-engaged-with-offline<br/> - other<br/><br/> | 
+
+
+### ECFParticipantDeclarationPre2025CompletedAttributesRequest
+
+
+An ECF completed participant declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique ID of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - completed<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - other<br/><br/> | 
+
+
+### ECFParticipantDeclarationPre2025ExtendedAttributesRequest
+
+
+An ECF extended participant declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique ID of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - extended-1<br/> - extended-2<br/> - extended-3<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - other<br/><br/> | 
+
+
+### ECFParticipantDeclarationPre2025RetainedAttributesRequest
+
+
+An ECF participant retained declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique ID of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - retained-1<br/> - retained-2<br/> - retained-3<br/> - retained-4<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - other<br/><br/> | 
+
+
+### ECFParticipantDeclarationPre2025StartedAttributesRequest
+
+
+An ECF started participant declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique ID of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - started<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+
+
+### ECFParticipantDefer
+
+
+The details of a participant deferral request
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| type | string | true | The data type<br/>Possible values:<br/><br/> - participant-defer<br/><br/> | 
+| attributes | object | true | An ECF participant deferral action<br/>It conforms to [ECFParticipantDeferAttributes](#schema-ecfparticipantdeferattributes) schema. | 
+
+
+### ECFParticipantDeferAttributes
+
+
+An ECF participant deferral action
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| reason | string | true | The reason for the deferral<br/>Possible values:<br/><br/> - bereavement<br/> - long-term-sickness<br/> - parental-leave<br/> - career-break<br/> - other<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+
+
+#### Example
+
+
+```
+{
+  "reason": "career-break",
+  "course_identifier": "ecf-mentor"
+}
+```
+
+
+### ECFParticipantDeferAttributesResponse
+
+
+The data attributes associated with an ECF participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| email | string | true | The email address registered for this ECF participant<br/> | 
+| full\_name | string | true | The full name of this ECF participant<br/> | 
+| mentor\_id | string | false | The unique identifier of this ECF participants mentor<br/> | 
+| school\_urn | string | true | The Unique Reference Number (URN) of the school that submitted this ECF participant<br/> | 
+| participant\_type | string | true | The type of ECF participant this record refers to<br/>Possible values:<br/><br/> - ect<br/> - mentor<br/><br/> | 
+| cohort | string | true | Indicates which call-off contract funds this participant’s training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year.<br/> | 
+| status | string | true | The status of this ECF participant record<br/>Possible values:<br/><br/> - active<br/> - withdrawn<br/><br/> | 
+| teacher\_reference\_number | string | false | The Teacher Reference Number (TRN) for this ECF participant<br/> | 
+| teacher\_reference\_number\_validated | boolean | false | Indicates whether the Teacher Reference Number (TRN) has been validated<br/> | 
+| eligible\_for\_funding | boolean | false | Indicates whether this participant is eligible to receive DfE funded induction<br/> | 
+| pupil\_premium\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to pupil premium<br/> | 
+| sparsity\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to sparsity<br/> | 
+| training\_status | string | true | The training status of the ECF participant<br/>Possible values:<br/><br/> - active<br/> - deferred<br/> - withdrawn<br/><br/> | 
+| schedule\_identifier | string | true | The schedule of the ECF participant<br/>Possible values:<br/><br/> - ecf-standard-september<br/> - ecf-standard-january<br/> - ecf-standard-april<br/> - ecf-reduced-september<br/> - ecf-reduced-january<br/> - ecf-reduced-april<br/> - ecf-extended-september<br/> - ecf-extended-january<br/> - ecf-extended-april<br/> - ecf-replacement-september<br/> - ecf-replacement-january<br/> - ecf-replacement-april<br/><br/> | 
+| updated\_at | string | true | The date the ECF participant was last updated<br/> | 
+
+
+### ECFParticipantDeferRequest
+
+
+The deferral request for a participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | object | true | The details of a participant deferral request<br/>It conforms to [ECFParticipantDefer](#schema-ecfparticipantdefer) schema. | 
+
+
+#### Example
+
+
+```
+{
+  "data": {
+    "type": "participant-defer",
+    "attributes": {
+      "reason": "career-break",
+      "course_identifier": "ecf-mentor"
+    }
+  }
+}
+```
+
+
+### ECFParticipantDeferResponse
+
+
+An ECF Participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantDeferResponseData](#schema-ecfparticipantdeferresponsedata) schema. | 
+
+
+### ECFParticipantDeferResponseData
+
+
+The details of a participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| id | string | true | The unique identifier of the participant record<br/> | 
+| type | string | true | The data type<br/> | 
+| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantDeferAttributesResponse](#schema-ecfparticipantdeferattributesresponse) schema. | 
+
+
+### ECFParticipantResponse
+
+
+An ECF Participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | object | true | The details of a participant<br/>It conforms to [ECFParticipant](#schema-ecfparticipant) schema. | 
+
+
+### ECFParticipantResume
+
+
+An ECF participant resume action
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| type | string | true | The data type<br/>Possible values:<br/><br/> - participant-resume<br/><br/> | 
+| attributes | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResumeAttributes](#schema-ecfparticipantresumeattributes) schema. | 
+
+
+### ECFParticipantResumeAttributes
+
+
+An ECF participant resume action
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+
+
+#### Example
+
+
+```
+{
+  "course_identifier": "ecf-mentor"
+}
+```
+
+
+### ECFParticipantResumeAttributesResponse
+
+
+The data attributes associated with an ECF participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| email | string | true | The email address registered for this ECF participant<br/> | 
+| full\_name | string | true | The full name of this ECF participant<br/> | 
+| mentor\_id | string | false | The unique identifier of this ECF participants mentor<br/> | 
+| school\_urn | string | true | The Unique Reference Number (URN) of the school that submitted this ECF participant<br/> | 
+| participant\_type | string | true | The type of ECF participant this record refers to<br/>Possible values:<br/><br/> - ect<br/> - mentor<br/><br/> | 
+| cohort | string | true | Indicates which call-off contract funds this participant’s training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year.<br/> | 
+| status | string | true | The status of this ECF participant record<br/>Possible values:<br/><br/> - active<br/> - withdrawn<br/><br/> | 
+| teacher\_reference\_number | string | false | The Teacher Reference Number (TRN) for this ECF participant<br/> | 
+| teacher\_reference\_number\_validated | boolean | false | Indicates whether the Teacher Reference Number (TRN) has been validated<br/> | 
+| eligible\_for\_funding | boolean | false | Indicates whether this participant is eligible to receive DfE funded induction<br/> | 
+| pupil\_premium\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to pupil premium<br/> | 
+| sparsity\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to sparsity<br/> | 
+| training\_status | string | true | The training status of the ECF participant<br/>Possible values:<br/><br/> - active<br/> - deferred<br/> - withdrawn<br/><br/> | 
+| schedule\_identifier | string | true | The schedule of the ECF participant<br/>Possible values:<br/><br/> - ecf-standard-september<br/> - ecf-standard-january<br/> - ecf-standard-april<br/> - ecf-reduced-september<br/> - ecf-reduced-january<br/> - ecf-reduced-april<br/> - ecf-extended-september<br/> - ecf-extended-january<br/> - ecf-extended-april<br/> - ecf-replacement-september<br/> - ecf-replacement-january<br/> - ecf-replacement-april<br/><br/> | 
+| updated\_at | string | true | The date the ECF participant was last updated<br/> | 
+
+
+### ECFParticipantResumeRequest
+
+
+The resume request for a participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResume](#schema-ecfparticipantresume) schema. | 
+
+
+#### Example
+
+
+```
+{
+  "data": {
+    "type": "participant-resume",
+    "attributes": {
+      "course_identifier": "ecf-mentor"
+    }
+  }
+}
+```
+
+
+### ECFParticipantResumeResponse
+
+
+An ECF Participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantResumeResponseData](#schema-ecfparticipantresumeresponsedata) schema. | 
+
+
+### ECFParticipantResumeResponseData
+
+
+The details of a participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| id | string | true | The unique identifier of the participant record<br/> | 
+| type | string | true | The data type<br/> | 
+| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantResumeAttributesResponse](#schema-ecfparticipantresumeattributesresponse) schema. | 
+
+
+### ECFParticipantRetainedDeclaration
+
+
+An ECF participant retained declaration request body
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| type | object | false | The request data<br/>Possible values:<br/><br/> - participant-declaration<br/><br/> | 
+| attributes | object | true | An ECF participant retained declaration<br/>It conforms to [ECFParticipantRetainedDeclarationAttributes](#schema-ecfparticipantretaineddeclarationattributes) schema. | 
+
+
+### ECFParticipantRetainedDeclarationAttributes
+
+
+An ECF participant retained declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique id of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - retained-1<br/> - retained-2<br/> - retained-3<br/> - retained-4<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - other<br/><br/> | 
+
+
+#### Example
+
+
+```
+{
+  "participant_id": "db3a7848-7308-4879-942a-c4a70ced400a",
+  "declaration_type": "retained-1",
+  "declaration_date": "2021-05-31T02:21:32.000Z",
+  "course_identifier": "ecf-induction",
+  "evidence_held": "training-event-attended"
+}
+```
+
+
+### ECFParticipantStartedDeclaration
+
+
+A participant started declaration request body
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| type | object | false | The request data<br/>Possible values:<br/><br/> - participant-declaration<br/><br/> | 
+| attributes | object | true | An ECF started and completed participant declaration<br/>It conforms to [ECFParticipantStartedDeclarationAttributes](#schema-ecfparticipantstarteddeclarationattributes) schema. | 
+
+
+### ECFParticipantStartedDeclarationAttributes
+
+
+An ECF started and completed participant declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique id of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - started<br/> - completed<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+
+
+#### Example
+
+
+```
+{
+  "participant_id": "db3a7848-7308-4879-942a-c4a70ced400a",
+  "declaration_type": "started",
+  "declaration_date": "2021-05-31T02:21:32.000Z",
+  "course_identifier": "ecf-mentor"
+}
+```
+
+
+### ECFParticipantWithdraw
+
+
+An ECF participant withdrawal action
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| type | string | false | The data type<br/>Possible values:<br/><br/> - participant-withdraw<br/><br/> | 
+| attributes | object | false | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdrawAttributes](#schema-ecfparticipantwithdrawattributes) schema. | 
+
+
+### ECFParticipantWithdrawAttributes
+
+
+An ECF participant withdrawal action
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| reason | string | true | The reason for the withdrawal<br/>Possible values:<br/><br/> - left-teaching-profession<br/> - moved-school<br/> - mentor-no-longer-being-mentor<br/> - switched-to-school-led<br/> - other<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+
+
+#### Example
+
+
+```
+{
+  "reason": "left-teaching-profession",
+  "course_identifier": "ecf-mentor"
+}
+```
+
+
+### ECFParticipantWithdrawAttributesResponse
+
+
+The data attributes associated with an ECF participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| email | string | true | The email address registered for this ECF participant<br/> | 
+| full\_name | string | true | The full name of this ECF participant<br/> | 
+| mentor\_id | string | false | The unique identifier of this ECF participants mentor<br/> | 
+| school\_urn | string | true | The Unique Reference Number (URN) of the school that submitted this ECF participant<br/> | 
+| participant\_type | string | true | The type of ECF participant this record refers to<br/>Possible values:<br/><br/> - ect<br/> - mentor<br/><br/> | 
+| cohort | string | true | Indicates which call-off contract funds this participant’s training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year.<br/> | 
+| status | string | true | The status of this ECF participant record<br/>Possible values:<br/><br/> - active<br/> - withdrawn<br/><br/> | 
+| teacher\_reference\_number | string | false | The Teacher Reference Number (TRN) for this ECF participant<br/> | 
+| teacher\_reference\_number\_validated | boolean | false | Indicates whether the Teacher Reference Number (TRN) has been validated<br/> | 
+| eligible\_for\_funding | boolean | false | Indicates whether this participant is eligible to receive DfE funded induction<br/> | 
+| pupil\_premium\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to pupil premium<br/> | 
+| sparsity\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to sparsity<br/> | 
+| training\_status | string | true | The training status of the ECF participant<br/>Possible values:<br/><br/> - active<br/> - deferred<br/> - withdrawn<br/><br/> | 
+| schedule\_identifier | string | true | The schedule of the ECF participant<br/>Possible values:<br/><br/> - ecf-standard-september<br/> - ecf-standard-january<br/> - ecf-standard-april<br/> - ecf-reduced-september<br/> - ecf-reduced-january<br/> - ecf-reduced-april<br/> - ecf-extended-september<br/> - ecf-extended-january<br/> - ecf-extended-april<br/> - ecf-replacement-september<br/> - ecf-replacement-january<br/> - ecf-replacement-april<br/><br/> | 
+| updated\_at | string | true | The date the ECF participant was last updated<br/> | 
+
+
+### ECFParticipantWithdrawDataResponse
+
+
+The details of a participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| id | string | true | The unique identifier of the participant record<br/> | 
+| type | string | true | The data type<br/> | 
+| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantWithdrawAttributesResponse](#schema-ecfparticipantwithdrawattributesresponse) schema. | 
+
+
+### ECFParticipantWithdrawRequest
+
+
+The withdrawal request for a participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | object | true | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdraw](#schema-ecfparticipantwithdraw) schema. | 
+
+
+#### Example
+
+
+```
+{
+  "data": {
+    "type": "participant-withdraw",
+    "attributes": {
+      "reason": "left-teaching-profession",
+      "course_identifier": "ecf-mentor"
+    }
+  }
+}
+```
+
+
+### ECFParticipantWithdrawResponse
+
+
+An ECF Participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantWithdrawDataResponse](#schema-ecfparticipantwithdrawdataresponse) schema. | 
+
+
+### Error
+
+
+An single error element
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| title | string | false | A title of the error<br/> | 
+| detail | string | false | Additional details of the error<br/> | 
+
+
+### ErrorResponse
+
+
+A list of errors
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| error | array | false | It conforms to [Error](#schema-error) schema. | 
+
+
+### ListFilter
+
+
+Filter a list of records to return more specific results
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| updated\_since | string | false | Return only records that have been updated since this date and time (ISO 8601 date format)<br/> | 
+
+
+### ListFilterDeclarations
+
+
+Filter a list of declarations records to return more specific results
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| updated\_since | string | false | Return only records that have been updated since this date and time (ISO 8601 date format)<br/> | 
+| participant\_id | string | false | The unique id of the participant<br/> | 
+
+
+### MultipleECFParticipantsCsvResponse
+
+
+A list of ECF participants in the Comma Separated Value (CSV) format
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | array | true | It conforms to [ECFParticipantCsvRow](#schema-ecfparticipantcsvrow) schema. | 
+
+
+### MultipleECFParticipantsResponse
+
+
+A list of ECF participants
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | array | true | It conforms to [ECFParticipant](#schema-ecfparticipant) schema. | 
+
+
+### MultipleParticipantDeclarationsCsvResponse
+
+
+A list of participant declarations in the Comma Separated Value (CSV) format
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | array | true | It conforms to [ParticipantDeclarationCsvRow](#schema-participantdeclarationcsvrow) schema. | 
+
+
+### MultipleParticipantDeclarationsResponse
+
+
+A list of participant declarations
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | array | true | It conforms to [ParticipantDeclarationResponse](#schema-participantdeclarationresponse) schema. | 
+
+
+### NotFoundResponse
+
+
+The requested resource was not found
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| error | string | false |  | 
+
+
+### Pagination
+
+
+This schema used to paginate through a collection.
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| page | integer | false | The page number to paginate to in the collection. If no value is specified it defaults to the first page.<br/> | 
+| per\_page | integer | false | The number items to display on a page. Defaults to 100. Maximum is 3000, if the value is greater that the maximum allowed it will fallback to 3000.<br/> | 
+
+
+### ParticipantDeclarationAttributes
+
+
+The data attributes associated with a participant declaration response
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique id of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - started<br/> - retained-1<br/> - retained-2<br/> - retained-3<br/> - retained-4<br/> - completed<br/> - extended-1<br/> - extended-2<br/> - extended-3<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| state | string | true | Indicates the state of this payment declaration<br/>Possible values:<br/><br/> - submitted<br/> - eligible<br/> - payable<br/> - paid<br/> - voided<br/> - ineligible<br/><br/> | 
+| updated\_at | string | true | The date the declaration was last updated<br/> | 
+| has\_passed | boolean | false | Whether the participant has failed or passed<br/> | 
+
+
+### ParticipantDeclarationCsvRow
+
+
+The details of a participant declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| id | string | true | The unique identifier of the participant declaration record<br/> | 
+| participant\_id | string | true | The unique identifier of the participant record the declaration refers to<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - started<br/> - retained-1<br/> - retained-2<br/> - retained-3<br/> - retained-4<br/> - completed<br/> - extended-1<br/> - extended-2<br/> - extended-3<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| state | string | false | Indicates the state of this payment declaration<br/> | 
+| updated\_at | string | true | The date the declaration was last updated<br/> | 
+
+
+### ParticipantDeclarationPost2024ECTDataRequest
+
+
+A participant declaration data request for ECT participants from cohort 2025 onwards
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| type | string | false | Possible values:<br/><br/> - participant-declaration<br/><br/> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><br/> -  [ECFParticipantDeclarationPost2024ECTStartedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectstartedattributesrequest) <br/> -  [ECFParticipantDeclarationPost2024ECTRetainedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectretainedattributesrequest) <br/> -  [ECFParticipantDeclarationPost2024ECTCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectcompletedattributesrequest) <br/> -  [ECFParticipantDeclarationPost2024ECTExtendedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectextendedattributesrequest) <br/><br/> | 
+
+
+### ParticipantDeclarationPost2024MentorDataRequest
+
+
+A participant declaration data request for mentor participants from cohort 2025 onwards
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| type | string | false | Possible values:<br/><br/> - participant-declaration<br/><br/> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><br/> -  [ECFParticipantDeclarationPost2024MentorStartedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorstartedattributesrequest) <br/> -  [ECFParticipantDeclarationPost2024MentorCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorcompletedattributesrequest) <br/><br/> | 
+
+
+### ParticipantDeclarationPre2025DataRequest
+
+
+A participant declaration data request for participants in cohort 2024 and previous years
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| type | string | false | Possible values:<br/><br/> - participant-declaration<br/><br/> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><br/> -  [ECFParticipantDeclarationPre2025StartedAttributesRequest](#schema-ecfparticipantdeclarationpre2025startedattributesrequest) <br/> -  [ECFParticipantDeclarationPre2025RetainedAttributesRequest](#schema-ecfparticipantdeclarationpre2025retainedattributesrequest) <br/> -  [ECFParticipantDeclarationPre2025CompletedAttributesRequest](#schema-ecfparticipantdeclarationpre2025completedattributesrequest) <br/> -  [ECFParticipantDeclarationPre2025ExtendedAttributesRequest](#schema-ecfparticipantdeclarationpre2025extendedattributesrequest) <br/><br/> | 
+
+
+### ParticipantDeclarationRequest
+
+
+An participant declaration request
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | object | true | This conforms to any of the following schemas:<br/><br/> -  [ParticipantDeclarationPre2025DataRequest](#schema-participantdeclarationpre2025datarequest) <br/> -  [ParticipantDeclarationPost2024ECTDataRequest](#schema-participantdeclarationpost2024ectdatarequest) <br/> -  [ParticipantDeclarationPost2024MentorDataRequest](#schema-participantdeclarationpost2024mentordatarequest) <br/><br/> | 
+
+
+### ParticipantDeclarationResponse
+
+
+A participant declaration response
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| id | string | true | The unique identifier of the participant declaration record<br/> | 
+| type | string | true | The data type<br/> | 
+| attributes | object | true | The data attributes associated with a participant declaration response<br/>It conforms to [ParticipantDeclarationAttributes](#schema-participantdeclarationattributes) schema. | 
+
+
+### ParticipantListFilter
+
+
+Filter a list of records to return more specific results
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| updated\_since | string | false | Return only records that have been updated since this date and time (ISO 8601 date format)<br/> | 
+| cohort | string | false | Return only records for the given cohort<br/> | 
+
+
+### SingleParticipantDeclarationResponse
+
+
+A confirmation that the participant declaration has been recorded successfully
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | object | true | A participant declaration response<br/>It conforms to [ParticipantDeclarationResponse](#schema-participantdeclarationresponse) schema. | 
+
+
+### UnauthorisedResponse
+
+
+Authorization information is missing or invalid
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| error | string | false |  | 
+

--- a/documentation/ecf1_guidance/reference-v2.md
+++ b/documentation/ecf1_guidance/reference-v2.md
@@ -26,8 +26,8 @@ The lead provider API for DfE’s manage teacher CPD service
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine participant declarations to return.<br/>This consumes a [ListFilterDeclarations](#schema-listfilterdeclarations) schema.<br/> | participant\_id=ab3a7848-1208-7679-942a-b4a70eed400a&updated\_since=2020-11-13T11:21:55Z | 
-| page | query | object | false | Pagination options to navigate through the list of participant declarations.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| filter | query | object | false | Refine participant declarations to return.<br/>This consumes a [ListFilterDeclarations](listfilterdeclarations) schema.<br/> | participant\_id=ab3a7848-1208-7679-942a-b4a70eed400a&updated\_since=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of participant declarations.<br/>This consumes a [Pagination](pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
 
 
 ### Responses
@@ -35,14 +35,14 @@ The lead provider API for DfE’s manage teacher CPD service
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A list of participant declarations<br/>This response returns a [MultipleParticipantDeclarationsResponse](#schema-multipleparticipantdeclarationsresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A list of participant declarations<br/>This response returns a [MultipleParticipantDeclarationsResponse](multipleparticipantdeclarationsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A list of participant declarations
-This response returns a [MultipleParticipantDeclarationsResponse](#schema-multipleparticipantdeclarationsresponse) schema.
+This response returns a [MultipleParticipantDeclarationsResponse](multipleparticipantdeclarationsresponse) schema.
 
 ```
 {
@@ -72,7 +72,7 @@ This response returns a [MultipleParticipantDeclarationsResponse](#schema-multip
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 ```
 {
@@ -95,23 +95,23 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ### Request body
 
 
-This consumes a [ParticipantDeclarationRequest](#schema-participantdeclarationrequest) schema.
+This consumes a [ParticipantDeclarationRequest](participantdeclarationrequest) schema.
 
 ### Responses
 
 
 | Status | Description |
 | ---- | ---- |
-| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.<br/> | 
-| 422 | Bad or Missing parameter<br/>This response returns a [ErrorResponse](#schema-errorresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
-| 400 | Bad Request<br/>This response returns a [BadRequestResponse](#schema-badrequestresponse) schema.<br/> | 
+| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](singleparticipantdeclarationresponse) schema.<br/> | 
+| 422 | Bad or Missing parameter<br/>This response returns a [ErrorResponse](errorresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
+| 400 | Bad Request<br/>This response returns a [BadRequestResponse](badrequestresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - Successful
-This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.
+This response returns a [SingleParticipantDeclarationResponse](singleparticipantdeclarationresponse) schema.
 
 ```
 {
@@ -132,7 +132,7 @@ This response returns a [SingleParticipantDeclarationResponse](#schema-singlepar
 ```
 
 422 - Bad or Missing parameter
-This response returns a [ErrorResponse](#schema-errorresponse) schema.
+This response returns a [ErrorResponse](errorresponse) schema.
 
 ```
 {
@@ -146,7 +146,7 @@ This response returns a [ErrorResponse](#schema-errorresponse) schema.
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 ```
 {
@@ -155,7 +155,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ```
 
 400 - Bad Request
-This response returns a [BadRequestResponse](#schema-badrequestresponse) schema.
+This response returns a [BadRequestResponse](badrequestresponse) schema.
 
 ```
 {
@@ -180,16 +180,16 @@ This response returns a [BadRequestResponse](#schema-badrequestresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A CSV file of participant declarations<br/>This response returns a [MultipleParticipantDeclarationsCsvResponse](#schema-multipleparticipantdeclarationscsvresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A CSV file of participant declarations<br/>This response returns a [MultipleParticipantDeclarationsCsvResponse](multipleparticipantdeclarationscsvresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A CSV file of participant declarations
-This response returns a [MultipleParticipantDeclarationsCsvResponse](#schema-multipleparticipantdeclarationscsvresponse) schema.
+This response returns a [MultipleParticipantDeclarationsCsvResponse](multipleparticipantdeclarationscsvresponse) schema.
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 ---
 
@@ -215,15 +215,15 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A single participant declaration<br/>This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.<br/> | 
-| 404 | Not found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A single participant declaration<br/>This response returns a [SingleParticipantDeclarationResponse](singleparticipantdeclarationresponse) schema.<br/> | 
+| 404 | Not found<br/>This response returns a [NotFoundResponse](notfoundresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A single participant declaration
-This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.
+This response returns a [SingleParticipantDeclarationResponse](singleparticipantdeclarationresponse) schema.
 
 ```
 {
@@ -244,7 +244,7 @@ This response returns a [SingleParticipantDeclarationResponse](#schema-singlepar
 ```
 
 404 - Not found
-This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
+This response returns a [NotFoundResponse](notfoundresponse) schema.
 
 ```
 {
@@ -253,7 +253,7 @@ This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 ```
 {
@@ -286,13 +286,13 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 
 | Status | Description |
 | ---- | ---- |
-| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.<br/> | 
+| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](singleparticipantdeclarationresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - Successful
-This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.
+This response returns a [SingleParticipantDeclarationResponse](singleparticipantdeclarationresponse) schema.
 
 ```
 {
@@ -329,8 +329,8 @@ This response returns a [SingleParticipantDeclarationResponse](#schema-singlepar
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine ECF participants to return.<br/>This consumes a [ListFilter](#schema-listfilter) schema.<br/> | filter[cohort]=2022&filter[updated\_since]=2020-11-13T11:21:55Z | 
-| page | query | object | false | Pagination options to navigate through the list of ECF participants.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| filter | query | object | false | Refine ECF participants to return.<br/>This consumes a [ListFilter](listfilter) schema.<br/> | filter[cohort]=2022&filter[updated\_since]=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of ECF participants.<br/>This consumes a [Pagination](pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
 
 
 ### Responses
@@ -338,14 +338,14 @@ This response returns a [SingleParticipantDeclarationResponse](#schema-singlepar
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A list of ECF participants<br/>This response returns a [MultipleECFParticipantsResponse](#schema-multipleecfparticipantsresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A list of ECF participants<br/>This response returns a [MultipleECFParticipantsResponse](multipleecfparticipantsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A list of ECF participants
-This response returns a [MultipleECFParticipantsResponse](#schema-multipleecfparticipantsresponse) schema.
+This response returns a [MultipleECFParticipantsResponse](multipleecfparticipantsresponse) schema.
 
 ```
 {
@@ -414,7 +414,7 @@ This response returns a [MultipleECFParticipantsResponse](#schema-multipleecfpar
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 ```
 {
@@ -439,7 +439,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine ECF participants to return.<br/>This consumes a [ListFilter](#schema-listfilter) schema.<br/> | updated\_since=2020-11-13T11:21:55Z | 
+| filter | query | object | false | Refine ECF participants to return.<br/>This consumes a [ListFilter](listfilter) schema.<br/> | updated\_since=2020-11-13T11:21:55Z | 
 
 
 ### Responses
@@ -447,16 +447,16 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A CSV file of ECF participants<br/>This response returns a [MultipleECFParticipantsCsvResponse](#schema-multipleecfparticipantscsvresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A CSV file of ECF participants<br/>This response returns a [MultipleECFParticipantsCsvResponse](multipleecfparticipantscsvresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A CSV file of ECF participants
-This response returns a [MultipleECFParticipantsCsvResponse](#schema-multipleecfparticipantscsvresponse) schema.
+This response returns a [MultipleECFParticipantsCsvResponse](multipleecfparticipantscsvresponse) schema.
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 ---
 
@@ -482,14 +482,14 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A single ECF participant<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A single ECF participant<br/>This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A single ECF participant
-This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
 
 ```
 {
@@ -519,7 +519,7 @@ This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse)
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 ```
 {
@@ -550,7 +550,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ### Request body
 
 
-This consumes a [ECFParticipantDeferRequest](#schema-ecfparticipantdeferrequest) schema.
+This consumes a [ECFParticipantDeferRequest](ecfparticipantdeferrequest) schema.
 
 ### Request example
 
@@ -573,13 +573,13 @@ This consumes a [ECFParticipantDeferRequest](#schema-ecfparticipantdeferrequest)
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant being deferred<br/>This response returns a [ECFParticipantDeferResponse](#schema-ecfparticipantdeferresponse) schema.<br/> | 
+| 200 | The ECF participant being deferred<br/>This response returns a [ECFParticipantDeferResponse](ecfparticipantdeferresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant being deferred
-This response returns a [ECFParticipantDeferResponse](#schema-ecfparticipantdeferresponse) schema.
+This response returns a [ECFParticipantDeferResponse](ecfparticipantdeferresponse) schema.
 
 ```
 {
@@ -630,7 +630,7 @@ This response returns a [ECFParticipantDeferResponse](#schema-ecfparticipantdefe
 ### Request body
 
 
-This consumes a [ECFParticipantResumeRequest](#schema-ecfparticipantresumerequest) schema.
+This consumes a [ECFParticipantResumeRequest](ecfparticipantresumerequest) schema.
 
 ### Request example
 
@@ -652,13 +652,13 @@ This consumes a [ECFParticipantResumeRequest](#schema-ecfparticipantresumereques
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant being resumed<br/>This response returns a [ECFParticipantResumeResponse](#schema-ecfparticipantresumeresponse) schema.<br/> | 
+| 200 | The ECF participant being resumed<br/>This response returns a [ECFParticipantResumeResponse](ecfparticipantresumeresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant being resumed
-This response returns a [ECFParticipantResumeResponse](#schema-ecfparticipantresumeresponse) schema.
+This response returns a [ECFParticipantResumeResponse](ecfparticipantresumeresponse) schema.
 
 ```
 {
@@ -709,7 +709,7 @@ This response returns a [ECFParticipantResumeResponse](#schema-ecfparticipantres
 ### Request body
 
 
-This consumes a [ECFParticipantWithdrawRequest](#schema-ecfparticipantwithdrawrequest) schema.
+This consumes a [ECFParticipantWithdrawRequest](ecfparticipantwithdrawrequest) schema.
 
 ### Request example
 
@@ -732,13 +732,13 @@ This consumes a [ECFParticipantWithdrawRequest](#schema-ecfparticipantwithdrawre
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant being withdrawn<br/>This response returns a [ECFParticipantWithdrawResponse](#schema-ecfparticipantwithdrawresponse) schema.<br/> | 
+| 200 | The ECF participant being withdrawn<br/>This response returns a [ECFParticipantWithdrawResponse](ecfparticipantwithdrawresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant being withdrawn
-This response returns a [ECFParticipantWithdrawResponse](#schema-ecfparticipantwithdrawresponse) schema.
+This response returns a [ECFParticipantWithdrawResponse](ecfparticipantwithdrawresponse) schema.
 
 ```
 {
@@ -789,7 +789,7 @@ This response returns a [ECFParticipantWithdrawResponse](#schema-ecfparticipantw
 ### Request body
 
 
-This consumes a [ECFParticipantChangeScheduleRequest](#schema-ecfparticipantchangeschedulerequest) schema.
+This consumes a [ECFParticipantChangeScheduleRequest](ecfparticipantchangeschedulerequest) schema.
 
 ### Request example
 
@@ -813,13 +813,13 @@ This consumes a [ECFParticipantChangeScheduleRequest](#schema-ecfparticipantchan
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant changing schedule<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
+| 200 | The ECF participant changing schedule<br/>This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant changing schedule
-This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
 
 ```
 {
@@ -899,7 +899,7 @@ The details of a participant
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantAttributes](#schema-ecfparticipantattributes) schema. | 
+| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantAttributes](ecfparticipantattributes) schema. | 
 
 
 ### ECFParticipantAttributes
@@ -935,7 +935,7 @@ An ECF participant change schedule action
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | true | The data type<br/>Possible values:<br/><ul><li>participant-change-schedule</li></ul> | 
-| attributes | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeScheduleAttributes](#schema-ecfparticipantchangescheduleattributes) schema. | 
+| attributes | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeScheduleAttributes](ecfparticipantchangescheduleattributes) schema. | 
 
 
 #### Example
@@ -983,7 +983,7 @@ The change schedule request for a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeSchedule](#schema-ecfparticipantchangeschedule) schema. | 
+| data | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeSchedule](ecfparticipantchangeschedule) schema. | 
 
 
 #### Example
@@ -1177,7 +1177,7 @@ The details of a participant deferral request
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | true | The data type<br/>Possible values:<br/><ul><li>participant-defer</li></ul> | 
-| attributes | object | true | An ECF participant deferral action<br/>It conforms to [ECFParticipantDeferAttributes](#schema-ecfparticipantdeferattributes) schema. | 
+| attributes | object | true | An ECF participant deferral action<br/>It conforms to [ECFParticipantDeferAttributes](ecfparticipantdeferattributes) schema. | 
 
 
 ### ECFParticipantDeferAttributes
@@ -1233,7 +1233,7 @@ The deferral request for a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | The details of a participant deferral request<br/>It conforms to [ECFParticipantDefer](#schema-ecfparticipantdefer) schema. | 
+| data | object | true | The details of a participant deferral request<br/>It conforms to [ECFParticipantDefer](ecfparticipantdefer) schema. | 
 
 
 #### Example
@@ -1259,7 +1259,7 @@ An ECF Participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantDeferResponseData](#schema-ecfparticipantdeferresponsedata) schema. | 
+| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantDeferResponseData](ecfparticipantdeferresponsedata) schema. | 
 
 
 ### ECFParticipantDeferResponseData
@@ -1271,7 +1271,7 @@ The details of a participant
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantDeferAttributesResponse](#schema-ecfparticipantdeferattributesresponse) schema. | 
+| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantDeferAttributesResponse](ecfparticipantdeferattributesresponse) schema. | 
 
 
 ### ECFParticipantResponse
@@ -1281,7 +1281,7 @@ An ECF Participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | The details of a participant<br/>It conforms to [ECFParticipant](#schema-ecfparticipant) schema. | 
+| data | object | true | The details of a participant<br/>It conforms to [ECFParticipant](ecfparticipant) schema. | 
 
 
 ### ECFParticipantResume
@@ -1292,7 +1292,7 @@ An ECF participant resume action
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | true | The data type<br/>Possible values:<br/><ul><li>participant-resume</li></ul> | 
-| attributes | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResumeAttributes](#schema-ecfparticipantresumeattributes) schema. | 
+| attributes | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResumeAttributes](ecfparticipantresumeattributes) schema. | 
 
 
 ### ECFParticipantResumeAttributes
@@ -1346,7 +1346,7 @@ The resume request for a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResume](#schema-ecfparticipantresume) schema. | 
+| data | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResume](ecfparticipantresume) schema. | 
 
 
 #### Example
@@ -1371,7 +1371,7 @@ An ECF Participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantResumeResponseData](#schema-ecfparticipantresumeresponsedata) schema. | 
+| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantResumeResponseData](ecfparticipantresumeresponsedata) schema. | 
 
 
 ### ECFParticipantResumeResponseData
@@ -1383,7 +1383,7 @@ The details of a participant
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantResumeAttributesResponse](#schema-ecfparticipantresumeattributesresponse) schema. | 
+| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantResumeAttributesResponse](ecfparticipantresumeattributesresponse) schema. | 
 
 
 ### ECFParticipantRetainedDeclaration
@@ -1394,7 +1394,7 @@ An ECF participant retained declaration request body
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | object | false | The request data<br/>Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | true | An ECF participant retained declaration<br/>It conforms to [ECFParticipantRetainedDeclarationAttributes](#schema-ecfparticipantretaineddeclarationattributes) schema. | 
+| attributes | object | true | An ECF participant retained declaration<br/>It conforms to [ECFParticipantRetainedDeclarationAttributes](ecfparticipantretaineddeclarationattributes) schema. | 
 
 
 ### ECFParticipantRetainedDeclarationAttributes
@@ -1433,7 +1433,7 @@ A participant started declaration request body
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | object | false | The request data<br/>Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | true | An ECF started and completed participant declaration<br/>It conforms to [ECFParticipantStartedDeclarationAttributes](#schema-ecfparticipantstarteddeclarationattributes) schema. | 
+| attributes | object | true | An ECF started and completed participant declaration<br/>It conforms to [ECFParticipantStartedDeclarationAttributes](ecfparticipantstarteddeclarationattributes) schema. | 
 
 
 ### ECFParticipantStartedDeclarationAttributes
@@ -1470,7 +1470,7 @@ An ECF participant withdrawal action
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | The data type<br/>Possible values:<br/><ul><li>participant-withdraw</li></ul> | 
-| attributes | object | false | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdrawAttributes](#schema-ecfparticipantwithdrawattributes) schema. | 
+| attributes | object | false | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdrawAttributes](ecfparticipantwithdrawattributes) schema. | 
 
 
 ### ECFParticipantWithdrawAttributes
@@ -1528,7 +1528,7 @@ The details of a participant
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantWithdrawAttributesResponse](#schema-ecfparticipantwithdrawattributesresponse) schema. | 
+| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantWithdrawAttributesResponse](ecfparticipantwithdrawattributesresponse) schema. | 
 
 
 ### ECFParticipantWithdrawRequest
@@ -1538,7 +1538,7 @@ The withdrawal request for a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdraw](#schema-ecfparticipantwithdraw) schema. | 
+| data | object | true | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdraw](ecfparticipantwithdraw) schema. | 
 
 
 #### Example
@@ -1564,7 +1564,7 @@ An ECF Participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantWithdrawDataResponse](#schema-ecfparticipantwithdrawdataresponse) schema. | 
+| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantWithdrawDataResponse](ecfparticipantwithdrawdataresponse) schema. | 
 
 
 ### Error
@@ -1585,7 +1585,7 @@ A list of errors
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| error | array | false | It conforms to [Error](#schema-error) schema. | 
+| error | array | false | It conforms to [Error](error) schema. | 
 
 
 ### ListFilter
@@ -1616,7 +1616,7 @@ A list of ECF participants in the Comma Separated Value (CSV) format
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ECFParticipantCsvRow](#schema-ecfparticipantcsvrow) schema. | 
+| data | array | true | It conforms to [ECFParticipantCsvRow](ecfparticipantcsvrow) schema. | 
 
 
 ### MultipleECFParticipantsResponse
@@ -1626,7 +1626,7 @@ A list of ECF participants
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ECFParticipant](#schema-ecfparticipant) schema. | 
+| data | array | true | It conforms to [ECFParticipant](ecfparticipant) schema. | 
 
 
 ### MultipleParticipantDeclarationsCsvResponse
@@ -1636,7 +1636,7 @@ A list of participant declarations in the Comma Separated Value (CSV) format
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ParticipantDeclarationCsvRow](#schema-participantdeclarationcsvrow) schema. | 
+| data | array | true | It conforms to [ParticipantDeclarationCsvRow](participantdeclarationcsvrow) schema. | 
 
 
 ### MultipleParticipantDeclarationsResponse
@@ -1646,7 +1646,7 @@ A list of participant declarations
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ParticipantDeclarationResponse](#schema-participantdeclarationresponse) schema. | 
+| data | array | true | It conforms to [ParticipantDeclarationResponse](participantdeclarationresponse) schema. | 
 
 
 ### NotFoundResponse
@@ -1710,7 +1710,7 @@ A participant declaration data request for ECT participants from cohort 2025 onw
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024ECTStartedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTRetainedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectretainedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectcompletedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTExtendedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectextendedattributesrequest) </li></ul> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024ECTStartedAttributesRequest](ecfparticipantdeclarationpost2024ectstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTRetainedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectretainedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectcompletedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTExtendedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectextendedattributesrequest) </li></ul> | 
 
 
 ### ParticipantDeclarationPost2024MentorDataRequest
@@ -1721,7 +1721,7 @@ A participant declaration data request for mentor participants from cohort 2025 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024MentorStartedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024MentorCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorcompletedattributesrequest) </li></ul> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024MentorStartedAttributesRequest](ecfparticipantdeclarationpost2024mentorstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024MentorCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorcompletedattributesrequest) </li></ul> | 
 
 
 ### ParticipantDeclarationPre2025DataRequest
@@ -1732,7 +1732,7 @@ A participant declaration data request for participants in cohort 2024 and previ
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPre2025StartedAttributesRequest](#schema-ecfparticipantdeclarationpre2025startedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025RetainedAttributesRequest](#schema-ecfparticipantdeclarationpre2025retainedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025CompletedAttributesRequest](#schema-ecfparticipantdeclarationpre2025completedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025ExtendedAttributesRequest](#schema-ecfparticipantdeclarationpre2025extendedattributesrequest) </li></ul> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPre2025StartedAttributesRequest](ecfparticipantdeclarationpre2025startedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025RetainedAttributesRequest](#schema-ecfparticipantdeclarationpre2025retainedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025CompletedAttributesRequest](#schema-ecfparticipantdeclarationpre2025completedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025ExtendedAttributesRequest](#schema-ecfparticipantdeclarationpre2025extendedattributesrequest) </li></ul> | 
 
 
 ### ParticipantDeclarationRequest
@@ -1742,7 +1742,7 @@ An participant declaration request
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | This conforms to any of the following schemas:<br/><ul><li> [ParticipantDeclarationPre2025DataRequest](#schema-participantdeclarationpre2025datarequest) </li><li> [ParticipantDeclarationPost2024ECTDataRequest](#schema-participantdeclarationpost2024ectdatarequest) </li><li> [ParticipantDeclarationPost2024MentorDataRequest](#schema-participantdeclarationpost2024mentordatarequest) </li></ul> | 
+| data | object | true | This conforms to any of the following schemas:<br/><ul><li> [ParticipantDeclarationPre2025DataRequest](participantdeclarationpre2025datarequest) </li><li> [ParticipantDeclarationPost2024ECTDataRequest](#schema-participantdeclarationpost2024ectdatarequest) </li><li> [ParticipantDeclarationPost2024MentorDataRequest](#schema-participantdeclarationpost2024mentordatarequest) </li></ul> | 
 
 
 ### ParticipantDeclarationResponse
@@ -1754,7 +1754,7 @@ A participant declaration response
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant declaration record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with a participant declaration response<br/>It conforms to [ParticipantDeclarationAttributes](#schema-participantdeclarationattributes) schema. | 
+| attributes | object | true | The data attributes associated with a participant declaration response<br/>It conforms to [ParticipantDeclarationAttributes](participantdeclarationattributes) schema. | 
 
 
 ### ParticipantListFilter
@@ -1775,7 +1775,7 @@ A confirmation that the participant declaration has been recorded successfully
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | A participant declaration response<br/>It conforms to [ParticipantDeclarationResponse](#schema-participantdeclarationresponse) schema. | 
+| data | object | true | A participant declaration response<br/>It conforms to [ParticipantDeclarationResponse](participantdeclarationresponse) schema. | 
 
 
 ### UnauthorisedResponse

--- a/documentation/ecf1_guidance/reference-v2.md
+++ b/documentation/ecf1_guidance/reference-v2.md
@@ -913,17 +913,17 @@ The data attributes associated with an ECF participant
 | full\_name | string | true | The full name of this ECF participant<br/> | 
 | mentor\_id | string | false | The unique identifier of this ECF participants mentor<br/> | 
 | school\_urn | string | true | The Unique Reference Number (URN) of the school that submitted this ECF participant<br/> | 
-| participant\_type | string | true | The type of ECF participant this record refers to<br/>Possible values:<br/><br/> - ect<br/> - mentor<br/><br/> | 
+| participant\_type | string | true | The type of ECF participant this record refers to<br/>Possible values:<br/><ul><li>ect</li><li>mentor</li></ul> | 
 | cohort | string | true | Indicates which call-off contract funds this participant’s training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year.<br/> | 
-| status | string | true | The status of this ECF participant record<br/>Possible values:<br/><br/> - active<br/> - withdrawn<br/><br/> | 
+| status | string | true | The status of this ECF participant record<br/>Possible values:<br/><ul><li>active</li><li>withdrawn</li></ul> | 
 | teacher\_reference\_number | string | false | The Teacher Reference Number (TRN) for this ECF participant<br/> | 
 | teacher\_reference\_number\_validated | boolean | false | Indicates whether the Teacher Reference Number (TRN) has been validated<br/> | 
 | eligible\_for\_funding | boolean | false | Indicates whether this participant is eligible to receive DfE funded induction<br/> | 
 | pupil\_premium\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to pupil premium<br/> | 
 | sparsity\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to sparsity<br/> | 
-| training\_status | string | true | The training status of the ECF participant<br/>Possible values:<br/><br/> - active<br/> - deferred<br/> - withdrawn<br/><br/> | 
+| training\_status | string | true | The training status of the ECF participant<br/>Possible values:<br/><ul><li>active</li><li>deferred</li><li>withdrawn</li></ul> | 
 | training\_record\_id | string | true | The unique identifier of the participant training record<br/> | 
-| schedule\_identifier | string | true | The schedule of the ECF participant<br/>Possible values:<br/><br/> - ecf-standard-september<br/> - ecf-standard-january<br/> - ecf-standard-april<br/> - ecf-reduced-september<br/> - ecf-reduced-january<br/> - ecf-reduced-april<br/> - ecf-extended-september<br/> - ecf-extended-january<br/> - ecf-extended-april<br/> - ecf-replacement-september<br/> - ecf-replacement-january<br/> - ecf-replacement-april<br/><br/> | 
+| schedule\_identifier | string | true | The schedule of the ECF participant<br/>Possible values:<br/><ul><li>ecf-standard-september</li><li>ecf-standard-january</li><li>ecf-standard-april</li><li>ecf-reduced-september</li><li>ecf-reduced-january</li><li>ecf-reduced-april</li><li>ecf-extended-september</li><li>ecf-extended-january</li><li>ecf-extended-april</li><li>ecf-replacement-september</li><li>ecf-replacement-january</li><li>ecf-replacement-april</li></ul> | 
 | updated\_at | string | true | The date the ECF participant was last updated<br/> | 
 
 
@@ -934,7 +934,7 @@ An ECF participant change schedule action
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| type | string | true | The data type<br/>Possible values:<br/><br/> - participant-change-schedule<br/><br/> | 
+| type | string | true | The data type<br/>Possible values:<br/><ul><li>participant-change-schedule</li></ul> | 
 | attributes | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeScheduleAttributes](#schema-ecfparticipantchangescheduleattributes) schema. | 
 
 
@@ -959,8 +959,8 @@ An ECF participant change schedule action
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| schedule\_identifier | string | true | The new schedule of the participant<br/>Possible values:<br/><br/> - ecf-standard-september<br/> - ecf-standard-january<br/> - ecf-standard-april<br/> - ecf-reduced-september<br/> - ecf-reduced-january<br/> - ecf-reduced-april<br/> - ecf-extended-september<br/> - ecf-extended-january<br/> - ecf-extended-april<br/> - ecf-replacement-september<br/> - ecf-replacement-january<br/> - ecf-replacement-april<br/><br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| schedule\_identifier | string | true | The new schedule of the participant<br/>Possible values:<br/><ul><li>ecf-standard-september</li><li>ecf-standard-january</li><li>ecf-standard-april</li><li>ecf-reduced-september</li><li>ecf-reduced-january</li><li>ecf-reduced-april</li><li>ecf-extended-september</li><li>ecf-extended-january</li><li>ecf-extended-april</li><li>ecf-replacement-september</li><li>ecf-replacement-january</li><li>ecf-replacement-april</li></ul> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li><li>ecf-mentor</li></ul> | 
 | cohort | string | false | Providers may not change the current value for ECF participants. Indicates which call-off contract funds this participant’s training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year.<br/> | 
 
 
@@ -1011,22 +1011,22 @@ The details of an ECF participant
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the ECF participant record<br/> | 
-| type | string | true | The data type<br/>Possible values:<br/><br/> - participant<br/><br/> | 
+| type | string | true | The data type<br/>Possible values:<br/><ul><li>participant</li></ul> | 
 | email | string | true | The email registered for this ECF participant<br/> | 
 | full\_name | string | true | The full name of the ECF participant<br/> | 
 | mentor\_id | string | false | The unique identifier of the ECF participants mentor<br/> | 
 | school\_urn | string | true | The Unique Reference Number (URN) of the school the submitted this ECF participant<br/> | 
-| participant\_type | string | true | The type of ECF Participant this record refers to either ECT or Mentor<br/>Possible values:<br/><br/> - ect<br/> - mentor<br/><br/> | 
+| participant\_type | string | true | The type of ECF Participant this record refers to either ECT or Mentor<br/>Possible values:<br/><ul><li>ect</li><li>mentor</li></ul> | 
 | cohort | string | true | Indicates which call-off contract funds this participant’s training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year.<br/> | 
-| status | string | true | The status of the ECF Participant record<br/>Possible values:<br/><br/> - active<br/> - withdrawn<br/><br/> | 
+| status | string | true | The status of the ECF Participant record<br/>Possible values:<br/><ul><li>active</li><li>withdrawn</li></ul> | 
 | teacher\_reference\_number | string | false | The Teacher Reference Number (TRN) for this ECF participant<br/> | 
 | teacher\_reference\_number\_validated | boolean | false | Indicates whether the Teacher Reference Number (TRN) has been validated<br/> | 
 | eligible\_for\_funding | boolean | false | Indicates whether this participant is eligible to receive DfE funded induction<br/> | 
 | pupil\_premium\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to pupil premium<br/> | 
 | sparsity\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to sparsity<br/> | 
-| training\_status | string | true | The training status of the ECF Participant<br/>Possible values:<br/><br/> - active<br/> - deferred<br/> - withdrawn<br/><br/> | 
+| training\_status | string | true | The training status of the ECF Participant<br/>Possible values:<br/><ul><li>active</li><li>deferred</li><li>withdrawn</li></ul> | 
 | training\_record\_id | string | true | The unique identifier of the participant training record<br/> | 
-| schedule\_identifier | string | true | The schedule of the ECF participant<br/>Possible values:<br/><br/> - ecf-standard-september<br/> - ecf-standard-january<br/> - ecf-standard-april<br/> - ecf-reduced-september<br/> - ecf-reduced-january<br/> - ecf-reduced-april<br/> - ecf-extended-september<br/> - ecf-extended-january<br/> - ecf-extended-april<br/> - ecf-replacement-september<br/> - ecf-replacement-january<br/> - ecf-replacement-april<br/><br/> | 
+| schedule\_identifier | string | true | The schedule of the ECF participant<br/>Possible values:<br/><ul><li>ecf-standard-september</li><li>ecf-standard-january</li><li>ecf-standard-april</li><li>ecf-reduced-september</li><li>ecf-reduced-january</li><li>ecf-reduced-april</li><li>ecf-extended-september</li><li>ecf-extended-january</li><li>ecf-extended-april</li><li>ecf-replacement-september</li><li>ecf-replacement-january</li><li>ecf-replacement-april</li></ul> | 
 | updated\_at | string | true | The date the ECF participant was last updated<br/> | 
 
 
@@ -1038,10 +1038,10 @@ An ECF completed participant declaration
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique ID of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - completed<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>completed</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/><br/> | 
-| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - 75-percent-engagement-met<br/> - 75-percent-engagement-met-reduced-induction<br/> - one-term-induction<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li></ul> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><ul><li>75-percent-engagement-met</li><li>75-percent-engagement-met-reduced-induction</li><li>one-term-induction</li></ul> | 
 
 
 ### ECFParticipantDeclarationPost2024ECTExtendedAttributesRequest
@@ -1052,10 +1052,10 @@ An ECF extended participant declaration
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique ID of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - extended-1<br/> - extended-2<br/> - extended-3<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>extended-1</li><li>extended-2</li><li>extended-3</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/><br/> | 
-| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - materials-engaged-with-offline<br/> - other<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li></ul> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><ul><li>training-event-attended</li><li>self-study-material-completed</li><li>materials-engaged-with-offline</li><li>other</li></ul> | 
 
 
 ### ECFParticipantDeclarationPost2024ECTRetainedAttributesRequest
@@ -1066,10 +1066,10 @@ An ECF participant retained declaration
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique ID of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - retained-1<br/> - retained-2<br/> - retained-3<br/> - retained-4<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>retained-1</li><li>retained-2</li><li>retained-3</li><li>retained-4</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/><br/> | 
-| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period. For retained-2 declarations, providers will need to confirm if the engagement threshold has been reached and only accept either the ‘75-percent-engagement-met’ or ‘75-percent-engagement-met-reduced-induction’ values.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - materials-engaged-with-offline<br/> - other<br/> - 75-percent-engagement-met<br/> - 75-percent-engagement-met-reduced-induction<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li></ul> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period. For retained-2 declarations, providers will need to confirm if the engagement threshold has been reached and only accept either the ‘75-percent-engagement-met’ or ‘75-percent-engagement-met-reduced-induction’ values.<br/>Possible values:<br/><ul><li>training-event-attended</li><li>self-study-material-completed</li><li>materials-engaged-with-offline</li><li>other</li><li>75-percent-engagement-met</li><li>75-percent-engagement-met-reduced-induction</li></ul> | 
 
 
 ### ECFParticipantDeclarationPost2024ECTStartedAttributesRequest
@@ -1080,10 +1080,10 @@ An ECF started participant declaration
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique ID of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - started<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>started</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/><br/> | 
-| evidence\_held | string | false | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - materials-engaged-with-offline<br/> - other<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li></ul> | 
+| evidence\_held | string | false | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><ul><li>training-event-attended</li><li>self-study-material-completed</li><li>materials-engaged-with-offline</li><li>other</li></ul> | 
 
 
 ### ECFParticipantDeclarationPost2024MentorCompletedAttributesRequest
@@ -1094,10 +1094,10 @@ An ECF completed participant declaration
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique ID of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - completed<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>completed</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-mentor<br/><br/> | 
-| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - 75-percent-engagement-met<br/> - 75-percent-engagement-met-reduced-induction<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-mentor</li></ul> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><ul><li>75-percent-engagement-met</li><li>75-percent-engagement-met-reduced-induction</li></ul> | 
 
 
 ### ECFParticipantDeclarationPost2024MentorStartedAttributesRequest
@@ -1108,10 +1108,10 @@ An ECF started participant declaration
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique ID of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - started<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>started</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-mentor<br/><br/> | 
-| evidence\_held | string | false | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - materials-engaged-with-offline<br/> - other<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-mentor</li></ul> | 
+| evidence\_held | string | false | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><ul><li>training-event-attended</li><li>self-study-material-completed</li><li>materials-engaged-with-offline</li><li>other</li></ul> | 
 
 
 ### ECFParticipantDeclarationPre2025CompletedAttributesRequest
@@ -1122,10 +1122,10 @@ An ECF completed participant declaration
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique ID of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - completed<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>completed</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
-| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - other<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li><li>ecf-mentor</li></ul> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><ul><li>training-event-attended</li><li>self-study-material-completed</li><li>other</li></ul> | 
 
 
 ### ECFParticipantDeclarationPre2025ExtendedAttributesRequest
@@ -1136,10 +1136,10 @@ An ECF extended participant declaration
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique ID of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - extended-1<br/> - extended-2<br/> - extended-3<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>extended-1</li><li>extended-2</li><li>extended-3</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
-| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - other<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li><li>ecf-mentor</li></ul> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><ul><li>training-event-attended</li><li>self-study-material-completed</li><li>other</li></ul> | 
 
 
 ### ECFParticipantDeclarationPre2025RetainedAttributesRequest
@@ -1150,10 +1150,10 @@ An ECF participant retained declaration
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique ID of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - retained-1<br/> - retained-2<br/> - retained-3<br/> - retained-4<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>retained-1</li><li>retained-2</li><li>retained-3</li><li>retained-4</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
-| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - other<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li><li>ecf-mentor</li></ul> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><ul><li>training-event-attended</li><li>self-study-material-completed</li><li>other</li></ul> | 
 
 
 ### ECFParticipantDeclarationPre2025StartedAttributesRequest
@@ -1164,9 +1164,9 @@ An ECF started participant declaration
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique ID of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - started<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>started</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li><li>ecf-mentor</li></ul> | 
 
 
 ### ECFParticipantDefer
@@ -1176,7 +1176,7 @@ The details of a participant deferral request
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| type | string | true | The data type<br/>Possible values:<br/><br/> - participant-defer<br/><br/> | 
+| type | string | true | The data type<br/>Possible values:<br/><ul><li>participant-defer</li></ul> | 
 | attributes | object | true | An ECF participant deferral action<br/>It conforms to [ECFParticipantDeferAttributes](#schema-ecfparticipantdeferattributes) schema. | 
 
 
@@ -1187,8 +1187,8 @@ An ECF participant deferral action
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| reason | string | true | The reason for the deferral<br/>Possible values:<br/><br/> - bereavement<br/> - long-term-sickness<br/> - parental-leave<br/> - career-break<br/> - other<br/><br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| reason | string | true | The reason for the deferral<br/>Possible values:<br/><ul><li>bereavement</li><li>long-term-sickness</li><li>parental-leave</li><li>career-break</li><li>other</li></ul> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li><li>ecf-mentor</li></ul> | 
 
 
 #### Example
@@ -1213,16 +1213,16 @@ The data attributes associated with an ECF participant
 | full\_name | string | true | The full name of this ECF participant<br/> | 
 | mentor\_id | string | false | The unique identifier of this ECF participants mentor<br/> | 
 | school\_urn | string | true | The Unique Reference Number (URN) of the school that submitted this ECF participant<br/> | 
-| participant\_type | string | true | The type of ECF participant this record refers to<br/>Possible values:<br/><br/> - ect<br/> - mentor<br/><br/> | 
+| participant\_type | string | true | The type of ECF participant this record refers to<br/>Possible values:<br/><ul><li>ect</li><li>mentor</li></ul> | 
 | cohort | string | true | Indicates which call-off contract funds this participant’s training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year.<br/> | 
-| status | string | true | The status of this ECF participant record<br/>Possible values:<br/><br/> - active<br/> - withdrawn<br/><br/> | 
+| status | string | true | The status of this ECF participant record<br/>Possible values:<br/><ul><li>active</li><li>withdrawn</li></ul> | 
 | teacher\_reference\_number | string | false | The Teacher Reference Number (TRN) for this ECF participant<br/> | 
 | teacher\_reference\_number\_validated | boolean | false | Indicates whether the Teacher Reference Number (TRN) has been validated<br/> | 
 | eligible\_for\_funding | boolean | false | Indicates whether this participant is eligible to receive DfE funded induction<br/> | 
 | pupil\_premium\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to pupil premium<br/> | 
 | sparsity\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to sparsity<br/> | 
-| training\_status | string | true | The training status of the ECF participant<br/>Possible values:<br/><br/> - active<br/> - deferred<br/> - withdrawn<br/><br/> | 
-| schedule\_identifier | string | true | The schedule of the ECF participant<br/>Possible values:<br/><br/> - ecf-standard-september<br/> - ecf-standard-january<br/> - ecf-standard-april<br/> - ecf-reduced-september<br/> - ecf-reduced-january<br/> - ecf-reduced-april<br/> - ecf-extended-september<br/> - ecf-extended-january<br/> - ecf-extended-april<br/> - ecf-replacement-september<br/> - ecf-replacement-january<br/> - ecf-replacement-april<br/><br/> | 
+| training\_status | string | true | The training status of the ECF participant<br/>Possible values:<br/><ul><li>active</li><li>deferred</li><li>withdrawn</li></ul> | 
+| schedule\_identifier | string | true | The schedule of the ECF participant<br/>Possible values:<br/><ul><li>ecf-standard-september</li><li>ecf-standard-january</li><li>ecf-standard-april</li><li>ecf-reduced-september</li><li>ecf-reduced-january</li><li>ecf-reduced-april</li><li>ecf-extended-september</li><li>ecf-extended-january</li><li>ecf-extended-april</li><li>ecf-replacement-september</li><li>ecf-replacement-january</li><li>ecf-replacement-april</li></ul> | 
 | updated\_at | string | true | The date the ECF participant was last updated<br/> | 
 
 
@@ -1291,7 +1291,7 @@ An ECF participant resume action
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| type | string | true | The data type<br/>Possible values:<br/><br/> - participant-resume<br/><br/> | 
+| type | string | true | The data type<br/>Possible values:<br/><ul><li>participant-resume</li></ul> | 
 | attributes | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResumeAttributes](#schema-ecfparticipantresumeattributes) schema. | 
 
 
@@ -1302,7 +1302,7 @@ An ECF participant resume action
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li><li>ecf-mentor</li></ul> | 
 
 
 #### Example
@@ -1326,16 +1326,16 @@ The data attributes associated with an ECF participant
 | full\_name | string | true | The full name of this ECF participant<br/> | 
 | mentor\_id | string | false | The unique identifier of this ECF participants mentor<br/> | 
 | school\_urn | string | true | The Unique Reference Number (URN) of the school that submitted this ECF participant<br/> | 
-| participant\_type | string | true | The type of ECF participant this record refers to<br/>Possible values:<br/><br/> - ect<br/> - mentor<br/><br/> | 
+| participant\_type | string | true | The type of ECF participant this record refers to<br/>Possible values:<br/><ul><li>ect</li><li>mentor</li></ul> | 
 | cohort | string | true | Indicates which call-off contract funds this participant’s training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year.<br/> | 
-| status | string | true | The status of this ECF participant record<br/>Possible values:<br/><br/> - active<br/> - withdrawn<br/><br/> | 
+| status | string | true | The status of this ECF participant record<br/>Possible values:<br/><ul><li>active</li><li>withdrawn</li></ul> | 
 | teacher\_reference\_number | string | false | The Teacher Reference Number (TRN) for this ECF participant<br/> | 
 | teacher\_reference\_number\_validated | boolean | false | Indicates whether the Teacher Reference Number (TRN) has been validated<br/> | 
 | eligible\_for\_funding | boolean | false | Indicates whether this participant is eligible to receive DfE funded induction<br/> | 
 | pupil\_premium\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to pupil premium<br/> | 
 | sparsity\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to sparsity<br/> | 
-| training\_status | string | true | The training status of the ECF participant<br/>Possible values:<br/><br/> - active<br/> - deferred<br/> - withdrawn<br/><br/> | 
-| schedule\_identifier | string | true | The schedule of the ECF participant<br/>Possible values:<br/><br/> - ecf-standard-september<br/> - ecf-standard-january<br/> - ecf-standard-april<br/> - ecf-reduced-september<br/> - ecf-reduced-january<br/> - ecf-reduced-april<br/> - ecf-extended-september<br/> - ecf-extended-january<br/> - ecf-extended-april<br/> - ecf-replacement-september<br/> - ecf-replacement-january<br/> - ecf-replacement-april<br/><br/> | 
+| training\_status | string | true | The training status of the ECF participant<br/>Possible values:<br/><ul><li>active</li><li>deferred</li><li>withdrawn</li></ul> | 
+| schedule\_identifier | string | true | The schedule of the ECF participant<br/>Possible values:<br/><ul><li>ecf-standard-september</li><li>ecf-standard-january</li><li>ecf-standard-april</li><li>ecf-reduced-september</li><li>ecf-reduced-january</li><li>ecf-reduced-april</li><li>ecf-extended-september</li><li>ecf-extended-january</li><li>ecf-extended-april</li><li>ecf-replacement-september</li><li>ecf-replacement-january</li><li>ecf-replacement-april</li></ul> | 
 | updated\_at | string | true | The date the ECF participant was last updated<br/> | 
 
 
@@ -1393,7 +1393,7 @@ An ECF participant retained declaration request body
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| type | object | false | The request data<br/>Possible values:<br/><br/> - participant-declaration<br/><br/> | 
+| type | object | false | The request data<br/>Possible values:<br/><ul><li>participant-declaration</li></ul> | 
 | attributes | object | true | An ECF participant retained declaration<br/>It conforms to [ECFParticipantRetainedDeclarationAttributes](#schema-ecfparticipantretaineddeclarationattributes) schema. | 
 
 
@@ -1405,10 +1405,10 @@ An ECF participant retained declaration
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique id of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - retained-1<br/> - retained-2<br/> - retained-3<br/> - retained-4<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>retained-1</li><li>retained-2</li><li>retained-3</li><li>retained-4</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
-| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - other<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li><li>ecf-mentor</li></ul> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><ul><li>training-event-attended</li><li>self-study-material-completed</li><li>other</li></ul> | 
 
 
 #### Example
@@ -1432,7 +1432,7 @@ A participant started declaration request body
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| type | object | false | The request data<br/>Possible values:<br/><br/> - participant-declaration<br/><br/> | 
+| type | object | false | The request data<br/>Possible values:<br/><ul><li>participant-declaration</li></ul> | 
 | attributes | object | true | An ECF started and completed participant declaration<br/>It conforms to [ECFParticipantStartedDeclarationAttributes](#schema-ecfparticipantstarteddeclarationattributes) schema. | 
 
 
@@ -1444,9 +1444,9 @@ An ECF started and completed participant declaration
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique id of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - started<br/> - completed<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>started</li><li>completed</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li><li>ecf-mentor</li></ul> | 
 
 
 #### Example
@@ -1469,7 +1469,7 @@ An ECF participant withdrawal action
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| type | string | false | The data type<br/>Possible values:<br/><br/> - participant-withdraw<br/><br/> | 
+| type | string | false | The data type<br/>Possible values:<br/><ul><li>participant-withdraw</li></ul> | 
 | attributes | object | false | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdrawAttributes](#schema-ecfparticipantwithdrawattributes) schema. | 
 
 
@@ -1480,8 +1480,8 @@ An ECF participant withdrawal action
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| reason | string | true | The reason for the withdrawal<br/>Possible values:<br/><br/> - left-teaching-profession<br/> - moved-school<br/> - mentor-no-longer-being-mentor<br/> - switched-to-school-led<br/> - other<br/><br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| reason | string | true | The reason for the withdrawal<br/>Possible values:<br/><ul><li>left-teaching-profession</li><li>moved-school</li><li>mentor-no-longer-being-mentor</li><li>switched-to-school-led</li><li>other</li></ul> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li><li>ecf-mentor</li></ul> | 
 
 
 #### Example
@@ -1506,16 +1506,16 @@ The data attributes associated with an ECF participant
 | full\_name | string | true | The full name of this ECF participant<br/> | 
 | mentor\_id | string | false | The unique identifier of this ECF participants mentor<br/> | 
 | school\_urn | string | true | The Unique Reference Number (URN) of the school that submitted this ECF participant<br/> | 
-| participant\_type | string | true | The type of ECF participant this record refers to<br/>Possible values:<br/><br/> - ect<br/> - mentor<br/><br/> | 
+| participant\_type | string | true | The type of ECF participant this record refers to<br/>Possible values:<br/><ul><li>ect</li><li>mentor</li></ul> | 
 | cohort | string | true | Indicates which call-off contract funds this participant’s training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year.<br/> | 
-| status | string | true | The status of this ECF participant record<br/>Possible values:<br/><br/> - active<br/> - withdrawn<br/><br/> | 
+| status | string | true | The status of this ECF participant record<br/>Possible values:<br/><ul><li>active</li><li>withdrawn</li></ul> | 
 | teacher\_reference\_number | string | false | The Teacher Reference Number (TRN) for this ECF participant<br/> | 
 | teacher\_reference\_number\_validated | boolean | false | Indicates whether the Teacher Reference Number (TRN) has been validated<br/> | 
 | eligible\_for\_funding | boolean | false | Indicates whether this participant is eligible to receive DfE funded induction<br/> | 
 | pupil\_premium\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to pupil premium<br/> | 
 | sparsity\_uplift | boolean | false | Indicates whether this participant qualifies for an uplift payment due to sparsity<br/> | 
-| training\_status | string | true | The training status of the ECF participant<br/>Possible values:<br/><br/> - active<br/> - deferred<br/> - withdrawn<br/><br/> | 
-| schedule\_identifier | string | true | The schedule of the ECF participant<br/>Possible values:<br/><br/> - ecf-standard-september<br/> - ecf-standard-january<br/> - ecf-standard-april<br/> - ecf-reduced-september<br/> - ecf-reduced-january<br/> - ecf-reduced-april<br/> - ecf-extended-september<br/> - ecf-extended-january<br/> - ecf-extended-april<br/> - ecf-replacement-september<br/> - ecf-replacement-january<br/> - ecf-replacement-april<br/><br/> | 
+| training\_status | string | true | The training status of the ECF participant<br/>Possible values:<br/><ul><li>active</li><li>deferred</li><li>withdrawn</li></ul> | 
+| schedule\_identifier | string | true | The schedule of the ECF participant<br/>Possible values:<br/><ul><li>ecf-standard-september</li><li>ecf-standard-january</li><li>ecf-standard-april</li><li>ecf-reduced-september</li><li>ecf-reduced-january</li><li>ecf-reduced-april</li><li>ecf-extended-september</li><li>ecf-extended-january</li><li>ecf-extended-april</li><li>ecf-replacement-september</li><li>ecf-replacement-january</li><li>ecf-replacement-april</li></ul> | 
 | updated\_at | string | true | The date the ECF participant was last updated<br/> | 
 
 
@@ -1678,10 +1678,10 @@ The data attributes associated with a participant declaration response
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique id of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - started<br/> - retained-1<br/> - retained-2<br/> - retained-3<br/> - retained-4<br/> - completed<br/> - extended-1<br/> - extended-2<br/> - extended-3<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>started</li><li>retained-1</li><li>retained-2</li><li>retained-3</li><li>retained-4</li><li>completed</li><li>extended-1</li><li>extended-2</li><li>extended-3</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
-| state | string | true | Indicates the state of this payment declaration<br/>Possible values:<br/><br/> - submitted<br/> - eligible<br/> - payable<br/> - paid<br/> - voided<br/> - ineligible<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li><li>ecf-mentor</li></ul> | 
+| state | string | true | Indicates the state of this payment declaration<br/>Possible values:<br/><ul><li>submitted</li><li>eligible</li><li>payable</li><li>paid</li><li>voided</li><li>ineligible</li></ul> | 
 | updated\_at | string | true | The date the declaration was last updated<br/> | 
 | has\_passed | boolean | false | Whether the participant has failed or passed<br/> | 
 
@@ -1695,9 +1695,9 @@ The details of a participant declaration
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant declaration record<br/> | 
 | participant\_id | string | true | The unique identifier of the participant record the declaration refers to<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - started<br/> - retained-1<br/> - retained-2<br/> - retained-3<br/> - retained-4<br/> - completed<br/> - extended-1<br/> - extended-2<br/> - extended-3<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>started</li><li>retained-1</li><li>retained-2</li><li>retained-3</li><li>retained-4</li><li>completed</li><li>extended-1</li><li>extended-2</li><li>extended-3</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li><li>ecf-mentor</li></ul> | 
 | state | string | false | Indicates the state of this payment declaration<br/> | 
 | updated\_at | string | true | The date the declaration was last updated<br/> | 
 
@@ -1709,8 +1709,8 @@ A participant declaration data request for ECT participants from cohort 2025 onw
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| type | string | false | Possible values:<br/><br/> - participant-declaration<br/><br/> | 
-| attributes | object | false | This conforms to any of the following schemas:<br/><br/> -  [ECFParticipantDeclarationPost2024ECTStartedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectstartedattributesrequest) <br/> -  [ECFParticipantDeclarationPost2024ECTRetainedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectretainedattributesrequest) <br/> -  [ECFParticipantDeclarationPost2024ECTCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectcompletedattributesrequest) <br/> -  [ECFParticipantDeclarationPost2024ECTExtendedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectextendedattributesrequest) <br/><br/> | 
+| type | string | false | Possible values:<br/><ul><li>participant-declaration</li></ul> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024ECTStartedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTRetainedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectretainedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectcompletedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTExtendedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectextendedattributesrequest) </li></ul> | 
 
 
 ### ParticipantDeclarationPost2024MentorDataRequest
@@ -1720,8 +1720,8 @@ A participant declaration data request for mentor participants from cohort 2025 
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| type | string | false | Possible values:<br/><br/> - participant-declaration<br/><br/> | 
-| attributes | object | false | This conforms to any of the following schemas:<br/><br/> -  [ECFParticipantDeclarationPost2024MentorStartedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorstartedattributesrequest) <br/> -  [ECFParticipantDeclarationPost2024MentorCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorcompletedattributesrequest) <br/><br/> | 
+| type | string | false | Possible values:<br/><ul><li>participant-declaration</li></ul> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024MentorStartedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024MentorCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorcompletedattributesrequest) </li></ul> | 
 
 
 ### ParticipantDeclarationPre2025DataRequest
@@ -1731,8 +1731,8 @@ A participant declaration data request for participants in cohort 2024 and previ
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| type | string | false | Possible values:<br/><br/> - participant-declaration<br/><br/> | 
-| attributes | object | false | This conforms to any of the following schemas:<br/><br/> -  [ECFParticipantDeclarationPre2025StartedAttributesRequest](#schema-ecfparticipantdeclarationpre2025startedattributesrequest) <br/> -  [ECFParticipantDeclarationPre2025RetainedAttributesRequest](#schema-ecfparticipantdeclarationpre2025retainedattributesrequest) <br/> -  [ECFParticipantDeclarationPre2025CompletedAttributesRequest](#schema-ecfparticipantdeclarationpre2025completedattributesrequest) <br/> -  [ECFParticipantDeclarationPre2025ExtendedAttributesRequest](#schema-ecfparticipantdeclarationpre2025extendedattributesrequest) <br/><br/> | 
+| type | string | false | Possible values:<br/><ul><li>participant-declaration</li></ul> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPre2025StartedAttributesRequest](#schema-ecfparticipantdeclarationpre2025startedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025RetainedAttributesRequest](#schema-ecfparticipantdeclarationpre2025retainedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025CompletedAttributesRequest](#schema-ecfparticipantdeclarationpre2025completedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025ExtendedAttributesRequest](#schema-ecfparticipantdeclarationpre2025extendedattributesrequest) </li></ul> | 
 
 
 ### ParticipantDeclarationRequest
@@ -1742,7 +1742,7 @@ An participant declaration request
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | This conforms to any of the following schemas:<br/><br/> -  [ParticipantDeclarationPre2025DataRequest](#schema-participantdeclarationpre2025datarequest) <br/> -  [ParticipantDeclarationPost2024ECTDataRequest](#schema-participantdeclarationpost2024ectdatarequest) <br/> -  [ParticipantDeclarationPost2024MentorDataRequest](#schema-participantdeclarationpost2024mentordatarequest) <br/><br/> | 
+| data | object | true | This conforms to any of the following schemas:<br/><ul><li> [ParticipantDeclarationPre2025DataRequest](#schema-participantdeclarationpre2025datarequest) </li><li> [ParticipantDeclarationPost2024ECTDataRequest](#schema-participantdeclarationpost2024ectdatarequest) </li><li> [ParticipantDeclarationPost2024MentorDataRequest](#schema-participantdeclarationpost2024mentordatarequest) </li></ul> | 
 
 
 ### ParticipantDeclarationResponse

--- a/documentation/ecf1_guidance/reference-v2.md
+++ b/documentation/ecf1_guidance/reference-v2.md
@@ -13,10 +13,7 @@ The lead provider API for DfE’s manage teacher CPD service
  [/](/) 
  **Production** 
  [https://manage-training-for-early-career-teachers.education.gov.uk](https://manage-training-for-early-career-teachers.education.gov.uk) 
-## GET
-    
-    
-      /api/v2/participant-declarations
+## GET /api/v2/participant-declarations
 
 
  _List all participant declarations_ 
@@ -84,10 +81,7 @@ This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 ---
 
 
-## POST
-    
-    
-      /api/v2/participant-declarations
+## POST /api/v2/participant-declarations
 
 
  _Declare a participant has reached a milestone. Idempotent endpoint - submitting exact copy of a request will return the same response body as submitting it the first time._ 
@@ -167,10 +161,7 @@ This response returns a [BadRequestResponse](#badrequestresponse) schema.
 ---
 
 
-## GET
-    
-    
-      /api/v2/participant-declarations.csv
+## GET /api/v2/participant-declarations.csv
 
 
  _Retrieve all participant declarations in CSV format_ 
@@ -194,10 +185,7 @@ This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 ---
 
 
-## GET
-    
-    
-      /api/v2/participant-declarations/{id}
+## GET /api/v2/participant-declarations/{id}
 
 
  _Get single participant declaration_ 
@@ -265,10 +253,7 @@ This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 ---
 
 
-## PUT
-    
-    
-      /api/v2/participant-declarations/{id}/void
+## PUT /api/v2/participant-declarations/{id}/void
 
 
  _Void a declaration - it will not be soft-deleted_ 
@@ -316,10 +301,7 @@ This response returns a [SingleParticipantDeclarationResponse](#singleparticipan
 ---
 
 
-## GET
-    
-    
-      /api/v2/participants/ecf
+## GET /api/v2/participants/ecf
 
 
  _Retrieve multiple participants, replaces /api/v2/participants_ 
@@ -426,10 +408,7 @@ This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 ---
 
 
-## GET
-    
-    
-      /api/v2/participants/ecf.csv
+## GET /api/v2/participants/ecf.csv
 
 
  _Retrieve all participants in CSV format, replaces /api/v2/participants.csv_ 
@@ -461,10 +440,7 @@ This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 ---
 
 
-## GET
-    
-    
-      /api/v2/participants/ecf/{id}
+## GET /api/v2/participants/ecf/{id}
 
 
  _Get a single ECF participant_ 
@@ -531,10 +507,7 @@ This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 ---
 
 
-## PUT
-    
-    
-      /api/v2/participants/ecf/{id}/defer
+## PUT /api/v2/participants/ecf/{id}/defer
 
 
  _Notify that an ECF participant is taking a break from their course_ 
@@ -611,10 +584,7 @@ This response returns a [ECFParticipantDeferResponse](#ecfparticipantdeferrespon
 ---
 
 
-## PUT
-    
-    
-      /api/v2/participants/ecf/{id}/resume
+## PUT /api/v2/participants/ecf/{id}/resume
 
 
  _Notify that an ECF participant is resuming their course_ 
@@ -690,10 +660,7 @@ This response returns a [ECFParticipantResumeResponse](#ecfparticipantresumeresp
 ---
 
 
-## PUT
-    
-    
-      /api/v2/participants/ecf/{id}/withdraw
+## PUT /api/v2/participants/ecf/{id}/withdraw
 
 
  _Notify that an ECF participant has withdrawn from their course_ 
@@ -770,10 +737,7 @@ This response returns a [ECFParticipantWithdrawResponse](#ecfparticipantwithdraw
 ---
 
 
-## PUT
-    
-    
-      /api/v2/participants/ecf/{id}/change-schedule
+## PUT /api/v2/participants/ecf/{id}/change-schedule
 
 
  _Notify that an ECF participant is changing training schedule_ 

--- a/documentation/ecf1_guidance/reference-v2.md
+++ b/documentation/ecf1_guidance/reference-v2.md
@@ -26,8 +26,8 @@ The lead provider API for DfE’s manage teacher CPD service
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine participant declarations to return.<br/>This consumes a [ListFilterDeclarations](listfilterdeclarations) schema.<br/> | participant\_id=ab3a7848-1208-7679-942a-b4a70eed400a&updated\_since=2020-11-13T11:21:55Z | 
-| page | query | object | false | Pagination options to navigate through the list of participant declarations.<br/>This consumes a [Pagination](pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| filter | query | object | false | Refine participant declarations to return.<br/>This consumes a [ListFilterDeclarations](#schema-listfilterdeclarations) schema.<br/> | participant\_id=ab3a7848-1208-7679-942a-b4a70eed400a&updated\_since=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of participant declarations.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
 
 
 ### Responses
@@ -35,14 +35,14 @@ The lead provider API for DfE’s manage teacher CPD service
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A list of participant declarations<br/>This response returns a [MultipleParticipantDeclarationsResponse](multipleparticipantdeclarationsresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
+| 200 | A list of participant declarations<br/>This response returns a [MultipleParticipantDeclarationsResponse](#schema-multipleparticipantdeclarationsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A list of participant declarations
-This response returns a [MultipleParticipantDeclarationsResponse](multipleparticipantdeclarationsresponse) schema.
+This response returns a [MultipleParticipantDeclarationsResponse](#schema-multipleparticipantdeclarationsresponse) schema.
 
 ```
 {
@@ -72,7 +72,7 @@ This response returns a [MultipleParticipantDeclarationsResponse](multiplepartic
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
 
 ```
 {
@@ -95,23 +95,23 @@ This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 ### Request body
 
 
-This consumes a [ParticipantDeclarationRequest](participantdeclarationrequest) schema.
+This consumes a [ParticipantDeclarationRequest](#schema-participantdeclarationrequest) schema.
 
 ### Responses
 
 
 | Status | Description |
 | ---- | ---- |
-| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](singleparticipantdeclarationresponse) schema.<br/> | 
-| 422 | Bad or Missing parameter<br/>This response returns a [ErrorResponse](errorresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
-| 400 | Bad Request<br/>This response returns a [BadRequestResponse](badrequestresponse) schema.<br/> | 
+| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.<br/> | 
+| 422 | Bad or Missing parameter<br/>This response returns a [ErrorResponse](#schema-errorresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 400 | Bad Request<br/>This response returns a [BadRequestResponse](#schema-badrequestresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - Successful
-This response returns a [SingleParticipantDeclarationResponse](singleparticipantdeclarationresponse) schema.
+This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.
 
 ```
 {
@@ -132,7 +132,7 @@ This response returns a [SingleParticipantDeclarationResponse](singleparticipant
 ```
 
 422 - Bad or Missing parameter
-This response returns a [ErrorResponse](errorresponse) schema.
+This response returns a [ErrorResponse](#schema-errorresponse) schema.
 
 ```
 {
@@ -146,7 +146,7 @@ This response returns a [ErrorResponse](errorresponse) schema.
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
 
 ```
 {
@@ -155,7 +155,7 @@ This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 ```
 
 400 - Bad Request
-This response returns a [BadRequestResponse](badrequestresponse) schema.
+This response returns a [BadRequestResponse](#schema-badrequestresponse) schema.
 
 ```
 {
@@ -180,16 +180,16 @@ This response returns a [BadRequestResponse](badrequestresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A CSV file of participant declarations<br/>This response returns a [MultipleParticipantDeclarationsCsvResponse](multipleparticipantdeclarationscsvresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
+| 200 | A CSV file of participant declarations<br/>This response returns a [MultipleParticipantDeclarationsCsvResponse](#schema-multipleparticipantdeclarationscsvresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A CSV file of participant declarations
-This response returns a [MultipleParticipantDeclarationsCsvResponse](multipleparticipantdeclarationscsvresponse) schema.
+This response returns a [MultipleParticipantDeclarationsCsvResponse](#schema-multipleparticipantdeclarationscsvresponse) schema.
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
 
 ---
 
@@ -215,15 +215,15 @@ This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A single participant declaration<br/>This response returns a [SingleParticipantDeclarationResponse](singleparticipantdeclarationresponse) schema.<br/> | 
-| 404 | Not found<br/>This response returns a [NotFoundResponse](notfoundresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
+| 200 | A single participant declaration<br/>This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.<br/> | 
+| 404 | Not found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A single participant declaration
-This response returns a [SingleParticipantDeclarationResponse](singleparticipantdeclarationresponse) schema.
+This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.
 
 ```
 {
@@ -244,7 +244,7 @@ This response returns a [SingleParticipantDeclarationResponse](singleparticipant
 ```
 
 404 - Not found
-This response returns a [NotFoundResponse](notfoundresponse) schema.
+This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 
 ```
 {
@@ -253,7 +253,7 @@ This response returns a [NotFoundResponse](notfoundresponse) schema.
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
 
 ```
 {
@@ -286,13 +286,13 @@ This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](singleparticipantdeclarationresponse) schema.<br/> | 
+| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - Successful
-This response returns a [SingleParticipantDeclarationResponse](singleparticipantdeclarationresponse) schema.
+This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.
 
 ```
 {
@@ -329,8 +329,8 @@ This response returns a [SingleParticipantDeclarationResponse](singleparticipant
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine ECF participants to return.<br/>This consumes a [ListFilter](listfilter) schema.<br/> | filter[cohort]=2022&filter[updated\_since]=2020-11-13T11:21:55Z | 
-| page | query | object | false | Pagination options to navigate through the list of ECF participants.<br/>This consumes a [Pagination](pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| filter | query | object | false | Refine ECF participants to return.<br/>This consumes a [ListFilter](#schema-listfilter) schema.<br/> | filter[cohort]=2022&filter[updated\_since]=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of ECF participants.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
 
 
 ### Responses
@@ -338,14 +338,14 @@ This response returns a [SingleParticipantDeclarationResponse](singleparticipant
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A list of ECF participants<br/>This response returns a [MultipleECFParticipantsResponse](multipleecfparticipantsresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
+| 200 | A list of ECF participants<br/>This response returns a [MultipleECFParticipantsResponse](#schema-multipleecfparticipantsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A list of ECF participants
-This response returns a [MultipleECFParticipantsResponse](multipleecfparticipantsresponse) schema.
+This response returns a [MultipleECFParticipantsResponse](#schema-multipleecfparticipantsresponse) schema.
 
 ```
 {
@@ -414,7 +414,7 @@ This response returns a [MultipleECFParticipantsResponse](multipleecfparticipant
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
 
 ```
 {
@@ -439,7 +439,7 @@ This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine ECF participants to return.<br/>This consumes a [ListFilter](listfilter) schema.<br/> | updated\_since=2020-11-13T11:21:55Z | 
+| filter | query | object | false | Refine ECF participants to return.<br/>This consumes a [ListFilter](#schema-listfilter) schema.<br/> | updated\_since=2020-11-13T11:21:55Z | 
 
 
 ### Responses
@@ -447,16 +447,16 @@ This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A CSV file of ECF participants<br/>This response returns a [MultipleECFParticipantsCsvResponse](multipleecfparticipantscsvresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
+| 200 | A CSV file of ECF participants<br/>This response returns a [MultipleECFParticipantsCsvResponse](#schema-multipleecfparticipantscsvresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A CSV file of ECF participants
-This response returns a [MultipleECFParticipantsCsvResponse](multipleecfparticipantscsvresponse) schema.
+This response returns a [MultipleECFParticipantsCsvResponse](#schema-multipleecfparticipantscsvresponse) schema.
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
 
 ---
 
@@ -482,14 +482,14 @@ This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A single ECF participant<br/>This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
+| 200 | A single ECF participant<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A single ECF participant
-This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
 
 ```
 {
@@ -519,7 +519,7 @@ This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
 
 ```
 {
@@ -550,7 +550,7 @@ This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 ### Request body
 
 
-This consumes a [ECFParticipantDeferRequest](ecfparticipantdeferrequest) schema.
+This consumes a [ECFParticipantDeferRequest](#schema-ecfparticipantdeferrequest) schema.
 
 ### Request example
 
@@ -573,13 +573,13 @@ This consumes a [ECFParticipantDeferRequest](ecfparticipantdeferrequest) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant being deferred<br/>This response returns a [ECFParticipantDeferResponse](ecfparticipantdeferresponse) schema.<br/> | 
+| 200 | The ECF participant being deferred<br/>This response returns a [ECFParticipantDeferResponse](#schema-ecfparticipantdeferresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant being deferred
-This response returns a [ECFParticipantDeferResponse](ecfparticipantdeferresponse) schema.
+This response returns a [ECFParticipantDeferResponse](#schema-ecfparticipantdeferresponse) schema.
 
 ```
 {
@@ -630,7 +630,7 @@ This response returns a [ECFParticipantDeferResponse](ecfparticipantdeferrespons
 ### Request body
 
 
-This consumes a [ECFParticipantResumeRequest](ecfparticipantresumerequest) schema.
+This consumes a [ECFParticipantResumeRequest](#schema-ecfparticipantresumerequest) schema.
 
 ### Request example
 
@@ -652,13 +652,13 @@ This consumes a [ECFParticipantResumeRequest](ecfparticipantresumerequest) schem
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant being resumed<br/>This response returns a [ECFParticipantResumeResponse](ecfparticipantresumeresponse) schema.<br/> | 
+| 200 | The ECF participant being resumed<br/>This response returns a [ECFParticipantResumeResponse](#schema-ecfparticipantresumeresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant being resumed
-This response returns a [ECFParticipantResumeResponse](ecfparticipantresumeresponse) schema.
+This response returns a [ECFParticipantResumeResponse](#schema-ecfparticipantresumeresponse) schema.
 
 ```
 {
@@ -709,7 +709,7 @@ This response returns a [ECFParticipantResumeResponse](ecfparticipantresumerespo
 ### Request body
 
 
-This consumes a [ECFParticipantWithdrawRequest](ecfparticipantwithdrawrequest) schema.
+This consumes a [ECFParticipantWithdrawRequest](#schema-ecfparticipantwithdrawrequest) schema.
 
 ### Request example
 
@@ -732,13 +732,13 @@ This consumes a [ECFParticipantWithdrawRequest](ecfparticipantwithdrawrequest) s
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant being withdrawn<br/>This response returns a [ECFParticipantWithdrawResponse](ecfparticipantwithdrawresponse) schema.<br/> | 
+| 200 | The ECF participant being withdrawn<br/>This response returns a [ECFParticipantWithdrawResponse](#schema-ecfparticipantwithdrawresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant being withdrawn
-This response returns a [ECFParticipantWithdrawResponse](ecfparticipantwithdrawresponse) schema.
+This response returns a [ECFParticipantWithdrawResponse](#schema-ecfparticipantwithdrawresponse) schema.
 
 ```
 {
@@ -789,7 +789,7 @@ This response returns a [ECFParticipantWithdrawResponse](ecfparticipantwithdrawr
 ### Request body
 
 
-This consumes a [ECFParticipantChangeScheduleRequest](ecfparticipantchangeschedulerequest) schema.
+This consumes a [ECFParticipantChangeScheduleRequest](#schema-ecfparticipantchangeschedulerequest) schema.
 
 ### Request example
 
@@ -813,13 +813,13 @@ This consumes a [ECFParticipantChangeScheduleRequest](ecfparticipantchangeschedu
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant changing schedule<br/>This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.<br/> | 
+| 200 | The ECF participant changing schedule<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant changing schedule
-This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
 
 ```
 {
@@ -899,7 +899,7 @@ The details of a participant
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantAttributes](ecfparticipantattributes) schema. | 
+| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantAttributes](#schema-ecfparticipantattributes) schema. | 
 
 
 ### ECFParticipantAttributes
@@ -935,7 +935,7 @@ An ECF participant change schedule action
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | true | The data type<br/>Possible values:<br/><ul><li>participant-change-schedule</li></ul> | 
-| attributes | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeScheduleAttributes](ecfparticipantchangescheduleattributes) schema. | 
+| attributes | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeScheduleAttributes](#schema-ecfparticipantchangescheduleattributes) schema. | 
 
 
 #### Example
@@ -983,7 +983,7 @@ The change schedule request for a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeSchedule](ecfparticipantchangeschedule) schema. | 
+| data | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeSchedule](#schema-ecfparticipantchangeschedule) schema. | 
 
 
 #### Example
@@ -1177,7 +1177,7 @@ The details of a participant deferral request
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | true | The data type<br/>Possible values:<br/><ul><li>participant-defer</li></ul> | 
-| attributes | object | true | An ECF participant deferral action<br/>It conforms to [ECFParticipantDeferAttributes](ecfparticipantdeferattributes) schema. | 
+| attributes | object | true | An ECF participant deferral action<br/>It conforms to [ECFParticipantDeferAttributes](#schema-ecfparticipantdeferattributes) schema. | 
 
 
 ### ECFParticipantDeferAttributes
@@ -1233,7 +1233,7 @@ The deferral request for a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | The details of a participant deferral request<br/>It conforms to [ECFParticipantDefer](ecfparticipantdefer) schema. | 
+| data | object | true | The details of a participant deferral request<br/>It conforms to [ECFParticipantDefer](#schema-ecfparticipantdefer) schema. | 
 
 
 #### Example
@@ -1259,7 +1259,7 @@ An ECF Participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantDeferResponseData](ecfparticipantdeferresponsedata) schema. | 
+| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantDeferResponseData](#schema-ecfparticipantdeferresponsedata) schema. | 
 
 
 ### ECFParticipantDeferResponseData
@@ -1271,7 +1271,7 @@ The details of a participant
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantDeferAttributesResponse](ecfparticipantdeferattributesresponse) schema. | 
+| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantDeferAttributesResponse](#schema-ecfparticipantdeferattributesresponse) schema. | 
 
 
 ### ECFParticipantResponse
@@ -1281,7 +1281,7 @@ An ECF Participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | The details of a participant<br/>It conforms to [ECFParticipant](ecfparticipant) schema. | 
+| data | object | true | The details of a participant<br/>It conforms to [ECFParticipant](#schema-ecfparticipant) schema. | 
 
 
 ### ECFParticipantResume
@@ -1292,7 +1292,7 @@ An ECF participant resume action
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | true | The data type<br/>Possible values:<br/><ul><li>participant-resume</li></ul> | 
-| attributes | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResumeAttributes](ecfparticipantresumeattributes) schema. | 
+| attributes | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResumeAttributes](#schema-ecfparticipantresumeattributes) schema. | 
 
 
 ### ECFParticipantResumeAttributes
@@ -1346,7 +1346,7 @@ The resume request for a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResume](ecfparticipantresume) schema. | 
+| data | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResume](#schema-ecfparticipantresume) schema. | 
 
 
 #### Example
@@ -1371,7 +1371,7 @@ An ECF Participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantResumeResponseData](ecfparticipantresumeresponsedata) schema. | 
+| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantResumeResponseData](#schema-ecfparticipantresumeresponsedata) schema. | 
 
 
 ### ECFParticipantResumeResponseData
@@ -1383,7 +1383,7 @@ The details of a participant
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantResumeAttributesResponse](ecfparticipantresumeattributesresponse) schema. | 
+| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantResumeAttributesResponse](#schema-ecfparticipantresumeattributesresponse) schema. | 
 
 
 ### ECFParticipantRetainedDeclaration
@@ -1394,7 +1394,7 @@ An ECF participant retained declaration request body
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | object | false | The request data<br/>Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | true | An ECF participant retained declaration<br/>It conforms to [ECFParticipantRetainedDeclarationAttributes](ecfparticipantretaineddeclarationattributes) schema. | 
+| attributes | object | true | An ECF participant retained declaration<br/>It conforms to [ECFParticipantRetainedDeclarationAttributes](#schema-ecfparticipantretaineddeclarationattributes) schema. | 
 
 
 ### ECFParticipantRetainedDeclarationAttributes
@@ -1433,7 +1433,7 @@ A participant started declaration request body
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | object | false | The request data<br/>Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | true | An ECF started and completed participant declaration<br/>It conforms to [ECFParticipantStartedDeclarationAttributes](ecfparticipantstarteddeclarationattributes) schema. | 
+| attributes | object | true | An ECF started and completed participant declaration<br/>It conforms to [ECFParticipantStartedDeclarationAttributes](#schema-ecfparticipantstarteddeclarationattributes) schema. | 
 
 
 ### ECFParticipantStartedDeclarationAttributes
@@ -1470,7 +1470,7 @@ An ECF participant withdrawal action
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | The data type<br/>Possible values:<br/><ul><li>participant-withdraw</li></ul> | 
-| attributes | object | false | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdrawAttributes](ecfparticipantwithdrawattributes) schema. | 
+| attributes | object | false | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdrawAttributes](#schema-ecfparticipantwithdrawattributes) schema. | 
 
 
 ### ECFParticipantWithdrawAttributes
@@ -1528,7 +1528,7 @@ The details of a participant
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantWithdrawAttributesResponse](ecfparticipantwithdrawattributesresponse) schema. | 
+| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantWithdrawAttributesResponse](#schema-ecfparticipantwithdrawattributesresponse) schema. | 
 
 
 ### ECFParticipantWithdrawRequest
@@ -1538,7 +1538,7 @@ The withdrawal request for a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdraw](ecfparticipantwithdraw) schema. | 
+| data | object | true | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdraw](#schema-ecfparticipantwithdraw) schema. | 
 
 
 #### Example
@@ -1564,7 +1564,7 @@ An ECF Participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantWithdrawDataResponse](ecfparticipantwithdrawdataresponse) schema. | 
+| data | object | true | The details of a participant<br/>It conforms to [ECFParticipantWithdrawDataResponse](#schema-ecfparticipantwithdrawdataresponse) schema. | 
 
 
 ### Error
@@ -1585,7 +1585,7 @@ A list of errors
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| error | array | false | It conforms to [Error](error) schema. | 
+| error | array | false | It conforms to [Error](#schema-error) schema. | 
 
 
 ### ListFilter
@@ -1616,7 +1616,7 @@ A list of ECF participants in the Comma Separated Value (CSV) format
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ECFParticipantCsvRow](ecfparticipantcsvrow) schema. | 
+| data | array | true | It conforms to [ECFParticipantCsvRow](#schema-ecfparticipantcsvrow) schema. | 
 
 
 ### MultipleECFParticipantsResponse
@@ -1626,7 +1626,7 @@ A list of ECF participants
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ECFParticipant](ecfparticipant) schema. | 
+| data | array | true | It conforms to [ECFParticipant](#schema-ecfparticipant) schema. | 
 
 
 ### MultipleParticipantDeclarationsCsvResponse
@@ -1636,7 +1636,7 @@ A list of participant declarations in the Comma Separated Value (CSV) format
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ParticipantDeclarationCsvRow](participantdeclarationcsvrow) schema. | 
+| data | array | true | It conforms to [ParticipantDeclarationCsvRow](#schema-participantdeclarationcsvrow) schema. | 
 
 
 ### MultipleParticipantDeclarationsResponse
@@ -1646,7 +1646,7 @@ A list of participant declarations
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ParticipantDeclarationResponse](participantdeclarationresponse) schema. | 
+| data | array | true | It conforms to [ParticipantDeclarationResponse](#schema-participantdeclarationresponse) schema. | 
 
 
 ### NotFoundResponse
@@ -1710,7 +1710,7 @@ A participant declaration data request for ECT participants from cohort 2025 onw
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024ECTStartedAttributesRequest](ecfparticipantdeclarationpost2024ectstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTRetainedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectretainedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectcompletedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTExtendedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectextendedattributesrequest) </li></ul> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024ECTStartedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTRetainedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectretainedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectcompletedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTExtendedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectextendedattributesrequest) </li></ul> | 
 
 
 ### ParticipantDeclarationPost2024MentorDataRequest
@@ -1721,7 +1721,7 @@ A participant declaration data request for mentor participants from cohort 2025 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024MentorStartedAttributesRequest](ecfparticipantdeclarationpost2024mentorstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024MentorCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorcompletedattributesrequest) </li></ul> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024MentorStartedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024MentorCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorcompletedattributesrequest) </li></ul> | 
 
 
 ### ParticipantDeclarationPre2025DataRequest
@@ -1732,7 +1732,7 @@ A participant declaration data request for participants in cohort 2024 and previ
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPre2025StartedAttributesRequest](ecfparticipantdeclarationpre2025startedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025RetainedAttributesRequest](#schema-ecfparticipantdeclarationpre2025retainedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025CompletedAttributesRequest](#schema-ecfparticipantdeclarationpre2025completedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025ExtendedAttributesRequest](#schema-ecfparticipantdeclarationpre2025extendedattributesrequest) </li></ul> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPre2025StartedAttributesRequest](#schema-ecfparticipantdeclarationpre2025startedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025RetainedAttributesRequest](#schema-ecfparticipantdeclarationpre2025retainedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025CompletedAttributesRequest](#schema-ecfparticipantdeclarationpre2025completedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025ExtendedAttributesRequest](#schema-ecfparticipantdeclarationpre2025extendedattributesrequest) </li></ul> | 
 
 
 ### ParticipantDeclarationRequest
@@ -1742,7 +1742,7 @@ An participant declaration request
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | This conforms to any of the following schemas:<br/><ul><li> [ParticipantDeclarationPre2025DataRequest](participantdeclarationpre2025datarequest) </li><li> [ParticipantDeclarationPost2024ECTDataRequest](#schema-participantdeclarationpost2024ectdatarequest) </li><li> [ParticipantDeclarationPost2024MentorDataRequest](#schema-participantdeclarationpost2024mentordatarequest) </li></ul> | 
+| data | object | true | This conforms to any of the following schemas:<br/><ul><li> [ParticipantDeclarationPre2025DataRequest](#schema-participantdeclarationpre2025datarequest) </li><li> [ParticipantDeclarationPost2024ECTDataRequest](#schema-participantdeclarationpost2024ectdatarequest) </li><li> [ParticipantDeclarationPost2024MentorDataRequest](#schema-participantdeclarationpost2024mentordatarequest) </li></ul> | 
 
 
 ### ParticipantDeclarationResponse
@@ -1754,7 +1754,7 @@ A participant declaration response
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant declaration record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with a participant declaration response<br/>It conforms to [ParticipantDeclarationAttributes](participantdeclarationattributes) schema. | 
+| attributes | object | true | The data attributes associated with a participant declaration response<br/>It conforms to [ParticipantDeclarationAttributes](#schema-participantdeclarationattributes) schema. | 
 
 
 ### ParticipantListFilter
@@ -1775,7 +1775,7 @@ A confirmation that the participant declaration has been recorded successfully
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | A participant declaration response<br/>It conforms to [ParticipantDeclarationResponse](participantdeclarationresponse) schema. | 
+| data | object | true | A participant declaration response<br/>It conforms to [ParticipantDeclarationResponse](#schema-participantdeclarationresponse) schema. | 
 
 
 ### UnauthorisedResponse

--- a/documentation/ecf1_guidance/reference-v3.md
+++ b/documentation/ecf1_guidance/reference-v3.md
@@ -29,9 +29,9 @@ The lead provider API for DfE’s manage teacher CPD service.
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine delivery partners to return.<br/>This consumes a [DeliveryPartnersFilter](#schema-deliverypartnersfilter) schema.<br/> | filter[cohort]=2021 | 
-| page | query | object | false | Pagination options to navigate through the list of delivery partners.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
-| sort | query | array | false | Sort delivery partners being returned.<br/>This consumes a [DeliveryPartnersSort](#schema-deliverypartnerssort) schema.<br/> | sort=-updated\_at | 
+| filter | query | object | false | Refine delivery partners to return.<br/>This consumes a [DeliveryPartnersFilter](#deliverypartnersfilter) schema.<br/> | filter[cohort]=2021 | 
+| page | query | object | false | Pagination options to navigate through the list of delivery partners.<br/>This consumes a [Pagination](#pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| sort | query | array | false | Sort delivery partners being returned.<br/>This consumes a [DeliveryPartnersSort](#deliverypartnerssort) schema.<br/> | sort=-updated\_at | 
 
 
 ### Responses
@@ -39,14 +39,14 @@ The lead provider API for DfE’s manage teacher CPD service.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | Successfully return a list of delivery partners<br/>This response returns a [DeliveryPartnersResponse](#schema-deliverypartnersresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | Successfully return a list of delivery partners<br/>This response returns a [DeliveryPartnersResponse](#deliverypartnersresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - Successfully return a list of delivery partners
-This response returns a [DeliveryPartnersResponse](#schema-deliverypartnersresponse) schema.
+This response returns a [DeliveryPartnersResponse](#deliverypartnersresponse) schema.
 
 ```
 {
@@ -69,7 +69,7 @@ This response returns a [DeliveryPartnersResponse](#schema-deliverypartnersrespo
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 
 ```
 {
@@ -102,15 +102,15 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 
 | Status | Description |
 | ---- | ---- |
-| 200 | Successfully return a specific delivery partner<br/>This response returns a [DeliveryPartnerResponse](#schema-deliverypartnerresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
-| 404 | Not Found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
+| 200 | Successfully return a specific delivery partner<br/>This response returns a [DeliveryPartnerResponse](#deliverypartnerresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.<br/> | 
+| 404 | Not Found<br/>This response returns a [NotFoundResponse](#notfoundresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - Successfully return a specific delivery partner
-This response returns a [DeliveryPartnerResponse](#schema-deliverypartnerresponse) schema.
+This response returns a [DeliveryPartnerResponse](#deliverypartnerresponse) schema.
 
 ```
 {
@@ -131,7 +131,7 @@ This response returns a [DeliveryPartnerResponse](#schema-deliverypartnerrespons
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 
 ```
 {
@@ -140,7 +140,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ```
 
 404 - Not Found
-This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
+This response returns a [NotFoundResponse](#notfoundresponse) schema.
 
 ```
 {
@@ -166,9 +166,9 @@ This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine partnerships to return.<br/>This consumes a [PartnershipsFilter](#schema-partnershipsfilter) schema.<br/> | filter[cohort]=2021,2022 | 
-| page | query | object | false | Pagination options to navigate through the list of partnerships.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
-| sort | query | array | false | Sort partnerships being returned.<br/>This consumes a [PartnershipsSort](#schema-partnershipssort) schema.<br/> | sort=-updated\_at | 
+| filter | query | object | false | Refine partnerships to return.<br/>This consumes a [PartnershipsFilter](#partnershipsfilter) schema.<br/> | filter[cohort]=2021,2022 | 
+| page | query | object | false | Pagination options to navigate through the list of partnerships.<br/>This consumes a [Pagination](#pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| sort | query | array | false | Sort partnerships being returned.<br/>This consumes a [PartnershipsSort](#partnershipssort) schema.<br/> | sort=-updated\_at | 
 
 
 ### Responses
@@ -176,14 +176,14 @@ This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A list of ECF partnerships<br/>This response returns a [MultipleECFPartnershipsResponse](#schema-multipleecfpartnershipsresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A list of ECF partnerships<br/>This response returns a [MultipleECFPartnershipsResponse](#multipleecfpartnershipsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A list of ECF partnerships
-This response returns a [MultipleECFPartnershipsResponse](#schema-multipleecfpartnershipsresponse) schema.
+This response returns a [MultipleECFPartnershipsResponse](#multipleecfpartnershipsresponse) schema.
 
 ```
 {
@@ -211,7 +211,7 @@ This response returns a [MultipleECFPartnershipsResponse](#schema-multipleecfpar
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 
 ```
 {
@@ -234,7 +234,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ### Request body
 
 
-This consumes a [ECFPartnershipRequest](#schema-ecfpartnershiprequest) schema.
+This consumes a [ECFPartnershipRequest](#ecfpartnershiprequest) schema.
 
 ### Request example
 
@@ -258,15 +258,15 @@ This consumes a [ECFPartnershipRequest](#schema-ecfpartnershiprequest) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | Create an ECF partnership<br/>This response returns a [ECFPartnershipResponse](#schema-ecfpartnershipresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
-| 422 | Unprocessable entity<br/>This response returns a [ECFPartnershipRequestErrorResponse](#schema-ecfpartnershiprequesterrorresponse) schema.<br/> | 
+| 200 | Create an ECF partnership<br/>This response returns a [ECFPartnershipResponse](#ecfpartnershipresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.<br/> | 
+| 422 | Unprocessable entity<br/>This response returns a [ECFPartnershipRequestErrorResponse](#ecfpartnershiprequesterrorresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - Create an ECF partnership
-This response returns a [ECFPartnershipResponse](#schema-ecfpartnershipresponse) schema.
+This response returns a [ECFPartnershipResponse](#ecfpartnershipresponse) schema.
 
 ```
 {
@@ -292,7 +292,7 @@ This response returns a [ECFPartnershipResponse](#schema-ecfpartnershipresponse)
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 
 ```
 {
@@ -301,7 +301,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ```
 
 422 - Unprocessable entity
-This response returns a [ECFPartnershipRequestErrorResponse](#schema-ecfpartnershiprequesterrorresponse) schema.
+This response returns a [ECFPartnershipRequestErrorResponse](#ecfpartnershiprequesterrorresponse) schema.
 
 ```
 {
@@ -339,15 +339,15 @@ This response returns a [ECFPartnershipRequestErrorResponse](#schema-ecfpartners
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A single partnership<br/>This response returns a [ECFPartnershipResponse](#schema-ecfpartnershipresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
-| 404 | Not Found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
+| 200 | A single partnership<br/>This response returns a [ECFPartnershipResponse](#ecfpartnershipresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.<br/> | 
+| 404 | Not Found<br/>This response returns a [NotFoundResponse](#notfoundresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A single partnership
-This response returns a [ECFPartnershipResponse](#schema-ecfpartnershipresponse) schema.
+This response returns a [ECFPartnershipResponse](#ecfpartnershipresponse) schema.
 
 ```
 {
@@ -373,7 +373,7 @@ This response returns a [ECFPartnershipResponse](#schema-ecfpartnershipresponse)
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 
 ```
 {
@@ -382,7 +382,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ```
 
 404 - Not Found
-This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
+This response returns a [NotFoundResponse](#notfoundresponse) schema.
 
 ```
 {
@@ -414,7 +414,7 @@ This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 ### Request body
 
 
-This consumes a [ECFPartnershipUpdateRequest](#schema-ecfpartnershipupdaterequest) schema.
+This consumes a [ECFPartnershipUpdateRequest](#ecfpartnershipupdaterequest) schema.
 
 ### Request example
 
@@ -436,16 +436,16 @@ This consumes a [ECFPartnershipUpdateRequest](#schema-ecfpartnershipupdatereques
 
 | Status | Description |
 | ---- | ---- |
-| 200 | Update an ECF partnership<br/>This response returns a [ECFPartnershipResponse](#schema-ecfpartnershipresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
-| 422 | Unprocessable entity<br/>This response returns a [ECFPartnershipRequestErrorResponse](#schema-ecfpartnershiprequesterrorresponse) schema.<br/> | 
-| 404 | Not Found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
+| 200 | Update an ECF partnership<br/>This response returns a [ECFPartnershipResponse](#ecfpartnershipresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.<br/> | 
+| 422 | Unprocessable entity<br/>This response returns a [ECFPartnershipRequestErrorResponse](#ecfpartnershiprequesterrorresponse) schema.<br/> | 
+| 404 | Not Found<br/>This response returns a [NotFoundResponse](#notfoundresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - Update an ECF partnership
-This response returns a [ECFPartnershipResponse](#schema-ecfpartnershipresponse) schema.
+This response returns a [ECFPartnershipResponse](#ecfpartnershipresponse) schema.
 
 ```
 {
@@ -471,7 +471,7 @@ This response returns a [ECFPartnershipResponse](#schema-ecfpartnershipresponse)
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 
 ```
 {
@@ -480,7 +480,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ```
 
 422 - Unprocessable entity
-This response returns a [ECFPartnershipRequestErrorResponse](#schema-ecfpartnershiprequesterrorresponse) schema.
+This response returns a [ECFPartnershipRequestErrorResponse](#ecfpartnershiprequesterrorresponse) schema.
 
 ```
 {
@@ -494,7 +494,7 @@ This response returns a [ECFPartnershipRequestErrorResponse](#schema-ecfpartners
 ```
 
 404 - Not Found
-This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
+This response returns a [NotFoundResponse](#notfoundresponse) schema.
 
 ```
 {
@@ -520,11 +520,11 @@ This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter[cohort] | query | object | true | Refine schools to return.<br/>This consumes a [ECFSchoolsFilter](#schema-ecfschoolsfilter) schema.<br/> | filter[cohort]=2021 | 
-| filter[urn] | query | object | false | Refine schools to return.<br/>This consumes a [ECFSchoolsFilter](#schema-ecfschoolsfilter) schema.<br/> | filter[urn]=106286 | 
-| filter[updated\_since] | query | object | false | Refine schools to return.<br/>This consumes a [ECFSchoolsFilter](#schema-ecfschoolsfilter) schema.<br/> | filter[updated\_since]=2020-11-13T11:21:55Z | 
-| page | query | object | false | Pagination options to navigate through the list of schools.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
-| sort | query | array | false | Sort schools being returned.<br/>This consumes a [ECFSchoolsSort](#schema-ecfschoolssort) schema.<br/> | sort=-updated\_at | 
+| filter[cohort] | query | object | true | Refine schools to return.<br/>This consumes a [ECFSchoolsFilter](#ecfschoolsfilter) schema.<br/> | filter[cohort]=2021 | 
+| filter[urn] | query | object | false | Refine schools to return.<br/>This consumes a [ECFSchoolsFilter](#ecfschoolsfilter) schema.<br/> | filter[urn]=106286 | 
+| filter[updated\_since] | query | object | false | Refine schools to return.<br/>This consumes a [ECFSchoolsFilter](#ecfschoolsfilter) schema.<br/> | filter[updated\_since]=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of schools.<br/>This consumes a [Pagination](#pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| sort | query | array | false | Sort schools being returned.<br/>This consumes a [ECFSchoolsSort](#ecfschoolssort) schema.<br/> | sort=-updated\_at | 
 
 
 ### Responses
@@ -532,14 +532,14 @@ This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A list of schools for the given cohort<br/>This response returns a [MultipleECFSchoolsResponse](#schema-multipleecfschoolsresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A list of schools for the given cohort<br/>This response returns a [MultipleECFSchoolsResponse](#multipleecfschoolsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A list of schools for the given cohort
-This response returns a [MultipleECFSchoolsResponse](#schema-multipleecfschoolsresponse) schema.
+This response returns a [MultipleECFSchoolsResponse](#multipleecfschoolsresponse) schema.
 
 ```
 {
@@ -562,7 +562,7 @@ This response returns a [MultipleECFSchoolsResponse](#schema-multipleecfschoolsr
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 
 ```
 {
@@ -588,7 +588,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
 | id | path | string | true | The unique ID of the school<br/> | 28c461ee-ffc0-4e56-96bd-788579a0ed75 | 
-| filter[cohort] | query | object | true | Refine schools to return.<br/>This consumes a [ECFSchoolsFilter](#schema-ecfschoolsfilter) schema.<br/> | filter[cohort]=2021 | 
+| filter[cohort] | query | object | true | Refine schools to return.<br/>This consumes a [ECFSchoolsFilter](#ecfschoolsfilter) schema.<br/> | filter[cohort]=2021 | 
 
 
 ### Responses
@@ -596,15 +596,15 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A single school<br/>This response returns a [ECFSchoolResponse](#schema-ecfschoolresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
-| 404 | Not Found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
+| 200 | A single school<br/>This response returns a [ECFSchoolResponse](#ecfschoolresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.<br/> | 
+| 404 | Not Found<br/>This response returns a [NotFoundResponse](#notfoundresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A single school
-This response returns a [ECFSchoolResponse](#schema-ecfschoolresponse) schema.
+This response returns a [ECFSchoolResponse](#ecfschoolresponse) schema.
 
 ```
 {
@@ -625,7 +625,7 @@ This response returns a [ECFSchoolResponse](#schema-ecfschoolresponse) schema.
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 
 ```
 {
@@ -634,7 +634,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ```
 
 404 - Not Found
-This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
+This response returns a [NotFoundResponse](#notfoundresponse) schema.
 
 ```
 {
@@ -660,8 +660,8 @@ This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine participant declarations to return.<br/>This consumes a [ParticipantDeclarationsFilter](#schema-participantdeclarationsfilter) schema.<br/> | filter[participant\_id]=ab3a7848-1208-7679-942a-b4a70eed400a&filter[updated\_since]=2020-11-13T11:21:55Z | 
-| page | query | object | false | Pagination options to navigate through the list of participant declarations.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| filter | query | object | false | Refine participant declarations to return.<br/>This consumes a [ParticipantDeclarationsFilter](#participantdeclarationsfilter) schema.<br/> | filter[participant\_id]=ab3a7848-1208-7679-942a-b4a70eed400a&filter[updated\_since]=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of participant declarations.<br/>This consumes a [Pagination](#pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
 
 
 ### Responses
@@ -669,14 +669,14 @@ This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A list of participant declarations<br/>This response returns a [MultipleParticipantDeclarationsResponse](#schema-multipleparticipantdeclarationsresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A list of participant declarations<br/>This response returns a [MultipleParticipantDeclarationsResponse](#multipleparticipantdeclarationsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A list of participant declarations
-This response returns a [MultipleParticipantDeclarationsResponse](#schema-multipleparticipantdeclarationsresponse) schema.
+This response returns a [MultipleParticipantDeclarationsResponse](#multipleparticipantdeclarationsresponse) schema.
 
 ```
 {
@@ -708,7 +708,7 @@ This response returns a [MultipleParticipantDeclarationsResponse](#schema-multip
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 
 ```
 {
@@ -731,23 +731,23 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ### Request body
 
 
-This consumes a [ParticipantDeclarationRequest](#schema-participantdeclarationrequest) schema.
+This consumes a [ParticipantDeclarationRequest](#participantdeclarationrequest) schema.
 
 ### Responses
 
 
 | Status | Description |
 | ---- | ---- |
-| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.<br/> | 
-| 422 | Bad or Missing parameter<br/>This response returns a [ErrorResponse](#schema-errorresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
-| 400 | Bad Request<br/>This response returns a [BadRequestResponse](#schema-badrequestresponse) schema.<br/> | 
+| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](#singleparticipantdeclarationresponse) schema.<br/> | 
+| 422 | Bad or Missing parameter<br/>This response returns a [ErrorResponse](#errorresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.<br/> | 
+| 400 | Bad Request<br/>This response returns a [BadRequestResponse](#badrequestresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - Successful
-This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.
+This response returns a [SingleParticipantDeclarationResponse](#singleparticipantdeclarationresponse) schema.
 
 ```
 {
@@ -777,7 +777,7 @@ This response returns a [SingleParticipantDeclarationResponse](#schema-singlepar
 ```
 
 422 - Bad or Missing parameter
-This response returns a [ErrorResponse](#schema-errorresponse) schema.
+This response returns a [ErrorResponse](#errorresponse) schema.
 
 ```
 {
@@ -791,7 +791,7 @@ This response returns a [ErrorResponse](#schema-errorresponse) schema.
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 
 ```
 {
@@ -800,7 +800,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ```
 
 400 - Bad Request
-This response returns a [BadRequestResponse](#schema-badrequestresponse) schema.
+This response returns a [BadRequestResponse](#badrequestresponse) schema.
 
 ```
 {
@@ -833,15 +833,15 @@ This response returns a [BadRequestResponse](#schema-badrequestresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A single participant declaration<br/>This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
-| 404 | Not found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
+| 200 | A single participant declaration<br/>This response returns a [SingleParticipantDeclarationResponse](#singleparticipantdeclarationresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.<br/> | 
+| 404 | Not found<br/>This response returns a [NotFoundResponse](#notfoundresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A single participant declaration
-This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.
+This response returns a [SingleParticipantDeclarationResponse](#singleparticipantdeclarationresponse) schema.
 
 ```
 {
@@ -871,7 +871,7 @@ This response returns a [SingleParticipantDeclarationResponse](#schema-singlepar
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 
 ```
 {
@@ -880,7 +880,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ```
 
 404 - Not found
-This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
+This response returns a [NotFoundResponse](#notfoundresponse) schema.
 
 ```
 {
@@ -914,13 +914,13 @@ This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.<br/> | 
+| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](#singleparticipantdeclarationresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - Successful
-This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.
+This response returns a [SingleParticipantDeclarationResponse](#singleparticipantdeclarationresponse) schema.
 
 ```
 {
@@ -966,9 +966,9 @@ This response returns a [SingleParticipantDeclarationResponse](#schema-singlepar
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine ECF participants to return.<br/>This consumes a [ECFParticipantFilter](#schema-ecfparticipantfilter) schema.<br/> | filter[cohort]=2022&filter[from\_participant\_id]=439ac4fe-a003-417f-9694-07c45b3482f8&filter[training\_status]=active&filter[updated\_since]=2020-11-13T11:21:55Z | 
-| page | query | object | false | Pagination options to navigate through the list of ECF participants.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
-| sort | query | array | false | Sort ECF participants being returned.<br/>This consumes a [ECFParticipantsSort](#schema-ecfparticipantssort) schema.<br/> | sort=-updated\_at | 
+| filter | query | object | false | Refine ECF participants to return.<br/>This consumes a [ECFParticipantFilter](#ecfparticipantfilter) schema.<br/> | filter[cohort]=2022&filter[from\_participant\_id]=439ac4fe-a003-417f-9694-07c45b3482f8&filter[training\_status]=active&filter[updated\_since]=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of ECF participants.<br/>This consumes a [Pagination](#pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| sort | query | array | false | Sort ECF participants being returned.<br/>This consumes a [ECFParticipantsSort](#ecfparticipantssort) schema.<br/> | sort=-updated\_at | 
 
 
 ### Responses
@@ -976,14 +976,14 @@ This response returns a [SingleParticipantDeclarationResponse](#schema-singlepar
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A list of ECF participants<br/>This response returns a [MultipleECFParticipantsResponse](#schema-multipleecfparticipantsresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A list of ECF participants<br/>This response returns a [MultipleECFParticipantsResponse](#multipleecfparticipantsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A list of ECF participants
-This response returns a [MultipleECFParticipantsResponse](#schema-multipleecfparticipantsresponse) schema.
+This response returns a [MultipleECFParticipantsResponse](#multipleecfparticipantsresponse) schema.
 
 ```
 {
@@ -1034,7 +1034,7 @@ This response returns a [MultipleECFParticipantsResponse](#schema-multipleecfpar
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 
 ```
 {
@@ -1067,15 +1067,15 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A single ECF participant<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
-| 404 | Not Found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
+| 200 | A single ECF participant<br/>This response returns a [ECFParticipantResponse](#ecfparticipantresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.<br/> | 
+| 404 | Not Found<br/>This response returns a [NotFoundResponse](#notfoundresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A single ECF participant
-This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](#ecfparticipantresponse) schema.
 
 ```
 {
@@ -1124,7 +1124,7 @@ This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse)
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 
 ```
 {
@@ -1133,7 +1133,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ```
 
 404 - Not Found
-This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
+This response returns a [NotFoundResponse](#notfoundresponse) schema.
 
 ```
 {
@@ -1159,8 +1159,8 @@ This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine participant transfers to return.<br/>This consumes a [ListFilter](#schema-listfilter) schema.<br/> | filter[updated\_since]=2020-11-13T11:21:55Z | 
-| page | query | object | false | Pagination options to navigate through the list of participant transfers.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| filter | query | object | false | Refine participant transfers to return.<br/>This consumes a [ListFilter](#listfilter) schema.<br/> | filter[updated\_since]=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of participant transfers.<br/>This consumes a [Pagination](#pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
 
 
 ### Responses
@@ -1168,14 +1168,14 @@ This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A list of ECF participant transfers<br/>This response returns a [MultipleECFParticipantTransferResponse](#schema-multipleecfparticipanttransferresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A list of ECF participant transfers<br/>This response returns a [MultipleECFParticipantTransferResponse](#multipleecfparticipanttransferresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A list of ECF participant transfers
-This response returns a [MultipleECFParticipantTransferResponse](#schema-multipleecfparticipanttransferresponse) schema.
+This response returns a [MultipleECFParticipantTransferResponse](#multipleecfparticipanttransferresponse) schema.
 
 ```
 {
@@ -1208,7 +1208,7 @@ This response returns a [MultipleECFParticipantTransferResponse](#schema-multipl
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 
 ```
 {
@@ -1239,7 +1239,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ### Request body
 
 
-This consumes a [ECFParticipantDeferRequest](#schema-ecfparticipantdeferrequest) schema.
+This consumes a [ECFParticipantDeferRequest](#ecfparticipantdeferrequest) schema.
 
 ### Request example
 
@@ -1262,13 +1262,13 @@ This consumes a [ECFParticipantDeferRequest](#schema-ecfparticipantdeferrequest)
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant being deferred<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
+| 200 | The ECF participant being deferred<br/>This response returns a [ECFParticipantResponse](#ecfparticipantresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant being deferred
-This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](#ecfparticipantresponse) schema.
 
 ```
 {
@@ -1342,7 +1342,7 @@ This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse)
 ### Request body
 
 
-This consumes a [ECFParticipantResumeRequest](#schema-ecfparticipantresumerequest) schema.
+This consumes a [ECFParticipantResumeRequest](#ecfparticipantresumerequest) schema.
 
 ### Request example
 
@@ -1364,13 +1364,13 @@ This consumes a [ECFParticipantResumeRequest](#schema-ecfparticipantresumereques
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant being resumed<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
+| 200 | The ECF participant being resumed<br/>This response returns a [ECFParticipantResponse](#ecfparticipantresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant being resumed
-This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](#ecfparticipantresponse) schema.
 
 ```
 {
@@ -1441,7 +1441,7 @@ This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse)
 ### Request body
 
 
-This consumes a [ECFParticipantWithdrawRequest](#schema-ecfparticipantwithdrawrequest) schema.
+This consumes a [ECFParticipantWithdrawRequest](#ecfparticipantwithdrawrequest) schema.
 
 ### Request example
 
@@ -1464,13 +1464,13 @@ This consumes a [ECFParticipantWithdrawRequest](#schema-ecfparticipantwithdrawre
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant being withdrawn<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
+| 200 | The ECF participant being withdrawn<br/>This response returns a [ECFParticipantResponse](#ecfparticipantresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant being withdrawn
-This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](#ecfparticipantresponse) schema.
 
 ```
 {
@@ -1546,15 +1546,15 @@ This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse)
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A single participant’s transfers<br/>This response returns a [ECFParticipantTransferResponse](#schema-ecfparticipanttransferresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
-| 404 | Not Found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
+| 200 | A single participant’s transfers<br/>This response returns a [ECFParticipantTransferResponse](#ecfparticipanttransferresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.<br/> | 
+| 404 | Not Found<br/>This response returns a [NotFoundResponse](#notfoundresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A single participant’s transfers
-This response returns a [ECFParticipantTransferResponse](#schema-ecfparticipanttransferresponse) schema.
+This response returns a [ECFParticipantTransferResponse](#ecfparticipanttransferresponse) schema.
 
 ```
 {
@@ -1579,7 +1579,7 @@ This response returns a [ECFParticipantTransferResponse](#schema-ecfparticipantt
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 
 ```
 {
@@ -1588,7 +1588,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ```
 
 404 - Not Found
-This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
+This response returns a [NotFoundResponse](#notfoundresponse) schema.
 
 ```
 {
@@ -1620,7 +1620,7 @@ This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 ### Request body
 
 
-This consumes a [ECFParticipantChangeScheduleRequest](#schema-ecfparticipantchangeschedulerequest) schema.
+This consumes a [ECFParticipantChangeScheduleRequest](#ecfparticipantchangeschedulerequest) schema.
 
 ### Request example
 
@@ -1644,13 +1644,13 @@ This consumes a [ECFParticipantChangeScheduleRequest](#schema-ecfparticipantchan
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF Participant changing schedule<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
+| 200 | The ECF Participant changing schedule<br/>This response returns a [ECFParticipantResponse](#ecfparticipantresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF Participant changing schedule
-This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](#ecfparticipantresponse) schema.
 
 ```
 {
@@ -1715,9 +1715,9 @@ This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse)
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine unfunded mentors to return.<br/>This consumes a [ListFilter](#schema-listfilter) schema.<br/> | filter[updated\_since]=2020-11-13T11:21:55Z | 
-| page | query | object | false | Pagination options to navigate through the list of unfunded mentors.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
-| sort | query | array | false | Sort unfunded mentors being returned.<br/>This consumes a [ECFUnfundedMentorsSort](#schema-ecfunfundedmentorssort) schema.<br/> | sort=-updated\_at | 
+| filter | query | object | false | Refine unfunded mentors to return.<br/>This consumes a [ListFilter](#listfilter) schema.<br/> | filter[updated\_since]=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of unfunded mentors.<br/>This consumes a [Pagination](#pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| sort | query | array | false | Sort unfunded mentors being returned.<br/>This consumes a [ECFUnfundedMentorsSort](#ecfunfundedmentorssort) schema.<br/> | sort=-updated\_at | 
 
 
 ### Responses
@@ -1725,14 +1725,14 @@ This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse)
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A list of unfunded mentors<br/>This response returns a [MultipleUnfundedMentorsResponse](#schema-multipleunfundedmentorsresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A list of unfunded mentors<br/>This response returns a [MultipleUnfundedMentorsResponse](#multipleunfundedmentorsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A list of unfunded mentors
-This response returns a [MultipleUnfundedMentorsResponse](#schema-multipleunfundedmentorsresponse) schema.
+This response returns a [MultipleUnfundedMentorsResponse](#multipleunfundedmentorsresponse) schema.
 
 ```
 {
@@ -1753,7 +1753,7 @@ This response returns a [MultipleUnfundedMentorsResponse](#schema-multipleunfund
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 
 ```
 {
@@ -1786,15 +1786,15 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A single unfunded mentor<br/>This response returns a [UnfundedMentorResponse](#schema-unfundedmentorresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
-| 404 | Not Found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
+| 200 | A single unfunded mentor<br/>This response returns a [UnfundedMentorResponse](#unfundedmentorresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.<br/> | 
+| 404 | Not Found<br/>This response returns a [NotFoundResponse](#notfoundresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A single unfunded mentor
-This response returns a [UnfundedMentorResponse](#schema-unfundedmentorresponse) schema.
+This response returns a [UnfundedMentorResponse](#unfundedmentorresponse) schema.
 
 ```
 {
@@ -1813,7 +1813,7 @@ This response returns a [UnfundedMentorResponse](#schema-unfundedmentorresponse)
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 
 ```
 {
@@ -1822,7 +1822,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ```
 
 404 - Not Found
-This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
+This response returns a [NotFoundResponse](#notfoundresponse) schema.
 
 ```
 {
@@ -1848,8 +1848,8 @@ This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine statements to return.<br/>This consumes a [StatementsFilter](#schema-statementsfilter) schema.<br/> | filter[cohort]=2021,2022&filter[type]=ecf&filter[updated\_since]=2020-11-13T11:21:55Z | 
-| page | query | object | false | Pagination options to navigate through the list of statements.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| filter | query | object | false | Refine statements to return.<br/>This consumes a [StatementsFilter](#statementsfilter) schema.<br/> | filter[cohort]=2021,2022&filter[type]=ecf&filter[updated\_since]=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of statements.<br/>This consumes a [Pagination](#pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
 
 
 ### Responses
@@ -1857,14 +1857,14 @@ This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A list of statements as part of which the DfE will make output payments for ecf participants<br/>This response returns a [StatementsResponse](#schema-statementsresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A list of statements as part of which the DfE will make output payments for ecf participants<br/>This response returns a [StatementsResponse](#statementsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A list of statements as part of which the DfE will make output payments for ecf participants
-This response returns a [StatementsResponse](#schema-statementsresponse) schema.
+This response returns a [StatementsResponse](#statementsresponse) schema.
 
 ```
 {
@@ -1889,7 +1889,7 @@ This response returns a [StatementsResponse](#schema-statementsresponse) schema.
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 
 ```
 {
@@ -1922,15 +1922,15 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A specific financial statement<br/>This response returns a [StatementResponse](#schema-statementresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
-| 404 | Not Found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
+| 200 | A specific financial statement<br/>This response returns a [StatementResponse](#statementresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.<br/> | 
+| 404 | Not Found<br/>This response returns a [NotFoundResponse](#notfoundresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A specific financial statement
-This response returns a [StatementResponse](#schema-statementresponse) schema.
+This response returns a [StatementResponse](#statementresponse) schema.
 
 ```
 {
@@ -1953,7 +1953,7 @@ This response returns a [StatementResponse](#schema-statementresponse) schema.
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 
 ```
 {
@@ -1962,7 +1962,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ```
 
 404 - Not Found
-This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
+This response returns a [NotFoundResponse](#notfoundresponse) schema.
 
 ```
 {
@@ -2022,7 +2022,7 @@ A delivery partner
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the delivery partner<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with a delivery partner<br/>It conforms to [DeliveryPartnerAttributes](#schema-deliverypartnerattributes) schema. | 
+| attributes | object | true | The data attributes associated with a delivery partner<br/>It conforms to [DeliveryPartnerAttributes](#deliverypartnerattributes) schema. | 
 
 
 ### DeliveryPartnerAttributes
@@ -2056,7 +2056,7 @@ A delivery partner
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | A delivery partner<br/>It conforms to [DeliveryPartner](#schema-deliverypartner) schema. | 
+| data | object | true | A delivery partner<br/>It conforms to [DeliveryPartner](#deliverypartner) schema. | 
 
 
 ### DeliveryPartnersFilter
@@ -2076,7 +2076,7 @@ A list of delivery partners
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [DeliveryPartner](#schema-deliverypartner) schema. | 
+| data | array | true | It conforms to [DeliveryPartner](#deliverypartner) schema. | 
 
 
 ### DeliveryPartnersSort
@@ -2086,7 +2086,7 @@ Sort delivery partners being returned
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| Item | string | false | It conforms to [DeliveryPartnersSort/items](#schema-deliverypartnerssort-items) schema.Possible values:<br/><ul><li>created\_at</li><li>-created\_at</li><li>updated\_at</li><li>-updated\_at</li></ul> | 
+| Item | string | false | It conforms to [DeliveryPartnersSort/items](#deliverypartnerssort-items) schema.Possible values:<br/><ul><li>created\_at</li><li>-created\_at</li><li>updated\_at</li><li>-updated\_at</li></ul> | 
 
 
 ### ECFDeferral
@@ -2132,8 +2132,8 @@ The details of an ECF Participant enrolment
 | sparsity\_uplift | boolean | true | Indicates whether this participant qualifies for an uplift payment due to sparsity<br/> | 
 | schedule\_identifier | string | true | The schedule of the ECF participant. For the possible values please refer to the [ECF schedules and milestone dates guidance](/api-reference/ecf/schedules-and-milestone-dates.html#schedules-and-milestone-dates) .<br/>Possible values:<br/><ul><li>ecf-standard-september</li><li>ecf-standard-january</li><li>ecf-standard-april</li><li>ecf-reduced-september</li><li>ecf-reduced-january</li><li>ecf-reduced-april</li><li>ecf-extended-september</li><li>ecf-extended-january</li><li>ecf-extended-april</li><li>ecf-replacement-september</li><li>ecf-replacement-january</li><li>ecf-replacement-april</li></ul> | 
 | delivery\_partner\_id | string | true | Unique ID of the delivery partner associated with the participant<br/> | 
-| withdrawal |  | false | This conforms to any of the following schemas:<br/><ul><li> [ECFWithdrawal](#schema-ecfwithdrawal) </li></ul> | 
-| deferral |  | false | This conforms to any of the following schemas:<br/><ul><li> [ECFDeferral](#schema-ecfdeferral) </li></ul> | 
+| withdrawal |  | false | This conforms to any of the following schemas:<br/><ul><li> [ECFWithdrawal](#ecfwithdrawal) </li></ul> | 
+| deferral |  | false | This conforms to any of the following schemas:<br/><ul><li> [ECFDeferral](#ecfdeferral) </li></ul> | 
 | created\_at | string | true | The date and time the ECF participant was created<br/> | 
 | induction\_end\_date | string | false | The ECF participant induction end date<br/> | 
 | mentor\_funding\_end\_date | string | false | The ECF participant mentor training completion date<br/> | 
@@ -2150,7 +2150,7 @@ The details of an ECF Participant enrolment
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantAttributes](#schema-ecfparticipantattributes) schema. | 
+| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantAttributes](#ecfparticipantattributes) schema. | 
 
 
 ### ECFParticipantAttributes
@@ -2163,8 +2163,8 @@ The data attributes associated with an ECF participant
 | full\_name | string | true | The full name of this ECF participant<br/> | 
 | teacher\_reference\_number | string | false | The Teacher Reference Number (TRN) for this participant<br/> | 
 | updated\_at | string | true | The date and time the ECF participant was last updated<br/> | 
-| ecf\_enrolments | array | true | Information about the course(s) the participant is enroled in<br/>It conforms to [ECFEnrolment](#schema-ecfenrolment) schema. | 
-| participant\_id\_changes | array | true | Information about the Participant ID changes<br/>It conforms to [ParticipantIdChange](#schema-participantidchange) schema. | 
+| ecf\_enrolments | array | true | Information about the course(s) the participant is enroled in<br/>It conforms to [ECFEnrolment](#ecfenrolment) schema. | 
+| participant\_id\_changes | array | true | Information about the Participant ID changes<br/>It conforms to [ParticipantIdChange](#participantidchange) schema. | 
 
 
 ### ECFParticipantChangeSchedule
@@ -2175,7 +2175,7 @@ An ECF participant change schedule action
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | true | The data type<br/>Possible values:<br/><ul><li>participant-change-schedule</li></ul> | 
-| attributes | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeScheduleAttributes](#schema-ecfparticipantchangescheduleattributes) schema. | 
+| attributes | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeScheduleAttributes](#ecfparticipantchangescheduleattributes) schema. | 
 
 
 #### Example
@@ -2223,7 +2223,7 @@ The change schedule request for a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeSchedule](#schema-ecfparticipantchangeschedule) schema. | 
+| data | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeSchedule](#ecfparticipantchangeschedule) schema. | 
 
 
 #### Example
@@ -2390,7 +2390,7 @@ The details of a participant deferral request
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | true | The data type<br/>Possible values:<br/><ul><li>participant-defer</li></ul> | 
-| attributes | object | true | An ECF participant deferral action<br/>It conforms to [ECFParticipantDeferAttributes](#schema-ecfparticipantdeferattributes) schema. | 
+| attributes | object | true | An ECF participant deferral action<br/>It conforms to [ECFParticipantDeferAttributes](#ecfparticipantdeferattributes) schema. | 
 
 
 ### ECFParticipantDeferAttributes
@@ -2422,7 +2422,7 @@ The deferral request for a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | The details of a participant deferral request<br/>It conforms to [ECFParticipantDefer](#schema-ecfparticipantdefer) schema. | 
+| data | object | true | The details of a participant deferral request<br/>It conforms to [ECFParticipantDefer](#ecfparticipantdefer) schema. | 
 
 
 #### Example
@@ -2509,7 +2509,7 @@ An ECF Participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true |  **Note, this endpoint includes updated specifications.** The details of a participant<br/>It conforms to [ECFParticipant](#schema-ecfparticipant) schema. | 
+| data | object | true |  **Note, this endpoint includes updated specifications.** The details of a participant<br/>It conforms to [ECFParticipant](#ecfparticipant) schema. | 
 
 
 ### ECFParticipantResume
@@ -2520,7 +2520,7 @@ An ECF participant resume action
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | true | The data type<br/>Possible values:<br/><ul><li>participant-resume</li></ul> | 
-| attributes | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResumeAttributes](#schema-ecfparticipantresumeattributes) schema. | 
+| attributes | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResumeAttributes](#ecfparticipantresumeattributes) schema. | 
 
 
 ### ECFParticipantResumeAttributes
@@ -2550,7 +2550,7 @@ The resume request for a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResume](#schema-ecfparticipantresume) schema. | 
+| data | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResume](#ecfparticipantresume) schema. | 
 
 
 #### Example
@@ -2577,7 +2577,7 @@ The resume request for a participant
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an ECF participant transfer<br/>It conforms to [ECFParticipantTransferAttributes](#schema-ecfparticipanttransferattributes) schema. | 
+| attributes | object | true | The data attributes associated with an ECF participant transfer<br/>It conforms to [ECFParticipantTransferAttributes](#ecfparticipanttransferattributes) schema. | 
 
 
 ### ECFParticipantTransferAttributes
@@ -2588,7 +2588,7 @@ The data attributes associated with an ECF participant transfer
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | updated\_at | string | true | The date and time the latest ECF participant was last updated<br/> | 
-| transfers | array | true | List of participant transfers<br/>It conforms to [ECFParticipantTransfers](#schema-ecfparticipanttransfers) schema. | 
+| transfers | array | true | List of participant transfers<br/>It conforms to [ECFParticipantTransfers](#ecfparticipanttransfers) schema. | 
 
 
 ### ECFParticipantTransferResponse
@@ -2598,7 +2598,7 @@ An ECF participant transfer
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true |  **Note, this is a new endpoint.** The details of an ECF participant transfer<br/>It conforms to [ECFParticipantTransfer](#schema-ecfparticipanttransfer) schema. | 
+| data | object | true |  **Note, this is a new endpoint.** The details of an ECF participant transfer<br/>It conforms to [ECFParticipantTransfer](#ecfparticipanttransfer) schema. | 
 
 
 ### ECFParticipantTransfers
@@ -2611,8 +2611,8 @@ The details of an ECF Participant enrolment
 | training\_record\_id | string | true | The unique identifier of the participant training record<br/> | 
 | transfer\_type | string | true | The type of transfer between schools<br/>Possible values:<br/><ul><li>new\_school</li><li>new\_provider</li><li>unknown</li></ul> | 
 | status | string | true | The status of the transfer, if both leaving and joining SIT have completed their journeys or only one has<br/>Possible values:<br/><ul><li>incomplete</li><li>complete</li></ul> | 
-| leaving |  | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantLeaving](#schema-ecfparticipantleaving) </li></ul> | 
-| joining |  | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantJoining](#schema-ecfparticipantjoining) </li></ul> | 
+| leaving |  | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantLeaving](#ecfparticipantleaving) </li></ul> | 
+| joining |  | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantJoining](#ecfparticipantjoining) </li></ul> | 
 | created\_at | string | true | The date and time the ECF participant transfer was created<br/> | 
 
 
@@ -2624,7 +2624,7 @@ An ECF participant withdrawal action
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | The data type<br/>Possible values:<br/><ul><li>participant-withdraw</li></ul> | 
-| attributes | object | false | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdrawAttributes](#schema-ecfparticipantwithdrawattributes) schema. | 
+| attributes | object | false | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdrawAttributes](#ecfparticipantwithdrawattributes) schema. | 
 
 
 ### ECFParticipantWithdrawAttributes
@@ -2656,7 +2656,7 @@ The withdrawal request for a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdraw](#schema-ecfparticipantwithdraw) schema. | 
+| data | object | true | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdraw](#ecfparticipantwithdraw) schema. | 
 
 
 #### Example
@@ -2682,7 +2682,7 @@ Sort ECF participants being returned
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| Item | string | false | It conforms to [ECFParticipantsSort/items](#schema-ecfparticipantssort-items) schema.Possible values:<br/><ul><li>created\_at</li><li>-created\_at</li><li>updated\_at</li><li>-updated\_at</li></ul> | 
+| Item | string | false | It conforms to [ECFParticipantsSort/items](#ecfparticipantssort-items) schema.Possible values:<br/><ul><li>created\_at</li><li>-created\_at</li><li>updated\_at</li><li>-updated\_at</li></ul> | 
 
 
 ### ECFPartnership
@@ -2694,7 +2694,7 @@ An ECF partnership
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the partnership<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an ECF partnership<br/>It conforms to [ECFPartnershipAttributes](#schema-ecfpartnershipattributes) schema. | 
+| attributes | object | true | The data attributes associated with an ECF partnership<br/>It conforms to [ECFPartnershipAttributes](#ecfpartnershipattributes) schema. | 
 
 
 ### ECFPartnershipAttibutesRequest
@@ -2736,7 +2736,7 @@ An ECF partnership
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | Possible values:<br/><ul><li>ecf-partnership</li></ul> | 
-| attributes | object | false | It conforms to [ECFPartnershipAttibutesRequest](#schema-ecfpartnershipattibutesrequest) schema. | 
+| attributes | object | false | It conforms to [ECFPartnershipAttibutesRequest](#ecfpartnershipattibutesrequest) schema. | 
 
 
 ### ECFPartnershipRequest
@@ -2746,7 +2746,7 @@ An ECF partnership
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | An ECF partnership<br/>It conforms to [ECFPartnershipDataRequest](#schema-ecfpartnershipdatarequest) schema. | 
+| data | object | true | An ECF partnership<br/>It conforms to [ECFPartnershipDataRequest](#ecfpartnershipdatarequest) schema. | 
 
 
 #### Example
@@ -2773,7 +2773,7 @@ A list of errors
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| error | array | false | This conforms to any of the following schemas:<br/><ul><li> [UrnInvalidError](#schema-urninvaliderror) </li><li> [PartnershipExistsError](#schema-partnershipexistserror) </li><li> [SchoolFundingError](#schema-schoolfundingerror) </li><li> [DeliveryPartnerCohortError](#schema-deliverypartnercohorterror) </li><li> [OtherProviderRecruitedError](#schema-otherproviderrecruitederror) </li></ul> | 
+| error | array | false | This conforms to any of the following schemas:<br/><ul><li> [UrnInvalidError](#urninvaliderror) </li><li> [PartnershipExistsError](#partnershipexistserror) </li><li> [SchoolFundingError](#schoolfundingerror) </li><li> [DeliveryPartnerCohortError](#deliverypartnercohorterror) </li><li> [OtherProviderRecruitedError](#otherproviderrecruitederror) </li></ul> | 
 
 
 ### ECFPartnershipResponse
@@ -2783,7 +2783,7 @@ An ECF partnership
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | An ECF partnership<br/>It conforms to [ECFPartnership](#schema-ecfpartnership) schema. | 
+| data | object | true | An ECF partnership<br/>It conforms to [ECFPartnership](#ecfpartnership) schema. | 
 
 
 ### ECFPartnershipUpdateAttibutesRequest
@@ -2802,7 +2802,7 @@ Update An ECF partnership
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | Possible values:<br/><ul><li>ecf-partnership-update</li></ul> | 
-| attributes | object | false | It conforms to [ECFPartnershipUpdateAttibutesRequest](#schema-ecfpartnershipupdateattibutesrequest) schema. | 
+| attributes | object | false | It conforms to [ECFPartnershipUpdateAttibutesRequest](#ecfpartnershipupdateattibutesrequest) schema. | 
 
 
 ### ECFPartnershipUpdateRequest
@@ -2812,7 +2812,7 @@ Update an ECF partnership
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | Update An ECF partnership<br/>It conforms to [ECFPartnershipUpdateDataRequest](#schema-ecfpartnershipupdatedatarequest) schema. | 
+| data | object | true | Update An ECF partnership<br/>It conforms to [ECFPartnershipUpdateDataRequest](#ecfpartnershipupdatedatarequest) schema. | 
 
 
 #### Example
@@ -2839,7 +2839,7 @@ An ECF school
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the school<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an ECF school<br/>It conforms to [ECFSchoolAttributes](#schema-ecfschoolattributes) schema. | 
+| attributes | object | true | The data attributes associated with an ECF school<br/>It conforms to [ECFSchoolAttributes](#ecfschoolattributes) schema. | 
 
 
 ### ECFSchoolAttributes
@@ -2865,7 +2865,7 @@ A single ECF school
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | An ECF school<br/>It conforms to [ECFSchool](#schema-ecfschool) schema. | 
+| data | object | true | An ECF school<br/>It conforms to [ECFSchool](#ecfschool) schema. | 
 
 
 ### ECFSchoolsFilter
@@ -2887,7 +2887,7 @@ Sort schools being returned
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| Item | string | false | It conforms to [ECFSchoolsSort/items](#schema-ecfschoolssort-items) schema.Possible values:<br/><ul><li>updated\_at</li><li>-updated\_at</li></ul> | 
+| Item | string | false | It conforms to [ECFSchoolsSort/items](#ecfschoolssort-items) schema.Possible values:<br/><ul><li>updated\_at</li><li>-updated\_at</li></ul> | 
 
 
 ### ECFUnfundedMentorsSort
@@ -2897,7 +2897,7 @@ Sort unfunded mentors being returned.
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| Item | string | false | It conforms to [ECFUnfundedMentorsSort/items](#schema-ecfunfundedmentorssort-items) schema.Possible values:<br/><ul><li>updated\_at</li><li>-updated\_at</li></ul> | 
+| Item | string | false | It conforms to [ECFUnfundedMentorsSort/items](#ecfunfundedmentorssort-items) schema.Possible values:<br/><ul><li>updated\_at</li><li>-updated\_at</li></ul> | 
 
 
 ### ECFWithdrawal
@@ -2940,7 +2940,7 @@ A list of errors
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| error | array | false | It conforms to [Error](#schema-error) schema. | 
+| error | array | false | It conforms to [Error](#error) schema. | 
 
 
 ### ListFilter
@@ -2971,7 +2971,7 @@ A list of ECF participant transfers
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ECFParticipantTransfer](#schema-ecfparticipanttransfer) schema. | 
+| data | array | true | It conforms to [ECFParticipantTransfer](#ecfparticipanttransfer) schema. | 
 
 
 ### MultipleECFParticipantsResponse
@@ -2981,7 +2981,7 @@ A list of ECF participants
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ECFParticipant](#schema-ecfparticipant) schema. | 
+| data | array | true | It conforms to [ECFParticipant](#ecfparticipant) schema. | 
 
 
 ### MultipleECFPartnershipsResponse
@@ -2991,7 +2991,7 @@ A list of ECF partnerships
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ECFPartnership](#schema-ecfpartnership) schema. | 
+| data | array | true | It conforms to [ECFPartnership](#ecfpartnership) schema. | 
 
 
 ### MultipleECFSchoolsResponse
@@ -3001,7 +3001,7 @@ A list of schools for the given cohort
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ECFSchool](#schema-ecfschool) schema. | 
+| data | array | true | It conforms to [ECFSchool](#ecfschool) schema. | 
 
 
 ### MultipleParticipantDeclarationsResponse
@@ -3011,7 +3011,7 @@ A list of participant declarations
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ParticipantDeclarationResponse](#schema-participantdeclarationresponse) schema. | 
+| data | array | true | It conforms to [ParticipantDeclarationResponse](#participantdeclarationresponse) schema. | 
 
 
 ### MultipleUnfundedMentorsResponse
@@ -3021,7 +3021,7 @@ A list of unfunded mentors
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [UnfundedMentor](#schema-unfundedmentor) schema. | 
+| data | array | true | It conforms to [UnfundedMentor](#unfundedmentor) schema. | 
 
 
 ### NotFoundResponse
@@ -3105,7 +3105,7 @@ A participant declaration data request for ECT participants from cohort 2025 onw
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024ECTStartedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTRetainedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectretainedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectcompletedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTExtendedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectextendedattributesrequest) </li></ul> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024ECTStartedAttributesRequest](#ecfparticipantdeclarationpost2024ectstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTRetainedAttributesRequest](#ecfparticipantdeclarationpost2024ectretainedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTCompletedAttributesRequest](#ecfparticipantdeclarationpost2024ectcompletedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTExtendedAttributesRequest](#ecfparticipantdeclarationpost2024ectextendedattributesrequest) </li></ul> | 
 
 
 ### ParticipantDeclarationPost2024MentorDataRequest
@@ -3116,7 +3116,7 @@ A participant declaration data request for mentor participants from cohort 2025 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024MentorStartedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024MentorCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorcompletedattributesrequest) </li></ul> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024MentorStartedAttributesRequest](#ecfparticipantdeclarationpost2024mentorstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024MentorCompletedAttributesRequest](#ecfparticipantdeclarationpost2024mentorcompletedattributesrequest) </li></ul> | 
 
 
 ### ParticipantDeclarationPre2025DataRequest
@@ -3127,7 +3127,7 @@ A participant declaration data request for participants in cohort 2024 and previ
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPre2025StartedAttributesRequest](#schema-ecfparticipantdeclarationpre2025startedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025RetainedAttributesRequest](#schema-ecfparticipantdeclarationpre2025retainedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025CompletedAttributesRequest](#schema-ecfparticipantdeclarationpre2025completedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025ExtendedAttributesRequest](#schema-ecfparticipantdeclarationpre2025extendedattributesrequest) </li></ul> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPre2025StartedAttributesRequest](#ecfparticipantdeclarationpre2025startedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025RetainedAttributesRequest](#ecfparticipantdeclarationpre2025retainedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025CompletedAttributesRequest](#ecfparticipantdeclarationpre2025completedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025ExtendedAttributesRequest](#ecfparticipantdeclarationpre2025extendedattributesrequest) </li></ul> | 
 
 
 ### ParticipantDeclarationRequest
@@ -3137,7 +3137,7 @@ An participant declaration request
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | This conforms to any of the following schemas:<br/><ul><li> [ParticipantDeclarationPre2025DataRequest](#schema-participantdeclarationpre2025datarequest) </li><li> [ParticipantDeclarationPost2024ECTDataRequest](#schema-participantdeclarationpost2024ectdatarequest) </li><li> [ParticipantDeclarationPost2024MentorDataRequest](#schema-participantdeclarationpost2024mentordatarequest) </li></ul> | 
+| data | object | true | This conforms to any of the following schemas:<br/><ul><li> [ParticipantDeclarationPre2025DataRequest](#participantdeclarationpre2025datarequest) </li><li> [ParticipantDeclarationPost2024ECTDataRequest](#participantdeclarationpost2024ectdatarequest) </li><li> [ParticipantDeclarationPost2024MentorDataRequest](#participantdeclarationpost2024mentordatarequest) </li></ul> | 
 
 
 ### ParticipantDeclarationResponse
@@ -3149,7 +3149,7 @@ A participant declaration response
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant declaration record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with a participant declaration response<br/>It conforms to [ParticipantDeclarationAttributes](#schema-participantdeclarationattributes) schema. | 
+| attributes | object | true | The data attributes associated with a participant declaration response<br/>It conforms to [ParticipantDeclarationAttributes](#participantdeclarationattributes) schema. | 
 
 
 ### ParticipantDeclarationsFilter
@@ -3219,7 +3219,7 @@ Sort partnerships being returned
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| Item | string | false | It conforms to [PartnershipsSort/items](#schema-partnershipssort-items) schema.Possible values:<br/><ul><li>created\_at</li><li>-created\_at</li><li>updated\_at</li><li>-updated\_at</li></ul> | 
+| Item | string | false | It conforms to [PartnershipsSort/items](#partnershipssort-items) schema.Possible values:<br/><ul><li>created\_at</li><li>-created\_at</li><li>updated\_at</li><li>-updated\_at</li></ul> | 
 
 
 ### SchoolFundingError
@@ -3240,7 +3240,7 @@ A confirmation that the participant declaration has been recorded successfully
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | A participant declaration response<br/>It conforms to [ParticipantDeclarationResponse](#schema-participantdeclarationresponse) schema. | 
+| data | object | true | A participant declaration response<br/>It conforms to [ParticipantDeclarationResponse](#participantdeclarationresponse) schema. | 
 
 
 ### Statement
@@ -3252,7 +3252,7 @@ A financial statement
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the financial statement<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with a financial statement<br/>It conforms to [StatementAttributes](#schema-statementattributes) schema. | 
+| attributes | object | true | The data attributes associated with a financial statement<br/>It conforms to [StatementAttributes](#statementattributes) schema. | 
 
 
 ### StatementAttributes
@@ -3280,7 +3280,7 @@ A single financial statement
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | A financial statement<br/>It conforms to [Statement](#schema-statement) schema. | 
+| data | object | true | A financial statement<br/>It conforms to [Statement](#statement) schema. | 
 
 
 ### StatementsFilter
@@ -3302,7 +3302,7 @@ A list of financial statements
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [Statement](#schema-statement) schema. | 
+| data | array | true | It conforms to [Statement](#statement) schema. | 
 
 
 ### UnauthorisedResponse
@@ -3324,7 +3324,7 @@ Authorization information is missing or invalid
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the mentor record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an unfunded mentor<br/>It conforms to [UnfundedMentorAttributes](#schema-unfundedmentorattributes) schema. | 
+| attributes | object | true | The data attributes associated with an unfunded mentor<br/>It conforms to [UnfundedMentorAttributes](#unfundedmentorattributes) schema. | 
 
 
 ### UnfundedMentorAttributes
@@ -3348,7 +3348,7 @@ An unfunded mentor
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true |  **Note, this is a new endpoint.** The details of an unfunded mentor<br/>It conforms to [UnfundedMentor](#schema-unfundedmentor) schema. | 
+| data | object | true |  **Note, this is a new endpoint.** The details of an unfunded mentor<br/>It conforms to [UnfundedMentor](#unfundedmentor) schema. | 
 
 
 ### UrnInvalidError

--- a/documentation/ecf1_guidance/reference-v3.md
+++ b/documentation/ecf1_guidance/reference-v3.md
@@ -1,0 +1,3365 @@
+# Lead provider API - 3.0.0
+
+
+The lead provider API for DfE’s manage teacher CPD service.
+
+## Base URLs
+
+
+ **Sandbox** 
+ [https://sb.manage-training-for-early-career-teachers.education.gov.uk](https://sb.manage-training-for-early-career-teachers.education.gov.uk) 
+ **Current environment** 
+ [/](/) 
+ **Production** 
+ [https://manage-training-for-early-career-teachers.education.gov.uk](https://manage-training-for-early-career-teachers.education.gov.uk) 
+## GET
+    
+    
+      /api/v3/delivery-partners
+
+
+ _Note, this endpoint is new.Retrieve delivery partners_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| filter | query | object | false | Refine delivery partners to return.<br/>This consumes a [DeliveryPartnersFilter](#schema-deliverypartnersfilter) schema.<br/> | filter[cohort]=2021 | 
+| page | query | object | false | Pagination options to navigate through the list of delivery partners.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| sort | query | array | false | Sort delivery partners being returned.<br/>This consumes a [DeliveryPartnersSort](#schema-deliverypartnerssort) schema.<br/> | sort=-updated\_at | 
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | Successfully return a list of delivery partners<br/>This response returns a [DeliveryPartnersResponse](#schema-deliverypartnersresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - Successfully return a list of delivery partners
+This response returns a [DeliveryPartnersResponse](#schema-deliverypartnersresponse) schema.
+
+```
+{
+  "data": [
+    {
+      "id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+      "type": "delivery-partner",
+      "attributes": {
+        "name": "Awesome Delivery Partner Ltd",
+        "cohort": [
+          "2021",
+          "2022"
+        ],
+        "created_at": "2021-05-31T02:22:32.000Z",
+        "updated_at": "2021-05-31T02:22:32.000Z"
+      }
+    }
+  ]
+}
+```
+
+401 - Unauthorized
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+
+```
+{
+  "error": "HTTP Token: Access denied"
+}
+```
+
+
+---
+
+
+## GET
+    
+    
+      /api/v3/delivery-partners/{id}
+
+
+ _Note, this endpoint is new.Retrieve a specific delivery partner_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| id | path | string | true | The unique ID of the delivery partner<br/> | 00acafd3-e6f6-41e7-a770-3207be94f755 | 
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | Successfully return a specific delivery partner<br/>This response returns a [DeliveryPartnerResponse](#schema-deliverypartnerresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 404 | Not Found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - Successfully return a specific delivery partner
+This response returns a [DeliveryPartnerResponse](#schema-deliverypartnerresponse) schema.
+
+```
+{
+  "data": {
+    "id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+    "type": "delivery-partner",
+    "attributes": {
+      "name": "Awesome Delivery Partner Ltd",
+      "cohort": [
+        "2021",
+        "2022"
+      ],
+      "created_at": "2021-05-31T02:22:32.000Z",
+      "updated_at": "2021-05-31T02:22:32.000Z"
+    }
+  }
+}
+```
+
+401 - Unauthorized
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+
+```
+{
+  "error": "HTTP Token: Access denied"
+}
+```
+
+404 - Not Found
+This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
+
+```
+{
+  "title": "string",
+  "detail": "string"
+}
+```
+
+
+---
+
+
+## GET
+    
+    
+      /api/v3/partnerships/ecf
+
+
+ _Note, this endpoint is new.Retrieve multiple ECF partnerships_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| filter | query | object | false | Refine partnerships to return.<br/>This consumes a [PartnershipsFilter](#schema-partnershipsfilter) schema.<br/> | filter[cohort]=2021,2022 | 
+| page | query | object | false | Pagination options to navigate through the list of partnerships.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| sort | query | array | false | Sort partnerships being returned.<br/>This consumes a [PartnershipsSort](#schema-partnershipssort) schema.<br/> | sort=-updated\_at | 
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | A list of ECF partnerships<br/>This response returns a [MultipleECFPartnershipsResponse](#schema-multipleecfpartnershipsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - A list of ECF partnerships
+This response returns a [MultipleECFPartnershipsResponse](#schema-multipleecfpartnershipsresponse) schema.
+
+```
+{
+  "data": [
+    {
+      "id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+      "type": "partnership",
+      "attributes": {
+        "cohort": 2021,
+        "urn": "123456",
+        "school_id": "dd4a11347-7308-4879-942a-c4a70ced400v",
+        "delivery_partner_id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+        "delivery_partner_name": "Delivery Partner Example",
+        "status": "challenged",
+        "challenged_reason": "mistake",
+        "challenged_at": "2021-05-31T02:22:32.000Z",
+        "induction_tutor_name": "John Doe",
+        "induction_tutor_email": "john.doe@example.com",
+        "updated_at": "2021-05-31T02:22:32.000Z",
+        "created_at": "2021-05-31T02:22:32.000Z"
+      }
+    }
+  ]
+}
+```
+
+401 - Unauthorized
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+
+```
+{
+  "error": "HTTP Token: Access denied"
+}
+```
+
+
+---
+
+
+## POST
+    
+    
+      /api/v3/partnerships/ecf
+
+
+ _Note, this endpoint is new.Create an ECF partnership with a school and delivery partner_ 
+
+### Request body
+
+
+This consumes a [ECFPartnershipRequest](#schema-ecfpartnershiprequest) schema.
+
+### Request example
+
+
+```
+{
+  "data": {
+    "type": "ecf-partnership",
+    "attributes": {
+      "cohort": "2021",
+      "school_id": "24b61d1c-ad95-4000-aee0-afbdd542294a",
+      "delivery_partner_id": "db2fbf67-b7b7-454f-a1b7-0020411e2314"
+    }
+  }
+}
+```
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | Create an ECF partnership<br/>This response returns a [ECFPartnershipResponse](#schema-ecfpartnershipresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 422 | Unprocessable entity<br/>This response returns a [ECFPartnershipRequestErrorResponse](#schema-ecfpartnershiprequesterrorresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - Create an ECF partnership
+This response returns a [ECFPartnershipResponse](#schema-ecfpartnershipresponse) schema.
+
+```
+{
+  "data": {
+    "id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+    "type": "partnership",
+    "attributes": {
+      "cohort": 2021,
+      "urn": "123456",
+      "school_id": "dd4a11347-7308-4879-942a-c4a70ced400v",
+      "delivery_partner_id": "db2fbf67-b7b7-454f-a1b7-0020411e2314",
+      "delivery_partner_name": "Delivery Partner Example",
+      "status": "active",
+      "challenged_reason": null,
+      "challenged_at": null,
+      "induction_tutor_name": "John Doe",
+      "induction_tutor_email": "john.doe@example.com",
+      "updated_at": "2021-05-31T02:22:32.000Z",
+      "created_at": "2021-05-31T02:22:32.000Z"
+    }
+  }
+}
+```
+
+401 - Unauthorized
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+
+```
+{
+  "error": "HTTP Token: Access denied"
+}
+```
+
+422 - Unprocessable entity
+This response returns a [ECFPartnershipRequestErrorResponse](#schema-ecfpartnershiprequesterrorresponse) schema.
+
+```
+{
+  "error": [
+    {
+      "title": "Recruited by other provider",
+      "detail": "This partnership cannot be created as it has already partnered with another provider"
+    }
+  ]
+}
+```
+
+
+---
+
+
+## GET
+    
+    
+      /api/v3/partnerships/ecf/{id}
+
+
+ _Note, this endpoint is new.Get a single ECF partnership_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| id | path | string | true | The unique ID of the partnership<br/> | 00acafd3-e6f6-41e7-a770-3207be94f755 | 
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | A single partnership<br/>This response returns a [ECFPartnershipResponse](#schema-ecfpartnershipresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 404 | Not Found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - A single partnership
+This response returns a [ECFPartnershipResponse](#schema-ecfpartnershipresponse) schema.
+
+```
+{
+  "data": {
+    "id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+    "type": "partnership",
+    "attributes": {
+      "cohort": 2021,
+      "urn": "123456",
+      "school_id": "dd4a11347-7308-4879-942a-c4a70ced400v",
+      "delivery_partner_id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+      "delivery_partner_name": "Delivery Partner Example",
+      "status": "challenged",
+      "challenged_reason": "mistake",
+      "challenged_at": "2021-05-31T02:22:32.000Z",
+      "induction_tutor_name": "John Doe",
+      "induction_tutor_email": "john.doe@example.com",
+      "updated_at": "2021-05-31T02:22:32.000Z",
+      "created_at": "2021-05-31T02:22:32.000Z"
+    }
+  }
+}
+```
+
+401 - Unauthorized
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+
+```
+{
+  "error": "HTTP Token: Access denied"
+}
+```
+
+404 - Not Found
+This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
+
+```
+{
+  "title": "string",
+  "detail": "string"
+}
+```
+
+
+---
+
+
+## PUT
+    
+    
+      /api/v3/partnerships/ecf/{id}
+
+
+ _Note, this endpoint is new.Update a partnership’s delivery partner in an existing partnership in a cohort_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| id | path | string | true | The ID of the partnership to update<br/> | 28c461ee-ffc0-4e56-96bd-788579a0ed75 | 
+
+
+### Request body
+
+
+This consumes a [ECFPartnershipUpdateRequest](#schema-ecfpartnershipupdaterequest) schema.
+
+### Request example
+
+
+```
+{
+  "data": {
+    "type": "ecf-partnership-update",
+    "attributes": {
+      "delivery_partner_id": "db2fbf67-b7b7-454f-a1b7-0020411e2314"
+    }
+  }
+}
+```
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | Update an ECF partnership<br/>This response returns a [ECFPartnershipResponse](#schema-ecfpartnershipresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 422 | Unprocessable entity<br/>This response returns a [ECFPartnershipRequestErrorResponse](#schema-ecfpartnershiprequesterrorresponse) schema.<br/> | 
+| 404 | Not Found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - Update an ECF partnership
+This response returns a [ECFPartnershipResponse](#schema-ecfpartnershipresponse) schema.
+
+```
+{
+  "data": {
+    "id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+    "type": "partnership",
+    "attributes": {
+      "cohort": 2021,
+      "urn": "123456",
+      "school_id": "dd4a11347-7308-4879-942a-c4a70ced400v",
+      "delivery_partner_id": "db2fbf67-b7b7-454f-a1b7-0020411e2314",
+      "delivery_partner_name": "Delivery Partner Example",
+      "status": "active",
+      "challenged_reason": null,
+      "challenged_at": null,
+      "induction_tutor_name": "John Doe",
+      "induction_tutor_email": "john.doe@example.com",
+      "updated_at": "2021-05-31T02:22:32.000Z",
+      "created_at": "2021-05-31T02:22:32.000Z"
+    }
+  }
+}
+```
+
+401 - Unauthorized
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+
+```
+{
+  "error": "HTTP Token: Access denied"
+}
+```
+
+422 - Unprocessable entity
+This response returns a [ECFPartnershipRequestErrorResponse](#schema-ecfpartnershiprequesterrorresponse) schema.
+
+```
+{
+  "error": [
+    {
+      "title": "Recruited by other provider",
+      "detail": "This partnership cannot be created as it has already partnered with another provider"
+    }
+  ]
+}
+```
+
+404 - Not Found
+This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
+
+```
+{
+  "title": "string",
+  "detail": "string"
+}
+```
+
+
+---
+
+
+## GET
+    
+    
+      /api/v3/schools/ecf
+
+
+ _Note, this endpoint is new.Retrieve multiple ECF schools scoped to cohort_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| filter[cohort] | query | object | true | Refine schools to return.<br/>This consumes a [ECFSchoolsFilter](#schema-ecfschoolsfilter) schema.<br/> | filter[cohort]=2021 | 
+| filter[urn] | query | object | false | Refine schools to return.<br/>This consumes a [ECFSchoolsFilter](#schema-ecfschoolsfilter) schema.<br/> | filter[urn]=106286 | 
+| filter[updated\_since] | query | object | false | Refine schools to return.<br/>This consumes a [ECFSchoolsFilter](#schema-ecfschoolsfilter) schema.<br/> | filter[updated\_since]=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of schools.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| sort | query | array | false | Sort schools being returned.<br/>This consumes a [ECFSchoolsSort](#schema-ecfschoolssort) schema.<br/> | sort=-updated\_at | 
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | A list of schools for the given cohort<br/>This response returns a [MultipleECFSchoolsResponse](#schema-multipleecfschoolsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - A list of schools for the given cohort
+This response returns a [MultipleECFSchoolsResponse](#schema-multipleecfschoolsresponse) schema.
+
+```
+{
+  "data": [
+    {
+      "id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+      "type": "school",
+      "attributes": {
+        "name": "School Example",
+        "urn": "123456",
+        "cohort": 2021,
+        "in_partnership": "boolean",
+        "induction_programme_choice": "not_yet_known",
+        "created_at": "2021-05-31T02:22:32.000Z",
+        "updated_at": "2021-05-31T02:22:32.000Z"
+      }
+    }
+  ]
+}
+```
+
+401 - Unauthorized
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+
+```
+{
+  "error": "HTTP Token: Access denied"
+}
+```
+
+
+---
+
+
+## GET
+    
+    
+      /api/v3/schools/ecf/{id}
+
+
+ _Note, this endpoint is new.Get a single ECF school scoped to cohort_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| id | path | string | true | The unique ID of the school<br/> | 28c461ee-ffc0-4e56-96bd-788579a0ed75 | 
+| filter[cohort] | query | object | true | Refine schools to return.<br/>This consumes a [ECFSchoolsFilter](#schema-ecfschoolsfilter) schema.<br/> | filter[cohort]=2021 | 
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | A single school<br/>This response returns a [ECFSchoolResponse](#schema-ecfschoolresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 404 | Not Found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - A single school
+This response returns a [ECFSchoolResponse](#schema-ecfschoolresponse) schema.
+
+```
+{
+  "data": {
+    "id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+    "type": "school",
+    "attributes": {
+      "name": "School Example",
+      "urn": "123456",
+      "cohort": 2021,
+      "in_partnership": "boolean",
+      "induction_programme_choice": "not_yet_known",
+      "created_at": "2021-05-31T02:22:32.000Z",
+      "updated_at": "2021-05-31T02:22:32.000Z"
+    }
+  }
+}
+```
+
+401 - Unauthorized
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+
+```
+{
+  "error": "HTTP Token: Access denied"
+}
+```
+
+404 - Not Found
+This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
+
+```
+{
+  "title": "string",
+  "detail": "string"
+}
+```
+
+
+---
+
+
+## GET
+    
+    
+      /api/v3/participant-declarations
+
+
+ _Note, this endpoint includes updated specifications.List all participant declarations_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| filter | query | object | false | Refine participant declarations to return.<br/>This consumes a [ParticipantDeclarationsFilter](#schema-participantdeclarationsfilter) schema.<br/> | filter[participant\_id]=ab3a7848-1208-7679-942a-b4a70eed400a&filter[updated\_since]=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of participant declarations.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | A list of participant declarations<br/>This response returns a [MultipleParticipantDeclarationsResponse](#schema-multipleparticipantdeclarationsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - A list of participant declarations
+This response returns a [MultipleParticipantDeclarationsResponse](#schema-multipleparticipantdeclarationsresponse) schema.
+
+```
+{
+  "data": [
+    {
+      "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+      "type": "participant-declaration",
+      "attributes": {
+        "participant_id": "08d78829-f864-417f-8a30-cb7655714e28",
+        "declaration_type": "started",
+        "declaration_date": "2020-11-13T11:21:55Z",
+        "course_identifier": "ecf-induction",
+        "state": "eligible",
+        "updated_at": "2020-11-13T11:21:55Z",
+        "created_at": "2020-11-13T11:21:55Z",
+        "delivery_partner_id": "99ca2223-8c1f-4ac8-985d-a0672e97694e",
+        "statement_id": "99ca2223-8c1f-4ac8-985d-a0672e97694e",
+        "clawback_statement_id": null,
+        "ineligible_for_funding_reason": null,
+        "mentor_id": "907f61ed-5770-4d38-b22c-1a4265939378",
+        "uplift_paid": true,
+        "evidence_held": "other",
+        "has_passed": null,
+        "lead_provider_name": "Example Institute"
+      }
+    }
+  ]
+}
+```
+
+401 - Unauthorized
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+
+```
+{
+  "error": "HTTP Token: Access denied"
+}
+```
+
+
+---
+
+
+## POST
+    
+    
+      /api/v3/participant-declarations
+
+
+ _Note, this endpoint includes updated specifications.Declare a participant has reached a milestone. Idempotent endpoint - submitting exact copy of a request will return the same response body as submitting it the first time._ 
+
+### Request body
+
+
+This consumes a [ParticipantDeclarationRequest](#schema-participantdeclarationrequest) schema.
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.<br/> | 
+| 422 | Bad or Missing parameter<br/>This response returns a [ErrorResponse](#schema-errorresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 400 | Bad Request<br/>This response returns a [BadRequestResponse](#schema-badrequestresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - Successful
+This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.
+
+```
+{
+  "data": {
+    "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+    "type": "participant-declaration",
+    "attributes": {
+      "participant_id": "08d78829-f864-417f-8a30-cb7655714e28",
+      "declaration_type": "started",
+      "declaration_date": "2020-11-13T11:21:55Z",
+      "course_identifier": "ecf-induction",
+      "state": "eligible",
+      "updated_at": "2020-11-13T11:21:55Z",
+      "created_at": "2020-11-13T11:21:55Z",
+      "delivery_partner_id": "99ca2223-8c1f-4ac8-985d-a0672e97694e",
+      "statement_id": "99ca2223-8c1f-4ac8-985d-a0672e97694e",
+      "clawback_statement_id": null,
+      "ineligible_for_funding_reason": null,
+      "mentor_id": "907f61ed-5770-4d38-b22c-1a4265939378",
+      "uplift_paid": true,
+      "evidence_held": "other",
+      "has_passed": null,
+      "lead_provider_name": "Example Institute"
+    }
+  }
+}
+```
+
+422 - Bad or Missing parameter
+This response returns a [ErrorResponse](#schema-errorresponse) schema.
+
+```
+{
+  "error": [
+    {
+      "title": "string",
+      "detail": "string"
+    }
+  ]
+}
+```
+
+401 - Unauthorized
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+
+```
+{
+  "error": "HTTP Token: Access denied"
+}
+```
+
+400 - Bad Request
+This response returns a [BadRequestResponse](#schema-badrequestresponse) schema.
+
+```
+{
+  "bad_request": "string"
+}
+```
+
+
+---
+
+
+## GET
+    
+    
+      /api/v3/participant-declarations/{id}
+
+
+ _Note, this endpoint includes updated specifications.Get single participant declaration_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| id | path | string | true | The ID of the participant declaration ID<br/> | 9ed4612b-f8bd-44d9-b296-38ab103fadd2 | 
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | A single participant declaration<br/>This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 404 | Not found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - A single participant declaration
+This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.
+
+```
+{
+  "data": {
+    "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+    "type": "participant-declaration",
+    "attributes": {
+      "participant_id": "08d78829-f864-417f-8a30-cb7655714e28",
+      "declaration_type": "started",
+      "declaration_date": "2020-11-13T11:21:55Z",
+      "course_identifier": "ecf-induction",
+      "state": "eligible",
+      "updated_at": "2020-11-13T11:21:55Z",
+      "created_at": "2020-11-13T11:21:55Z",
+      "delivery_partner_id": "99ca2223-8c1f-4ac8-985d-a0672e97694e",
+      "statement_id": "99ca2223-8c1f-4ac8-985d-a0672e97694e",
+      "clawback_statement_id": null,
+      "ineligible_for_funding_reason": null,
+      "mentor_id": "907f61ed-5770-4d38-b22c-1a4265939378",
+      "uplift_paid": true,
+      "evidence_held": "other",
+      "has_passed": null,
+      "lead_provider_name": "Example Institute"
+    }
+  }
+}
+```
+
+401 - Unauthorized
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+
+```
+{
+  "error": "HTTP Token: Access denied"
+}
+```
+
+404 - Not found
+This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
+
+```
+{
+  "title": "string",
+  "detail": "string"
+}
+```
+
+
+---
+
+
+## PUT
+    
+    
+      /api/v3/participant-declarations/{id}/void
+
+
+ _Note, this endpoint includes updated specifications.Void a declaration - it will not be soft-deleted_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| id | path | string | true | The ID of the declaration to void<br/> | 28c461ee-ffc0-4e56-96bd-788579a0ed75 | 
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - Successful
+This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.
+
+```
+{
+  "data": {
+    "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+    "type": "participant-declaration",
+    "attributes": {
+      "participant_id": "08d78829-f864-417f-8a30-cb7655714e28",
+      "declaration_type": "started",
+      "declaration_date": "2020-11-13T11:21:55Z",
+      "course_identifier": "ecf-induction",
+      "state": "voided",
+      "updated_at": "2020-11-13T11:21:55Z",
+      "created_at": "2020-11-13T11:21:55Z",
+      "delivery_partner_id": "99ca2223-8c1f-4ac8-985d-a0672e97694e",
+      "statement_id": "99ca2223-8c1f-4ac8-985d-a0672e97694e",
+      "clawback_statement_id": null,
+      "ineligible_for_funding_reason": null,
+      "mentor_id": "907f61ed-5770-4d38-b22c-1a4265939378",
+      "uplift_paid": true,
+      "evidence_held": "other",
+      "has_passed": null,
+      "lead_provider_name": "Example Institute"
+    }
+  }
+}
+```
+
+
+---
+
+
+## GET
+    
+    
+      /api/v3/participants/ecf
+
+
+ _Note, this endpoint includes updated specifications.Retrieve multiple participants, replaces /api/v3/participants_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| filter | query | object | false | Refine ECF participants to return.<br/>This consumes a [ECFParticipantFilter](#schema-ecfparticipantfilter) schema.<br/> | filter[cohort]=2022&filter[from\_participant\_id]=439ac4fe-a003-417f-9694-07c45b3482f8&filter[training\_status]=active&filter[updated\_since]=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of ECF participants.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| sort | query | array | false | Sort ECF participants being returned.<br/>This consumes a [ECFParticipantsSort](#schema-ecfparticipantssort) schema.<br/> | sort=-updated\_at | 
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | A list of ECF participants<br/>This response returns a [MultipleECFParticipantsResponse](#schema-multipleecfparticipantsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - A list of ECF participants
+This response returns a [MultipleECFParticipantsResponse](#schema-multipleecfparticipantsresponse) schema.
+
+```
+{
+  "data": [
+    {
+      "id": "ac3d1243-7308-4879-942a-c4a70ced400a",
+      "type": "participant",
+      "attributes": {
+        "full_name": "Jane Smith",
+        "teacher_reference_number": "1234567",
+        "updated_at": "2021-05-31T02:22:32.000Z",
+        "ecf_enrolments": [
+          {
+            "training_record_id": "000a97ff-d2a9-4779-a397-9bfd9063072e",
+            "email": "jane.smith@some-school.example.com",
+            "mentor_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+            "school_urn": "106286",
+            "participant_type": "ect",
+            "cohort": "2021",
+            "training_status": "active",
+            "participant_status": "active",
+            "teacher_reference_number_validated": true,
+            "eligible_for_funding": true,
+            "pupil_premium_uplift": true,
+            "sparsity_uplift": true,
+            "schedule_identifier": "ecf-standard-january",
+            "delivery_partner_id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+            "withdrawal": null,
+            "deferral": null,
+            "created_at": "2021-05-31T02:22:32.000Z",
+            "induction_end_date": "2022-01-12",
+            "mentor_funding_end_date": "2021-04-19",
+            "cohort_changed_after_payments_frozen": true,
+            "mentor_ineligible_for_funding_reason": "completed_declaration_received"
+          }
+        ],
+        "participant_id_changes": [
+          {
+            "from_participant_id": "23dd8d66-e11f-4139-9001-86b4f9abcb02",
+            "to_participant_id": "ac3d1243-7308-4879-942a-c4a70ced400a",
+            "changed_at": "2021-05-31T02:22:32.000Z"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+401 - Unauthorized
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+
+```
+{
+  "error": "HTTP Token: Access denied"
+}
+```
+
+
+---
+
+
+## GET
+    
+    
+      /api/v3/participants/ecf/{id}
+
+
+ _Note, this endpoint includes updated specifications.Get a single ECF participant_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| id | path | string | true | The ID of the ECF participant.<br/> | 28c461ee-ffc0-4e56-96bd-788579a0ed75 | 
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | A single ECF participant<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 404 | Not Found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - A single ECF participant
+This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+
+```
+{
+  "data": {
+    "id": "ac3d1243-7308-4879-942a-c4a70ced400a",
+    "type": "participant",
+    "attributes": {
+      "full_name": "Jane Smith",
+      "teacher_reference_number": "1234567",
+      "updated_at": "2021-05-31T02:22:32.000Z",
+      "ecf_enrolments": [
+        {
+          "training_record_id": "000a97ff-d2a9-4779-a397-9bfd9063072e",
+          "email": "jane.smith@some-school.example.com",
+          "mentor_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+          "school_urn": "106286",
+          "participant_type": "ect",
+          "cohort": "2021",
+          "training_status": "active",
+          "participant_status": "active",
+          "teacher_reference_number_validated": true,
+          "eligible_for_funding": true,
+          "pupil_premium_uplift": true,
+          "sparsity_uplift": true,
+          "schedule_identifier": "ecf-standard-january",
+          "delivery_partner_id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+          "withdrawal": null,
+          "deferral": null,
+          "created_at": "2021-05-31T02:22:32.000Z",
+          "induction_end_date": "2022-01-12",
+          "mentor_funding_end_date": "2021-04-19",
+          "cohort_changed_after_payments_frozen": true,
+          "mentor_ineligible_for_funding_reason": "completed_declaration_received"
+        }
+      ],
+      "participant_id_changes": [
+        {
+          "from_participant_id": "23dd8d66-e11f-4139-9001-86b4f9abcb02",
+          "to_participant_id": "ac3d1243-7308-4879-942a-c4a70ced400a",
+          "changed_at": "2021-05-31T02:22:32.000Z"
+        }
+      ]
+    }
+  }
+}
+```
+
+401 - Unauthorized
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+
+```
+{
+  "error": "HTTP Token: Access denied"
+}
+```
+
+404 - Not Found
+This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
+
+```
+{
+  "title": "string",
+  "detail": "string"
+}
+```
+
+
+---
+
+
+## GET
+    
+    
+      /api/v3/participants/ecf/transfers
+
+
+ _Note, this endpoint is new.Retrieve multiple ECF participant transfers_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| filter | query | object | false | Refine participant transfers to return.<br/>This consumes a [ListFilter](#schema-listfilter) schema.<br/> | filter[updated\_since]=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of participant transfers.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | A list of ECF participant transfers<br/>This response returns a [MultipleECFParticipantTransferResponse](#schema-multipleecfparticipanttransferresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - A list of ECF participant transfers
+This response returns a [MultipleECFParticipantTransferResponse](#schema-multipleecfparticipanttransferresponse) schema.
+
+```
+{
+  "data": [
+    {
+      "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+      "type": "participant-transfer",
+      "attributes": {
+        "updated_at": "2021-05-31T02:22:32.000Z",
+        "transfers": {
+          "training_record_id": "000a97ff-d2a9-4779-a397-9bfd9063072e",
+          "transfer_type": "new_provider",
+          "status": "complete",
+          "leaving": {
+            "school_urn": "123456",
+            "provider": "Old Institute",
+            "date": "2021-05-31"
+          },
+          "joining": {
+            "school_urn": "654321",
+            "provider": "New Institute",
+            "date": "2021-06-01"
+          },
+          "created_at": "2021-05-31T02:22:32.000Z"
+        }
+      }
+    }
+  ]
+}
+```
+
+401 - Unauthorized
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+
+```
+{
+  "error": "HTTP Token: Access denied"
+}
+```
+
+
+---
+
+
+## PUT
+    
+    
+      /api/v3/participants/ecf/{id}/defer
+
+
+ _Note, this endpoint includes updated specifications.Notify that an ECF participant is taking a break from their course_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| id | path | string | true | The ID of the participant to defer<br/> | 28c461ee-ffc0-4e56-96bd-788579a0ed75 | 
+
+
+### Request body
+
+
+This consumes a [ECFParticipantDeferRequest](#schema-ecfparticipantdeferrequest) schema.
+
+### Request example
+
+
+```
+{
+  "data": {
+    "type": "participant-defer",
+    "attributes": {
+      "reason": "career-break",
+      "course_identifier": "ecf-mentor"
+    }
+  }
+}
+```
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | The ECF participant being deferred<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - The ECF participant being deferred
+This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+
+```
+{
+  "data": {
+    "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+    "type": "participant",
+    "attributes": {
+      "full_name": "Jane Smith",
+      "teacher_reference_number": "1234567",
+      "updated_at": "2021-05-31T02:22:32.000Z",
+      "ecf_enrolments": [
+        {
+          "training_record_id": "000a97ff-d2a9-4779-a397-9bfd9063072e",
+          "email": "jane.smith@some-school.example.com",
+          "mentor_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+          "school_urn": "106286",
+          "participant_type": "ect",
+          "cohort": "2021",
+          "training_status": "withdrawn",
+          "participant_status": "withdrawn",
+          "teacher_reference_number_validated": true,
+          "eligible_for_funding": true,
+          "pupil_premium_uplift": true,
+          "sparsity_uplift": true,
+          "schedule_identifier": "ecf-standard-january",
+          "delivery_partner_id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+          "withdrawal": null,
+          "deferral": {
+            "reason": "other",
+            "date": "2021-06-31T02:22:32.000Z"
+          },
+          "created_at": "2022-11-09T16:07:38Z",
+          "induction_end_date": "2022-01-12",
+          "mentor_funding_end_date": "2021-04-19",
+          "cohort_changed_after_payments_frozen": true,
+          "mentor_ineligible_for_funding_reason": null
+        }
+      ],
+      "participant_id_changes": [
+        {
+          "from_participant_id": "23dd8d66-e11f-4139-9001-86b4f9abcb02",
+          "to_participant_id": "db3a7848-7308-4879-942a-c4a70ced400a",
+          "changed_at": "2023-09-23T02:22:32.000Z"
+        }
+      ]
+    }
+  }
+}
+```
+
+
+---
+
+
+## PUT
+    
+    
+      /api/v3/participants/ecf/{id}/resume
+
+
+ _Note, this endpoint includes updated specifications.Notify that an ECF participant is resuming their course_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| id | path | string | true | The ID of the participant to resume<br/> | 28c461ee-ffc0-4e56-96bd-788579a0ed75 | 
+
+
+### Request body
+
+
+This consumes a [ECFParticipantResumeRequest](#schema-ecfparticipantresumerequest) schema.
+
+### Request example
+
+
+```
+{
+  "data": {
+    "type": "participant-resume",
+    "attributes": {
+      "course_identifier": "ecf-mentor"
+    }
+  }
+}
+```
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | The ECF participant being resumed<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - The ECF participant being resumed
+This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+
+```
+{
+  "data": {
+    "id": "ac3d1243-7308-4879-942a-c4a70ced400a",
+    "type": "participant",
+    "attributes": {
+      "full_name": "Jane Smith",
+      "teacher_reference_number": "1234567",
+      "updated_at": "2021-05-31T02:22:32.000Z",
+      "ecf_enrolments": [
+        {
+          "training_record_id": "000a97ff-d2a9-4779-a397-9bfd9063072e",
+          "email": "jane.smith@some-school.example.com",
+          "mentor_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+          "school_urn": "106286",
+          "participant_type": "ect",
+          "cohort": "2021",
+          "training_status": "active",
+          "participant_status": "active",
+          "teacher_reference_number_validated": true,
+          "eligible_for_funding": true,
+          "pupil_premium_uplift": true,
+          "sparsity_uplift": true,
+          "schedule_identifier": "ecf-standard-january",
+          "delivery_partner_id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+          "withdrawal": null,
+          "deferral": null,
+          "created_at": "2021-05-31T02:22:32.000Z",
+          "induction_end_date": "2022-01-12",
+          "mentor_funding_end_date": "2021-04-19",
+          "cohort_changed_after_payments_frozen": true,
+          "mentor_ineligible_for_funding_reason": "completed_declaration_received"
+        }
+      ],
+      "participant_id_changes": [
+        {
+          "from_participant_id": "23dd8d66-e11f-4139-9001-86b4f9abcb02",
+          "to_participant_id": "ac3d1243-7308-4879-942a-c4a70ced400a",
+          "changed_at": "2021-05-31T02:22:32.000Z"
+        }
+      ]
+    }
+  }
+}
+```
+
+
+---
+
+
+## PUT
+    
+    
+      /api/v3/participants/ecf/{id}/withdraw
+
+
+ _Note, this endpoint includes updated specifications.Notify that an ECF participant has withdrawn from their course_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| id | path | string | true | The ID of the participant to withdraw<br/> | 28c461ee-ffc0-4e56-96bd-788579a0ed75 | 
+
+
+### Request body
+
+
+This consumes a [ECFParticipantWithdrawRequest](#schema-ecfparticipantwithdrawrequest) schema.
+
+### Request example
+
+
+```
+{
+  "data": {
+    "type": "participant-withdraw",
+    "attributes": {
+      "reason": "left-teaching-profession",
+      "course_identifier": "ecf-mentor"
+    }
+  }
+}
+```
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | The ECF participant being withdrawn<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - The ECF participant being withdrawn
+This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+
+```
+{
+  "data": {
+    "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+    "type": "participant",
+    "attributes": {
+      "full_name": "Jane Smith",
+      "teacher_reference_number": "1234567",
+      "updated_at": "2021-05-31T02:22:32.000Z",
+      "ecf_enrolments": [
+        {
+          "training_record_id": "000a97ff-d2a9-4779-a397-9bfd9063072e",
+          "email": "jane.smith@some-school.example.com",
+          "mentor_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+          "school_urn": "106286",
+          "participant_type": "ect",
+          "cohort": "2021",
+          "training_status": "withdrawn",
+          "participant_status": "withdrawn",
+          "teacher_reference_number_validated": true,
+          "eligible_for_funding": true,
+          "pupil_premium_uplift": true,
+          "sparsity_uplift": true,
+          "schedule_identifier": "ecf-standard-january",
+          "delivery_partner_id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+          "withdrawal": {
+            "reason": "other",
+            "date": "2021-06-31T02:22:32.000Z"
+          },
+          "deferral": null,
+          "created_at": "2022-11-09T16:07:38Z",
+          "induction_end_date": "2022-01-12",
+          "mentor_funding_end_date": "2021-04-19",
+          "cohort_changed_after_payments_frozen": false,
+          "mentor_ineligible_for_funding_reason": null
+        }
+      ],
+      "participant_id_changes": [
+        {
+          "from_participant_id": "23dd8d66-e11f-4139-9001-86b4f9abcb02",
+          "to_participant_id": "db3a7848-7308-4879-942a-c4a70ced400a",
+          "changed_at": "2023-09-23T02:22:32.000Z"
+        }
+      ]
+    }
+  }
+}
+```
+
+
+---
+
+
+## GET
+    
+    
+      /api/v3/participants/ecf/{id}/transfers
+
+
+ _Note, this endpoint is new.Get a single participant’s transfers_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| id | path | string | true | The ID of the ECF participant.<br/> | 28c461ee-ffc0-4e56-96bd-788579a0ed75 | 
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | A single participant’s transfers<br/>This response returns a [ECFParticipantTransferResponse](#schema-ecfparticipanttransferresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 404 | Not Found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - A single participant’s transfers
+This response returns a [ECFParticipantTransferResponse](#schema-ecfparticipanttransferresponse) schema.
+
+```
+{
+  "data": {
+    "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+    "type": "participant-transfer",
+    "attributes": {
+      "updated_at": "2021-05-31T02:22:32.000Z",
+      "transfers": [
+        {
+          "training_record_id": "000a97ff-d2a9-4779-a397-9bfd9063072e",
+          "transfer_type": "new_provider",
+          "status": "complete",
+          "leaving": null,
+          "joining": null,
+          "created_at": "2021-05-31T02:22:32.000Z"
+        }
+      ]
+    }
+  }
+}
+```
+
+401 - Unauthorized
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+
+```
+{
+  "error": "HTTP Token: Access denied"
+}
+```
+
+404 - Not Found
+This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
+
+```
+{
+  "title": "string",
+  "detail": "string"
+}
+```
+
+
+---
+
+
+## PUT
+    
+    
+      /api/v3/participants/ecf/{id}/change-schedule
+
+
+ _Note, this endpoint includes updated specifications.Notify that an ECF Participant is changing training schedule_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| id | path | string | true | The ID of the participant<br/> | 28c461ee-ffc0-4e56-96bd-788579a0ed75 | 
+
+
+### Request body
+
+
+This consumes a [ECFParticipantChangeScheduleRequest](#schema-ecfparticipantchangeschedulerequest) schema.
+
+### Request example
+
+
+```
+{
+  "data": {
+    "type": "participant-change-schedule",
+    "attributes": {
+      "schedule_identifier": "ecf-standard-january",
+      "course_identifier": "ecf-mentor",
+      "cohort": "2021"
+    }
+  }
+}
+```
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | The ECF Participant changing schedule<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - The ECF Participant changing schedule
+This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+
+```
+{
+  "data": {
+    "id": "ac3d1243-7308-4879-942a-c4a70ced400a",
+    "type": "participant",
+    "attributes": {
+      "full_name": "Jane Smith",
+      "teacher_reference_number": "1234567",
+      "updated_at": "2021-05-31T02:22:32.000Z",
+      "ecf_enrolments": [
+        {
+          "training_record_id": "000a97ff-d2a9-4779-a397-9bfd9063072e",
+          "email": "jane.smith@some-school.example.com",
+          "mentor_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+          "school_urn": "106286",
+          "participant_type": "ect",
+          "cohort": "2021",
+          "training_status": "active",
+          "participant_status": "active",
+          "teacher_reference_number_validated": true,
+          "eligible_for_funding": true,
+          "pupil_premium_uplift": true,
+          "sparsity_uplift": true,
+          "schedule_identifier": "ecf-standard-january",
+          "delivery_partner_id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+          "withdrawal": null,
+          "deferral": null,
+          "created_at": "2021-05-31T02:22:32.000Z",
+          "induction_end_date": "2022-01-12",
+          "mentor_funding_end_date": "2021-04-19",
+          "cohort_changed_after_payments_frozen": true,
+          "mentor_ineligible_for_funding_reason": "completed_declaration_received"
+        }
+      ],
+      "participant_id_changes": [
+        {
+          "from_participant_id": "23dd8d66-e11f-4139-9001-86b4f9abcb02",
+          "to_participant_id": "ac3d1243-7308-4879-942a-c4a70ced400a",
+          "changed_at": "2021-05-31T02:22:32.000Z"
+        }
+      ]
+    }
+  }
+}
+```
+
+
+---
+
+
+## GET
+    
+    
+      /api/v3/unfunded-mentors/ecf
+
+
+ _Note, this endpoint is new.Retrieve multiple unfunded mentors_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| filter | query | object | false | Refine unfunded mentors to return.<br/>This consumes a [ListFilter](#schema-listfilter) schema.<br/> | filter[updated\_since]=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of unfunded mentors.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| sort | query | array | false | Sort unfunded mentors being returned.<br/>This consumes a [ECFUnfundedMentorsSort](#schema-ecfunfundedmentorssort) schema.<br/> | sort=-updated\_at | 
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | A list of unfunded mentors<br/>This response returns a [MultipleUnfundedMentorsResponse](#schema-multipleunfundedmentorsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - A list of unfunded mentors
+This response returns a [MultipleUnfundedMentorsResponse](#schema-multipleunfundedmentorsresponse) schema.
+
+```
+{
+  "data": [
+    {
+      "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+      "type": "unfunded-mentor",
+      "attributes": {
+        "full_name": "Jane Smith",
+        "email": "jane.smith@some-school.example.com",
+        "teacher_reference_number": "1234567",
+        "created_at": "2021-05-31T02:22:32.000Z",
+        "updated_at": "2021-05-31T02:22:32.000Z"
+      }
+    }
+  ]
+}
+```
+
+401 - Unauthorized
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+
+```
+{
+  "error": "HTTP Token: Access denied"
+}
+```
+
+
+---
+
+
+## GET
+    
+    
+      /api/v3/unfunded-mentors/ecf/{id}
+
+
+ _Note, this endpoint is new.Get a single unfunded mentor_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| id | path | string | true | The ID of the unfunded mentor.<br/> | 28c461ee-ffc0-4e56-96bd-788579a0ed75 | 
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | A single unfunded mentor<br/>This response returns a [UnfundedMentorResponse](#schema-unfundedmentorresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 404 | Not Found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - A single unfunded mentor
+This response returns a [UnfundedMentorResponse](#schema-unfundedmentorresponse) schema.
+
+```
+{
+  "data": {
+    "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+    "type": "unfunded-mentor",
+    "attributes": {
+      "full_name": "Jane Smith",
+      "email": "jane.smith@some-school.example.com",
+      "teacher_reference_number": "1234567",
+      "created_at": "2021-05-31T02:22:32.000Z",
+      "updated_at": "2021-05-31T02:22:32.000Z"
+    }
+  }
+}
+```
+
+401 - Unauthorized
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+
+```
+{
+  "error": "HTTP Token: Access denied"
+}
+```
+
+404 - Not Found
+This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
+
+```
+{
+  "title": "string",
+  "detail": "string"
+}
+```
+
+
+---
+
+
+## GET
+    
+    
+      /api/v3/statements
+
+
+ _Note, this endpoint is new.Retrieve financial statements_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| filter | query | object | false | Refine statements to return.<br/>This consumes a [StatementsFilter](#schema-statementsfilter) schema.<br/> | filter[cohort]=2021,2022&filter[type]=ecf&filter[updated\_since]=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of statements.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | A list of statements as part of which the DfE will make output payments for ecf participants<br/>This response returns a [StatementsResponse](#schema-statementsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - A list of statements as part of which the DfE will make output payments for ecf participants
+This response returns a [StatementsResponse](#schema-statementsresponse) schema.
+
+```
+{
+  "data": [
+    {
+      "id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+      "type": "statement",
+      "attributes": {
+        "month": "May",
+        "year": "2022",
+        "type": "ecf",
+        "cohort": "2021",
+        "cut_off_date": "2022-04-30",
+        "payment_date": "2022-05-25",
+        "paid": true,
+        "created_at": "2021-05-31T02:22:32.000Z",
+        "updated_at": "2021-05-31T02:22:32.000Z"
+      }
+    }
+  ]
+}
+```
+
+401 - Unauthorized
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+
+```
+{
+  "error": "HTTP Token: Access denied"
+}
+```
+
+
+---
+
+
+## GET
+    
+    
+      /api/v3/statements/{id}
+
+
+ _Note, this endpoint is new.Retrieve specific financial statement_ 
+
+### Parameters
+
+
+| Parameter | In | Type | Required | Description | Example |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| id | path | string | true | The unique ID of the statement<br/> | fe82db5d-a7ff-42b4-9eb7-19a87bf0ce5f | 
+
+
+### Responses
+
+
+| Status | Description |
+| ---- | ---- |
+| 200 | A specific financial statement<br/>This response returns a [StatementResponse](#schema-statementresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 404 | Not Found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
+
+
+### Response examples
+
+200 - A specific financial statement
+This response returns a [StatementResponse](#schema-statementresponse) schema.
+
+```
+{
+  "data": {
+    "id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+    "type": "statement",
+    "attributes": {
+      "month": "May",
+      "year": "2022",
+      "type": "ecf",
+      "cohort": "2021",
+      "cut_off_date": "2022-04-30",
+      "payment_date": "2022-05-25",
+      "paid": true,
+      "created_at": "2021-05-31T02:22:32.000Z",
+      "updated_at": "2021-05-31T02:22:32.000Z"
+    }
+  }
+}
+```
+
+401 - Unauthorized
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+
+```
+{
+  "error": "HTTP Token: Access denied"
+}
+```
+
+404 - Not Found
+This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
+
+```
+{
+  "title": "string",
+  "detail": "string"
+}
+```
+
+
+---
+
+
+## Schemas
+
+
+### BadOrMissingParametersResponse
+
+
+Request was missing data or contained invalid data
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| bad\_or\_missing\_parameters | array | true | An error message for each bad or missing attribute describing the problems<br/> | 
+
+
+### BadRequestResponse
+
+
+Bad Request
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| bad\_request | string | false | An error message for bad request<br/> | 
+
+
+#### Example
+
+
+```
+{
+  "errors": [
+    {
+      "title": "Bad request",
+      "detail": "correct json data structure required. See API docs for reference"
+    }
+  ]
+}
+```
+
+
+### DeliveryPartner
+
+
+A delivery partner
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| id | string | true | The unique identifier of the delivery partner<br/> | 
+| type | string | true | The data type<br/> | 
+| attributes | object | true | The data attributes associated with a delivery partner<br/>It conforms to [DeliveryPartnerAttributes](#schema-deliverypartnerattributes) schema. | 
+
+
+### DeliveryPartnerAttributes
+
+
+The data attributes associated with a delivery partner
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| name | string | true | The name of the delivery partner you are working with<br/> | 
+| cohort | array | false | The cohorts for which you may report school partnerships with this delivery partner<br/> | 
+| created\_at | string | true | The date and time the delivery partner was created<br/> | 
+| updated\_at | string | true | The date and time the delivery partner was last updated<br/> | 
+
+
+### DeliveryPartnerCohortError
+
+
+Not a delivery partner you have a relationship with for this cohort
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| title | string | false | Title of error message<br/>Possible values:<br/><br/> - Not a delivery partner you have a relationship with for this cohort<br/><br/> | 
+| detail | string | false | Additional info on which cohorts are available<br/> | 
+
+
+### DeliveryPartnerResponse
+
+
+A delivery partner
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | object | true | A delivery partner<br/>It conforms to [DeliveryPartner](#schema-deliverypartner) schema. | 
+
+
+### DeliveryPartnersFilter
+
+
+Filter delivery partners to return more specific results
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| cohort | string | false | Return delivery partners from the specified cohort or cohorts. This is a comma delimited string of years.<br/> | 
+
+
+### DeliveryPartnersResponse
+
+
+A list of delivery partners
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | array | true | It conforms to [DeliveryPartner](#schema-deliverypartner) schema. | 
+
+
+### DeliveryPartnersSort
+
+
+Sort delivery partners being returned
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| Item | string | false | It conforms to [DeliveryPartnersSort/items](#schema-deliverypartnerssort-items) schema.Possible values:<br/><br/> - created\_at<br/> - -created\_at<br/> - updated\_at<br/> - -updated\_at<br/><br/> | 
+
+
+### ECFDeferral
+
+
+The details of an ECF Participant deferral
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| reason | string | true | The reason a participant was deferred<br/>Possible values:<br/><br/> - bereavement<br/> - long-term-sickness<br/> - parental-leave<br/> - career-break<br/> - other<br/><br/> | 
+| date | string | true | The date and time the participant was deferred<br/> | 
+
+
+#### Example
+
+
+```
+{
+  "reason": "career-break",
+  "date": "2021-05-31T02:22:32.000Z"
+}
+```
+
+
+### ECFEnrolment
+
+
+The details of an ECF Participant enrolment
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| training\_record\_id | string | true | The unique identifier of the participant training record. Should the DfE dedupe a participant, this value will not change.<br/> | 
+| email | string | true | The email address registered for this ECF participant<br/> | 
+| mentor\_id | string | false | The unique identifier of this ECF participants mentor<br/> | 
+| school\_urn | string | true | The Unique Reference Number (URN) of the school that submitted this ECF participant<br/> | 
+| participant\_type | string | true | The type of ECF participant this record refers to<br/>Possible values:<br/><br/> - ect<br/> - mentor<br/><br/> | 
+| cohort | string | true | Indicates which call-off contract funds this participant’s training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year.<br/> | 
+| training\_status | string | true | The training status of the ECF participant<br/>Possible values:<br/><br/> - active<br/> - deferred<br/> - withdrawn<br/><br/> | 
+| participant\_status | string | true | Replaces the old status field. Indicates if a SIT has advised DfE of a transfer or a withdrawal of the participant from the school<br/>Possible values:<br/><br/> - active<br/> - joining<br/> - leaving<br/> - left<br/> - withdrawn<br/><br/> | 
+| teacher\_reference\_number\_validated | boolean | true | Indicates whether the Teacher Reference Number (TRN) has been validated<br/> | 
+| eligible\_for\_funding | boolean | true | Indicates whether this participant is eligible to receive DfE funded induction<br/> | 
+| pupil\_premium\_uplift | boolean | true | Indicates whether this participant qualifies for an uplift payment due to pupil premium<br/> | 
+| sparsity\_uplift | boolean | true | Indicates whether this participant qualifies for an uplift payment due to sparsity<br/> | 
+| schedule\_identifier | string | true | The schedule of the ECF participant. For the possible values please refer to the [ECF schedules and milestone dates guidance](/api-reference/ecf/schedules-and-milestone-dates.html#schedules-and-milestone-dates) .<br/>Possible values:<br/><br/> - ecf-standard-september<br/> - ecf-standard-january<br/> - ecf-standard-april<br/> - ecf-reduced-september<br/> - ecf-reduced-january<br/> - ecf-reduced-april<br/> - ecf-extended-september<br/> - ecf-extended-january<br/> - ecf-extended-april<br/> - ecf-replacement-september<br/> - ecf-replacement-january<br/> - ecf-replacement-april<br/><br/> | 
+| delivery\_partner\_id | string | true | Unique ID of the delivery partner associated with the participant<br/> | 
+| withdrawal |  | false | This conforms to any of the following schemas:<br/><br/> -  [ECFWithdrawal](#schema-ecfwithdrawal) <br/><br/> | 
+| deferral |  | false | This conforms to any of the following schemas:<br/><br/> -  [ECFDeferral](#schema-ecfdeferral) <br/><br/> | 
+| created\_at | string | true | The date and time the ECF participant was created<br/> | 
+| induction\_end\_date | string | false | The ECF participant induction end date<br/> | 
+| mentor\_funding\_end\_date | string | false | The ECF participant mentor training completion date<br/> | 
+| cohort\_changed\_after\_payments\_frozen | boolean | false | Identify participants that migrated to a new cohort as payments were frozen on their original cohort<br/> | 
+| mentor\_ineligible\_for\_funding\_reason | string | false | The reason why funding for a mentor’s training has ended<br/>Possible values:<br/><br/> - completed\_declaration\_received<br/> - completed\_during\_early\_roll\_out<br/> - started\_not\_completed<br/><br/> | 
+
+
+### ECFParticipant
+
+
+ ==== A [B] NODE  (1 children) ====
+ ==== A [BR] NODE  (0 children) ====
+The details of a participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| id | string | true | The unique identifier of the participant record<br/> | 
+| type | string | true | The data type<br/> | 
+| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantAttributes](#schema-ecfparticipantattributes) schema. | 
+
+
+### ECFParticipantAttributes
+
+
+The data attributes associated with an ECF participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| full\_name | string | true | The full name of this ECF participant<br/> | 
+| teacher\_reference\_number | string | false | The Teacher Reference Number (TRN) for this participant<br/> | 
+| updated\_at | string | true | The date and time the ECF participant was last updated<br/> | 
+| ecf\_enrolments | array | true | Information about the course(s) the participant is enroled in<br/>It conforms to [ECFEnrolment](#schema-ecfenrolment) schema. | 
+| participant\_id\_changes | array | true | Information about the Participant ID changes<br/>It conforms to [ParticipantIdChange](#schema-participantidchange) schema. | 
+
+
+### ECFParticipantChangeSchedule
+
+
+An ECF participant change schedule action
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| type | string | true | The data type<br/>Possible values:<br/><br/> - participant-change-schedule<br/><br/> | 
+| attributes | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeScheduleAttributes](#schema-ecfparticipantchangescheduleattributes) schema. | 
+
+
+#### Example
+
+
+```
+{
+  "type": "participant-change-schedule",
+  "attributes": {
+    "schedule_identifier": "ecf-standard-january",
+    "course_identifier": "ecf-mentor"
+  }
+}
+```
+
+
+### ECFParticipantChangeScheduleAttributes
+
+
+An ECF participant change schedule action
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| schedule\_identifier | string | true | The new schedule of the participant<br/>Possible values:<br/><br/> - ecf-standard-september<br/> - ecf-standard-january<br/> - ecf-standard-april<br/> - ecf-reduced-september<br/> - ecf-reduced-january<br/> - ecf-reduced-april<br/> - ecf-extended-september<br/> - ecf-extended-january<br/> - ecf-extended-april<br/> - ecf-replacement-september<br/> - ecf-replacement-january<br/> - ecf-replacement-april<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| cohort | string | false | Providers may not change the current value for ECF participants. Indicates which call-off contract funds this participant’s training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year.<br/> | 
+
+
+#### Example
+
+
+```
+{
+  "schedule_identifier": "ecf-standard-january",
+  "course_identifier": "ecf-mentor",
+  "cohort": "2021"
+}
+```
+
+
+### ECFParticipantChangeScheduleRequest
+
+
+The change schedule request for a participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeSchedule](#schema-ecfparticipantchangeschedule) schema. | 
+
+
+#### Example
+
+
+```
+{
+  "data": {
+    "type": "participant-change-schedule",
+    "attributes": {
+      "schedule_identifier": "ecf-standard-january",
+      "course_identifier": "ecf-mentor",
+      "cohort": "2021"
+    }
+  }
+}
+```
+
+
+### ECFParticipantDeclarationPost2024ECTCompletedAttributesRequest
+
+
+An ECF completed participant declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique ID of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - completed<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/><br/> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - 75-percent-engagement-met<br/> - 75-percent-engagement-met-reduced-induction<br/> - one-term-induction<br/><br/> | 
+
+
+### ECFParticipantDeclarationPost2024ECTExtendedAttributesRequest
+
+
+An ECF extended participant declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique ID of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - extended-1<br/> - extended-2<br/> - extended-3<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/><br/> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - materials-engaged-with-offline<br/> - other<br/><br/> | 
+
+
+### ECFParticipantDeclarationPost2024ECTRetainedAttributesRequest
+
+
+An ECF participant retained declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique ID of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - retained-1<br/> - retained-2<br/> - retained-3<br/> - retained-4<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/><br/> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period. For retained-2 declarations, providers will need to confirm if the engagement threshold has been reached and only accept either the ‘75-percent-engagement-met’ or ‘75-percent-engagement-met-reduced-induction’ values.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - materials-engaged-with-offline<br/> - other<br/> - 75-percent-engagement-met<br/> - 75-percent-engagement-met-reduced-induction<br/><br/> | 
+
+
+### ECFParticipantDeclarationPost2024ECTStartedAttributesRequest
+
+
+An ECF started participant declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique ID of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - started<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/><br/> | 
+| evidence\_held | string | false | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - materials-engaged-with-offline<br/> - other<br/><br/> | 
+
+
+### ECFParticipantDeclarationPost2024MentorCompletedAttributesRequest
+
+
+An ECF completed participant declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique ID of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - completed<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-mentor<br/><br/> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - 75-percent-engagement-met<br/> - 75-percent-engagement-met-reduced-induction<br/><br/> | 
+
+
+### ECFParticipantDeclarationPost2024MentorStartedAttributesRequest
+
+
+An ECF started participant declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique ID of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - started<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-mentor<br/><br/> | 
+| evidence\_held | string | false | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - materials-engaged-with-offline<br/> - other<br/><br/> | 
+
+
+### ECFParticipantDeclarationPre2025CompletedAttributesRequest
+
+
+An ECF completed participant declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique ID of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - completed<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - other<br/><br/> | 
+
+
+### ECFParticipantDeclarationPre2025ExtendedAttributesRequest
+
+
+An ECF extended participant declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique ID of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - extended-1<br/> - extended-2<br/> - extended-3<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - other<br/><br/> | 
+
+
+### ECFParticipantDeclarationPre2025RetainedAttributesRequest
+
+
+An ECF participant retained declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique ID of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - retained-1<br/> - retained-2<br/> - retained-3<br/> - retained-4<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - other<br/><br/> | 
+
+
+### ECFParticipantDeclarationPre2025StartedAttributesRequest
+
+
+An ECF started participant declaration
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique ID of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - started<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+
+
+### ECFParticipantDefer
+
+
+The details of a participant deferral request
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| type | string | true | The data type<br/>Possible values:<br/><br/> - participant-defer<br/><br/> | 
+| attributes | object | true | An ECF participant deferral action<br/>It conforms to [ECFParticipantDeferAttributes](#schema-ecfparticipantdeferattributes) schema. | 
+
+
+### ECFParticipantDeferAttributes
+
+
+An ECF participant deferral action
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| reason | string | true | The reason for the deferral<br/>Possible values:<br/><br/> - bereavement<br/> - long-term-sickness<br/> - parental-leave<br/> - career-break<br/> - other<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+
+
+#### Example
+
+
+```
+{
+  "reason": "career-break",
+  "course_identifier": "ecf-mentor"
+}
+```
+
+
+### ECFParticipantDeferRequest
+
+
+The deferral request for a participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | object | true | The details of a participant deferral request<br/>It conforms to [ECFParticipantDefer](#schema-ecfparticipantdefer) schema. | 
+
+
+#### Example
+
+
+```
+{
+  "data": {
+    "type": "participant-defer",
+    "attributes": {
+      "reason": "career-break",
+      "course_identifier": "ecf-mentor"
+    }
+  }
+}
+```
+
+
+### ECFParticipantFilter
+
+
+Filter a list of records to return more specific results
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| updated\_since | string | false | Return only records that have been updated since this date and time (ISO 8601 date format)<br/> | 
+| cohort | string | false | Return only records for the given cohort<br/> | 
+| training\_status | string | false | Return only records that have this training status<br/> | 
+| from\_participant\_id | string | false | Return only records that have this from Participant ID<br/> | 
+
+
+### ECFParticipantJoining
+
+
+The details of an ECF Participant joining a school
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| school\_urn | string | true | The URN of the school the participant is joining<br/> | 
+| provider | string | true | The name of the provider the participant is joining<br/> | 
+| date | string | true | The date the participant will be joining the school<br/> | 
+
+
+#### Example
+
+
+```
+{
+  "school_urn": 123456,
+  "provider": "Example Institute",
+  "date": "2021-05-31"
+}
+```
+
+
+### ECFParticipantLeaving
+
+
+The details of an ECF Participant leaving a school
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| school\_urn | string | true | The URN of the school the participant is leaving<br/> | 
+| provider | string | true | The name of the provider the participant is leaving<br/> | 
+| date | string | false | The date the participant will be leaving the school<br/> | 
+
+
+#### Example
+
+
+```
+{
+  "school_urn": 123456,
+  "provider": "Example Institute",
+  "date": "2021-05-31"
+}
+```
+
+
+### ECFParticipantResponse
+
+
+An ECF Participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | object | true |  ==== A [B] NODE  (1 children) ==== ==== A [BR] NODE  (0 children) ====The details of a participant<br/>It conforms to [ECFParticipant](#schema-ecfparticipant) schema. | 
+
+
+### ECFParticipantResume
+
+
+An ECF participant resume action
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| type | string | true | The data type<br/>Possible values:<br/><br/> - participant-resume<br/><br/> | 
+| attributes | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResumeAttributes](#schema-ecfparticipantresumeattributes) schema. | 
+
+
+### ECFParticipantResumeAttributes
+
+
+An ECF participant resume action
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+
+
+#### Example
+
+
+```
+{
+  "course_identifier": "ecf-mentor"
+}
+```
+
+
+### ECFParticipantResumeRequest
+
+
+The resume request for a participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResume](#schema-ecfparticipantresume) schema. | 
+
+
+#### Example
+
+
+```
+{
+  "data": {
+    "type": "participant-resume",
+    "attributes": {
+      "course_identifier": "ecf-mentor"
+    }
+  }
+}
+```
+
+
+### ECFParticipantTransfer
+
+
+ ==== A [B] NODE  (1 children) ====
+ ==== A [BR] NODE  (0 children) ====
+The details of an ECF participant transfer
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| id | string | true | The unique identifier of the participant record<br/> | 
+| type | string | true | The data type<br/> | 
+| attributes | object | true | The data attributes associated with an ECF participant transfer<br/>It conforms to [ECFParticipantTransferAttributes](#schema-ecfparticipanttransferattributes) schema. | 
+
+
+### ECFParticipantTransferAttributes
+
+
+The data attributes associated with an ECF participant transfer
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| updated\_at | string | true | The date and time the latest ECF participant was last updated<br/> | 
+| transfers | array | true | List of participant transfers<br/>It conforms to [ECFParticipantTransfers](#schema-ecfparticipanttransfers) schema. | 
+
+
+### ECFParticipantTransferResponse
+
+
+An ECF participant transfer
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | object | true |  ==== A [B] NODE  (1 children) ==== ==== A [BR] NODE  (0 children) ====The details of an ECF participant transfer<br/>It conforms to [ECFParticipantTransfer](#schema-ecfparticipanttransfer) schema. | 
+
+
+### ECFParticipantTransfers
+
+
+The details of an ECF Participant enrolment
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| training\_record\_id | string | true | The unique identifier of the participant training record<br/> | 
+| transfer\_type | string | true | The type of transfer between schools<br/>Possible values:<br/><br/> - new\_school<br/> - new\_provider<br/> - unknown<br/><br/> | 
+| status | string | true | The status of the transfer, if both leaving and joining SIT have completed their journeys or only one has<br/>Possible values:<br/><br/> - incomplete<br/> - complete<br/><br/> | 
+| leaving |  | false | This conforms to any of the following schemas:<br/><br/> -  [ECFParticipantLeaving](#schema-ecfparticipantleaving) <br/><br/> | 
+| joining |  | false | This conforms to any of the following schemas:<br/><br/> -  [ECFParticipantJoining](#schema-ecfparticipantjoining) <br/><br/> | 
+| created\_at | string | true | The date and time the ECF participant transfer was created<br/> | 
+
+
+### ECFParticipantWithdraw
+
+
+An ECF participant withdrawal action
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| type | string | false | The data type<br/>Possible values:<br/><br/> - participant-withdraw<br/><br/> | 
+| attributes | object | false | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdrawAttributes](#schema-ecfparticipantwithdrawattributes) schema. | 
+
+
+### ECFParticipantWithdrawAttributes
+
+
+An ECF participant withdrawal action
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| reason | string | true | The reason for the withdrawal<br/>Possible values:<br/><br/> - left-teaching-profession<br/> - moved-school<br/> - mentor-no-longer-being-mentor<br/> - switched-to-school-led<br/> - other<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+
+
+#### Example
+
+
+```
+{
+  "reason": "left-teaching-profession",
+  "course_identifier": "ecf-mentor"
+}
+```
+
+
+### ECFParticipantWithdrawRequest
+
+
+The withdrawal request for a participant
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | object | true | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdraw](#schema-ecfparticipantwithdraw) schema. | 
+
+
+#### Example
+
+
+```
+{
+  "data": {
+    "type": "participant-withdraw",
+    "attributes": {
+      "reason": "left-teaching-profession",
+      "course_identifier": "ecf-mentor"
+    }
+  }
+}
+```
+
+
+### ECFParticipantsSort
+
+
+Sort ECF participants being returned
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| Item | string | false | It conforms to [ECFParticipantsSort/items](#schema-ecfparticipantssort-items) schema.Possible values:<br/><br/> - created\_at<br/> - -created\_at<br/> - updated\_at<br/> - -updated\_at<br/><br/> | 
+
+
+### ECFPartnership
+
+
+An ECF partnership
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| id | string | true | The unique identifier of the partnership<br/> | 
+| type | string | true | The data type<br/> | 
+| attributes | object | true | The data attributes associated with an ECF partnership<br/>It conforms to [ECFPartnershipAttributes](#schema-ecfpartnershipattributes) schema. | 
+
+
+### ECFPartnershipAttibutesRequest
+
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| cohort | string | true | The cohort for which you are reporting the partnership<br/> | 
+| delivery\_partner\_id | string | true | The unique ID of the delivery partner you will work with for this school partnership<br/> | 
+| school\_id | string | true | The Unique ID of the school you are partnering with<br/> | 
+
+
+### ECFPartnershipAttributes
+
+
+The data attributes associated with an ECF partnership
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| cohort | string | true | The cohort for which you are reporting the partnership<br/> | 
+| urn | string | true | The Unique Reference Number (URN) of the school you are partnered with<br/> | 
+| school\_id | string | true | The unique ID of the school you are partnered with<br/> | 
+| delivery\_partner\_id | string | true | The unique ID of the delivery partner you are working with for this partnership<br/> | 
+| delivery\_partner\_name | string | false | The name of the delivery partner you are working with for this partnership<br/> | 
+| status | string | true | The status of the partnership which includes active or challenged<br/>Possible values:<br/><br/> - active<br/> - challenged<br/><br/> | 
+| challenged\_reason | string | false | If the partnership has been challenged, the reason provided for the challenge by the SIT<br/>Possible values:<br/><br/> - another\_provider<br/> - not\_confirmed<br/> - do\_not\_recognise<br/> - no\_ects<br/> - mistake<br/><br/> | 
+| challenged\_at | string | false | The date the partnership has been challenged<br/> | 
+| induction\_tutor\_name | string | false | The name of the induction tutor at the school you are in partnership with<br/> | 
+| induction\_tutor\_email | string | false | The email address of the induction tutor at the school you are in partnership with<br/> | 
+| updated\_at | string | true | The date the partnership was last updated<br/> | 
+| created\_at | string | true | The date the partnership was reported by you<br/> | 
+
+
+### ECFPartnershipDataRequest
+
+
+An ECF partnership
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| type | string | false | Possible values:<br/><br/> - ecf-partnership<br/><br/> | 
+| attributes | object | false | It conforms to [ECFPartnershipAttibutesRequest](#schema-ecfpartnershipattibutesrequest) schema. | 
+
+
+### ECFPartnershipRequest
+
+
+An ECF partnership
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | object | true | An ECF partnership<br/>It conforms to [ECFPartnershipDataRequest](#schema-ecfpartnershipdatarequest) schema. | 
+
+
+#### Example
+
+
+```
+{
+  "data": {
+    "type": "ecf-partnership",
+    "attributes": {
+      "cohort": "2021",
+      "school_id": "24b61d1c-ad95-4000-aee0-afbdd542294a",
+      "delivery_partner_id": "db2fbf67-b7b7-454f-a1b7-0020411e2314"
+    }
+  }
+}
+```
+
+
+### ECFPartnershipRequestErrorResponse
+
+
+A list of errors
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| error | array | false | This conforms to any of the following schemas:<br/><br/> -  [UrnInvalidError](#schema-urninvaliderror) <br/> -  [PartnershipExistsError](#schema-partnershipexistserror) <br/> -  [SchoolFundingError](#schema-schoolfundingerror) <br/> -  [DeliveryPartnerCohortError](#schema-deliverypartnercohorterror) <br/> -  [OtherProviderRecruitedError](#schema-otherproviderrecruitederror) <br/><br/> | 
+
+
+### ECFPartnershipResponse
+
+
+An ECF partnership
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | object | true | An ECF partnership<br/>It conforms to [ECFPartnership](#schema-ecfpartnership) schema. | 
+
+
+### ECFPartnershipUpdateAttibutesRequest
+
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| delivery\_partner\_id | string | true | The unique ID of the delivery partner you will work with for this school partnership<br/> | 
+
+
+### ECFPartnershipUpdateDataRequest
+
+
+Update An ECF partnership
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| type | string | false | Possible values:<br/><br/> - ecf-partnership-update<br/><br/> | 
+| attributes | object | false | It conforms to [ECFPartnershipUpdateAttibutesRequest](#schema-ecfpartnershipupdateattibutesrequest) schema. | 
+
+
+### ECFPartnershipUpdateRequest
+
+
+Update an ECF partnership
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | object | true | Update An ECF partnership<br/>It conforms to [ECFPartnershipUpdateDataRequest](#schema-ecfpartnershipupdatedatarequest) schema. | 
+
+
+#### Example
+
+
+```
+{
+  "data": {
+    "type": "ecf-partnership-update",
+    "attributes": {
+      "delivery_partner_id": "db2fbf67-b7b7-454f-a1b7-0020411e2314"
+    }
+  }
+}
+```
+
+
+### ECFSchool
+
+
+An ECF school
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| id | string | true | The unique identifier of the school<br/> | 
+| type | string | true | The data type<br/> | 
+| attributes | object | true | The data attributes associated with an ECF school<br/>It conforms to [ECFSchoolAttributes](#schema-ecfschoolattributes) schema. | 
+
+
+### ECFSchoolAttributes
+
+
+The data attributes associated with an ECF school
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| name | string | true | The name of the school<br/> | 
+| urn | string | true | The Unique Reference Number (URN) of the school<br/> | 
+| cohort | string | true | Indicates which call-off contract funds this participant’s training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year.<br/> | 
+| in\_partnership | boolean | true | Whether or not the school already has an active partnership, if it is doing a funded induction programme<br/> | 
+| induction\_programme\_choice | string | true | The induction programme the school offers<br/>Possible values:<br/><br/> - school\_led<br/> - provider\_led<br/> - no\_early\_career\_teachers<br/> - not\_yet\_known<br/><br/> | 
+| created\_at | string | true | The date and time the school was created<br/> | 
+| updated\_at | string | true | The last time a change was made to this school record by the DfE<br/> | 
+
+
+### ECFSchoolResponse
+
+
+A single ECF school
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | object | true | An ECF school<br/>It conforms to [ECFSchool](#schema-ecfschool) schema. | 
+
+
+### ECFSchoolsFilter
+
+
+Filter schools to return more specific results
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| cohort | string | false | Return schools within the specified cohort.<br/> | 
+| urn | string | false | Return a school with the specified Unique Reference Number (URN).<br/> | 
+| updated\_since | string | false | Return only records that have been updated since this date and time (ISO 8601 date format)<br/> | 
+
+
+### ECFSchoolsSort
+
+
+Sort schools being returned
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| Item | string | false | It conforms to [ECFSchoolsSort/items](#schema-ecfschoolssort-items) schema.Possible values:<br/><br/> - updated\_at<br/> - -updated\_at<br/><br/> | 
+
+
+### ECFUnfundedMentorsSort
+
+
+Sort unfunded mentors being returned.
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| Item | string | false | It conforms to [ECFUnfundedMentorsSort/items](#schema-ecfunfundedmentorssort-items) schema.Possible values:<br/><br/> - updated\_at<br/> - -updated\_at<br/><br/> | 
+
+
+### ECFWithdrawal
+
+
+The details of an ECF Participant withdrawal
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| reason | string | true | The reason a participant was withdrawn<br/>Possible values:<br/><br/> - left-teaching-profession<br/> - moved-school<br/> - mentor-no-longer-being-mentor<br/> - switched-to-school-led<br/> - other<br/><br/> | 
+| date | string | true | The date and time the participant was withdrawn<br/> | 
+
+
+#### Example
+
+
+```
+{
+  "reason": "moved-school",
+  "date": "2021-05-31T02:22:32.000Z"
+}
+```
+
+
+### Error
+
+
+An single error element
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| title | string | false | A title of the error<br/> | 
+| detail | string | false | Additional details of the error<br/> | 
+
+
+### ErrorResponse
+
+
+A list of errors
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| error | array | false | It conforms to [Error](#schema-error) schema. | 
+
+
+### ListFilter
+
+
+Filter a list of records to return more specific results
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| updated\_since | string | false | Return only records that have been updated since this date and time (ISO 8601 date format)<br/> | 
+
+
+### ListFilterDeclarations
+
+
+Filter a list of declarations records to return more specific results
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| updated\_since | string | false | Return only records that have been updated since this date and time (ISO 8601 date format)<br/> | 
+| participant\_id | string | false | The unique id of the participant<br/> | 
+
+
+### MultipleECFParticipantTransferResponse
+
+
+A list of ECF participant transfers
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | array | true | It conforms to [ECFParticipantTransfer](#schema-ecfparticipanttransfer) schema. | 
+
+
+### MultipleECFParticipantsResponse
+
+
+A list of ECF participants
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | array | true | It conforms to [ECFParticipant](#schema-ecfparticipant) schema. | 
+
+
+### MultipleECFPartnershipsResponse
+
+
+A list of ECF partnerships
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | array | true | It conforms to [ECFPartnership](#schema-ecfpartnership) schema. | 
+
+
+### MultipleECFSchoolsResponse
+
+
+A list of schools for the given cohort
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | array | true | It conforms to [ECFSchool](#schema-ecfschool) schema. | 
+
+
+### MultipleParticipantDeclarationsResponse
+
+
+A list of participant declarations
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | array | true | It conforms to [ParticipantDeclarationResponse](#schema-participantdeclarationresponse) schema. | 
+
+
+### MultipleUnfundedMentorsResponse
+
+
+A list of unfunded mentors
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | array | true | It conforms to [UnfundedMentor](#schema-unfundedmentor) schema. | 
+
+
+### NotFoundResponse
+
+
+The requested resource was not found
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| title | string | false | The title of the error message<br/> | 
+| detail | string | false | Further information regarding the error<br/> | 
+
+
+#### Example
+
+
+```
+{
+  "errors": [
+    {
+      "title": "The requested resource was not found",
+      "detail": "Nothing could be found for the provided details"
+    }
+  ]
+}
+```
+
+
+### OtherProviderRecruitedError
+
+
+Recruited by other provider
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| title | string | false | Title of error message<br/>Possible values:<br/><br/> - Recruited by other provider<br/><br/> | 
+| detail | string | false | Additional info<br/> | 
+
+
+### Pagination
+
+
+This schema used to paginate through a collection.
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| page | integer | false | The page number to paginate to in the collection. If no value is specified it defaults to the first page.<br/> | 
+| per\_page | integer | false | The number items to display on a page. Defaults to 100. Maximum is 3000, if the value is greater that the maximum allowed it will fallback to 3000.<br/> | 
+
+
+### ParticipantDeclarationAttributes
+
+
+The data attributes associated with a participant declaration response
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| participant\_id | string | true | The unique id of the participant<br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - started<br/> - retained-1<br/> - retained-2<br/> - retained-3<br/> - retained-4<br/> - completed<br/> - extended-1<br/> - extended-2<br/> - extended-3<br/><br/> | 
+| declaration\_date | string | true | The event declaration date<br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| state | string | true | Indicates the state of this payment declaration<br/>Possible values:<br/><br/> - submitted<br/> - eligible<br/> - payable<br/> - paid<br/> - voided<br/> - ineligible<br/> - awaiting-clawback<br/> - clawed-back<br/><br/> | 
+| updated\_at | string | true | The date the declaration was last updated<br/> | 
+| created\_at | string | false | The date the declaration was created<br/> | 
+| delivery\_partner\_id | string | false | Unique ID of the delivery partner associated with the participant at the time the declaration was created<br/> | 
+| statement\_id | string | false | Unique ID of the statement the declaration will be paid as part of<br/> | 
+| clawback\_statement\_id | string | false | Unique id of the statement to which the declaration will be clawed back on, if any<br/> | 
+| ineligible\_for\_funding\_reason | string | false | If the declaration is ineligible, the reason why<br/>Possible values:<br/><br/> - duplicate\_declaration<br/><br/> | 
+| mentor\_id | string | false | Unique ID of the ECT’s mentor<br/> | 
+| uplift\_paid | boolean | false | If participant is eligible for uplift, whether it has been paid as part of this declaration<br/> | 
+| evidence\_held | string | false | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period. For retained-2 declarations, providers will need to confirm if the engagement threshold has been reached and only accept either the ‘75-percent-engagement-met’ or ‘75-percent-engagement-met-reduced-induction’ values.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - other<br/> - materials-engaged-with-offline<br/> - 75-percent-engagement-met<br/> - 75-percent-engagement-met-reduced-induction<br/> - one-term-induction<br/><br/> | 
+| has\_passed | boolean | false | Whether the participant has failed or passed<br/> | 
+| lead\_provider\_name | string | true | The name of the provider that submitted the declaration<br/> | 
+
+
+### ParticipantDeclarationPost2024ECTDataRequest
+
+
+A participant declaration data request for ECT participants from cohort 2025 onwards
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| type | string | false | Possible values:<br/><br/> - participant-declaration<br/><br/> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><br/> -  [ECFParticipantDeclarationPost2024ECTStartedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectstartedattributesrequest) <br/> -  [ECFParticipantDeclarationPost2024ECTRetainedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectretainedattributesrequest) <br/> -  [ECFParticipantDeclarationPost2024ECTCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectcompletedattributesrequest) <br/> -  [ECFParticipantDeclarationPost2024ECTExtendedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectextendedattributesrequest) <br/><br/> | 
+
+
+### ParticipantDeclarationPost2024MentorDataRequest
+
+
+A participant declaration data request for mentor participants from cohort 2025 onwards
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| type | string | false | Possible values:<br/><br/> - participant-declaration<br/><br/> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><br/> -  [ECFParticipantDeclarationPost2024MentorStartedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorstartedattributesrequest) <br/> -  [ECFParticipantDeclarationPost2024MentorCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorcompletedattributesrequest) <br/><br/> | 
+
+
+### ParticipantDeclarationPre2025DataRequest
+
+
+A participant declaration data request for participants in cohort 2024 and previous years
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| type | string | false | Possible values:<br/><br/> - participant-declaration<br/><br/> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><br/> -  [ECFParticipantDeclarationPre2025StartedAttributesRequest](#schema-ecfparticipantdeclarationpre2025startedattributesrequest) <br/> -  [ECFParticipantDeclarationPre2025RetainedAttributesRequest](#schema-ecfparticipantdeclarationpre2025retainedattributesrequest) <br/> -  [ECFParticipantDeclarationPre2025CompletedAttributesRequest](#schema-ecfparticipantdeclarationpre2025completedattributesrequest) <br/> -  [ECFParticipantDeclarationPre2025ExtendedAttributesRequest](#schema-ecfparticipantdeclarationpre2025extendedattributesrequest) <br/><br/> | 
+
+
+### ParticipantDeclarationRequest
+
+
+An participant declaration request
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | object | true | This conforms to any of the following schemas:<br/><br/> -  [ParticipantDeclarationPre2025DataRequest](#schema-participantdeclarationpre2025datarequest) <br/> -  [ParticipantDeclarationPost2024ECTDataRequest](#schema-participantdeclarationpost2024ectdatarequest) <br/> -  [ParticipantDeclarationPost2024MentorDataRequest](#schema-participantdeclarationpost2024mentordatarequest) <br/><br/> | 
+
+
+### ParticipantDeclarationResponse
+
+
+A participant declaration response
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| id | string | true | The unique identifier of the participant declaration record<br/> | 
+| type | string | true | The data type<br/> | 
+| attributes | object | true | The data attributes associated with a participant declaration response<br/>It conforms to [ParticipantDeclarationAttributes](#schema-participantdeclarationattributes) schema. | 
+
+
+### ParticipantDeclarationsFilter
+
+
+Filter participant declarations to return more specific results
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| cohort | string | false | Return participant declarations associated to the specified cohort or cohorts. This is a comma delimited string of years.<br/> | 
+| participant\_id | string | false | Return participant declarations associated to the specified participant ID. This is a comma delimited string where multiple participant IDs can be specified<br/> | 
+| updated\_since | string | false | Return only records that have been updated since this date and time (ISO 8601 date format)<br/> | 
+| delivery\_partner\_id | string | false | Return participant declarations associated to the specified delivery partner or delivery partners. This is a comma delimited string of delivery partner IDs.<br/> | 
+
+
+### ParticipantIdChange
+
+
+The details of an Participant ID change
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| from\_participant\_id | string | true | The unique identifier of the changed from participant training record.<br/> | 
+| to\_participant\_id | string | true | The unique identifier of the changed to participant training record.<br/> | 
+| changed\_at | string | true | The date and time the Participant ID change<br/> | 
+
+
+#### Example
+
+
+```
+{
+  "from_participant_id": "23dd8d66-e11f-4139-9001-86b4f9abcb02",
+  "to_participant_id": "ac3d1243-7308-4879-942a-c4a70ced400a",
+  "changed_at": "2021-05-31T02:22:32.000Z"
+}
+```
+
+
+### PartnershipExistsError
+
+
+Partnership already exists
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| title | string | false | Title of error message<br/>Possible values:<br/><br/> - Partnership already exists<br/><br/> | 
+| detail | string | false | Additional info about existing partnership<br/> | 
+
+
+### PartnershipsFilter
+
+
+Filter partnerships to return more specific results
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| cohort | string | false | Return partnerships within the specified cohorts. This is a comma delimited string of years.<br/> | 
+| updated\_since | string | false | Return only partnerships that have been updated since this date and time (ISO 8601 date format)<br/> | 
+| delivery\_partner\_id | string | false | Return partnerships associated to the specified delivery partner or delivery partners. This is a comma delimited string of delivery partner IDs.<br/> | 
+
+
+### PartnershipsSort
+
+
+Sort partnerships being returned
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| Item | string | false | It conforms to [PartnershipsSort/items](#schema-partnershipssort-items) schema.Possible values:<br/><br/> - created\_at<br/> - -created\_at<br/> - updated\_at<br/> - -updated\_at<br/><br/> | 
+
+
+### SchoolFundingError
+
+
+The school you have entered has not registered to deliver DfE-funded training. Contact the school for more information.
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| title | string | false | Title of error message<br/>Possible values:<br/><br/> - The school you have entered has not registered to deliver DfE-funded training. Contact the school for more information.<br/><br/> | 
+| detail | string | false | Additional info why school is not for DfE-funded training if any<br/> | 
+
+
+### SingleParticipantDeclarationResponse
+
+
+A confirmation that the participant declaration has been recorded successfully
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | object | true | A participant declaration response<br/>It conforms to [ParticipantDeclarationResponse](#schema-participantdeclarationresponse) schema. | 
+
+
+### Statement
+
+
+A financial statement
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| id | string | true | The unique identifier of the financial statement<br/> | 
+| type | string | true | The data type<br/> | 
+| attributes | object | true | The data attributes associated with a financial statement<br/>It conforms to [StatementAttributes](#schema-statementattributes) schema. | 
+
+
+### StatementAttributes
+
+
+The data attributes associated with a financial statement
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| month | string | false | The month which appears on the statement in the DfE portal<br/> | 
+| year | string | false | The calendar year which appears on the statement in the dfe portal<br/> | 
+| type | string | false | Type of statement<br/>Possible values:<br/><br/> - ecf<br/><br/> | 
+| cohort | string | false | The cohort - 2021 or 2022 - which the statement funds<br/> | 
+| cut\_off\_date | string | false | The milestone cut off or review point for the statement<br/> | 
+| payment\_date | string | false | The date we expect to pay you for any declarations attached to the statement, which are eligible for payment<br/> | 
+| paid | boolean | false | Indicates whether the DfE has paid providers for any declarations attached to the statement<br/> | 
+| created\_at | string | false | The date the statement was created<br/> | 
+| updated\_at | string | false | The date the statement was last updated<br/> | 
+
+
+### StatementResponse
+
+
+A single financial statement
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | object | true | A financial statement<br/>It conforms to [Statement](#schema-statement) schema. | 
+
+
+### StatementsFilter
+
+
+Filter statements to return more specific results
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| cohort | string | false | Return statements associated to the specified cohort or cohorts. This is a comma delimited string of years.<br/> | 
+| type | string | false | Return statements of a given type<br/>Possible values:<br/><br/> - ecf<br/><br/> | 
+| updated\_since | string | false | Return only records that have been updated since this date and time (ISO 8601 date format)<br/> | 
+
+
+### StatementsResponse
+
+
+A list of financial statements
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | array | true | It conforms to [Statement](#schema-statement) schema. | 
+
+
+### UnauthorisedResponse
+
+
+Authorization information is missing or invalid
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| error | string | false |  | 
+
+
+### UnfundedMentor
+
+
+ ==== A [B] NODE  (1 children) ====
+ ==== A [BR] NODE  (0 children) ====
+The details of an unfunded mentor
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| id | string | true | The unique identifier of the mentor record<br/> | 
+| type | string | true | The data type<br/> | 
+| attributes | object | true | The data attributes associated with an unfunded mentor<br/>It conforms to [UnfundedMentorAttributes](#schema-unfundedmentorattributes) schema. | 
+
+
+### UnfundedMentorAttributes
+
+
+The data attributes associated with an unfunded mentor
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| full\_name | string | true | The full name of this mentor<br/> | 
+| email | string | true | The email address registered for this unfunded mentor<br/> | 
+| teacher\_reference\_number | string | false | The Teacher Reference Number (TRN) for this participant<br/> | 
+| created\_at | string | true | The date and time the unfunded mentor was created<br/> | 
+| updated\_at | string | true | The date and time the unfunded mentor was last updated<br/> | 
+
+
+### UnfundedMentorResponse
+
+
+An unfunded mentor
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | object | true |  ==== A [B] NODE  (1 children) ==== ==== A [BR] NODE  (0 children) ====The details of an unfunded mentor<br/>It conforms to [UnfundedMentor](#schema-unfundedmentor) schema. | 
+
+
+### UrnInvalidError
+
+
+URN entered is not valid
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| title | string | false | Title of error message<br/>Possible values:<br/><br/> - URN is not valid<br/><br/> | 
+| detail | string | false | Additional info why URN is not valid<br/> | 
+

--- a/documentation/ecf1_guidance/reference-v3.md
+++ b/documentation/ecf1_guidance/reference-v3.md
@@ -29,9 +29,9 @@ The lead provider API for DfE’s manage teacher CPD service.
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine delivery partners to return.<br/>This consumes a [DeliveryPartnersFilter](#schema-deliverypartnersfilter) schema.<br/> | filter[cohort]=2021 | 
-| page | query | object | false | Pagination options to navigate through the list of delivery partners.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
-| sort | query | array | false | Sort delivery partners being returned.<br/>This consumes a [DeliveryPartnersSort](#schema-deliverypartnerssort) schema.<br/> | sort=-updated\_at | 
+| filter | query | object | false | Refine delivery partners to return.<br/>This consumes a [DeliveryPartnersFilter](deliverypartnersfilter) schema.<br/> | filter[cohort]=2021 | 
+| page | query | object | false | Pagination options to navigate through the list of delivery partners.<br/>This consumes a [Pagination](pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| sort | query | array | false | Sort delivery partners being returned.<br/>This consumes a [DeliveryPartnersSort](deliverypartnerssort) schema.<br/> | sort=-updated\_at | 
 
 
 ### Responses
@@ -39,14 +39,14 @@ The lead provider API for DfE’s manage teacher CPD service.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | Successfully return a list of delivery partners<br/>This response returns a [DeliveryPartnersResponse](#schema-deliverypartnersresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | Successfully return a list of delivery partners<br/>This response returns a [DeliveryPartnersResponse](deliverypartnersresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - Successfully return a list of delivery partners
-This response returns a [DeliveryPartnersResponse](#schema-deliverypartnersresponse) schema.
+This response returns a [DeliveryPartnersResponse](deliverypartnersresponse) schema.
 
 ```
 {
@@ -69,7 +69,7 @@ This response returns a [DeliveryPartnersResponse](#schema-deliverypartnersrespo
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 ```
 {
@@ -102,15 +102,15 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 
 | Status | Description |
 | ---- | ---- |
-| 200 | Successfully return a specific delivery partner<br/>This response returns a [DeliveryPartnerResponse](#schema-deliverypartnerresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
-| 404 | Not Found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
+| 200 | Successfully return a specific delivery partner<br/>This response returns a [DeliveryPartnerResponse](deliverypartnerresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
+| 404 | Not Found<br/>This response returns a [NotFoundResponse](notfoundresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - Successfully return a specific delivery partner
-This response returns a [DeliveryPartnerResponse](#schema-deliverypartnerresponse) schema.
+This response returns a [DeliveryPartnerResponse](deliverypartnerresponse) schema.
 
 ```
 {
@@ -131,7 +131,7 @@ This response returns a [DeliveryPartnerResponse](#schema-deliverypartnerrespons
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 ```
 {
@@ -140,7 +140,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ```
 
 404 - Not Found
-This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
+This response returns a [NotFoundResponse](notfoundresponse) schema.
 
 ```
 {
@@ -166,9 +166,9 @@ This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine partnerships to return.<br/>This consumes a [PartnershipsFilter](#schema-partnershipsfilter) schema.<br/> | filter[cohort]=2021,2022 | 
-| page | query | object | false | Pagination options to navigate through the list of partnerships.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
-| sort | query | array | false | Sort partnerships being returned.<br/>This consumes a [PartnershipsSort](#schema-partnershipssort) schema.<br/> | sort=-updated\_at | 
+| filter | query | object | false | Refine partnerships to return.<br/>This consumes a [PartnershipsFilter](partnershipsfilter) schema.<br/> | filter[cohort]=2021,2022 | 
+| page | query | object | false | Pagination options to navigate through the list of partnerships.<br/>This consumes a [Pagination](pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| sort | query | array | false | Sort partnerships being returned.<br/>This consumes a [PartnershipsSort](partnershipssort) schema.<br/> | sort=-updated\_at | 
 
 
 ### Responses
@@ -176,14 +176,14 @@ This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A list of ECF partnerships<br/>This response returns a [MultipleECFPartnershipsResponse](#schema-multipleecfpartnershipsresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A list of ECF partnerships<br/>This response returns a [MultipleECFPartnershipsResponse](multipleecfpartnershipsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A list of ECF partnerships
-This response returns a [MultipleECFPartnershipsResponse](#schema-multipleecfpartnershipsresponse) schema.
+This response returns a [MultipleECFPartnershipsResponse](multipleecfpartnershipsresponse) schema.
 
 ```
 {
@@ -211,7 +211,7 @@ This response returns a [MultipleECFPartnershipsResponse](#schema-multipleecfpar
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 ```
 {
@@ -234,7 +234,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ### Request body
 
 
-This consumes a [ECFPartnershipRequest](#schema-ecfpartnershiprequest) schema.
+This consumes a [ECFPartnershipRequest](ecfpartnershiprequest) schema.
 
 ### Request example
 
@@ -258,15 +258,15 @@ This consumes a [ECFPartnershipRequest](#schema-ecfpartnershiprequest) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | Create an ECF partnership<br/>This response returns a [ECFPartnershipResponse](#schema-ecfpartnershipresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
-| 422 | Unprocessable entity<br/>This response returns a [ECFPartnershipRequestErrorResponse](#schema-ecfpartnershiprequesterrorresponse) schema.<br/> | 
+| 200 | Create an ECF partnership<br/>This response returns a [ECFPartnershipResponse](ecfpartnershipresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
+| 422 | Unprocessable entity<br/>This response returns a [ECFPartnershipRequestErrorResponse](ecfpartnershiprequesterrorresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - Create an ECF partnership
-This response returns a [ECFPartnershipResponse](#schema-ecfpartnershipresponse) schema.
+This response returns a [ECFPartnershipResponse](ecfpartnershipresponse) schema.
 
 ```
 {
@@ -292,7 +292,7 @@ This response returns a [ECFPartnershipResponse](#schema-ecfpartnershipresponse)
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 ```
 {
@@ -301,7 +301,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ```
 
 422 - Unprocessable entity
-This response returns a [ECFPartnershipRequestErrorResponse](#schema-ecfpartnershiprequesterrorresponse) schema.
+This response returns a [ECFPartnershipRequestErrorResponse](ecfpartnershiprequesterrorresponse) schema.
 
 ```
 {
@@ -339,15 +339,15 @@ This response returns a [ECFPartnershipRequestErrorResponse](#schema-ecfpartners
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A single partnership<br/>This response returns a [ECFPartnershipResponse](#schema-ecfpartnershipresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
-| 404 | Not Found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
+| 200 | A single partnership<br/>This response returns a [ECFPartnershipResponse](ecfpartnershipresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
+| 404 | Not Found<br/>This response returns a [NotFoundResponse](notfoundresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A single partnership
-This response returns a [ECFPartnershipResponse](#schema-ecfpartnershipresponse) schema.
+This response returns a [ECFPartnershipResponse](ecfpartnershipresponse) schema.
 
 ```
 {
@@ -373,7 +373,7 @@ This response returns a [ECFPartnershipResponse](#schema-ecfpartnershipresponse)
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 ```
 {
@@ -382,7 +382,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ```
 
 404 - Not Found
-This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
+This response returns a [NotFoundResponse](notfoundresponse) schema.
 
 ```
 {
@@ -414,7 +414,7 @@ This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 ### Request body
 
 
-This consumes a [ECFPartnershipUpdateRequest](#schema-ecfpartnershipupdaterequest) schema.
+This consumes a [ECFPartnershipUpdateRequest](ecfpartnershipupdaterequest) schema.
 
 ### Request example
 
@@ -436,16 +436,16 @@ This consumes a [ECFPartnershipUpdateRequest](#schema-ecfpartnershipupdatereques
 
 | Status | Description |
 | ---- | ---- |
-| 200 | Update an ECF partnership<br/>This response returns a [ECFPartnershipResponse](#schema-ecfpartnershipresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
-| 422 | Unprocessable entity<br/>This response returns a [ECFPartnershipRequestErrorResponse](#schema-ecfpartnershiprequesterrorresponse) schema.<br/> | 
-| 404 | Not Found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
+| 200 | Update an ECF partnership<br/>This response returns a [ECFPartnershipResponse](ecfpartnershipresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
+| 422 | Unprocessable entity<br/>This response returns a [ECFPartnershipRequestErrorResponse](ecfpartnershiprequesterrorresponse) schema.<br/> | 
+| 404 | Not Found<br/>This response returns a [NotFoundResponse](notfoundresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - Update an ECF partnership
-This response returns a [ECFPartnershipResponse](#schema-ecfpartnershipresponse) schema.
+This response returns a [ECFPartnershipResponse](ecfpartnershipresponse) schema.
 
 ```
 {
@@ -471,7 +471,7 @@ This response returns a [ECFPartnershipResponse](#schema-ecfpartnershipresponse)
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 ```
 {
@@ -480,7 +480,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ```
 
 422 - Unprocessable entity
-This response returns a [ECFPartnershipRequestErrorResponse](#schema-ecfpartnershiprequesterrorresponse) schema.
+This response returns a [ECFPartnershipRequestErrorResponse](ecfpartnershiprequesterrorresponse) schema.
 
 ```
 {
@@ -494,7 +494,7 @@ This response returns a [ECFPartnershipRequestErrorResponse](#schema-ecfpartners
 ```
 
 404 - Not Found
-This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
+This response returns a [NotFoundResponse](notfoundresponse) schema.
 
 ```
 {
@@ -520,11 +520,11 @@ This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter[cohort] | query | object | true | Refine schools to return.<br/>This consumes a [ECFSchoolsFilter](#schema-ecfschoolsfilter) schema.<br/> | filter[cohort]=2021 | 
-| filter[urn] | query | object | false | Refine schools to return.<br/>This consumes a [ECFSchoolsFilter](#schema-ecfschoolsfilter) schema.<br/> | filter[urn]=106286 | 
-| filter[updated\_since] | query | object | false | Refine schools to return.<br/>This consumes a [ECFSchoolsFilter](#schema-ecfschoolsfilter) schema.<br/> | filter[updated\_since]=2020-11-13T11:21:55Z | 
-| page | query | object | false | Pagination options to navigate through the list of schools.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
-| sort | query | array | false | Sort schools being returned.<br/>This consumes a [ECFSchoolsSort](#schema-ecfschoolssort) schema.<br/> | sort=-updated\_at | 
+| filter[cohort] | query | object | true | Refine schools to return.<br/>This consumes a [ECFSchoolsFilter](ecfschoolsfilter) schema.<br/> | filter[cohort]=2021 | 
+| filter[urn] | query | object | false | Refine schools to return.<br/>This consumes a [ECFSchoolsFilter](ecfschoolsfilter) schema.<br/> | filter[urn]=106286 | 
+| filter[updated\_since] | query | object | false | Refine schools to return.<br/>This consumes a [ECFSchoolsFilter](ecfschoolsfilter) schema.<br/> | filter[updated\_since]=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of schools.<br/>This consumes a [Pagination](pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| sort | query | array | false | Sort schools being returned.<br/>This consumes a [ECFSchoolsSort](ecfschoolssort) schema.<br/> | sort=-updated\_at | 
 
 
 ### Responses
@@ -532,14 +532,14 @@ This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A list of schools for the given cohort<br/>This response returns a [MultipleECFSchoolsResponse](#schema-multipleecfschoolsresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A list of schools for the given cohort<br/>This response returns a [MultipleECFSchoolsResponse](multipleecfschoolsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A list of schools for the given cohort
-This response returns a [MultipleECFSchoolsResponse](#schema-multipleecfschoolsresponse) schema.
+This response returns a [MultipleECFSchoolsResponse](multipleecfschoolsresponse) schema.
 
 ```
 {
@@ -562,7 +562,7 @@ This response returns a [MultipleECFSchoolsResponse](#schema-multipleecfschoolsr
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 ```
 {
@@ -588,7 +588,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
 | id | path | string | true | The unique ID of the school<br/> | 28c461ee-ffc0-4e56-96bd-788579a0ed75 | 
-| filter[cohort] | query | object | true | Refine schools to return.<br/>This consumes a [ECFSchoolsFilter](#schema-ecfschoolsfilter) schema.<br/> | filter[cohort]=2021 | 
+| filter[cohort] | query | object | true | Refine schools to return.<br/>This consumes a [ECFSchoolsFilter](ecfschoolsfilter) schema.<br/> | filter[cohort]=2021 | 
 
 
 ### Responses
@@ -596,15 +596,15 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A single school<br/>This response returns a [ECFSchoolResponse](#schema-ecfschoolresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
-| 404 | Not Found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
+| 200 | A single school<br/>This response returns a [ECFSchoolResponse](ecfschoolresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
+| 404 | Not Found<br/>This response returns a [NotFoundResponse](notfoundresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A single school
-This response returns a [ECFSchoolResponse](#schema-ecfschoolresponse) schema.
+This response returns a [ECFSchoolResponse](ecfschoolresponse) schema.
 
 ```
 {
@@ -625,7 +625,7 @@ This response returns a [ECFSchoolResponse](#schema-ecfschoolresponse) schema.
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 ```
 {
@@ -634,7 +634,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ```
 
 404 - Not Found
-This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
+This response returns a [NotFoundResponse](notfoundresponse) schema.
 
 ```
 {
@@ -660,8 +660,8 @@ This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine participant declarations to return.<br/>This consumes a [ParticipantDeclarationsFilter](#schema-participantdeclarationsfilter) schema.<br/> | filter[participant\_id]=ab3a7848-1208-7679-942a-b4a70eed400a&filter[updated\_since]=2020-11-13T11:21:55Z | 
-| page | query | object | false | Pagination options to navigate through the list of participant declarations.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| filter | query | object | false | Refine participant declarations to return.<br/>This consumes a [ParticipantDeclarationsFilter](participantdeclarationsfilter) schema.<br/> | filter[participant\_id]=ab3a7848-1208-7679-942a-b4a70eed400a&filter[updated\_since]=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of participant declarations.<br/>This consumes a [Pagination](pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
 
 
 ### Responses
@@ -669,14 +669,14 @@ This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A list of participant declarations<br/>This response returns a [MultipleParticipantDeclarationsResponse](#schema-multipleparticipantdeclarationsresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A list of participant declarations<br/>This response returns a [MultipleParticipantDeclarationsResponse](multipleparticipantdeclarationsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A list of participant declarations
-This response returns a [MultipleParticipantDeclarationsResponse](#schema-multipleparticipantdeclarationsresponse) schema.
+This response returns a [MultipleParticipantDeclarationsResponse](multipleparticipantdeclarationsresponse) schema.
 
 ```
 {
@@ -708,7 +708,7 @@ This response returns a [MultipleParticipantDeclarationsResponse](#schema-multip
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 ```
 {
@@ -731,23 +731,23 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ### Request body
 
 
-This consumes a [ParticipantDeclarationRequest](#schema-participantdeclarationrequest) schema.
+This consumes a [ParticipantDeclarationRequest](participantdeclarationrequest) schema.
 
 ### Responses
 
 
 | Status | Description |
 | ---- | ---- |
-| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.<br/> | 
-| 422 | Bad or Missing parameter<br/>This response returns a [ErrorResponse](#schema-errorresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
-| 400 | Bad Request<br/>This response returns a [BadRequestResponse](#schema-badrequestresponse) schema.<br/> | 
+| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](singleparticipantdeclarationresponse) schema.<br/> | 
+| 422 | Bad or Missing parameter<br/>This response returns a [ErrorResponse](errorresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
+| 400 | Bad Request<br/>This response returns a [BadRequestResponse](badrequestresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - Successful
-This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.
+This response returns a [SingleParticipantDeclarationResponse](singleparticipantdeclarationresponse) schema.
 
 ```
 {
@@ -777,7 +777,7 @@ This response returns a [SingleParticipantDeclarationResponse](#schema-singlepar
 ```
 
 422 - Bad or Missing parameter
-This response returns a [ErrorResponse](#schema-errorresponse) schema.
+This response returns a [ErrorResponse](errorresponse) schema.
 
 ```
 {
@@ -791,7 +791,7 @@ This response returns a [ErrorResponse](#schema-errorresponse) schema.
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 ```
 {
@@ -800,7 +800,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ```
 
 400 - Bad Request
-This response returns a [BadRequestResponse](#schema-badrequestresponse) schema.
+This response returns a [BadRequestResponse](badrequestresponse) schema.
 
 ```
 {
@@ -833,15 +833,15 @@ This response returns a [BadRequestResponse](#schema-badrequestresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A single participant declaration<br/>This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
-| 404 | Not found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
+| 200 | A single participant declaration<br/>This response returns a [SingleParticipantDeclarationResponse](singleparticipantdeclarationresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
+| 404 | Not found<br/>This response returns a [NotFoundResponse](notfoundresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A single participant declaration
-This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.
+This response returns a [SingleParticipantDeclarationResponse](singleparticipantdeclarationresponse) schema.
 
 ```
 {
@@ -871,7 +871,7 @@ This response returns a [SingleParticipantDeclarationResponse](#schema-singlepar
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 ```
 {
@@ -880,7 +880,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ```
 
 404 - Not found
-This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
+This response returns a [NotFoundResponse](notfoundresponse) schema.
 
 ```
 {
@@ -914,13 +914,13 @@ This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.<br/> | 
+| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](singleparticipantdeclarationresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - Successful
-This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.
+This response returns a [SingleParticipantDeclarationResponse](singleparticipantdeclarationresponse) schema.
 
 ```
 {
@@ -966,9 +966,9 @@ This response returns a [SingleParticipantDeclarationResponse](#schema-singlepar
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine ECF participants to return.<br/>This consumes a [ECFParticipantFilter](#schema-ecfparticipantfilter) schema.<br/> | filter[cohort]=2022&filter[from\_participant\_id]=439ac4fe-a003-417f-9694-07c45b3482f8&filter[training\_status]=active&filter[updated\_since]=2020-11-13T11:21:55Z | 
-| page | query | object | false | Pagination options to navigate through the list of ECF participants.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
-| sort | query | array | false | Sort ECF participants being returned.<br/>This consumes a [ECFParticipantsSort](#schema-ecfparticipantssort) schema.<br/> | sort=-updated\_at | 
+| filter | query | object | false | Refine ECF participants to return.<br/>This consumes a [ECFParticipantFilter](ecfparticipantfilter) schema.<br/> | filter[cohort]=2022&filter[from\_participant\_id]=439ac4fe-a003-417f-9694-07c45b3482f8&filter[training\_status]=active&filter[updated\_since]=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of ECF participants.<br/>This consumes a [Pagination](pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| sort | query | array | false | Sort ECF participants being returned.<br/>This consumes a [ECFParticipantsSort](ecfparticipantssort) schema.<br/> | sort=-updated\_at | 
 
 
 ### Responses
@@ -976,14 +976,14 @@ This response returns a [SingleParticipantDeclarationResponse](#schema-singlepar
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A list of ECF participants<br/>This response returns a [MultipleECFParticipantsResponse](#schema-multipleecfparticipantsresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A list of ECF participants<br/>This response returns a [MultipleECFParticipantsResponse](multipleecfparticipantsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A list of ECF participants
-This response returns a [MultipleECFParticipantsResponse](#schema-multipleecfparticipantsresponse) schema.
+This response returns a [MultipleECFParticipantsResponse](multipleecfparticipantsresponse) schema.
 
 ```
 {
@@ -1034,7 +1034,7 @@ This response returns a [MultipleECFParticipantsResponse](#schema-multipleecfpar
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 ```
 {
@@ -1067,15 +1067,15 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A single ECF participant<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
-| 404 | Not Found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
+| 200 | A single ECF participant<br/>This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
+| 404 | Not Found<br/>This response returns a [NotFoundResponse](notfoundresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A single ECF participant
-This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
 
 ```
 {
@@ -1124,7 +1124,7 @@ This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse)
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 ```
 {
@@ -1133,7 +1133,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ```
 
 404 - Not Found
-This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
+This response returns a [NotFoundResponse](notfoundresponse) schema.
 
 ```
 {
@@ -1159,8 +1159,8 @@ This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine participant transfers to return.<br/>This consumes a [ListFilter](#schema-listfilter) schema.<br/> | filter[updated\_since]=2020-11-13T11:21:55Z | 
-| page | query | object | false | Pagination options to navigate through the list of participant transfers.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| filter | query | object | false | Refine participant transfers to return.<br/>This consumes a [ListFilter](listfilter) schema.<br/> | filter[updated\_since]=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of participant transfers.<br/>This consumes a [Pagination](pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
 
 
 ### Responses
@@ -1168,14 +1168,14 @@ This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A list of ECF participant transfers<br/>This response returns a [MultipleECFParticipantTransferResponse](#schema-multipleecfparticipanttransferresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A list of ECF participant transfers<br/>This response returns a [MultipleECFParticipantTransferResponse](multipleecfparticipanttransferresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A list of ECF participant transfers
-This response returns a [MultipleECFParticipantTransferResponse](#schema-multipleecfparticipanttransferresponse) schema.
+This response returns a [MultipleECFParticipantTransferResponse](multipleecfparticipanttransferresponse) schema.
 
 ```
 {
@@ -1208,7 +1208,7 @@ This response returns a [MultipleECFParticipantTransferResponse](#schema-multipl
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 ```
 {
@@ -1239,7 +1239,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ### Request body
 
 
-This consumes a [ECFParticipantDeferRequest](#schema-ecfparticipantdeferrequest) schema.
+This consumes a [ECFParticipantDeferRequest](ecfparticipantdeferrequest) schema.
 
 ### Request example
 
@@ -1262,13 +1262,13 @@ This consumes a [ECFParticipantDeferRequest](#schema-ecfparticipantdeferrequest)
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant being deferred<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
+| 200 | The ECF participant being deferred<br/>This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant being deferred
-This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
 
 ```
 {
@@ -1342,7 +1342,7 @@ This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse)
 ### Request body
 
 
-This consumes a [ECFParticipantResumeRequest](#schema-ecfparticipantresumerequest) schema.
+This consumes a [ECFParticipantResumeRequest](ecfparticipantresumerequest) schema.
 
 ### Request example
 
@@ -1364,13 +1364,13 @@ This consumes a [ECFParticipantResumeRequest](#schema-ecfparticipantresumereques
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant being resumed<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
+| 200 | The ECF participant being resumed<br/>This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant being resumed
-This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
 
 ```
 {
@@ -1441,7 +1441,7 @@ This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse)
 ### Request body
 
 
-This consumes a [ECFParticipantWithdrawRequest](#schema-ecfparticipantwithdrawrequest) schema.
+This consumes a [ECFParticipantWithdrawRequest](ecfparticipantwithdrawrequest) schema.
 
 ### Request example
 
@@ -1464,13 +1464,13 @@ This consumes a [ECFParticipantWithdrawRequest](#schema-ecfparticipantwithdrawre
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant being withdrawn<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
+| 200 | The ECF participant being withdrawn<br/>This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant being withdrawn
-This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
 
 ```
 {
@@ -1546,15 +1546,15 @@ This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse)
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A single participant’s transfers<br/>This response returns a [ECFParticipantTransferResponse](#schema-ecfparticipanttransferresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
-| 404 | Not Found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
+| 200 | A single participant’s transfers<br/>This response returns a [ECFParticipantTransferResponse](ecfparticipanttransferresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
+| 404 | Not Found<br/>This response returns a [NotFoundResponse](notfoundresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A single participant’s transfers
-This response returns a [ECFParticipantTransferResponse](#schema-ecfparticipanttransferresponse) schema.
+This response returns a [ECFParticipantTransferResponse](ecfparticipanttransferresponse) schema.
 
 ```
 {
@@ -1579,7 +1579,7 @@ This response returns a [ECFParticipantTransferResponse](#schema-ecfparticipantt
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 ```
 {
@@ -1588,7 +1588,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ```
 
 404 - Not Found
-This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
+This response returns a [NotFoundResponse](notfoundresponse) schema.
 
 ```
 {
@@ -1620,7 +1620,7 @@ This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 ### Request body
 
 
-This consumes a [ECFParticipantChangeScheduleRequest](#schema-ecfparticipantchangeschedulerequest) schema.
+This consumes a [ECFParticipantChangeScheduleRequest](ecfparticipantchangeschedulerequest) schema.
 
 ### Request example
 
@@ -1644,13 +1644,13 @@ This consumes a [ECFParticipantChangeScheduleRequest](#schema-ecfparticipantchan
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF Participant changing schedule<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
+| 200 | The ECF Participant changing schedule<br/>This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF Participant changing schedule
-This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
 
 ```
 {
@@ -1715,9 +1715,9 @@ This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse)
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine unfunded mentors to return.<br/>This consumes a [ListFilter](#schema-listfilter) schema.<br/> | filter[updated\_since]=2020-11-13T11:21:55Z | 
-| page | query | object | false | Pagination options to navigate through the list of unfunded mentors.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
-| sort | query | array | false | Sort unfunded mentors being returned.<br/>This consumes a [ECFUnfundedMentorsSort](#schema-ecfunfundedmentorssort) schema.<br/> | sort=-updated\_at | 
+| filter | query | object | false | Refine unfunded mentors to return.<br/>This consumes a [ListFilter](listfilter) schema.<br/> | filter[updated\_since]=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of unfunded mentors.<br/>This consumes a [Pagination](pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| sort | query | array | false | Sort unfunded mentors being returned.<br/>This consumes a [ECFUnfundedMentorsSort](ecfunfundedmentorssort) schema.<br/> | sort=-updated\_at | 
 
 
 ### Responses
@@ -1725,14 +1725,14 @@ This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse)
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A list of unfunded mentors<br/>This response returns a [MultipleUnfundedMentorsResponse](#schema-multipleunfundedmentorsresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A list of unfunded mentors<br/>This response returns a [MultipleUnfundedMentorsResponse](multipleunfundedmentorsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A list of unfunded mentors
-This response returns a [MultipleUnfundedMentorsResponse](#schema-multipleunfundedmentorsresponse) schema.
+This response returns a [MultipleUnfundedMentorsResponse](multipleunfundedmentorsresponse) schema.
 
 ```
 {
@@ -1753,7 +1753,7 @@ This response returns a [MultipleUnfundedMentorsResponse](#schema-multipleunfund
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 ```
 {
@@ -1786,15 +1786,15 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A single unfunded mentor<br/>This response returns a [UnfundedMentorResponse](#schema-unfundedmentorresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
-| 404 | Not Found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
+| 200 | A single unfunded mentor<br/>This response returns a [UnfundedMentorResponse](unfundedmentorresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
+| 404 | Not Found<br/>This response returns a [NotFoundResponse](notfoundresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A single unfunded mentor
-This response returns a [UnfundedMentorResponse](#schema-unfundedmentorresponse) schema.
+This response returns a [UnfundedMentorResponse](unfundedmentorresponse) schema.
 
 ```
 {
@@ -1813,7 +1813,7 @@ This response returns a [UnfundedMentorResponse](#schema-unfundedmentorresponse)
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 ```
 {
@@ -1822,7 +1822,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ```
 
 404 - Not Found
-This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
+This response returns a [NotFoundResponse](notfoundresponse) schema.
 
 ```
 {
@@ -1848,8 +1848,8 @@ This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine statements to return.<br/>This consumes a [StatementsFilter](#schema-statementsfilter) schema.<br/> | filter[cohort]=2021,2022&filter[type]=ecf&filter[updated\_since]=2020-11-13T11:21:55Z | 
-| page | query | object | false | Pagination options to navigate through the list of statements.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| filter | query | object | false | Refine statements to return.<br/>This consumes a [StatementsFilter](statementsfilter) schema.<br/> | filter[cohort]=2021,2022&filter[type]=ecf&filter[updated\_since]=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of statements.<br/>This consumes a [Pagination](pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
 
 
 ### Responses
@@ -1857,14 +1857,14 @@ This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A list of statements as part of which the DfE will make output payments for ecf participants<br/>This response returns a [StatementsResponse](#schema-statementsresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 200 | A list of statements as part of which the DfE will make output payments for ecf participants<br/>This response returns a [StatementsResponse](statementsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A list of statements as part of which the DfE will make output payments for ecf participants
-This response returns a [StatementsResponse](#schema-statementsresponse) schema.
+This response returns a [StatementsResponse](statementsresponse) schema.
 
 ```
 {
@@ -1889,7 +1889,7 @@ This response returns a [StatementsResponse](#schema-statementsresponse) schema.
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 ```
 {
@@ -1922,15 +1922,15 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A specific financial statement<br/>This response returns a [StatementResponse](#schema-statementresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
-| 404 | Not Found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
+| 200 | A specific financial statement<br/>This response returns a [StatementResponse](statementresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
+| 404 | Not Found<br/>This response returns a [NotFoundResponse](notfoundresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A specific financial statement
-This response returns a [StatementResponse](#schema-statementresponse) schema.
+This response returns a [StatementResponse](statementresponse) schema.
 
 ```
 {
@@ -1953,7 +1953,7 @@ This response returns a [StatementResponse](#schema-statementresponse) schema.
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 ```
 {
@@ -1962,7 +1962,7 @@ This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) sch
 ```
 
 404 - Not Found
-This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
+This response returns a [NotFoundResponse](notfoundresponse) schema.
 
 ```
 {
@@ -2022,7 +2022,7 @@ A delivery partner
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the delivery partner<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with a delivery partner<br/>It conforms to [DeliveryPartnerAttributes](#schema-deliverypartnerattributes) schema. | 
+| attributes | object | true | The data attributes associated with a delivery partner<br/>It conforms to [DeliveryPartnerAttributes](deliverypartnerattributes) schema. | 
 
 
 ### DeliveryPartnerAttributes
@@ -2056,7 +2056,7 @@ A delivery partner
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | A delivery partner<br/>It conforms to [DeliveryPartner](#schema-deliverypartner) schema. | 
+| data | object | true | A delivery partner<br/>It conforms to [DeliveryPartner](deliverypartner) schema. | 
 
 
 ### DeliveryPartnersFilter
@@ -2076,7 +2076,7 @@ A list of delivery partners
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [DeliveryPartner](#schema-deliverypartner) schema. | 
+| data | array | true | It conforms to [DeliveryPartner](deliverypartner) schema. | 
 
 
 ### DeliveryPartnersSort
@@ -2086,7 +2086,7 @@ Sort delivery partners being returned
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| Item | string | false | It conforms to [DeliveryPartnersSort/items](#schema-deliverypartnerssort-items) schema.Possible values:<br/><ul><li>created\_at</li><li>-created\_at</li><li>updated\_at</li><li>-updated\_at</li></ul> | 
+| Item | string | false | It conforms to [DeliveryPartnersSort/items](deliverypartnerssort-items) schema.Possible values:<br/><ul><li>created\_at</li><li>-created\_at</li><li>updated\_at</li><li>-updated\_at</li></ul> | 
 
 
 ### ECFDeferral
@@ -2132,8 +2132,8 @@ The details of an ECF Participant enrolment
 | sparsity\_uplift | boolean | true | Indicates whether this participant qualifies for an uplift payment due to sparsity<br/> | 
 | schedule\_identifier | string | true | The schedule of the ECF participant. For the possible values please refer to the [ECF schedules and milestone dates guidance](/api-reference/ecf/schedules-and-milestone-dates.html#schedules-and-milestone-dates) .<br/>Possible values:<br/><ul><li>ecf-standard-september</li><li>ecf-standard-january</li><li>ecf-standard-april</li><li>ecf-reduced-september</li><li>ecf-reduced-january</li><li>ecf-reduced-april</li><li>ecf-extended-september</li><li>ecf-extended-january</li><li>ecf-extended-april</li><li>ecf-replacement-september</li><li>ecf-replacement-january</li><li>ecf-replacement-april</li></ul> | 
 | delivery\_partner\_id | string | true | Unique ID of the delivery partner associated with the participant<br/> | 
-| withdrawal |  | false | This conforms to any of the following schemas:<br/><ul><li> [ECFWithdrawal](#schema-ecfwithdrawal) </li></ul> | 
-| deferral |  | false | This conforms to any of the following schemas:<br/><ul><li> [ECFDeferral](#schema-ecfdeferral) </li></ul> | 
+| withdrawal |  | false | This conforms to any of the following schemas:<br/><ul><li> [ECFWithdrawal](ecfwithdrawal) </li></ul> | 
+| deferral |  | false | This conforms to any of the following schemas:<br/><ul><li> [ECFDeferral](ecfdeferral) </li></ul> | 
 | created\_at | string | true | The date and time the ECF participant was created<br/> | 
 | induction\_end\_date | string | false | The ECF participant induction end date<br/> | 
 | mentor\_funding\_end\_date | string | false | The ECF participant mentor training completion date<br/> | 
@@ -2150,7 +2150,7 @@ The details of an ECF Participant enrolment
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantAttributes](#schema-ecfparticipantattributes) schema. | 
+| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantAttributes](ecfparticipantattributes) schema. | 
 
 
 ### ECFParticipantAttributes
@@ -2163,8 +2163,8 @@ The data attributes associated with an ECF participant
 | full\_name | string | true | The full name of this ECF participant<br/> | 
 | teacher\_reference\_number | string | false | The Teacher Reference Number (TRN) for this participant<br/> | 
 | updated\_at | string | true | The date and time the ECF participant was last updated<br/> | 
-| ecf\_enrolments | array | true | Information about the course(s) the participant is enroled in<br/>It conforms to [ECFEnrolment](#schema-ecfenrolment) schema. | 
-| participant\_id\_changes | array | true | Information about the Participant ID changes<br/>It conforms to [ParticipantIdChange](#schema-participantidchange) schema. | 
+| ecf\_enrolments | array | true | Information about the course(s) the participant is enroled in<br/>It conforms to [ECFEnrolment](ecfenrolment) schema. | 
+| participant\_id\_changes | array | true | Information about the Participant ID changes<br/>It conforms to [ParticipantIdChange](participantidchange) schema. | 
 
 
 ### ECFParticipantChangeSchedule
@@ -2175,7 +2175,7 @@ An ECF participant change schedule action
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | true | The data type<br/>Possible values:<br/><ul><li>participant-change-schedule</li></ul> | 
-| attributes | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeScheduleAttributes](#schema-ecfparticipantchangescheduleattributes) schema. | 
+| attributes | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeScheduleAttributes](ecfparticipantchangescheduleattributes) schema. | 
 
 
 #### Example
@@ -2223,7 +2223,7 @@ The change schedule request for a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeSchedule](#schema-ecfparticipantchangeschedule) schema. | 
+| data | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeSchedule](ecfparticipantchangeschedule) schema. | 
 
 
 #### Example
@@ -2390,7 +2390,7 @@ The details of a participant deferral request
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | true | The data type<br/>Possible values:<br/><ul><li>participant-defer</li></ul> | 
-| attributes | object | true | An ECF participant deferral action<br/>It conforms to [ECFParticipantDeferAttributes](#schema-ecfparticipantdeferattributes) schema. | 
+| attributes | object | true | An ECF participant deferral action<br/>It conforms to [ECFParticipantDeferAttributes](ecfparticipantdeferattributes) schema. | 
 
 
 ### ECFParticipantDeferAttributes
@@ -2422,7 +2422,7 @@ The deferral request for a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | The details of a participant deferral request<br/>It conforms to [ECFParticipantDefer](#schema-ecfparticipantdefer) schema. | 
+| data | object | true | The details of a participant deferral request<br/>It conforms to [ECFParticipantDefer](ecfparticipantdefer) schema. | 
 
 
 #### Example
@@ -2509,7 +2509,7 @@ An ECF Participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true |  **Note, this endpoint includes updated specifications.** The details of a participant<br/>It conforms to [ECFParticipant](#schema-ecfparticipant) schema. | 
+| data | object | true |  **Note, this endpoint includes updated specifications.** The details of a participant<br/>It conforms to [ECFParticipant](ecfparticipant) schema. | 
 
 
 ### ECFParticipantResume
@@ -2520,7 +2520,7 @@ An ECF participant resume action
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | true | The data type<br/>Possible values:<br/><ul><li>participant-resume</li></ul> | 
-| attributes | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResumeAttributes](#schema-ecfparticipantresumeattributes) schema. | 
+| attributes | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResumeAttributes](ecfparticipantresumeattributes) schema. | 
 
 
 ### ECFParticipantResumeAttributes
@@ -2550,7 +2550,7 @@ The resume request for a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResume](#schema-ecfparticipantresume) schema. | 
+| data | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResume](ecfparticipantresume) schema. | 
 
 
 #### Example
@@ -2577,7 +2577,7 @@ The resume request for a participant
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an ECF participant transfer<br/>It conforms to [ECFParticipantTransferAttributes](#schema-ecfparticipanttransferattributes) schema. | 
+| attributes | object | true | The data attributes associated with an ECF participant transfer<br/>It conforms to [ECFParticipantTransferAttributes](ecfparticipanttransferattributes) schema. | 
 
 
 ### ECFParticipantTransferAttributes
@@ -2588,7 +2588,7 @@ The data attributes associated with an ECF participant transfer
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | updated\_at | string | true | The date and time the latest ECF participant was last updated<br/> | 
-| transfers | array | true | List of participant transfers<br/>It conforms to [ECFParticipantTransfers](#schema-ecfparticipanttransfers) schema. | 
+| transfers | array | true | List of participant transfers<br/>It conforms to [ECFParticipantTransfers](ecfparticipanttransfers) schema. | 
 
 
 ### ECFParticipantTransferResponse
@@ -2598,7 +2598,7 @@ An ECF participant transfer
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true |  **Note, this is a new endpoint.** The details of an ECF participant transfer<br/>It conforms to [ECFParticipantTransfer](#schema-ecfparticipanttransfer) schema. | 
+| data | object | true |  **Note, this is a new endpoint.** The details of an ECF participant transfer<br/>It conforms to [ECFParticipantTransfer](ecfparticipanttransfer) schema. | 
 
 
 ### ECFParticipantTransfers
@@ -2611,8 +2611,8 @@ The details of an ECF Participant enrolment
 | training\_record\_id | string | true | The unique identifier of the participant training record<br/> | 
 | transfer\_type | string | true | The type of transfer between schools<br/>Possible values:<br/><ul><li>new\_school</li><li>new\_provider</li><li>unknown</li></ul> | 
 | status | string | true | The status of the transfer, if both leaving and joining SIT have completed their journeys or only one has<br/>Possible values:<br/><ul><li>incomplete</li><li>complete</li></ul> | 
-| leaving |  | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantLeaving](#schema-ecfparticipantleaving) </li></ul> | 
-| joining |  | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantJoining](#schema-ecfparticipantjoining) </li></ul> | 
+| leaving |  | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantLeaving](ecfparticipantleaving) </li></ul> | 
+| joining |  | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantJoining](ecfparticipantjoining) </li></ul> | 
 | created\_at | string | true | The date and time the ECF participant transfer was created<br/> | 
 
 
@@ -2624,7 +2624,7 @@ An ECF participant withdrawal action
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | The data type<br/>Possible values:<br/><ul><li>participant-withdraw</li></ul> | 
-| attributes | object | false | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdrawAttributes](#schema-ecfparticipantwithdrawattributes) schema. | 
+| attributes | object | false | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdrawAttributes](ecfparticipantwithdrawattributes) schema. | 
 
 
 ### ECFParticipantWithdrawAttributes
@@ -2656,7 +2656,7 @@ The withdrawal request for a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdraw](#schema-ecfparticipantwithdraw) schema. | 
+| data | object | true | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdraw](ecfparticipantwithdraw) schema. | 
 
 
 #### Example
@@ -2682,7 +2682,7 @@ Sort ECF participants being returned
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| Item | string | false | It conforms to [ECFParticipantsSort/items](#schema-ecfparticipantssort-items) schema.Possible values:<br/><ul><li>created\_at</li><li>-created\_at</li><li>updated\_at</li><li>-updated\_at</li></ul> | 
+| Item | string | false | It conforms to [ECFParticipantsSort/items](ecfparticipantssort-items) schema.Possible values:<br/><ul><li>created\_at</li><li>-created\_at</li><li>updated\_at</li><li>-updated\_at</li></ul> | 
 
 
 ### ECFPartnership
@@ -2694,7 +2694,7 @@ An ECF partnership
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the partnership<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an ECF partnership<br/>It conforms to [ECFPartnershipAttributes](#schema-ecfpartnershipattributes) schema. | 
+| attributes | object | true | The data attributes associated with an ECF partnership<br/>It conforms to [ECFPartnershipAttributes](ecfpartnershipattributes) schema. | 
 
 
 ### ECFPartnershipAttibutesRequest
@@ -2736,7 +2736,7 @@ An ECF partnership
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | Possible values:<br/><ul><li>ecf-partnership</li></ul> | 
-| attributes | object | false | It conforms to [ECFPartnershipAttibutesRequest](#schema-ecfpartnershipattibutesrequest) schema. | 
+| attributes | object | false | It conforms to [ECFPartnershipAttibutesRequest](ecfpartnershipattibutesrequest) schema. | 
 
 
 ### ECFPartnershipRequest
@@ -2746,7 +2746,7 @@ An ECF partnership
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | An ECF partnership<br/>It conforms to [ECFPartnershipDataRequest](#schema-ecfpartnershipdatarequest) schema. | 
+| data | object | true | An ECF partnership<br/>It conforms to [ECFPartnershipDataRequest](ecfpartnershipdatarequest) schema. | 
 
 
 #### Example
@@ -2773,7 +2773,7 @@ A list of errors
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| error | array | false | This conforms to any of the following schemas:<br/><ul><li> [UrnInvalidError](#schema-urninvaliderror) </li><li> [PartnershipExistsError](#schema-partnershipexistserror) </li><li> [SchoolFundingError](#schema-schoolfundingerror) </li><li> [DeliveryPartnerCohortError](#schema-deliverypartnercohorterror) </li><li> [OtherProviderRecruitedError](#schema-otherproviderrecruitederror) </li></ul> | 
+| error | array | false | This conforms to any of the following schemas:<br/><ul><li> [UrnInvalidError](urninvaliderror) </li><li> [PartnershipExistsError](#schema-partnershipexistserror) </li><li> [SchoolFundingError](#schema-schoolfundingerror) </li><li> [DeliveryPartnerCohortError](#schema-deliverypartnercohorterror) </li><li> [OtherProviderRecruitedError](#schema-otherproviderrecruitederror) </li></ul> | 
 
 
 ### ECFPartnershipResponse
@@ -2783,7 +2783,7 @@ An ECF partnership
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | An ECF partnership<br/>It conforms to [ECFPartnership](#schema-ecfpartnership) schema. | 
+| data | object | true | An ECF partnership<br/>It conforms to [ECFPartnership](ecfpartnership) schema. | 
 
 
 ### ECFPartnershipUpdateAttibutesRequest
@@ -2802,7 +2802,7 @@ Update An ECF partnership
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | Possible values:<br/><ul><li>ecf-partnership-update</li></ul> | 
-| attributes | object | false | It conforms to [ECFPartnershipUpdateAttibutesRequest](#schema-ecfpartnershipupdateattibutesrequest) schema. | 
+| attributes | object | false | It conforms to [ECFPartnershipUpdateAttibutesRequest](ecfpartnershipupdateattibutesrequest) schema. | 
 
 
 ### ECFPartnershipUpdateRequest
@@ -2812,7 +2812,7 @@ Update an ECF partnership
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | Update An ECF partnership<br/>It conforms to [ECFPartnershipUpdateDataRequest](#schema-ecfpartnershipupdatedatarequest) schema. | 
+| data | object | true | Update An ECF partnership<br/>It conforms to [ECFPartnershipUpdateDataRequest](ecfpartnershipupdatedatarequest) schema. | 
 
 
 #### Example
@@ -2839,7 +2839,7 @@ An ECF school
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the school<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an ECF school<br/>It conforms to [ECFSchoolAttributes](#schema-ecfschoolattributes) schema. | 
+| attributes | object | true | The data attributes associated with an ECF school<br/>It conforms to [ECFSchoolAttributes](ecfschoolattributes) schema. | 
 
 
 ### ECFSchoolAttributes
@@ -2865,7 +2865,7 @@ A single ECF school
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | An ECF school<br/>It conforms to [ECFSchool](#schema-ecfschool) schema. | 
+| data | object | true | An ECF school<br/>It conforms to [ECFSchool](ecfschool) schema. | 
 
 
 ### ECFSchoolsFilter
@@ -2887,7 +2887,7 @@ Sort schools being returned
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| Item | string | false | It conforms to [ECFSchoolsSort/items](#schema-ecfschoolssort-items) schema.Possible values:<br/><ul><li>updated\_at</li><li>-updated\_at</li></ul> | 
+| Item | string | false | It conforms to [ECFSchoolsSort/items](ecfschoolssort-items) schema.Possible values:<br/><ul><li>updated\_at</li><li>-updated\_at</li></ul> | 
 
 
 ### ECFUnfundedMentorsSort
@@ -2897,7 +2897,7 @@ Sort unfunded mentors being returned.
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| Item | string | false | It conforms to [ECFUnfundedMentorsSort/items](#schema-ecfunfundedmentorssort-items) schema.Possible values:<br/><ul><li>updated\_at</li><li>-updated\_at</li></ul> | 
+| Item | string | false | It conforms to [ECFUnfundedMentorsSort/items](ecfunfundedmentorssort-items) schema.Possible values:<br/><ul><li>updated\_at</li><li>-updated\_at</li></ul> | 
 
 
 ### ECFWithdrawal
@@ -2940,7 +2940,7 @@ A list of errors
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| error | array | false | It conforms to [Error](#schema-error) schema. | 
+| error | array | false | It conforms to [Error](error) schema. | 
 
 
 ### ListFilter
@@ -2971,7 +2971,7 @@ A list of ECF participant transfers
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ECFParticipantTransfer](#schema-ecfparticipanttransfer) schema. | 
+| data | array | true | It conforms to [ECFParticipantTransfer](ecfparticipanttransfer) schema. | 
 
 
 ### MultipleECFParticipantsResponse
@@ -2981,7 +2981,7 @@ A list of ECF participants
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ECFParticipant](#schema-ecfparticipant) schema. | 
+| data | array | true | It conforms to [ECFParticipant](ecfparticipant) schema. | 
 
 
 ### MultipleECFPartnershipsResponse
@@ -2991,7 +2991,7 @@ A list of ECF partnerships
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ECFPartnership](#schema-ecfpartnership) schema. | 
+| data | array | true | It conforms to [ECFPartnership](ecfpartnership) schema. | 
 
 
 ### MultipleECFSchoolsResponse
@@ -3001,7 +3001,7 @@ A list of schools for the given cohort
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ECFSchool](#schema-ecfschool) schema. | 
+| data | array | true | It conforms to [ECFSchool](ecfschool) schema. | 
 
 
 ### MultipleParticipantDeclarationsResponse
@@ -3011,7 +3011,7 @@ A list of participant declarations
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ParticipantDeclarationResponse](#schema-participantdeclarationresponse) schema. | 
+| data | array | true | It conforms to [ParticipantDeclarationResponse](participantdeclarationresponse) schema. | 
 
 
 ### MultipleUnfundedMentorsResponse
@@ -3021,7 +3021,7 @@ A list of unfunded mentors
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [UnfundedMentor](#schema-unfundedmentor) schema. | 
+| data | array | true | It conforms to [UnfundedMentor](unfundedmentor) schema. | 
 
 
 ### NotFoundResponse
@@ -3105,7 +3105,7 @@ A participant declaration data request for ECT participants from cohort 2025 onw
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024ECTStartedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTRetainedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectretainedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectcompletedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTExtendedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectextendedattributesrequest) </li></ul> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024ECTStartedAttributesRequest](ecfparticipantdeclarationpost2024ectstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTRetainedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectretainedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectcompletedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTExtendedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectextendedattributesrequest) </li></ul> | 
 
 
 ### ParticipantDeclarationPost2024MentorDataRequest
@@ -3116,7 +3116,7 @@ A participant declaration data request for mentor participants from cohort 2025 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024MentorStartedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024MentorCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorcompletedattributesrequest) </li></ul> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024MentorStartedAttributesRequest](ecfparticipantdeclarationpost2024mentorstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024MentorCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorcompletedattributesrequest) </li></ul> | 
 
 
 ### ParticipantDeclarationPre2025DataRequest
@@ -3127,7 +3127,7 @@ A participant declaration data request for participants in cohort 2024 and previ
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPre2025StartedAttributesRequest](#schema-ecfparticipantdeclarationpre2025startedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025RetainedAttributesRequest](#schema-ecfparticipantdeclarationpre2025retainedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025CompletedAttributesRequest](#schema-ecfparticipantdeclarationpre2025completedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025ExtendedAttributesRequest](#schema-ecfparticipantdeclarationpre2025extendedattributesrequest) </li></ul> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPre2025StartedAttributesRequest](ecfparticipantdeclarationpre2025startedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025RetainedAttributesRequest](#schema-ecfparticipantdeclarationpre2025retainedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025CompletedAttributesRequest](#schema-ecfparticipantdeclarationpre2025completedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025ExtendedAttributesRequest](#schema-ecfparticipantdeclarationpre2025extendedattributesrequest) </li></ul> | 
 
 
 ### ParticipantDeclarationRequest
@@ -3137,7 +3137,7 @@ An participant declaration request
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | This conforms to any of the following schemas:<br/><ul><li> [ParticipantDeclarationPre2025DataRequest](#schema-participantdeclarationpre2025datarequest) </li><li> [ParticipantDeclarationPost2024ECTDataRequest](#schema-participantdeclarationpost2024ectdatarequest) </li><li> [ParticipantDeclarationPost2024MentorDataRequest](#schema-participantdeclarationpost2024mentordatarequest) </li></ul> | 
+| data | object | true | This conforms to any of the following schemas:<br/><ul><li> [ParticipantDeclarationPre2025DataRequest](participantdeclarationpre2025datarequest) </li><li> [ParticipantDeclarationPost2024ECTDataRequest](#schema-participantdeclarationpost2024ectdatarequest) </li><li> [ParticipantDeclarationPost2024MentorDataRequest](#schema-participantdeclarationpost2024mentordatarequest) </li></ul> | 
 
 
 ### ParticipantDeclarationResponse
@@ -3149,7 +3149,7 @@ A participant declaration response
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant declaration record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with a participant declaration response<br/>It conforms to [ParticipantDeclarationAttributes](#schema-participantdeclarationattributes) schema. | 
+| attributes | object | true | The data attributes associated with a participant declaration response<br/>It conforms to [ParticipantDeclarationAttributes](participantdeclarationattributes) schema. | 
 
 
 ### ParticipantDeclarationsFilter
@@ -3219,7 +3219,7 @@ Sort partnerships being returned
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| Item | string | false | It conforms to [PartnershipsSort/items](#schema-partnershipssort-items) schema.Possible values:<br/><ul><li>created\_at</li><li>-created\_at</li><li>updated\_at</li><li>-updated\_at</li></ul> | 
+| Item | string | false | It conforms to [PartnershipsSort/items](partnershipssort-items) schema.Possible values:<br/><ul><li>created\_at</li><li>-created\_at</li><li>updated\_at</li><li>-updated\_at</li></ul> | 
 
 
 ### SchoolFundingError
@@ -3240,7 +3240,7 @@ A confirmation that the participant declaration has been recorded successfully
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | A participant declaration response<br/>It conforms to [ParticipantDeclarationResponse](#schema-participantdeclarationresponse) schema. | 
+| data | object | true | A participant declaration response<br/>It conforms to [ParticipantDeclarationResponse](participantdeclarationresponse) schema. | 
 
 
 ### Statement
@@ -3252,7 +3252,7 @@ A financial statement
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the financial statement<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with a financial statement<br/>It conforms to [StatementAttributes](#schema-statementattributes) schema. | 
+| attributes | object | true | The data attributes associated with a financial statement<br/>It conforms to [StatementAttributes](statementattributes) schema. | 
 
 
 ### StatementAttributes
@@ -3280,7 +3280,7 @@ A single financial statement
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | A financial statement<br/>It conforms to [Statement](#schema-statement) schema. | 
+| data | object | true | A financial statement<br/>It conforms to [Statement](statement) schema. | 
 
 
 ### StatementsFilter
@@ -3302,7 +3302,7 @@ A list of financial statements
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [Statement](#schema-statement) schema. | 
+| data | array | true | It conforms to [Statement](statement) schema. | 
 
 
 ### UnauthorisedResponse
@@ -3324,7 +3324,7 @@ Authorization information is missing or invalid
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the mentor record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an unfunded mentor<br/>It conforms to [UnfundedMentorAttributes](#schema-unfundedmentorattributes) schema. | 
+| attributes | object | true | The data attributes associated with an unfunded mentor<br/>It conforms to [UnfundedMentorAttributes](unfundedmentorattributes) schema. | 
 
 
 ### UnfundedMentorAttributes
@@ -3348,7 +3348,7 @@ An unfunded mentor
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true |  **Note, this is a new endpoint.** The details of an unfunded mentor<br/>It conforms to [UnfundedMentor](#schema-unfundedmentor) schema. | 
+| data | object | true |  **Note, this is a new endpoint.** The details of an unfunded mentor<br/>It conforms to [UnfundedMentor](unfundedmentor) schema. | 
 
 
 ### UrnInvalidError

--- a/documentation/ecf1_guidance/reference-v3.md
+++ b/documentation/ecf1_guidance/reference-v3.md
@@ -29,9 +29,9 @@ The lead provider API for DfE’s manage teacher CPD service.
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine delivery partners to return.<br/>This consumes a [DeliveryPartnersFilter](deliverypartnersfilter) schema.<br/> | filter[cohort]=2021 | 
-| page | query | object | false | Pagination options to navigate through the list of delivery partners.<br/>This consumes a [Pagination](pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
-| sort | query | array | false | Sort delivery partners being returned.<br/>This consumes a [DeliveryPartnersSort](deliverypartnerssort) schema.<br/> | sort=-updated\_at | 
+| filter | query | object | false | Refine delivery partners to return.<br/>This consumes a [DeliveryPartnersFilter](#schema-deliverypartnersfilter) schema.<br/> | filter[cohort]=2021 | 
+| page | query | object | false | Pagination options to navigate through the list of delivery partners.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| sort | query | array | false | Sort delivery partners being returned.<br/>This consumes a [DeliveryPartnersSort](#schema-deliverypartnerssort) schema.<br/> | sort=-updated\_at | 
 
 
 ### Responses
@@ -39,14 +39,14 @@ The lead provider API for DfE’s manage teacher CPD service.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | Successfully return a list of delivery partners<br/>This response returns a [DeliveryPartnersResponse](deliverypartnersresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
+| 200 | Successfully return a list of delivery partners<br/>This response returns a [DeliveryPartnersResponse](#schema-deliverypartnersresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - Successfully return a list of delivery partners
-This response returns a [DeliveryPartnersResponse](deliverypartnersresponse) schema.
+This response returns a [DeliveryPartnersResponse](#schema-deliverypartnersresponse) schema.
 
 ```
 {
@@ -69,7 +69,7 @@ This response returns a [DeliveryPartnersResponse](deliverypartnersresponse) sch
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
 
 ```
 {
@@ -102,15 +102,15 @@ This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | Successfully return a specific delivery partner<br/>This response returns a [DeliveryPartnerResponse](deliverypartnerresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
-| 404 | Not Found<br/>This response returns a [NotFoundResponse](notfoundresponse) schema.<br/> | 
+| 200 | Successfully return a specific delivery partner<br/>This response returns a [DeliveryPartnerResponse](#schema-deliverypartnerresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 404 | Not Found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - Successfully return a specific delivery partner
-This response returns a [DeliveryPartnerResponse](deliverypartnerresponse) schema.
+This response returns a [DeliveryPartnerResponse](#schema-deliverypartnerresponse) schema.
 
 ```
 {
@@ -131,7 +131,7 @@ This response returns a [DeliveryPartnerResponse](deliverypartnerresponse) schem
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
 
 ```
 {
@@ -140,7 +140,7 @@ This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 ```
 
 404 - Not Found
-This response returns a [NotFoundResponse](notfoundresponse) schema.
+This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 
 ```
 {
@@ -166,9 +166,9 @@ This response returns a [NotFoundResponse](notfoundresponse) schema.
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine partnerships to return.<br/>This consumes a [PartnershipsFilter](partnershipsfilter) schema.<br/> | filter[cohort]=2021,2022 | 
-| page | query | object | false | Pagination options to navigate through the list of partnerships.<br/>This consumes a [Pagination](pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
-| sort | query | array | false | Sort partnerships being returned.<br/>This consumes a [PartnershipsSort](partnershipssort) schema.<br/> | sort=-updated\_at | 
+| filter | query | object | false | Refine partnerships to return.<br/>This consumes a [PartnershipsFilter](#schema-partnershipsfilter) schema.<br/> | filter[cohort]=2021,2022 | 
+| page | query | object | false | Pagination options to navigate through the list of partnerships.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| sort | query | array | false | Sort partnerships being returned.<br/>This consumes a [PartnershipsSort](#schema-partnershipssort) schema.<br/> | sort=-updated\_at | 
 
 
 ### Responses
@@ -176,14 +176,14 @@ This response returns a [NotFoundResponse](notfoundresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A list of ECF partnerships<br/>This response returns a [MultipleECFPartnershipsResponse](multipleecfpartnershipsresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
+| 200 | A list of ECF partnerships<br/>This response returns a [MultipleECFPartnershipsResponse](#schema-multipleecfpartnershipsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A list of ECF partnerships
-This response returns a [MultipleECFPartnershipsResponse](multipleecfpartnershipsresponse) schema.
+This response returns a [MultipleECFPartnershipsResponse](#schema-multipleecfpartnershipsresponse) schema.
 
 ```
 {
@@ -211,7 +211,7 @@ This response returns a [MultipleECFPartnershipsResponse](multipleecfpartnership
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
 
 ```
 {
@@ -234,7 +234,7 @@ This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 ### Request body
 
 
-This consumes a [ECFPartnershipRequest](ecfpartnershiprequest) schema.
+This consumes a [ECFPartnershipRequest](#schema-ecfpartnershiprequest) schema.
 
 ### Request example
 
@@ -258,15 +258,15 @@ This consumes a [ECFPartnershipRequest](ecfpartnershiprequest) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | Create an ECF partnership<br/>This response returns a [ECFPartnershipResponse](ecfpartnershipresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
-| 422 | Unprocessable entity<br/>This response returns a [ECFPartnershipRequestErrorResponse](ecfpartnershiprequesterrorresponse) schema.<br/> | 
+| 200 | Create an ECF partnership<br/>This response returns a [ECFPartnershipResponse](#schema-ecfpartnershipresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 422 | Unprocessable entity<br/>This response returns a [ECFPartnershipRequestErrorResponse](#schema-ecfpartnershiprequesterrorresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - Create an ECF partnership
-This response returns a [ECFPartnershipResponse](ecfpartnershipresponse) schema.
+This response returns a [ECFPartnershipResponse](#schema-ecfpartnershipresponse) schema.
 
 ```
 {
@@ -292,7 +292,7 @@ This response returns a [ECFPartnershipResponse](ecfpartnershipresponse) schema.
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
 
 ```
 {
@@ -301,7 +301,7 @@ This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 ```
 
 422 - Unprocessable entity
-This response returns a [ECFPartnershipRequestErrorResponse](ecfpartnershiprequesterrorresponse) schema.
+This response returns a [ECFPartnershipRequestErrorResponse](#schema-ecfpartnershiprequesterrorresponse) schema.
 
 ```
 {
@@ -339,15 +339,15 @@ This response returns a [ECFPartnershipRequestErrorResponse](ecfpartnershipreque
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A single partnership<br/>This response returns a [ECFPartnershipResponse](ecfpartnershipresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
-| 404 | Not Found<br/>This response returns a [NotFoundResponse](notfoundresponse) schema.<br/> | 
+| 200 | A single partnership<br/>This response returns a [ECFPartnershipResponse](#schema-ecfpartnershipresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 404 | Not Found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A single partnership
-This response returns a [ECFPartnershipResponse](ecfpartnershipresponse) schema.
+This response returns a [ECFPartnershipResponse](#schema-ecfpartnershipresponse) schema.
 
 ```
 {
@@ -373,7 +373,7 @@ This response returns a [ECFPartnershipResponse](ecfpartnershipresponse) schema.
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
 
 ```
 {
@@ -382,7 +382,7 @@ This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 ```
 
 404 - Not Found
-This response returns a [NotFoundResponse](notfoundresponse) schema.
+This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 
 ```
 {
@@ -414,7 +414,7 @@ This response returns a [NotFoundResponse](notfoundresponse) schema.
 ### Request body
 
 
-This consumes a [ECFPartnershipUpdateRequest](ecfpartnershipupdaterequest) schema.
+This consumes a [ECFPartnershipUpdateRequest](#schema-ecfpartnershipupdaterequest) schema.
 
 ### Request example
 
@@ -436,16 +436,16 @@ This consumes a [ECFPartnershipUpdateRequest](ecfpartnershipupdaterequest) schem
 
 | Status | Description |
 | ---- | ---- |
-| 200 | Update an ECF partnership<br/>This response returns a [ECFPartnershipResponse](ecfpartnershipresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
-| 422 | Unprocessable entity<br/>This response returns a [ECFPartnershipRequestErrorResponse](ecfpartnershiprequesterrorresponse) schema.<br/> | 
-| 404 | Not Found<br/>This response returns a [NotFoundResponse](notfoundresponse) schema.<br/> | 
+| 200 | Update an ECF partnership<br/>This response returns a [ECFPartnershipResponse](#schema-ecfpartnershipresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 422 | Unprocessable entity<br/>This response returns a [ECFPartnershipRequestErrorResponse](#schema-ecfpartnershiprequesterrorresponse) schema.<br/> | 
+| 404 | Not Found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - Update an ECF partnership
-This response returns a [ECFPartnershipResponse](ecfpartnershipresponse) schema.
+This response returns a [ECFPartnershipResponse](#schema-ecfpartnershipresponse) schema.
 
 ```
 {
@@ -471,7 +471,7 @@ This response returns a [ECFPartnershipResponse](ecfpartnershipresponse) schema.
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
 
 ```
 {
@@ -480,7 +480,7 @@ This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 ```
 
 422 - Unprocessable entity
-This response returns a [ECFPartnershipRequestErrorResponse](ecfpartnershiprequesterrorresponse) schema.
+This response returns a [ECFPartnershipRequestErrorResponse](#schema-ecfpartnershiprequesterrorresponse) schema.
 
 ```
 {
@@ -494,7 +494,7 @@ This response returns a [ECFPartnershipRequestErrorResponse](ecfpartnershipreque
 ```
 
 404 - Not Found
-This response returns a [NotFoundResponse](notfoundresponse) schema.
+This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 
 ```
 {
@@ -520,11 +520,11 @@ This response returns a [NotFoundResponse](notfoundresponse) schema.
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter[cohort] | query | object | true | Refine schools to return.<br/>This consumes a [ECFSchoolsFilter](ecfschoolsfilter) schema.<br/> | filter[cohort]=2021 | 
-| filter[urn] | query | object | false | Refine schools to return.<br/>This consumes a [ECFSchoolsFilter](ecfschoolsfilter) schema.<br/> | filter[urn]=106286 | 
-| filter[updated\_since] | query | object | false | Refine schools to return.<br/>This consumes a [ECFSchoolsFilter](ecfschoolsfilter) schema.<br/> | filter[updated\_since]=2020-11-13T11:21:55Z | 
-| page | query | object | false | Pagination options to navigate through the list of schools.<br/>This consumes a [Pagination](pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
-| sort | query | array | false | Sort schools being returned.<br/>This consumes a [ECFSchoolsSort](ecfschoolssort) schema.<br/> | sort=-updated\_at | 
+| filter[cohort] | query | object | true | Refine schools to return.<br/>This consumes a [ECFSchoolsFilter](#schema-ecfschoolsfilter) schema.<br/> | filter[cohort]=2021 | 
+| filter[urn] | query | object | false | Refine schools to return.<br/>This consumes a [ECFSchoolsFilter](#schema-ecfschoolsfilter) schema.<br/> | filter[urn]=106286 | 
+| filter[updated\_since] | query | object | false | Refine schools to return.<br/>This consumes a [ECFSchoolsFilter](#schema-ecfschoolsfilter) schema.<br/> | filter[updated\_since]=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of schools.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| sort | query | array | false | Sort schools being returned.<br/>This consumes a [ECFSchoolsSort](#schema-ecfschoolssort) schema.<br/> | sort=-updated\_at | 
 
 
 ### Responses
@@ -532,14 +532,14 @@ This response returns a [NotFoundResponse](notfoundresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A list of schools for the given cohort<br/>This response returns a [MultipleECFSchoolsResponse](multipleecfschoolsresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
+| 200 | A list of schools for the given cohort<br/>This response returns a [MultipleECFSchoolsResponse](#schema-multipleecfschoolsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A list of schools for the given cohort
-This response returns a [MultipleECFSchoolsResponse](multipleecfschoolsresponse) schema.
+This response returns a [MultipleECFSchoolsResponse](#schema-multipleecfschoolsresponse) schema.
 
 ```
 {
@@ -562,7 +562,7 @@ This response returns a [MultipleECFSchoolsResponse](multipleecfschoolsresponse)
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
 
 ```
 {
@@ -588,7 +588,7 @@ This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
 | id | path | string | true | The unique ID of the school<br/> | 28c461ee-ffc0-4e56-96bd-788579a0ed75 | 
-| filter[cohort] | query | object | true | Refine schools to return.<br/>This consumes a [ECFSchoolsFilter](ecfschoolsfilter) schema.<br/> | filter[cohort]=2021 | 
+| filter[cohort] | query | object | true | Refine schools to return.<br/>This consumes a [ECFSchoolsFilter](#schema-ecfschoolsfilter) schema.<br/> | filter[cohort]=2021 | 
 
 
 ### Responses
@@ -596,15 +596,15 @@ This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A single school<br/>This response returns a [ECFSchoolResponse](ecfschoolresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
-| 404 | Not Found<br/>This response returns a [NotFoundResponse](notfoundresponse) schema.<br/> | 
+| 200 | A single school<br/>This response returns a [ECFSchoolResponse](#schema-ecfschoolresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 404 | Not Found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A single school
-This response returns a [ECFSchoolResponse](ecfschoolresponse) schema.
+This response returns a [ECFSchoolResponse](#schema-ecfschoolresponse) schema.
 
 ```
 {
@@ -625,7 +625,7 @@ This response returns a [ECFSchoolResponse](ecfschoolresponse) schema.
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
 
 ```
 {
@@ -634,7 +634,7 @@ This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 ```
 
 404 - Not Found
-This response returns a [NotFoundResponse](notfoundresponse) schema.
+This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 
 ```
 {
@@ -660,8 +660,8 @@ This response returns a [NotFoundResponse](notfoundresponse) schema.
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine participant declarations to return.<br/>This consumes a [ParticipantDeclarationsFilter](participantdeclarationsfilter) schema.<br/> | filter[participant\_id]=ab3a7848-1208-7679-942a-b4a70eed400a&filter[updated\_since]=2020-11-13T11:21:55Z | 
-| page | query | object | false | Pagination options to navigate through the list of participant declarations.<br/>This consumes a [Pagination](pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| filter | query | object | false | Refine participant declarations to return.<br/>This consumes a [ParticipantDeclarationsFilter](#schema-participantdeclarationsfilter) schema.<br/> | filter[participant\_id]=ab3a7848-1208-7679-942a-b4a70eed400a&filter[updated\_since]=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of participant declarations.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
 
 
 ### Responses
@@ -669,14 +669,14 @@ This response returns a [NotFoundResponse](notfoundresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A list of participant declarations<br/>This response returns a [MultipleParticipantDeclarationsResponse](multipleparticipantdeclarationsresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
+| 200 | A list of participant declarations<br/>This response returns a [MultipleParticipantDeclarationsResponse](#schema-multipleparticipantdeclarationsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A list of participant declarations
-This response returns a [MultipleParticipantDeclarationsResponse](multipleparticipantdeclarationsresponse) schema.
+This response returns a [MultipleParticipantDeclarationsResponse](#schema-multipleparticipantdeclarationsresponse) schema.
 
 ```
 {
@@ -708,7 +708,7 @@ This response returns a [MultipleParticipantDeclarationsResponse](multiplepartic
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
 
 ```
 {
@@ -731,23 +731,23 @@ This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 ### Request body
 
 
-This consumes a [ParticipantDeclarationRequest](participantdeclarationrequest) schema.
+This consumes a [ParticipantDeclarationRequest](#schema-participantdeclarationrequest) schema.
 
 ### Responses
 
 
 | Status | Description |
 | ---- | ---- |
-| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](singleparticipantdeclarationresponse) schema.<br/> | 
-| 422 | Bad or Missing parameter<br/>This response returns a [ErrorResponse](errorresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
-| 400 | Bad Request<br/>This response returns a [BadRequestResponse](badrequestresponse) schema.<br/> | 
+| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.<br/> | 
+| 422 | Bad or Missing parameter<br/>This response returns a [ErrorResponse](#schema-errorresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 400 | Bad Request<br/>This response returns a [BadRequestResponse](#schema-badrequestresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - Successful
-This response returns a [SingleParticipantDeclarationResponse](singleparticipantdeclarationresponse) schema.
+This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.
 
 ```
 {
@@ -777,7 +777,7 @@ This response returns a [SingleParticipantDeclarationResponse](singleparticipant
 ```
 
 422 - Bad or Missing parameter
-This response returns a [ErrorResponse](errorresponse) schema.
+This response returns a [ErrorResponse](#schema-errorresponse) schema.
 
 ```
 {
@@ -791,7 +791,7 @@ This response returns a [ErrorResponse](errorresponse) schema.
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
 
 ```
 {
@@ -800,7 +800,7 @@ This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 ```
 
 400 - Bad Request
-This response returns a [BadRequestResponse](badrequestresponse) schema.
+This response returns a [BadRequestResponse](#schema-badrequestresponse) schema.
 
 ```
 {
@@ -833,15 +833,15 @@ This response returns a [BadRequestResponse](badrequestresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A single participant declaration<br/>This response returns a [SingleParticipantDeclarationResponse](singleparticipantdeclarationresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
-| 404 | Not found<br/>This response returns a [NotFoundResponse](notfoundresponse) schema.<br/> | 
+| 200 | A single participant declaration<br/>This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 404 | Not found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A single participant declaration
-This response returns a [SingleParticipantDeclarationResponse](singleparticipantdeclarationresponse) schema.
+This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.
 
 ```
 {
@@ -871,7 +871,7 @@ This response returns a [SingleParticipantDeclarationResponse](singleparticipant
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
 
 ```
 {
@@ -880,7 +880,7 @@ This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 ```
 
 404 - Not found
-This response returns a [NotFoundResponse](notfoundresponse) schema.
+This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 
 ```
 {
@@ -914,13 +914,13 @@ This response returns a [NotFoundResponse](notfoundresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](singleparticipantdeclarationresponse) schema.<br/> | 
+| 200 | Successful<br/>This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - Successful
-This response returns a [SingleParticipantDeclarationResponse](singleparticipantdeclarationresponse) schema.
+This response returns a [SingleParticipantDeclarationResponse](#schema-singleparticipantdeclarationresponse) schema.
 
 ```
 {
@@ -966,9 +966,9 @@ This response returns a [SingleParticipantDeclarationResponse](singleparticipant
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine ECF participants to return.<br/>This consumes a [ECFParticipantFilter](ecfparticipantfilter) schema.<br/> | filter[cohort]=2022&filter[from\_participant\_id]=439ac4fe-a003-417f-9694-07c45b3482f8&filter[training\_status]=active&filter[updated\_since]=2020-11-13T11:21:55Z | 
-| page | query | object | false | Pagination options to navigate through the list of ECF participants.<br/>This consumes a [Pagination](pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
-| sort | query | array | false | Sort ECF participants being returned.<br/>This consumes a [ECFParticipantsSort](ecfparticipantssort) schema.<br/> | sort=-updated\_at | 
+| filter | query | object | false | Refine ECF participants to return.<br/>This consumes a [ECFParticipantFilter](#schema-ecfparticipantfilter) schema.<br/> | filter[cohort]=2022&filter[from\_participant\_id]=439ac4fe-a003-417f-9694-07c45b3482f8&filter[training\_status]=active&filter[updated\_since]=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of ECF participants.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| sort | query | array | false | Sort ECF participants being returned.<br/>This consumes a [ECFParticipantsSort](#schema-ecfparticipantssort) schema.<br/> | sort=-updated\_at | 
 
 
 ### Responses
@@ -976,14 +976,14 @@ This response returns a [SingleParticipantDeclarationResponse](singleparticipant
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A list of ECF participants<br/>This response returns a [MultipleECFParticipantsResponse](multipleecfparticipantsresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
+| 200 | A list of ECF participants<br/>This response returns a [MultipleECFParticipantsResponse](#schema-multipleecfparticipantsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A list of ECF participants
-This response returns a [MultipleECFParticipantsResponse](multipleecfparticipantsresponse) schema.
+This response returns a [MultipleECFParticipantsResponse](#schema-multipleecfparticipantsresponse) schema.
 
 ```
 {
@@ -1034,7 +1034,7 @@ This response returns a [MultipleECFParticipantsResponse](multipleecfparticipant
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
 
 ```
 {
@@ -1067,15 +1067,15 @@ This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A single ECF participant<br/>This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
-| 404 | Not Found<br/>This response returns a [NotFoundResponse](notfoundresponse) schema.<br/> | 
+| 200 | A single ECF participant<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 404 | Not Found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A single ECF participant
-This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
 
 ```
 {
@@ -1124,7 +1124,7 @@ This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
 
 ```
 {
@@ -1133,7 +1133,7 @@ This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 ```
 
 404 - Not Found
-This response returns a [NotFoundResponse](notfoundresponse) schema.
+This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 
 ```
 {
@@ -1159,8 +1159,8 @@ This response returns a [NotFoundResponse](notfoundresponse) schema.
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine participant transfers to return.<br/>This consumes a [ListFilter](listfilter) schema.<br/> | filter[updated\_since]=2020-11-13T11:21:55Z | 
-| page | query | object | false | Pagination options to navigate through the list of participant transfers.<br/>This consumes a [Pagination](pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| filter | query | object | false | Refine participant transfers to return.<br/>This consumes a [ListFilter](#schema-listfilter) schema.<br/> | filter[updated\_since]=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of participant transfers.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
 
 
 ### Responses
@@ -1168,14 +1168,14 @@ This response returns a [NotFoundResponse](notfoundresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A list of ECF participant transfers<br/>This response returns a [MultipleECFParticipantTransferResponse](multipleecfparticipanttransferresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
+| 200 | A list of ECF participant transfers<br/>This response returns a [MultipleECFParticipantTransferResponse](#schema-multipleecfparticipanttransferresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A list of ECF participant transfers
-This response returns a [MultipleECFParticipantTransferResponse](multipleecfparticipanttransferresponse) schema.
+This response returns a [MultipleECFParticipantTransferResponse](#schema-multipleecfparticipanttransferresponse) schema.
 
 ```
 {
@@ -1208,7 +1208,7 @@ This response returns a [MultipleECFParticipantTransferResponse](multipleecfpart
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
 
 ```
 {
@@ -1239,7 +1239,7 @@ This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 ### Request body
 
 
-This consumes a [ECFParticipantDeferRequest](ecfparticipantdeferrequest) schema.
+This consumes a [ECFParticipantDeferRequest](#schema-ecfparticipantdeferrequest) schema.
 
 ### Request example
 
@@ -1262,13 +1262,13 @@ This consumes a [ECFParticipantDeferRequest](ecfparticipantdeferrequest) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant being deferred<br/>This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.<br/> | 
+| 200 | The ECF participant being deferred<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant being deferred
-This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
 
 ```
 {
@@ -1342,7 +1342,7 @@ This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
 ### Request body
 
 
-This consumes a [ECFParticipantResumeRequest](ecfparticipantresumerequest) schema.
+This consumes a [ECFParticipantResumeRequest](#schema-ecfparticipantresumerequest) schema.
 
 ### Request example
 
@@ -1364,13 +1364,13 @@ This consumes a [ECFParticipantResumeRequest](ecfparticipantresumerequest) schem
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant being resumed<br/>This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.<br/> | 
+| 200 | The ECF participant being resumed<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant being resumed
-This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
 
 ```
 {
@@ -1441,7 +1441,7 @@ This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
 ### Request body
 
 
-This consumes a [ECFParticipantWithdrawRequest](ecfparticipantwithdrawrequest) schema.
+This consumes a [ECFParticipantWithdrawRequest](#schema-ecfparticipantwithdrawrequest) schema.
 
 ### Request example
 
@@ -1464,13 +1464,13 @@ This consumes a [ECFParticipantWithdrawRequest](ecfparticipantwithdrawrequest) s
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF participant being withdrawn<br/>This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.<br/> | 
+| 200 | The ECF participant being withdrawn<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF participant being withdrawn
-This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
 
 ```
 {
@@ -1546,15 +1546,15 @@ This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A single participant’s transfers<br/>This response returns a [ECFParticipantTransferResponse](ecfparticipanttransferresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
-| 404 | Not Found<br/>This response returns a [NotFoundResponse](notfoundresponse) schema.<br/> | 
+| 200 | A single participant’s transfers<br/>This response returns a [ECFParticipantTransferResponse](#schema-ecfparticipanttransferresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 404 | Not Found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A single participant’s transfers
-This response returns a [ECFParticipantTransferResponse](ecfparticipanttransferresponse) schema.
+This response returns a [ECFParticipantTransferResponse](#schema-ecfparticipanttransferresponse) schema.
 
 ```
 {
@@ -1579,7 +1579,7 @@ This response returns a [ECFParticipantTransferResponse](ecfparticipanttransferr
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
 
 ```
 {
@@ -1588,7 +1588,7 @@ This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 ```
 
 404 - Not Found
-This response returns a [NotFoundResponse](notfoundresponse) schema.
+This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 
 ```
 {
@@ -1620,7 +1620,7 @@ This response returns a [NotFoundResponse](notfoundresponse) schema.
 ### Request body
 
 
-This consumes a [ECFParticipantChangeScheduleRequest](ecfparticipantchangeschedulerequest) schema.
+This consumes a [ECFParticipantChangeScheduleRequest](#schema-ecfparticipantchangeschedulerequest) schema.
 
 ### Request example
 
@@ -1644,13 +1644,13 @@ This consumes a [ECFParticipantChangeScheduleRequest](ecfparticipantchangeschedu
 
 | Status | Description |
 | ---- | ---- |
-| 200 | The ECF Participant changing schedule<br/>This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.<br/> | 
+| 200 | The ECF Participant changing schedule<br/>This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - The ECF Participant changing schedule
-This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
+This response returns a [ECFParticipantResponse](#schema-ecfparticipantresponse) schema.
 
 ```
 {
@@ -1715,9 +1715,9 @@ This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine unfunded mentors to return.<br/>This consumes a [ListFilter](listfilter) schema.<br/> | filter[updated\_since]=2020-11-13T11:21:55Z | 
-| page | query | object | false | Pagination options to navigate through the list of unfunded mentors.<br/>This consumes a [Pagination](pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
-| sort | query | array | false | Sort unfunded mentors being returned.<br/>This consumes a [ECFUnfundedMentorsSort](ecfunfundedmentorssort) schema.<br/> | sort=-updated\_at | 
+| filter | query | object | false | Refine unfunded mentors to return.<br/>This consumes a [ListFilter](#schema-listfilter) schema.<br/> | filter[updated\_since]=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of unfunded mentors.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| sort | query | array | false | Sort unfunded mentors being returned.<br/>This consumes a [ECFUnfundedMentorsSort](#schema-ecfunfundedmentorssort) schema.<br/> | sort=-updated\_at | 
 
 
 ### Responses
@@ -1725,14 +1725,14 @@ This response returns a [ECFParticipantResponse](ecfparticipantresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A list of unfunded mentors<br/>This response returns a [MultipleUnfundedMentorsResponse](multipleunfundedmentorsresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
+| 200 | A list of unfunded mentors<br/>This response returns a [MultipleUnfundedMentorsResponse](#schema-multipleunfundedmentorsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A list of unfunded mentors
-This response returns a [MultipleUnfundedMentorsResponse](multipleunfundedmentorsresponse) schema.
+This response returns a [MultipleUnfundedMentorsResponse](#schema-multipleunfundedmentorsresponse) schema.
 
 ```
 {
@@ -1753,7 +1753,7 @@ This response returns a [MultipleUnfundedMentorsResponse](multipleunfundedmentor
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
 
 ```
 {
@@ -1786,15 +1786,15 @@ This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A single unfunded mentor<br/>This response returns a [UnfundedMentorResponse](unfundedmentorresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
-| 404 | Not Found<br/>This response returns a [NotFoundResponse](notfoundresponse) schema.<br/> | 
+| 200 | A single unfunded mentor<br/>This response returns a [UnfundedMentorResponse](#schema-unfundedmentorresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 404 | Not Found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A single unfunded mentor
-This response returns a [UnfundedMentorResponse](unfundedmentorresponse) schema.
+This response returns a [UnfundedMentorResponse](#schema-unfundedmentorresponse) schema.
 
 ```
 {
@@ -1813,7 +1813,7 @@ This response returns a [UnfundedMentorResponse](unfundedmentorresponse) schema.
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
 
 ```
 {
@@ -1822,7 +1822,7 @@ This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 ```
 
 404 - Not Found
-This response returns a [NotFoundResponse](notfoundresponse) schema.
+This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 
 ```
 {
@@ -1848,8 +1848,8 @@ This response returns a [NotFoundResponse](notfoundresponse) schema.
 
 | Parameter | In | Type | Required | Description | Example |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| filter | query | object | false | Refine statements to return.<br/>This consumes a [StatementsFilter](statementsfilter) schema.<br/> | filter[cohort]=2021,2022&filter[type]=ecf&filter[updated\_since]=2020-11-13T11:21:55Z | 
-| page | query | object | false | Pagination options to navigate through the list of statements.<br/>This consumes a [Pagination](pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
+| filter | query | object | false | Refine statements to return.<br/>This consumes a [StatementsFilter](#schema-statementsfilter) schema.<br/> | filter[cohort]=2021,2022&filter[type]=ecf&filter[updated\_since]=2020-11-13T11:21:55Z | 
+| page | query | object | false | Pagination options to navigate through the list of statements.<br/>This consumes a [Pagination](#schema-pagination) schema.<br/> | page[page]=1&page[per\_page]=5 | 
 
 
 ### Responses
@@ -1857,14 +1857,14 @@ This response returns a [NotFoundResponse](notfoundresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A list of statements as part of which the DfE will make output payments for ecf participants<br/>This response returns a [StatementsResponse](statementsresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
+| 200 | A list of statements as part of which the DfE will make output payments for ecf participants<br/>This response returns a [StatementsResponse](#schema-statementsresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A list of statements as part of which the DfE will make output payments for ecf participants
-This response returns a [StatementsResponse](statementsresponse) schema.
+This response returns a [StatementsResponse](#schema-statementsresponse) schema.
 
 ```
 {
@@ -1889,7 +1889,7 @@ This response returns a [StatementsResponse](statementsresponse) schema.
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
 
 ```
 {
@@ -1922,15 +1922,15 @@ This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 
 | Status | Description |
 | ---- | ---- |
-| 200 | A specific financial statement<br/>This response returns a [StatementResponse](statementresponse) schema.<br/> | 
-| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.<br/> | 
-| 404 | Not Found<br/>This response returns a [NotFoundResponse](notfoundresponse) schema.<br/> | 
+| 200 | A specific financial statement<br/>This response returns a [StatementResponse](#schema-statementresponse) schema.<br/> | 
+| 401 | Unauthorized<br/>This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.<br/> | 
+| 404 | Not Found<br/>This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.<br/> | 
 
 
 ### Response examples
 
 200 - A specific financial statement
-This response returns a [StatementResponse](statementresponse) schema.
+This response returns a [StatementResponse](#schema-statementresponse) schema.
 
 ```
 {
@@ -1953,7 +1953,7 @@ This response returns a [StatementResponse](statementresponse) schema.
 ```
 
 401 - Unauthorized
-This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
+This response returns a [UnauthorisedResponse](#schema-unauthorisedresponse) schema.
 
 ```
 {
@@ -1962,7 +1962,7 @@ This response returns a [UnauthorisedResponse](unauthorisedresponse) schema.
 ```
 
 404 - Not Found
-This response returns a [NotFoundResponse](notfoundresponse) schema.
+This response returns a [NotFoundResponse](#schema-notfoundresponse) schema.
 
 ```
 {
@@ -2022,7 +2022,7 @@ A delivery partner
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the delivery partner<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with a delivery partner<br/>It conforms to [DeliveryPartnerAttributes](deliverypartnerattributes) schema. | 
+| attributes | object | true | The data attributes associated with a delivery partner<br/>It conforms to [DeliveryPartnerAttributes](#schema-deliverypartnerattributes) schema. | 
 
 
 ### DeliveryPartnerAttributes
@@ -2056,7 +2056,7 @@ A delivery partner
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | A delivery partner<br/>It conforms to [DeliveryPartner](deliverypartner) schema. | 
+| data | object | true | A delivery partner<br/>It conforms to [DeliveryPartner](#schema-deliverypartner) schema. | 
 
 
 ### DeliveryPartnersFilter
@@ -2076,7 +2076,7 @@ A list of delivery partners
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [DeliveryPartner](deliverypartner) schema. | 
+| data | array | true | It conforms to [DeliveryPartner](#schema-deliverypartner) schema. | 
 
 
 ### DeliveryPartnersSort
@@ -2086,7 +2086,7 @@ Sort delivery partners being returned
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| Item | string | false | It conforms to [DeliveryPartnersSort/items](deliverypartnerssort-items) schema.Possible values:<br/><ul><li>created\_at</li><li>-created\_at</li><li>updated\_at</li><li>-updated\_at</li></ul> | 
+| Item | string | false | It conforms to [DeliveryPartnersSort/items](#schema-deliverypartnerssort-items) schema.Possible values:<br/><ul><li>created\_at</li><li>-created\_at</li><li>updated\_at</li><li>-updated\_at</li></ul> | 
 
 
 ### ECFDeferral
@@ -2132,8 +2132,8 @@ The details of an ECF Participant enrolment
 | sparsity\_uplift | boolean | true | Indicates whether this participant qualifies for an uplift payment due to sparsity<br/> | 
 | schedule\_identifier | string | true | The schedule of the ECF participant. For the possible values please refer to the [ECF schedules and milestone dates guidance](/api-reference/ecf/schedules-and-milestone-dates.html#schedules-and-milestone-dates) .<br/>Possible values:<br/><ul><li>ecf-standard-september</li><li>ecf-standard-january</li><li>ecf-standard-april</li><li>ecf-reduced-september</li><li>ecf-reduced-january</li><li>ecf-reduced-april</li><li>ecf-extended-september</li><li>ecf-extended-january</li><li>ecf-extended-april</li><li>ecf-replacement-september</li><li>ecf-replacement-january</li><li>ecf-replacement-april</li></ul> | 
 | delivery\_partner\_id | string | true | Unique ID of the delivery partner associated with the participant<br/> | 
-| withdrawal |  | false | This conforms to any of the following schemas:<br/><ul><li> [ECFWithdrawal](ecfwithdrawal) </li></ul> | 
-| deferral |  | false | This conforms to any of the following schemas:<br/><ul><li> [ECFDeferral](ecfdeferral) </li></ul> | 
+| withdrawal |  | false | This conforms to any of the following schemas:<br/><ul><li> [ECFWithdrawal](#schema-ecfwithdrawal) </li></ul> | 
+| deferral |  | false | This conforms to any of the following schemas:<br/><ul><li> [ECFDeferral](#schema-ecfdeferral) </li></ul> | 
 | created\_at | string | true | The date and time the ECF participant was created<br/> | 
 | induction\_end\_date | string | false | The ECF participant induction end date<br/> | 
 | mentor\_funding\_end\_date | string | false | The ECF participant mentor training completion date<br/> | 
@@ -2150,7 +2150,7 @@ The details of an ECF Participant enrolment
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantAttributes](ecfparticipantattributes) schema. | 
+| attributes | object | true | The data attributes associated with an ECF participant<br/>It conforms to [ECFParticipantAttributes](#schema-ecfparticipantattributes) schema. | 
 
 
 ### ECFParticipantAttributes
@@ -2163,8 +2163,8 @@ The data attributes associated with an ECF participant
 | full\_name | string | true | The full name of this ECF participant<br/> | 
 | teacher\_reference\_number | string | false | The Teacher Reference Number (TRN) for this participant<br/> | 
 | updated\_at | string | true | The date and time the ECF participant was last updated<br/> | 
-| ecf\_enrolments | array | true | Information about the course(s) the participant is enroled in<br/>It conforms to [ECFEnrolment](ecfenrolment) schema. | 
-| participant\_id\_changes | array | true | Information about the Participant ID changes<br/>It conforms to [ParticipantIdChange](participantidchange) schema. | 
+| ecf\_enrolments | array | true | Information about the course(s) the participant is enroled in<br/>It conforms to [ECFEnrolment](#schema-ecfenrolment) schema. | 
+| participant\_id\_changes | array | true | Information about the Participant ID changes<br/>It conforms to [ParticipantIdChange](#schema-participantidchange) schema. | 
 
 
 ### ECFParticipantChangeSchedule
@@ -2175,7 +2175,7 @@ An ECF participant change schedule action
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | true | The data type<br/>Possible values:<br/><ul><li>participant-change-schedule</li></ul> | 
-| attributes | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeScheduleAttributes](ecfparticipantchangescheduleattributes) schema. | 
+| attributes | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeScheduleAttributes](#schema-ecfparticipantchangescheduleattributes) schema. | 
 
 
 #### Example
@@ -2223,7 +2223,7 @@ The change schedule request for a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeSchedule](ecfparticipantchangeschedule) schema. | 
+| data | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeSchedule](#schema-ecfparticipantchangeschedule) schema. | 
 
 
 #### Example
@@ -2390,7 +2390,7 @@ The details of a participant deferral request
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | true | The data type<br/>Possible values:<br/><ul><li>participant-defer</li></ul> | 
-| attributes | object | true | An ECF participant deferral action<br/>It conforms to [ECFParticipantDeferAttributes](ecfparticipantdeferattributes) schema. | 
+| attributes | object | true | An ECF participant deferral action<br/>It conforms to [ECFParticipantDeferAttributes](#schema-ecfparticipantdeferattributes) schema. | 
 
 
 ### ECFParticipantDeferAttributes
@@ -2422,7 +2422,7 @@ The deferral request for a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | The details of a participant deferral request<br/>It conforms to [ECFParticipantDefer](ecfparticipantdefer) schema. | 
+| data | object | true | The details of a participant deferral request<br/>It conforms to [ECFParticipantDefer](#schema-ecfparticipantdefer) schema. | 
 
 
 #### Example
@@ -2509,7 +2509,7 @@ An ECF Participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true |  **Note, this endpoint includes updated specifications.** The details of a participant<br/>It conforms to [ECFParticipant](ecfparticipant) schema. | 
+| data | object | true |  **Note, this endpoint includes updated specifications.** The details of a participant<br/>It conforms to [ECFParticipant](#schema-ecfparticipant) schema. | 
 
 
 ### ECFParticipantResume
@@ -2520,7 +2520,7 @@ An ECF participant resume action
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | true | The data type<br/>Possible values:<br/><ul><li>participant-resume</li></ul> | 
-| attributes | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResumeAttributes](ecfparticipantresumeattributes) schema. | 
+| attributes | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResumeAttributes](#schema-ecfparticipantresumeattributes) schema. | 
 
 
 ### ECFParticipantResumeAttributes
@@ -2550,7 +2550,7 @@ The resume request for a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResume](ecfparticipantresume) schema. | 
+| data | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResume](#schema-ecfparticipantresume) schema. | 
 
 
 #### Example
@@ -2577,7 +2577,7 @@ The resume request for a participant
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an ECF participant transfer<br/>It conforms to [ECFParticipantTransferAttributes](ecfparticipanttransferattributes) schema. | 
+| attributes | object | true | The data attributes associated with an ECF participant transfer<br/>It conforms to [ECFParticipantTransferAttributes](#schema-ecfparticipanttransferattributes) schema. | 
 
 
 ### ECFParticipantTransferAttributes
@@ -2588,7 +2588,7 @@ The data attributes associated with an ECF participant transfer
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | updated\_at | string | true | The date and time the latest ECF participant was last updated<br/> | 
-| transfers | array | true | List of participant transfers<br/>It conforms to [ECFParticipantTransfers](ecfparticipanttransfers) schema. | 
+| transfers | array | true | List of participant transfers<br/>It conforms to [ECFParticipantTransfers](#schema-ecfparticipanttransfers) schema. | 
 
 
 ### ECFParticipantTransferResponse
@@ -2598,7 +2598,7 @@ An ECF participant transfer
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true |  **Note, this is a new endpoint.** The details of an ECF participant transfer<br/>It conforms to [ECFParticipantTransfer](ecfparticipanttransfer) schema. | 
+| data | object | true |  **Note, this is a new endpoint.** The details of an ECF participant transfer<br/>It conforms to [ECFParticipantTransfer](#schema-ecfparticipanttransfer) schema. | 
 
 
 ### ECFParticipantTransfers
@@ -2611,8 +2611,8 @@ The details of an ECF Participant enrolment
 | training\_record\_id | string | true | The unique identifier of the participant training record<br/> | 
 | transfer\_type | string | true | The type of transfer between schools<br/>Possible values:<br/><ul><li>new\_school</li><li>new\_provider</li><li>unknown</li></ul> | 
 | status | string | true | The status of the transfer, if both leaving and joining SIT have completed their journeys or only one has<br/>Possible values:<br/><ul><li>incomplete</li><li>complete</li></ul> | 
-| leaving |  | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantLeaving](ecfparticipantleaving) </li></ul> | 
-| joining |  | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantJoining](ecfparticipantjoining) </li></ul> | 
+| leaving |  | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantLeaving](#schema-ecfparticipantleaving) </li></ul> | 
+| joining |  | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantJoining](#schema-ecfparticipantjoining) </li></ul> | 
 | created\_at | string | true | The date and time the ECF participant transfer was created<br/> | 
 
 
@@ -2624,7 +2624,7 @@ An ECF participant withdrawal action
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | The data type<br/>Possible values:<br/><ul><li>participant-withdraw</li></ul> | 
-| attributes | object | false | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdrawAttributes](ecfparticipantwithdrawattributes) schema. | 
+| attributes | object | false | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdrawAttributes](#schema-ecfparticipantwithdrawattributes) schema. | 
 
 
 ### ECFParticipantWithdrawAttributes
@@ -2656,7 +2656,7 @@ The withdrawal request for a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdraw](ecfparticipantwithdraw) schema. | 
+| data | object | true | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdraw](#schema-ecfparticipantwithdraw) schema. | 
 
 
 #### Example
@@ -2682,7 +2682,7 @@ Sort ECF participants being returned
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| Item | string | false | It conforms to [ECFParticipantsSort/items](ecfparticipantssort-items) schema.Possible values:<br/><ul><li>created\_at</li><li>-created\_at</li><li>updated\_at</li><li>-updated\_at</li></ul> | 
+| Item | string | false | It conforms to [ECFParticipantsSort/items](#schema-ecfparticipantssort-items) schema.Possible values:<br/><ul><li>created\_at</li><li>-created\_at</li><li>updated\_at</li><li>-updated\_at</li></ul> | 
 
 
 ### ECFPartnership
@@ -2694,7 +2694,7 @@ An ECF partnership
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the partnership<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an ECF partnership<br/>It conforms to [ECFPartnershipAttributes](ecfpartnershipattributes) schema. | 
+| attributes | object | true | The data attributes associated with an ECF partnership<br/>It conforms to [ECFPartnershipAttributes](#schema-ecfpartnershipattributes) schema. | 
 
 
 ### ECFPartnershipAttibutesRequest
@@ -2736,7 +2736,7 @@ An ECF partnership
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | Possible values:<br/><ul><li>ecf-partnership</li></ul> | 
-| attributes | object | false | It conforms to [ECFPartnershipAttibutesRequest](ecfpartnershipattibutesrequest) schema. | 
+| attributes | object | false | It conforms to [ECFPartnershipAttibutesRequest](#schema-ecfpartnershipattibutesrequest) schema. | 
 
 
 ### ECFPartnershipRequest
@@ -2746,7 +2746,7 @@ An ECF partnership
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | An ECF partnership<br/>It conforms to [ECFPartnershipDataRequest](ecfpartnershipdatarequest) schema. | 
+| data | object | true | An ECF partnership<br/>It conforms to [ECFPartnershipDataRequest](#schema-ecfpartnershipdatarequest) schema. | 
 
 
 #### Example
@@ -2773,7 +2773,7 @@ A list of errors
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| error | array | false | This conforms to any of the following schemas:<br/><ul><li> [UrnInvalidError](urninvaliderror) </li><li> [PartnershipExistsError](#schema-partnershipexistserror) </li><li> [SchoolFundingError](#schema-schoolfundingerror) </li><li> [DeliveryPartnerCohortError](#schema-deliverypartnercohorterror) </li><li> [OtherProviderRecruitedError](#schema-otherproviderrecruitederror) </li></ul> | 
+| error | array | false | This conforms to any of the following schemas:<br/><ul><li> [UrnInvalidError](#schema-urninvaliderror) </li><li> [PartnershipExistsError](#schema-partnershipexistserror) </li><li> [SchoolFundingError](#schema-schoolfundingerror) </li><li> [DeliveryPartnerCohortError](#schema-deliverypartnercohorterror) </li><li> [OtherProviderRecruitedError](#schema-otherproviderrecruitederror) </li></ul> | 
 
 
 ### ECFPartnershipResponse
@@ -2783,7 +2783,7 @@ An ECF partnership
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | An ECF partnership<br/>It conforms to [ECFPartnership](ecfpartnership) schema. | 
+| data | object | true | An ECF partnership<br/>It conforms to [ECFPartnership](#schema-ecfpartnership) schema. | 
 
 
 ### ECFPartnershipUpdateAttibutesRequest
@@ -2802,7 +2802,7 @@ Update An ECF partnership
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | Possible values:<br/><ul><li>ecf-partnership-update</li></ul> | 
-| attributes | object | false | It conforms to [ECFPartnershipUpdateAttibutesRequest](ecfpartnershipupdateattibutesrequest) schema. | 
+| attributes | object | false | It conforms to [ECFPartnershipUpdateAttibutesRequest](#schema-ecfpartnershipupdateattibutesrequest) schema. | 
 
 
 ### ECFPartnershipUpdateRequest
@@ -2812,7 +2812,7 @@ Update an ECF partnership
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | Update An ECF partnership<br/>It conforms to [ECFPartnershipUpdateDataRequest](ecfpartnershipupdatedatarequest) schema. | 
+| data | object | true | Update An ECF partnership<br/>It conforms to [ECFPartnershipUpdateDataRequest](#schema-ecfpartnershipupdatedatarequest) schema. | 
 
 
 #### Example
@@ -2839,7 +2839,7 @@ An ECF school
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the school<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an ECF school<br/>It conforms to [ECFSchoolAttributes](ecfschoolattributes) schema. | 
+| attributes | object | true | The data attributes associated with an ECF school<br/>It conforms to [ECFSchoolAttributes](#schema-ecfschoolattributes) schema. | 
 
 
 ### ECFSchoolAttributes
@@ -2865,7 +2865,7 @@ A single ECF school
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | An ECF school<br/>It conforms to [ECFSchool](ecfschool) schema. | 
+| data | object | true | An ECF school<br/>It conforms to [ECFSchool](#schema-ecfschool) schema. | 
 
 
 ### ECFSchoolsFilter
@@ -2887,7 +2887,7 @@ Sort schools being returned
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| Item | string | false | It conforms to [ECFSchoolsSort/items](ecfschoolssort-items) schema.Possible values:<br/><ul><li>updated\_at</li><li>-updated\_at</li></ul> | 
+| Item | string | false | It conforms to [ECFSchoolsSort/items](#schema-ecfschoolssort-items) schema.Possible values:<br/><ul><li>updated\_at</li><li>-updated\_at</li></ul> | 
 
 
 ### ECFUnfundedMentorsSort
@@ -2897,7 +2897,7 @@ Sort unfunded mentors being returned.
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| Item | string | false | It conforms to [ECFUnfundedMentorsSort/items](ecfunfundedmentorssort-items) schema.Possible values:<br/><ul><li>updated\_at</li><li>-updated\_at</li></ul> | 
+| Item | string | false | It conforms to [ECFUnfundedMentorsSort/items](#schema-ecfunfundedmentorssort-items) schema.Possible values:<br/><ul><li>updated\_at</li><li>-updated\_at</li></ul> | 
 
 
 ### ECFWithdrawal
@@ -2940,7 +2940,7 @@ A list of errors
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| error | array | false | It conforms to [Error](error) schema. | 
+| error | array | false | It conforms to [Error](#schema-error) schema. | 
 
 
 ### ListFilter
@@ -2971,7 +2971,7 @@ A list of ECF participant transfers
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ECFParticipantTransfer](ecfparticipanttransfer) schema. | 
+| data | array | true | It conforms to [ECFParticipantTransfer](#schema-ecfparticipanttransfer) schema. | 
 
 
 ### MultipleECFParticipantsResponse
@@ -2981,7 +2981,7 @@ A list of ECF participants
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ECFParticipant](ecfparticipant) schema. | 
+| data | array | true | It conforms to [ECFParticipant](#schema-ecfparticipant) schema. | 
 
 
 ### MultipleECFPartnershipsResponse
@@ -2991,7 +2991,7 @@ A list of ECF partnerships
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ECFPartnership](ecfpartnership) schema. | 
+| data | array | true | It conforms to [ECFPartnership](#schema-ecfpartnership) schema. | 
 
 
 ### MultipleECFSchoolsResponse
@@ -3001,7 +3001,7 @@ A list of schools for the given cohort
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ECFSchool](ecfschool) schema. | 
+| data | array | true | It conforms to [ECFSchool](#schema-ecfschool) schema. | 
 
 
 ### MultipleParticipantDeclarationsResponse
@@ -3011,7 +3011,7 @@ A list of participant declarations
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [ParticipantDeclarationResponse](participantdeclarationresponse) schema. | 
+| data | array | true | It conforms to [ParticipantDeclarationResponse](#schema-participantdeclarationresponse) schema. | 
 
 
 ### MultipleUnfundedMentorsResponse
@@ -3021,7 +3021,7 @@ A list of unfunded mentors
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [UnfundedMentor](unfundedmentor) schema. | 
+| data | array | true | It conforms to [UnfundedMentor](#schema-unfundedmentor) schema. | 
 
 
 ### NotFoundResponse
@@ -3105,7 +3105,7 @@ A participant declaration data request for ECT participants from cohort 2025 onw
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024ECTStartedAttributesRequest](ecfparticipantdeclarationpost2024ectstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTRetainedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectretainedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectcompletedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTExtendedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectextendedattributesrequest) </li></ul> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024ECTStartedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTRetainedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectretainedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectcompletedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTExtendedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectextendedattributesrequest) </li></ul> | 
 
 
 ### ParticipantDeclarationPost2024MentorDataRequest
@@ -3116,7 +3116,7 @@ A participant declaration data request for mentor participants from cohort 2025 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024MentorStartedAttributesRequest](ecfparticipantdeclarationpost2024mentorstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024MentorCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorcompletedattributesrequest) </li></ul> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024MentorStartedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024MentorCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorcompletedattributesrequest) </li></ul> | 
 
 
 ### ParticipantDeclarationPre2025DataRequest
@@ -3127,7 +3127,7 @@ A participant declaration data request for participants in cohort 2024 and previ
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | type | string | false | Possible values:<br/><ul><li>participant-declaration</li></ul> | 
-| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPre2025StartedAttributesRequest](ecfparticipantdeclarationpre2025startedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025RetainedAttributesRequest](#schema-ecfparticipantdeclarationpre2025retainedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025CompletedAttributesRequest](#schema-ecfparticipantdeclarationpre2025completedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025ExtendedAttributesRequest](#schema-ecfparticipantdeclarationpre2025extendedattributesrequest) </li></ul> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPre2025StartedAttributesRequest](#schema-ecfparticipantdeclarationpre2025startedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025RetainedAttributesRequest](#schema-ecfparticipantdeclarationpre2025retainedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025CompletedAttributesRequest](#schema-ecfparticipantdeclarationpre2025completedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025ExtendedAttributesRequest](#schema-ecfparticipantdeclarationpre2025extendedattributesrequest) </li></ul> | 
 
 
 ### ParticipantDeclarationRequest
@@ -3137,7 +3137,7 @@ An participant declaration request
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | This conforms to any of the following schemas:<br/><ul><li> [ParticipantDeclarationPre2025DataRequest](participantdeclarationpre2025datarequest) </li><li> [ParticipantDeclarationPost2024ECTDataRequest](#schema-participantdeclarationpost2024ectdatarequest) </li><li> [ParticipantDeclarationPost2024MentorDataRequest](#schema-participantdeclarationpost2024mentordatarequest) </li></ul> | 
+| data | object | true | This conforms to any of the following schemas:<br/><ul><li> [ParticipantDeclarationPre2025DataRequest](#schema-participantdeclarationpre2025datarequest) </li><li> [ParticipantDeclarationPost2024ECTDataRequest](#schema-participantdeclarationpost2024ectdatarequest) </li><li> [ParticipantDeclarationPost2024MentorDataRequest](#schema-participantdeclarationpost2024mentordatarequest) </li></ul> | 
 
 
 ### ParticipantDeclarationResponse
@@ -3149,7 +3149,7 @@ A participant declaration response
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the participant declaration record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with a participant declaration response<br/>It conforms to [ParticipantDeclarationAttributes](participantdeclarationattributes) schema. | 
+| attributes | object | true | The data attributes associated with a participant declaration response<br/>It conforms to [ParticipantDeclarationAttributes](#schema-participantdeclarationattributes) schema. | 
 
 
 ### ParticipantDeclarationsFilter
@@ -3219,7 +3219,7 @@ Sort partnerships being returned
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| Item | string | false | It conforms to [PartnershipsSort/items](partnershipssort-items) schema.Possible values:<br/><ul><li>created\_at</li><li>-created\_at</li><li>updated\_at</li><li>-updated\_at</li></ul> | 
+| Item | string | false | It conforms to [PartnershipsSort/items](#schema-partnershipssort-items) schema.Possible values:<br/><ul><li>created\_at</li><li>-created\_at</li><li>updated\_at</li><li>-updated\_at</li></ul> | 
 
 
 ### SchoolFundingError
@@ -3240,7 +3240,7 @@ A confirmation that the participant declaration has been recorded successfully
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | A participant declaration response<br/>It conforms to [ParticipantDeclarationResponse](participantdeclarationresponse) schema. | 
+| data | object | true | A participant declaration response<br/>It conforms to [ParticipantDeclarationResponse](#schema-participantdeclarationresponse) schema. | 
 
 
 ### Statement
@@ -3252,7 +3252,7 @@ A financial statement
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the financial statement<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with a financial statement<br/>It conforms to [StatementAttributes](statementattributes) schema. | 
+| attributes | object | true | The data attributes associated with a financial statement<br/>It conforms to [StatementAttributes](#schema-statementattributes) schema. | 
 
 
 ### StatementAttributes
@@ -3280,7 +3280,7 @@ A single financial statement
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | A financial statement<br/>It conforms to [Statement](statement) schema. | 
+| data | object | true | A financial statement<br/>It conforms to [Statement](#schema-statement) schema. | 
 
 
 ### StatementsFilter
@@ -3302,7 +3302,7 @@ A list of financial statements
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | array | true | It conforms to [Statement](statement) schema. | 
+| data | array | true | It conforms to [Statement](#schema-statement) schema. | 
 
 
 ### UnauthorisedResponse
@@ -3324,7 +3324,7 @@ Authorization information is missing or invalid
 | ---- | ---- | ---- | ---- |
 | id | string | true | The unique identifier of the mentor record<br/> | 
 | type | string | true | The data type<br/> | 
-| attributes | object | true | The data attributes associated with an unfunded mentor<br/>It conforms to [UnfundedMentorAttributes](unfundedmentorattributes) schema. | 
+| attributes | object | true | The data attributes associated with an unfunded mentor<br/>It conforms to [UnfundedMentorAttributes](#schema-unfundedmentorattributes) schema. | 
 
 
 ### UnfundedMentorAttributes
@@ -3348,7 +3348,7 @@ An unfunded mentor
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true |  **Note, this is a new endpoint.** The details of an unfunded mentor<br/>It conforms to [UnfundedMentor](unfundedmentor) schema. | 
+| data | object | true |  **Note, this is a new endpoint.** The details of an unfunded mentor<br/>It conforms to [UnfundedMentor](#schema-unfundedmentor) schema. | 
 
 
 ### UrnInvalidError

--- a/documentation/ecf1_guidance/reference-v3.md
+++ b/documentation/ecf1_guidance/reference-v3.md
@@ -1,3 +1,4 @@
+
 # Lead provider API - 3.0.0
 
 
@@ -8,10 +9,13 @@ The lead provider API for DfE’s manage teacher CPD service.
 
  **Sandbox** 
  [https://sb.manage-training-for-early-career-teachers.education.gov.uk](https://sb.manage-training-for-early-career-teachers.education.gov.uk) 
+
  **Current environment** 
  [/](/) 
+
  **Production** 
  [https://manage-training-for-early-career-teachers.education.gov.uk](https://manage-training-for-early-career-teachers.education.gov.uk) 
+
 ## GET
     
     
@@ -2041,7 +2045,7 @@ Not a delivery partner you have a relationship with for this cohort
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| title | string | false | Title of error message<br/>Possible values:<br/><br/> - Not a delivery partner you have a relationship with for this cohort<br/><br/> | 
+| title | string | false | Title of error message<br/>Possible values:<br/><ul><li>Not a delivery partner you have a relationship with for this cohort</li></ul> | 
 | detail | string | false | Additional info on which cohorts are available<br/> | 
 
 
@@ -2082,7 +2086,7 @@ Sort delivery partners being returned
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| Item | string | false | It conforms to [DeliveryPartnersSort/items](#schema-deliverypartnerssort-items) schema.Possible values:<br/><br/> - created\_at<br/> - -created\_at<br/> - updated\_at<br/> - -updated\_at<br/><br/> | 
+| Item | string | false | It conforms to [DeliveryPartnersSort/items](#schema-deliverypartnerssort-items) schema.Possible values:<br/><ul><li>created\_at</li><li>-created\_at</li><li>updated\_at</li><li>-updated\_at</li></ul> | 
 
 
 ### ECFDeferral
@@ -2092,7 +2096,7 @@ The details of an ECF Participant deferral
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| reason | string | true | The reason a participant was deferred<br/>Possible values:<br/><br/> - bereavement<br/> - long-term-sickness<br/> - parental-leave<br/> - career-break<br/> - other<br/><br/> | 
+| reason | string | true | The reason a participant was deferred<br/>Possible values:<br/><ul><li>bereavement</li><li>long-term-sickness</li><li>parental-leave</li><li>career-break</li><li>other</li></ul> | 
 | date | string | true | The date and time the participant was deferred<br/> | 
 
 
@@ -2118,31 +2122,29 @@ The details of an ECF Participant enrolment
 | email | string | true | The email address registered for this ECF participant<br/> | 
 | mentor\_id | string | false | The unique identifier of this ECF participants mentor<br/> | 
 | school\_urn | string | true | The Unique Reference Number (URN) of the school that submitted this ECF participant<br/> | 
-| participant\_type | string | true | The type of ECF participant this record refers to<br/>Possible values:<br/><br/> - ect<br/> - mentor<br/><br/> | 
+| participant\_type | string | true | The type of ECF participant this record refers to<br/>Possible values:<br/><ul><li>ect</li><li>mentor</li></ul> | 
 | cohort | string | true | Indicates which call-off contract funds this participant’s training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year.<br/> | 
-| training\_status | string | true | The training status of the ECF participant<br/>Possible values:<br/><br/> - active<br/> - deferred<br/> - withdrawn<br/><br/> | 
-| participant\_status | string | true | Replaces the old status field. Indicates if a SIT has advised DfE of a transfer or a withdrawal of the participant from the school<br/>Possible values:<br/><br/> - active<br/> - joining<br/> - leaving<br/> - left<br/> - withdrawn<br/><br/> | 
+| training\_status | string | true | The training status of the ECF participant<br/>Possible values:<br/><ul><li>active</li><li>deferred</li><li>withdrawn</li></ul> | 
+| participant\_status | string | true | Replaces the old status field. Indicates if a SIT has advised DfE of a transfer or a withdrawal of the participant from the school<br/>Possible values:<br/><ul><li>active</li><li>joining</li><li>leaving</li><li>left</li><li>withdrawn</li></ul> | 
 | teacher\_reference\_number\_validated | boolean | true | Indicates whether the Teacher Reference Number (TRN) has been validated<br/> | 
 | eligible\_for\_funding | boolean | true | Indicates whether this participant is eligible to receive DfE funded induction<br/> | 
 | pupil\_premium\_uplift | boolean | true | Indicates whether this participant qualifies for an uplift payment due to pupil premium<br/> | 
 | sparsity\_uplift | boolean | true | Indicates whether this participant qualifies for an uplift payment due to sparsity<br/> | 
-| schedule\_identifier | string | true | The schedule of the ECF participant. For the possible values please refer to the [ECF schedules and milestone dates guidance](/api-reference/ecf/schedules-and-milestone-dates.html#schedules-and-milestone-dates) .<br/>Possible values:<br/><br/> - ecf-standard-september<br/> - ecf-standard-january<br/> - ecf-standard-april<br/> - ecf-reduced-september<br/> - ecf-reduced-january<br/> - ecf-reduced-april<br/> - ecf-extended-september<br/> - ecf-extended-january<br/> - ecf-extended-april<br/> - ecf-replacement-september<br/> - ecf-replacement-january<br/> - ecf-replacement-april<br/><br/> | 
+| schedule\_identifier | string | true | The schedule of the ECF participant. For the possible values please refer to the [ECF schedules and milestone dates guidance](/api-reference/ecf/schedules-and-milestone-dates.html#schedules-and-milestone-dates) .<br/>Possible values:<br/><ul><li>ecf-standard-september</li><li>ecf-standard-january</li><li>ecf-standard-april</li><li>ecf-reduced-september</li><li>ecf-reduced-january</li><li>ecf-reduced-april</li><li>ecf-extended-september</li><li>ecf-extended-january</li><li>ecf-extended-april</li><li>ecf-replacement-september</li><li>ecf-replacement-january</li><li>ecf-replacement-april</li></ul> | 
 | delivery\_partner\_id | string | true | Unique ID of the delivery partner associated with the participant<br/> | 
-| withdrawal |  | false | This conforms to any of the following schemas:<br/><br/> -  [ECFWithdrawal](#schema-ecfwithdrawal) <br/><br/> | 
-| deferral |  | false | This conforms to any of the following schemas:<br/><br/> -  [ECFDeferral](#schema-ecfdeferral) <br/><br/> | 
+| withdrawal |  | false | This conforms to any of the following schemas:<br/><ul><li> [ECFWithdrawal](#schema-ecfwithdrawal) </li></ul> | 
+| deferral |  | false | This conforms to any of the following schemas:<br/><ul><li> [ECFDeferral](#schema-ecfdeferral) </li></ul> | 
 | created\_at | string | true | The date and time the ECF participant was created<br/> | 
 | induction\_end\_date | string | false | The ECF participant induction end date<br/> | 
 | mentor\_funding\_end\_date | string | false | The ECF participant mentor training completion date<br/> | 
 | cohort\_changed\_after\_payments\_frozen | boolean | false | Identify participants that migrated to a new cohort as payments were frozen on their original cohort<br/> | 
-| mentor\_ineligible\_for\_funding\_reason | string | false | The reason why funding for a mentor’s training has ended<br/>Possible values:<br/><br/> - completed\_declaration\_received<br/> - completed\_during\_early\_roll\_out<br/> - started\_not\_completed<br/><br/> | 
+| mentor\_ineligible\_for\_funding\_reason | string | false | The reason why funding for a mentor’s training has ended<br/>Possible values:<br/><ul><li>completed\_declaration\_received</li><li>completed\_during\_early\_roll\_out</li><li>started\_not\_completed</li></ul> | 
 
 
 ### ECFParticipant
 
 
- ==== A [B] NODE  (1 children) ====
- ==== A [BR] NODE  (0 children) ====
-The details of a participant
+ **Note, this endpoint includes updated specifications.** The details of a participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
@@ -2172,7 +2174,7 @@ An ECF participant change schedule action
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| type | string | true | The data type<br/>Possible values:<br/><br/> - participant-change-schedule<br/><br/> | 
+| type | string | true | The data type<br/>Possible values:<br/><ul><li>participant-change-schedule</li></ul> | 
 | attributes | object | true | An ECF participant change schedule action<br/>It conforms to [ECFParticipantChangeScheduleAttributes](#schema-ecfparticipantchangescheduleattributes) schema. | 
 
 
@@ -2197,8 +2199,8 @@ An ECF participant change schedule action
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| schedule\_identifier | string | true | The new schedule of the participant<br/>Possible values:<br/><br/> - ecf-standard-september<br/> - ecf-standard-january<br/> - ecf-standard-april<br/> - ecf-reduced-september<br/> - ecf-reduced-january<br/> - ecf-reduced-april<br/> - ecf-extended-september<br/> - ecf-extended-january<br/> - ecf-extended-april<br/> - ecf-replacement-september<br/> - ecf-replacement-january<br/> - ecf-replacement-april<br/><br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| schedule\_identifier | string | true | The new schedule of the participant<br/>Possible values:<br/><ul><li>ecf-standard-september</li><li>ecf-standard-january</li><li>ecf-standard-april</li><li>ecf-reduced-september</li><li>ecf-reduced-january</li><li>ecf-reduced-april</li><li>ecf-extended-september</li><li>ecf-extended-january</li><li>ecf-extended-april</li><li>ecf-replacement-september</li><li>ecf-replacement-january</li><li>ecf-replacement-april</li></ul> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li><li>ecf-mentor</li></ul> | 
 | cohort | string | false | Providers may not change the current value for ECF participants. Indicates which call-off contract funds this participant’s training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year.<br/> | 
 
 
@@ -2249,10 +2251,10 @@ An ECF completed participant declaration
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique ID of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - completed<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>completed</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/><br/> | 
-| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - 75-percent-engagement-met<br/> - 75-percent-engagement-met-reduced-induction<br/> - one-term-induction<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li></ul> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><ul><li>75-percent-engagement-met</li><li>75-percent-engagement-met-reduced-induction</li><li>one-term-induction</li></ul> | 
 
 
 ### ECFParticipantDeclarationPost2024ECTExtendedAttributesRequest
@@ -2263,10 +2265,10 @@ An ECF extended participant declaration
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique ID of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - extended-1<br/> - extended-2<br/> - extended-3<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>extended-1</li><li>extended-2</li><li>extended-3</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/><br/> | 
-| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - materials-engaged-with-offline<br/> - other<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li></ul> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><ul><li>training-event-attended</li><li>self-study-material-completed</li><li>materials-engaged-with-offline</li><li>other</li></ul> | 
 
 
 ### ECFParticipantDeclarationPost2024ECTRetainedAttributesRequest
@@ -2277,10 +2279,10 @@ An ECF participant retained declaration
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique ID of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - retained-1<br/> - retained-2<br/> - retained-3<br/> - retained-4<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>retained-1</li><li>retained-2</li><li>retained-3</li><li>retained-4</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/><br/> | 
-| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period. For retained-2 declarations, providers will need to confirm if the engagement threshold has been reached and only accept either the ‘75-percent-engagement-met’ or ‘75-percent-engagement-met-reduced-induction’ values.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - materials-engaged-with-offline<br/> - other<br/> - 75-percent-engagement-met<br/> - 75-percent-engagement-met-reduced-induction<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li></ul> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period. For retained-2 declarations, providers will need to confirm if the engagement threshold has been reached and only accept either the ‘75-percent-engagement-met’ or ‘75-percent-engagement-met-reduced-induction’ values.<br/>Possible values:<br/><ul><li>training-event-attended</li><li>self-study-material-completed</li><li>materials-engaged-with-offline</li><li>other</li><li>75-percent-engagement-met</li><li>75-percent-engagement-met-reduced-induction</li></ul> | 
 
 
 ### ECFParticipantDeclarationPost2024ECTStartedAttributesRequest
@@ -2291,10 +2293,10 @@ An ECF started participant declaration
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique ID of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - started<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>started</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/><br/> | 
-| evidence\_held | string | false | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - materials-engaged-with-offline<br/> - other<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li></ul> | 
+| evidence\_held | string | false | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><ul><li>training-event-attended</li><li>self-study-material-completed</li><li>materials-engaged-with-offline</li><li>other</li></ul> | 
 
 
 ### ECFParticipantDeclarationPost2024MentorCompletedAttributesRequest
@@ -2305,10 +2307,10 @@ An ECF completed participant declaration
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique ID of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - completed<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>completed</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-mentor<br/><br/> | 
-| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - 75-percent-engagement-met<br/> - 75-percent-engagement-met-reduced-induction<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-mentor</li></ul> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><ul><li>75-percent-engagement-met</li><li>75-percent-engagement-met-reduced-induction</li></ul> | 
 
 
 ### ECFParticipantDeclarationPost2024MentorStartedAttributesRequest
@@ -2319,10 +2321,10 @@ An ECF started participant declaration
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique ID of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - started<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>started</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-mentor<br/><br/> | 
-| evidence\_held | string | false | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - materials-engaged-with-offline<br/> - other<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-mentor</li></ul> | 
+| evidence\_held | string | false | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><ul><li>training-event-attended</li><li>self-study-material-completed</li><li>materials-engaged-with-offline</li><li>other</li></ul> | 
 
 
 ### ECFParticipantDeclarationPre2025CompletedAttributesRequest
@@ -2333,10 +2335,10 @@ An ECF completed participant declaration
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique ID of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - completed<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>completed</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
-| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - other<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li><li>ecf-mentor</li></ul> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><ul><li>training-event-attended</li><li>self-study-material-completed</li><li>other</li></ul> | 
 
 
 ### ECFParticipantDeclarationPre2025ExtendedAttributesRequest
@@ -2347,10 +2349,10 @@ An ECF extended participant declaration
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique ID of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - extended-1<br/> - extended-2<br/> - extended-3<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>extended-1</li><li>extended-2</li><li>extended-3</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
-| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - other<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li><li>ecf-mentor</li></ul> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><ul><li>training-event-attended</li><li>self-study-material-completed</li><li>other</li></ul> | 
 
 
 ### ECFParticipantDeclarationPre2025RetainedAttributesRequest
@@ -2361,10 +2363,10 @@ An ECF participant retained declaration
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique ID of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - retained-1<br/> - retained-2<br/> - retained-3<br/> - retained-4<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>retained-1</li><li>retained-2</li><li>retained-3</li><li>retained-4</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
-| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - other<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li><li>ecf-mentor</li></ul> | 
+| evidence\_held | string | true | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period.<br/>Possible values:<br/><ul><li>training-event-attended</li><li>self-study-material-completed</li><li>other</li></ul> | 
 
 
 ### ECFParticipantDeclarationPre2025StartedAttributesRequest
@@ -2375,9 +2377,9 @@ An ECF started participant declaration
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique ID of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - started<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>started</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li><li>ecf-mentor</li></ul> | 
 
 
 ### ECFParticipantDefer
@@ -2387,7 +2389,7 @@ The details of a participant deferral request
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| type | string | true | The data type<br/>Possible values:<br/><br/> - participant-defer<br/><br/> | 
+| type | string | true | The data type<br/>Possible values:<br/><ul><li>participant-defer</li></ul> | 
 | attributes | object | true | An ECF participant deferral action<br/>It conforms to [ECFParticipantDeferAttributes](#schema-ecfparticipantdeferattributes) schema. | 
 
 
@@ -2398,8 +2400,8 @@ An ECF participant deferral action
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| reason | string | true | The reason for the deferral<br/>Possible values:<br/><br/> - bereavement<br/> - long-term-sickness<br/> - parental-leave<br/> - career-break<br/> - other<br/><br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| reason | string | true | The reason for the deferral<br/>Possible values:<br/><ul><li>bereavement</li><li>long-term-sickness</li><li>parental-leave</li><li>career-break</li><li>other</li></ul> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li><li>ecf-mentor</li></ul> | 
 
 
 #### Example
@@ -2507,7 +2509,7 @@ An ECF Participant
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true |  ==== A [B] NODE  (1 children) ==== ==== A [BR] NODE  (0 children) ====The details of a participant<br/>It conforms to [ECFParticipant](#schema-ecfparticipant) schema. | 
+| data | object | true |  **Note, this endpoint includes updated specifications.** The details of a participant<br/>It conforms to [ECFParticipant](#schema-ecfparticipant) schema. | 
 
 
 ### ECFParticipantResume
@@ -2517,7 +2519,7 @@ An ECF participant resume action
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| type | string | true | The data type<br/>Possible values:<br/><br/> - participant-resume<br/><br/> | 
+| type | string | true | The data type<br/>Possible values:<br/><ul><li>participant-resume</li></ul> | 
 | attributes | object | true | An ECF participant resume action<br/>It conforms to [ECFParticipantResumeAttributes](#schema-ecfparticipantresumeattributes) schema. | 
 
 
@@ -2528,7 +2530,7 @@ An ECF participant resume action
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li><li>ecf-mentor</li></ul> | 
 
 
 #### Example
@@ -2569,9 +2571,7 @@ The resume request for a participant
 ### ECFParticipantTransfer
 
 
- ==== A [B] NODE  (1 children) ====
- ==== A [BR] NODE  (0 children) ====
-The details of an ECF participant transfer
+ **Note, this is a new endpoint.** The details of an ECF participant transfer
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
@@ -2598,7 +2598,7 @@ An ECF participant transfer
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true |  ==== A [B] NODE  (1 children) ==== ==== A [BR] NODE  (0 children) ====The details of an ECF participant transfer<br/>It conforms to [ECFParticipantTransfer](#schema-ecfparticipanttransfer) schema. | 
+| data | object | true |  **Note, this is a new endpoint.** The details of an ECF participant transfer<br/>It conforms to [ECFParticipantTransfer](#schema-ecfparticipanttransfer) schema. | 
 
 
 ### ECFParticipantTransfers
@@ -2609,10 +2609,10 @@ The details of an ECF Participant enrolment
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | training\_record\_id | string | true | The unique identifier of the participant training record<br/> | 
-| transfer\_type | string | true | The type of transfer between schools<br/>Possible values:<br/><br/> - new\_school<br/> - new\_provider<br/> - unknown<br/><br/> | 
-| status | string | true | The status of the transfer, if both leaving and joining SIT have completed their journeys or only one has<br/>Possible values:<br/><br/> - incomplete<br/> - complete<br/><br/> | 
-| leaving |  | false | This conforms to any of the following schemas:<br/><br/> -  [ECFParticipantLeaving](#schema-ecfparticipantleaving) <br/><br/> | 
-| joining |  | false | This conforms to any of the following schemas:<br/><br/> -  [ECFParticipantJoining](#schema-ecfparticipantjoining) <br/><br/> | 
+| transfer\_type | string | true | The type of transfer between schools<br/>Possible values:<br/><ul><li>new\_school</li><li>new\_provider</li><li>unknown</li></ul> | 
+| status | string | true | The status of the transfer, if both leaving and joining SIT have completed their journeys or only one has<br/>Possible values:<br/><ul><li>incomplete</li><li>complete</li></ul> | 
+| leaving |  | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantLeaving](#schema-ecfparticipantleaving) </li></ul> | 
+| joining |  | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantJoining](#schema-ecfparticipantjoining) </li></ul> | 
 | created\_at | string | true | The date and time the ECF participant transfer was created<br/> | 
 
 
@@ -2623,7 +2623,7 @@ An ECF participant withdrawal action
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| type | string | false | The data type<br/>Possible values:<br/><br/> - participant-withdraw<br/><br/> | 
+| type | string | false | The data type<br/>Possible values:<br/><ul><li>participant-withdraw</li></ul> | 
 | attributes | object | false | An ECF participant withdrawal action<br/>It conforms to [ECFParticipantWithdrawAttributes](#schema-ecfparticipantwithdrawattributes) schema. | 
 
 
@@ -2634,8 +2634,8 @@ An ECF participant withdrawal action
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| reason | string | true | The reason for the withdrawal<br/>Possible values:<br/><br/> - left-teaching-profession<br/> - moved-school<br/> - mentor-no-longer-being-mentor<br/> - switched-to-school-led<br/> - other<br/><br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
+| reason | string | true | The reason for the withdrawal<br/>Possible values:<br/><ul><li>left-teaching-profession</li><li>moved-school</li><li>mentor-no-longer-being-mentor</li><li>switched-to-school-led</li><li>other</li></ul> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li><li>ecf-mentor</li></ul> | 
 
 
 #### Example
@@ -2682,7 +2682,7 @@ Sort ECF participants being returned
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| Item | string | false | It conforms to [ECFParticipantsSort/items](#schema-ecfparticipantssort-items) schema.Possible values:<br/><br/> - created\_at<br/> - -created\_at<br/> - updated\_at<br/> - -updated\_at<br/><br/> | 
+| Item | string | false | It conforms to [ECFParticipantsSort/items](#schema-ecfparticipantssort-items) schema.Possible values:<br/><ul><li>created\_at</li><li>-created\_at</li><li>updated\_at</li><li>-updated\_at</li></ul> | 
 
 
 ### ECFPartnership
@@ -2719,8 +2719,8 @@ The data attributes associated with an ECF partnership
 | school\_id | string | true | The unique ID of the school you are partnered with<br/> | 
 | delivery\_partner\_id | string | true | The unique ID of the delivery partner you are working with for this partnership<br/> | 
 | delivery\_partner\_name | string | false | The name of the delivery partner you are working with for this partnership<br/> | 
-| status | string | true | The status of the partnership which includes active or challenged<br/>Possible values:<br/><br/> - active<br/> - challenged<br/><br/> | 
-| challenged\_reason | string | false | If the partnership has been challenged, the reason provided for the challenge by the SIT<br/>Possible values:<br/><br/> - another\_provider<br/> - not\_confirmed<br/> - do\_not\_recognise<br/> - no\_ects<br/> - mistake<br/><br/> | 
+| status | string | true | The status of the partnership which includes active or challenged<br/>Possible values:<br/><ul><li>active</li><li>challenged</li></ul> | 
+| challenged\_reason | string | false | If the partnership has been challenged, the reason provided for the challenge by the SIT<br/>Possible values:<br/><ul><li>another\_provider</li><li>not\_confirmed</li><li>do\_not\_recognise</li><li>no\_ects</li><li>mistake</li></ul> | 
 | challenged\_at | string | false | The date the partnership has been challenged<br/> | 
 | induction\_tutor\_name | string | false | The name of the induction tutor at the school you are in partnership with<br/> | 
 | induction\_tutor\_email | string | false | The email address of the induction tutor at the school you are in partnership with<br/> | 
@@ -2735,7 +2735,7 @@ An ECF partnership
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| type | string | false | Possible values:<br/><br/> - ecf-partnership<br/><br/> | 
+| type | string | false | Possible values:<br/><ul><li>ecf-partnership</li></ul> | 
 | attributes | object | false | It conforms to [ECFPartnershipAttibutesRequest](#schema-ecfpartnershipattibutesrequest) schema. | 
 
 
@@ -2773,7 +2773,7 @@ A list of errors
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| error | array | false | This conforms to any of the following schemas:<br/><br/> -  [UrnInvalidError](#schema-urninvaliderror) <br/> -  [PartnershipExistsError](#schema-partnershipexistserror) <br/> -  [SchoolFundingError](#schema-schoolfundingerror) <br/> -  [DeliveryPartnerCohortError](#schema-deliverypartnercohorterror) <br/> -  [OtherProviderRecruitedError](#schema-otherproviderrecruitederror) <br/><br/> | 
+| error | array | false | This conforms to any of the following schemas:<br/><ul><li> [UrnInvalidError](#schema-urninvaliderror) </li><li> [PartnershipExistsError](#schema-partnershipexistserror) </li><li> [SchoolFundingError](#schema-schoolfundingerror) </li><li> [DeliveryPartnerCohortError](#schema-deliverypartnercohorterror) </li><li> [OtherProviderRecruitedError](#schema-otherproviderrecruitederror) </li></ul> | 
 
 
 ### ECFPartnershipResponse
@@ -2801,7 +2801,7 @@ Update An ECF partnership
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| type | string | false | Possible values:<br/><br/> - ecf-partnership-update<br/><br/> | 
+| type | string | false | Possible values:<br/><ul><li>ecf-partnership-update</li></ul> | 
 | attributes | object | false | It conforms to [ECFPartnershipUpdateAttibutesRequest](#schema-ecfpartnershipupdateattibutesrequest) schema. | 
 
 
@@ -2853,7 +2853,7 @@ The data attributes associated with an ECF school
 | urn | string | true | The Unique Reference Number (URN) of the school<br/> | 
 | cohort | string | true | Indicates which call-off contract funds this participant’s training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year.<br/> | 
 | in\_partnership | boolean | true | Whether or not the school already has an active partnership, if it is doing a funded induction programme<br/> | 
-| induction\_programme\_choice | string | true | The induction programme the school offers<br/>Possible values:<br/><br/> - school\_led<br/> - provider\_led<br/> - no\_early\_career\_teachers<br/> - not\_yet\_known<br/><br/> | 
+| induction\_programme\_choice | string | true | The induction programme the school offers<br/>Possible values:<br/><ul><li>school\_led</li><li>provider\_led</li><li>no\_early\_career\_teachers</li><li>not\_yet\_known</li></ul> | 
 | created\_at | string | true | The date and time the school was created<br/> | 
 | updated\_at | string | true | The last time a change was made to this school record by the DfE<br/> | 
 
@@ -2887,7 +2887,7 @@ Sort schools being returned
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| Item | string | false | It conforms to [ECFSchoolsSort/items](#schema-ecfschoolssort-items) schema.Possible values:<br/><br/> - updated\_at<br/> - -updated\_at<br/><br/> | 
+| Item | string | false | It conforms to [ECFSchoolsSort/items](#schema-ecfschoolssort-items) schema.Possible values:<br/><ul><li>updated\_at</li><li>-updated\_at</li></ul> | 
 
 
 ### ECFUnfundedMentorsSort
@@ -2897,7 +2897,7 @@ Sort unfunded mentors being returned.
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| Item | string | false | It conforms to [ECFUnfundedMentorsSort/items](#schema-ecfunfundedmentorssort-items) schema.Possible values:<br/><br/> - updated\_at<br/> - -updated\_at<br/><br/> | 
+| Item | string | false | It conforms to [ECFUnfundedMentorsSort/items](#schema-ecfunfundedmentorssort-items) schema.Possible values:<br/><ul><li>updated\_at</li><li>-updated\_at</li></ul> | 
 
 
 ### ECFWithdrawal
@@ -2907,7 +2907,7 @@ The details of an ECF Participant withdrawal
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| reason | string | true | The reason a participant was withdrawn<br/>Possible values:<br/><br/> - left-teaching-profession<br/> - moved-school<br/> - mentor-no-longer-being-mentor<br/> - switched-to-school-led<br/> - other<br/><br/> | 
+| reason | string | true | The reason a participant was withdrawn<br/>Possible values:<br/><ul><li>left-teaching-profession</li><li>moved-school</li><li>mentor-no-longer-being-mentor</li><li>switched-to-school-led</li><li>other</li></ul> | 
 | date | string | true | The date and time the participant was withdrawn<br/> | 
 
 
@@ -3057,7 +3057,7 @@ Recruited by other provider
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| title | string | false | Title of error message<br/>Possible values:<br/><br/> - Recruited by other provider<br/><br/> | 
+| title | string | false | Title of error message<br/>Possible values:<br/><ul><li>Recruited by other provider</li></ul> | 
 | detail | string | false | Additional info<br/> | 
 
 
@@ -3080,19 +3080,19 @@ The data attributes associated with a participant declaration response
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | participant\_id | string | true | The unique id of the participant<br/> | 
-| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><br/> - started<br/> - retained-1<br/> - retained-2<br/> - retained-3<br/> - retained-4<br/> - completed<br/> - extended-1<br/> - extended-2<br/> - extended-3<br/><br/> | 
+| declaration\_type | string | true | The event declaration type<br/>Possible values:<br/><ul><li>started</li><li>retained-1</li><li>retained-2</li><li>retained-3</li><li>retained-4</li><li>completed</li><li>extended-1</li><li>extended-2</li><li>extended-3</li></ul> | 
 | declaration\_date | string | true | The event declaration date<br/> | 
-| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><br/> - ecf-induction<br/> - ecf-mentor<br/><br/> | 
-| state | string | true | Indicates the state of this payment declaration<br/>Possible values:<br/><br/> - submitted<br/> - eligible<br/> - payable<br/> - paid<br/> - voided<br/> - ineligible<br/> - awaiting-clawback<br/> - clawed-back<br/><br/> | 
+| course\_identifier | string | true | The type of course the participant is enrolled in<br/>Possible values:<br/><ul><li>ecf-induction</li><li>ecf-mentor</li></ul> | 
+| state | string | true | Indicates the state of this payment declaration<br/>Possible values:<br/><ul><li>submitted</li><li>eligible</li><li>payable</li><li>paid</li><li>voided</li><li>ineligible</li><li>awaiting-clawback</li><li>clawed-back</li></ul> | 
 | updated\_at | string | true | The date the declaration was last updated<br/> | 
 | created\_at | string | false | The date the declaration was created<br/> | 
 | delivery\_partner\_id | string | false | Unique ID of the delivery partner associated with the participant at the time the declaration was created<br/> | 
 | statement\_id | string | false | Unique ID of the statement the declaration will be paid as part of<br/> | 
 | clawback\_statement\_id | string | false | Unique id of the statement to which the declaration will be clawed back on, if any<br/> | 
-| ineligible\_for\_funding\_reason | string | false | If the declaration is ineligible, the reason why<br/>Possible values:<br/><br/> - duplicate\_declaration<br/><br/> | 
+| ineligible\_for\_funding\_reason | string | false | If the declaration is ineligible, the reason why<br/>Possible values:<br/><ul><li>duplicate\_declaration</li></ul> | 
 | mentor\_id | string | false | Unique ID of the ECT’s mentor<br/> | 
 | uplift\_paid | boolean | false | If participant is eligible for uplift, whether it has been paid as part of this declaration<br/> | 
-| evidence\_held | string | false | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period. For retained-2 declarations, providers will need to confirm if the engagement threshold has been reached and only accept either the ‘75-percent-engagement-met’ or ‘75-percent-engagement-met-reduced-induction’ values.<br/>Possible values:<br/><br/> - training-event-attended<br/> - self-study-material-completed<br/> - other<br/> - materials-engaged-with-offline<br/> - 75-percent-engagement-met<br/> - 75-percent-engagement-met-reduced-induction<br/> - one-term-induction<br/><br/> | 
+| evidence\_held | string | false | The type of evidence the lead provider holds on their platform to demonstrate the participant has met the retention criteria for the current milestone period. For retained-2 declarations, providers will need to confirm if the engagement threshold has been reached and only accept either the ‘75-percent-engagement-met’ or ‘75-percent-engagement-met-reduced-induction’ values.<br/>Possible values:<br/><ul><li>training-event-attended</li><li>self-study-material-completed</li><li>other</li><li>materials-engaged-with-offline</li><li>75-percent-engagement-met</li><li>75-percent-engagement-met-reduced-induction</li><li>one-term-induction</li></ul> | 
 | has\_passed | boolean | false | Whether the participant has failed or passed<br/> | 
 | lead\_provider\_name | string | true | The name of the provider that submitted the declaration<br/> | 
 
@@ -3104,8 +3104,8 @@ A participant declaration data request for ECT participants from cohort 2025 onw
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| type | string | false | Possible values:<br/><br/> - participant-declaration<br/><br/> | 
-| attributes | object | false | This conforms to any of the following schemas:<br/><br/> -  [ECFParticipantDeclarationPost2024ECTStartedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectstartedattributesrequest) <br/> -  [ECFParticipantDeclarationPost2024ECTRetainedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectretainedattributesrequest) <br/> -  [ECFParticipantDeclarationPost2024ECTCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectcompletedattributesrequest) <br/> -  [ECFParticipantDeclarationPost2024ECTExtendedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectextendedattributesrequest) <br/><br/> | 
+| type | string | false | Possible values:<br/><ul><li>participant-declaration</li></ul> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024ECTStartedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTRetainedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectretainedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectcompletedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024ECTExtendedAttributesRequest](#schema-ecfparticipantdeclarationpost2024ectextendedattributesrequest) </li></ul> | 
 
 
 ### ParticipantDeclarationPost2024MentorDataRequest
@@ -3115,8 +3115,8 @@ A participant declaration data request for mentor participants from cohort 2025 
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| type | string | false | Possible values:<br/><br/> - participant-declaration<br/><br/> | 
-| attributes | object | false | This conforms to any of the following schemas:<br/><br/> -  [ECFParticipantDeclarationPost2024MentorStartedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorstartedattributesrequest) <br/> -  [ECFParticipantDeclarationPost2024MentorCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorcompletedattributesrequest) <br/><br/> | 
+| type | string | false | Possible values:<br/><ul><li>participant-declaration</li></ul> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPost2024MentorStartedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorstartedattributesrequest) </li><li> [ECFParticipantDeclarationPost2024MentorCompletedAttributesRequest](#schema-ecfparticipantdeclarationpost2024mentorcompletedattributesrequest) </li></ul> | 
 
 
 ### ParticipantDeclarationPre2025DataRequest
@@ -3126,8 +3126,8 @@ A participant declaration data request for participants in cohort 2024 and previ
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| type | string | false | Possible values:<br/><br/> - participant-declaration<br/><br/> | 
-| attributes | object | false | This conforms to any of the following schemas:<br/><br/> -  [ECFParticipantDeclarationPre2025StartedAttributesRequest](#schema-ecfparticipantdeclarationpre2025startedattributesrequest) <br/> -  [ECFParticipantDeclarationPre2025RetainedAttributesRequest](#schema-ecfparticipantdeclarationpre2025retainedattributesrequest) <br/> -  [ECFParticipantDeclarationPre2025CompletedAttributesRequest](#schema-ecfparticipantdeclarationpre2025completedattributesrequest) <br/> -  [ECFParticipantDeclarationPre2025ExtendedAttributesRequest](#schema-ecfparticipantdeclarationpre2025extendedattributesrequest) <br/><br/> | 
+| type | string | false | Possible values:<br/><ul><li>participant-declaration</li></ul> | 
+| attributes | object | false | This conforms to any of the following schemas:<br/><ul><li> [ECFParticipantDeclarationPre2025StartedAttributesRequest](#schema-ecfparticipantdeclarationpre2025startedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025RetainedAttributesRequest](#schema-ecfparticipantdeclarationpre2025retainedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025CompletedAttributesRequest](#schema-ecfparticipantdeclarationpre2025completedattributesrequest) </li><li> [ECFParticipantDeclarationPre2025ExtendedAttributesRequest](#schema-ecfparticipantdeclarationpre2025extendedattributesrequest) </li></ul> | 
 
 
 ### ParticipantDeclarationRequest
@@ -3137,7 +3137,7 @@ An participant declaration request
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true | This conforms to any of the following schemas:<br/><br/> -  [ParticipantDeclarationPre2025DataRequest](#schema-participantdeclarationpre2025datarequest) <br/> -  [ParticipantDeclarationPost2024ECTDataRequest](#schema-participantdeclarationpost2024ectdatarequest) <br/> -  [ParticipantDeclarationPost2024MentorDataRequest](#schema-participantdeclarationpost2024mentordatarequest) <br/><br/> | 
+| data | object | true | This conforms to any of the following schemas:<br/><ul><li> [ParticipantDeclarationPre2025DataRequest](#schema-participantdeclarationpre2025datarequest) </li><li> [ParticipantDeclarationPost2024ECTDataRequest](#schema-participantdeclarationpost2024ectdatarequest) </li><li> [ParticipantDeclarationPost2024MentorDataRequest](#schema-participantdeclarationpost2024mentordatarequest) </li></ul> | 
 
 
 ### ParticipantDeclarationResponse
@@ -3196,7 +3196,7 @@ Partnership already exists
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| title | string | false | Title of error message<br/>Possible values:<br/><br/> - Partnership already exists<br/><br/> | 
+| title | string | false | Title of error message<br/>Possible values:<br/><ul><li>Partnership already exists</li></ul> | 
 | detail | string | false | Additional info about existing partnership<br/> | 
 
 
@@ -3219,7 +3219,7 @@ Sort partnerships being returned
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| Item | string | false | It conforms to [PartnershipsSort/items](#schema-partnershipssort-items) schema.Possible values:<br/><br/> - created\_at<br/> - -created\_at<br/> - updated\_at<br/> - -updated\_at<br/><br/> | 
+| Item | string | false | It conforms to [PartnershipsSort/items](#schema-partnershipssort-items) schema.Possible values:<br/><ul><li>created\_at</li><li>-created\_at</li><li>updated\_at</li><li>-updated\_at</li></ul> | 
 
 
 ### SchoolFundingError
@@ -3229,7 +3229,7 @@ The school you have entered has not registered to deliver DfE-funded training. C
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| title | string | false | Title of error message<br/>Possible values:<br/><br/> - The school you have entered has not registered to deliver DfE-funded training. Contact the school for more information.<br/><br/> | 
+| title | string | false | Title of error message<br/>Possible values:<br/><ul><li>The school you have entered has not registered to deliver DfE-funded training. Contact the school for more information.</li></ul> | 
 | detail | string | false | Additional info why school is not for DfE-funded training if any<br/> | 
 
 
@@ -3264,7 +3264,7 @@ The data attributes associated with a financial statement
 | ---- | ---- | ---- | ---- |
 | month | string | false | The month which appears on the statement in the DfE portal<br/> | 
 | year | string | false | The calendar year which appears on the statement in the dfe portal<br/> | 
-| type | string | false | Type of statement<br/>Possible values:<br/><br/> - ecf<br/><br/> | 
+| type | string | false | Type of statement<br/>Possible values:<br/><ul><li>ecf</li></ul> | 
 | cohort | string | false | The cohort - 2021 or 2022 - which the statement funds<br/> | 
 | cut\_off\_date | string | false | The milestone cut off or review point for the statement<br/> | 
 | payment\_date | string | false | The date we expect to pay you for any declarations attached to the statement, which are eligible for payment<br/> | 
@@ -3291,7 +3291,7 @@ Filter statements to return more specific results
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | cohort | string | false | Return statements associated to the specified cohort or cohorts. This is a comma delimited string of years.<br/> | 
-| type | string | false | Return statements of a given type<br/>Possible values:<br/><br/> - ecf<br/><br/> | 
+| type | string | false | Return statements of a given type<br/>Possible values:<br/><ul><li>ecf</li></ul> | 
 | updated\_since | string | false | Return only records that have been updated since this date and time (ISO 8601 date format)<br/> | 
 
 
@@ -3318,9 +3318,7 @@ Authorization information is missing or invalid
 ### UnfundedMentor
 
 
- ==== A [B] NODE  (1 children) ====
- ==== A [BR] NODE  (0 children) ====
-The details of an unfunded mentor
+ **Note, this is a new endpoint.** The details of an unfunded mentor
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
@@ -3350,7 +3348,7 @@ An unfunded mentor
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| data | object | true |  ==== A [B] NODE  (1 children) ==== ==== A [BR] NODE  (0 children) ====The details of an unfunded mentor<br/>It conforms to [UnfundedMentor](#schema-unfundedmentor) schema. | 
+| data | object | true |  **Note, this is a new endpoint.** The details of an unfunded mentor<br/>It conforms to [UnfundedMentor](#schema-unfundedmentor) schema. | 
 
 
 ### UrnInvalidError
@@ -3360,6 +3358,6 @@ URN entered is not valid
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| title | string | false | Title of error message<br/>Possible values:<br/><br/> - URN is not valid<br/><br/> | 
+| title | string | false | Title of error message<br/>Possible values:<br/><ul><li>URN is not valid</li></ul> | 
 | detail | string | false | Additional info why URN is not valid<br/> | 
 

--- a/documentation/ecf1_guidance/reference-v3.md
+++ b/documentation/ecf1_guidance/reference-v3.md
@@ -16,10 +16,7 @@ The lead provider API for DfE’s manage teacher CPD service.
  **Production** 
  [https://manage-training-for-early-career-teachers.education.gov.uk](https://manage-training-for-early-career-teachers.education.gov.uk) 
 
-## GET
-    
-    
-      /api/v3/delivery-partners
+## GET /api/v3/delivery-partners
 
 
  _Note, this endpoint is new.Retrieve delivery partners_ 
@@ -81,10 +78,7 @@ This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 ---
 
 
-## GET
-    
-    
-      /api/v3/delivery-partners/{id}
+## GET /api/v3/delivery-partners/{id}
 
 
  _Note, this endpoint is new.Retrieve a specific delivery partner_ 
@@ -153,10 +147,7 @@ This response returns a [NotFoundResponse](#notfoundresponse) schema.
 ---
 
 
-## GET
-    
-    
-      /api/v3/partnerships/ecf
+## GET /api/v3/partnerships/ecf
 
 
  _Note, this endpoint is new.Retrieve multiple ECF partnerships_ 
@@ -223,10 +214,7 @@ This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 ---
 
 
-## POST
-    
-    
-      /api/v3/partnerships/ecf
+## POST /api/v3/partnerships/ecf
 
 
  _Note, this endpoint is new.Create an ECF partnership with a school and delivery partner_ 
@@ -318,10 +306,7 @@ This response returns a [ECFPartnershipRequestErrorResponse](#ecfpartnershiprequ
 ---
 
 
-## GET
-    
-    
-      /api/v3/partnerships/ecf/{id}
+## GET /api/v3/partnerships/ecf/{id}
 
 
  _Note, this endpoint is new.Get a single ECF partnership_ 
@@ -395,10 +380,7 @@ This response returns a [NotFoundResponse](#notfoundresponse) schema.
 ---
 
 
-## PUT
-    
-    
-      /api/v3/partnerships/ecf/{id}
+## PUT /api/v3/partnerships/ecf/{id}
 
 
  _Note, this endpoint is new.Update a partnership’s delivery partner in an existing partnership in a cohort_ 
@@ -507,10 +489,7 @@ This response returns a [NotFoundResponse](#notfoundresponse) schema.
 ---
 
 
-## GET
-    
-    
-      /api/v3/schools/ecf
+## GET /api/v3/schools/ecf
 
 
  _Note, this endpoint is new.Retrieve multiple ECF schools scoped to cohort_ 
@@ -574,10 +553,7 @@ This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 ---
 
 
-## GET
-    
-    
-      /api/v3/schools/ecf/{id}
+## GET /api/v3/schools/ecf/{id}
 
 
  _Note, this endpoint is new.Get a single ECF school scoped to cohort_ 
@@ -647,10 +623,7 @@ This response returns a [NotFoundResponse](#notfoundresponse) schema.
 ---
 
 
-## GET
-    
-    
-      /api/v3/participant-declarations
+## GET /api/v3/participant-declarations
 
 
  _Note, this endpoint includes updated specifications.List all participant declarations_ 
@@ -720,10 +693,7 @@ This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 ---
 
 
-## POST
-    
-    
-      /api/v3/participant-declarations
+## POST /api/v3/participant-declarations
 
 
  _Note, this endpoint includes updated specifications.Declare a participant has reached a milestone. Idempotent endpoint - submitting exact copy of a request will return the same response body as submitting it the first time._ 
@@ -812,10 +782,7 @@ This response returns a [BadRequestResponse](#badrequestresponse) schema.
 ---
 
 
-## GET
-    
-    
-      /api/v3/participant-declarations/{id}
+## GET /api/v3/participant-declarations/{id}
 
 
  _Note, this endpoint includes updated specifications.Get single participant declaration_ 
@@ -893,10 +860,7 @@ This response returns a [NotFoundResponse](#notfoundresponse) schema.
 ---
 
 
-## PUT
-    
-    
-      /api/v3/participant-declarations/{id}/void
+## PUT /api/v3/participant-declarations/{id}/void
 
 
  _Note, this endpoint includes updated specifications.Void a declaration - it will not be soft-deleted_ 
@@ -953,10 +917,7 @@ This response returns a [SingleParticipantDeclarationResponse](#singleparticipan
 ---
 
 
-## GET
-    
-    
-      /api/v3/participants/ecf
+## GET /api/v3/participants/ecf
 
 
  _Note, this endpoint includes updated specifications.Retrieve multiple participants, replaces /api/v3/participants_ 
@@ -1046,10 +1007,7 @@ This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 ---
 
 
-## GET
-    
-    
-      /api/v3/participants/ecf/{id}
+## GET /api/v3/participants/ecf/{id}
 
 
  _Note, this endpoint includes updated specifications.Get a single ECF participant_ 
@@ -1146,10 +1104,7 @@ This response returns a [NotFoundResponse](#notfoundresponse) schema.
 ---
 
 
-## GET
-    
-    
-      /api/v3/participants/ecf/transfers
+## GET /api/v3/participants/ecf/transfers
 
 
  _Note, this endpoint is new.Retrieve multiple ECF participant transfers_ 
@@ -1220,10 +1175,7 @@ This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 ---
 
 
-## PUT
-    
-    
-      /api/v3/participants/ecf/{id}/defer
+## PUT /api/v3/participants/ecf/{id}/defer
 
 
  _Note, this endpoint includes updated specifications.Notify that an ECF participant is taking a break from their course_ 
@@ -1323,10 +1275,7 @@ This response returns a [ECFParticipantResponse](#ecfparticipantresponse) schema
 ---
 
 
-## PUT
-    
-    
-      /api/v3/participants/ecf/{id}/resume
+## PUT /api/v3/participants/ecf/{id}/resume
 
 
  _Note, this endpoint includes updated specifications.Notify that an ECF participant is resuming their course_ 
@@ -1422,10 +1371,7 @@ This response returns a [ECFParticipantResponse](#ecfparticipantresponse) schema
 ---
 
 
-## PUT
-    
-    
-      /api/v3/participants/ecf/{id}/withdraw
+## PUT /api/v3/participants/ecf/{id}/withdraw
 
 
  _Note, this endpoint includes updated specifications.Notify that an ECF participant has withdrawn from their course_ 
@@ -1525,10 +1471,7 @@ This response returns a [ECFParticipantResponse](#ecfparticipantresponse) schema
 ---
 
 
-## GET
-    
-    
-      /api/v3/participants/ecf/{id}/transfers
+## GET /api/v3/participants/ecf/{id}/transfers
 
 
  _Note, this endpoint is new.Get a single participant’s transfers_ 
@@ -1601,10 +1544,7 @@ This response returns a [NotFoundResponse](#notfoundresponse) schema.
 ---
 
 
-## PUT
-    
-    
-      /api/v3/participants/ecf/{id}/change-schedule
+## PUT /api/v3/participants/ecf/{id}/change-schedule
 
 
  _Note, this endpoint includes updated specifications.Notify that an ECF Participant is changing training schedule_ 
@@ -1702,10 +1642,7 @@ This response returns a [ECFParticipantResponse](#ecfparticipantresponse) schema
 ---
 
 
-## GET
-    
-    
-      /api/v3/unfunded-mentors/ecf
+## GET /api/v3/unfunded-mentors/ecf
 
 
  _Note, this endpoint is new.Retrieve multiple unfunded mentors_ 
@@ -1765,10 +1702,7 @@ This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 ---
 
 
-## GET
-    
-    
-      /api/v3/unfunded-mentors/ecf/{id}
+## GET /api/v3/unfunded-mentors/ecf/{id}
 
 
  _Note, this endpoint is new.Get a single unfunded mentor_ 
@@ -1835,10 +1769,7 @@ This response returns a [NotFoundResponse](#notfoundresponse) schema.
 ---
 
 
-## GET
-    
-    
-      /api/v3/statements
+## GET /api/v3/statements
 
 
  _Note, this endpoint is new.Retrieve financial statements_ 
@@ -1901,10 +1832,7 @@ This response returns a [UnauthorisedResponse](#unauthorisedresponse) schema.
 ---
 
 
-## GET
-    
-    
-      /api/v3/statements/{id}
+## GET /api/v3/statements/{id}
 
 
  _Note, this endpoint is new.Retrieve specific financial statement_ 

--- a/documentation/ecf1_guidance/release-notes.md
+++ b/documentation/ecf1_guidance/release-notes.md
@@ -1,0 +1,1136 @@
+# Release notes
+
+## 8 September 2025
+
+[#bug-fix #data-update]
+
+### Declarations query bug fixed
+
+We’ve fixed a bug in the declarations query affecting some participants who transferred to a new lead provider.
+
+Due to a data issue, the new provider couldn’t see all declarations made by the previous provider. This prevented them from viewing the participant’s full training engagement.
+
+As a result of this fix, lead providers might notice additional declarations in their next sync.
+
+If you have any questions or comments about these notes, please contact DfE via Slack or email.
+
+## 24 June 2025
+
+[#bug-fix]
+
+### Declaration submission error for resumed participants resolved
+
+We’ve fixed an issue that prevented lead providers from submitting training declarations for some participants who’d resumed training after being withdrawn. An incorrect error message said the declaration date must be before the withdrawal date.
+
+Providers can now submit declarations for these participants as expected.
+
+## 16 June 2025
+
+[#new-feature #production-release #data-update]
+
+Registration is now open for the 2025/26 intake of early career teachers and mentors, so we’ve added the schedules and contract data for this academic year to the production environment.
+
+For more details, [view our guidance on changes for the 2025/26 academic year](changes-for-the-2025-2026-academic-year).
+
+## 23 April 2025
+
+[#sandbox-release #breaking-change]
+
+We’ve updated the field value options in several v3 API test environment (sandbox) endpoints to reflect changes to the names we use for induction programme types. These changes will apply to all cohorts.
+
+### Endpoints: `GET schools/ecf` and `GET schools/ecf/{id}`
+
+**Field: `induction_programme_choice`**
+
+| Original values | Updated values |
+| -------------------- | ---------------------- |
+| `core-induction-programme` and `design_our_own` | `school-led` |
+| `full-induction-programme` and `school-funded-full-induction-programme` | `provider-led` |
+
+The `no_early_career_teachers` and `not_yet_known` values stay the same.
+
+### Endpoint: `PUT participants/ecf/{id}/withdraw`
+
+**Field: `reason`**
+
+| Original values | Updated values |
+| -------------------- | ---------------------- |
+| `school-left-fip` | `switched-to-school-led` |
+
+The `left-teaching-profession`, `moved-school`, `mentor-no-longer-being-mentor` and `other` values are unchanged.
+
+We’ve updated participant records across all cohorts that have previously used the `school-left-fip` value. This is not expected to affect how the endpoint functions. However, lead providers should resync with the API participants endpoint to ensure their systems integrate correctly. Records for withdrawn participants will surface the new value and have a modified `updated_at` timestamp.
+
+To keep records up to date following these changes, lead providers should run regular full syncs across all cohorts using the `GET /api/v3/schools/ecf` endpoint. Providers will also need to perform a full sync when these changes go into production. This update aligns with the new `school-led` terminology we’ve introduced for the `induction_programme_choice` field in the `GET schools/ecf` and `GET schools/ecf/{id}` endpoints to replace the `core-induction-programme` and `diy` options.
+
+We’ll contact providers directly to ensure their integrations can support the new values.
+
+## 11 April 2025
+
+[#cohort-closure #sandbox-release]
+
+We’ve set up dummy data/contracts and milestones in the [API v3 test (sandbox) environment](https://sb.manage-training-for-early-career-teachers.education.gov.uk/) to support providers ahead of the closure of the 2022 ECF cohort at the end of July.
+
+[View detailed guidance about the closure of the 2022 cohort](2022-cohort-closure-information-for-lead-providers)
+
+### How we’ll handle participants who haven’t completed their training by 31 July
+
+| Training status   | Post-2022 cohort closure |
+| -------------------- | ---------------------- |
+| Partially trained ECTs | We'll move these ECTs to the 2024 cohort if there’s evidence they require training during the 2025/26 academic year |
+| Partially trained mentors | We will not transfer mentors to the 2024 cohort because they’re not eligible for further training. We’ll mark them as `completed` and update their `mentor_funding_end_date` |
+| ECTs and mentors with no `eligible`, `payable`, `paid`, `awaiting_clawback` or `clawed_back` declarations | We’ll archive these participants. Providers should retire their records. If they’re re-registered in the 2025/26 academic year, they’ll have new IDs |
+
+### Identifying ECTs who we’ve moved to the 2024 cohorts
+
+To help providers identify these ECTs in the API v3 test environment, there’s a field in the `GET participant` API endpoints called `cohort_changed_after_payments_frozen`.
+
+For ECTs who’ve moved cohorts, the field will have a `TRUE` value in it.
+
+When calling the `GET participant` endpoint, the ECT’s `cohort` value will be 2024.
+
+When calling the `GET participant-declarations` endpoint, the ECT will have historical declarations in their original cohort.
+
+To simplify this, we recommend using the `cohort_changed_after_payments_frozen` field to identify the ECT.
+
+We’ll also assign these ECTs to the `ecf-extended-september` schedule. This allows providers to submit any required declarations for the 2025/26 academic year.
+
+<div class="govuk-inset-text">Unlike when we closed the 2021 cohort, mentors who started training in 2022 will not be able to be moved between frozen cohorts. This is because they will be marked as <code>completed</code>.</div>
+
+### Provider checklist
+
+We recommend providers use the dummy data we’ve set up in the test environment to:
+
+- check their CRM to make sure they can handle an enrolment in a new cohort with declarations spanning across 2022 and 2024
+- familiarise themselves with the `cohort_changed_after_payments_frozen` field in the `GET participant` endpoint response
+- check they can see historically submitted declarations made in a previous cohort in the `GET participant-declarations` endpoint when using the cohort filter
+- attempt some [future declarations](ecf/guidance/?#test-the-ability-to-submit-declarations-in-sandbox-ahead-of-time) and ensure they’re recorded and handled safely in their CRM
+
+## 14 March 2025
+
+[#new-feature #sandbox-release]
+
+We've updated the test (sandbox) environment with all the `evidence_held` values lead providers will be able to use when they submit participant declarations for the 2025/26 intake of early career teachers (ECTs) and mentors.
+
+These values represent the evidence lead providers hold to show participants have met the retention criteria for the current milestone period.
+
+For 2025/26, every `declaration_type` will have its own `evidence_held` values (see tables). In previous years we’d applied the `training-event-attended`, `self-study-material-completed` and `other` values across all declaration types.
+
+### Early career teachers
+
+| Declaration type   | Evidence held values |
+| -------------------- | ---------------------- |
+| `started`   |  <ul class="govuk-list govuk-list--bullet"><li>`training-event-attended`</li> <li>`self-study-material-completed`</li> <li>`other`</li> <li>`materials-engaged-with-offline` (new value for 2025 onwards)</li></ul> |
+| `retained-1` |  <ul class="govuk-list govuk-list--bullet"><li>`training-event-attended`</li> <li>`self-study-material-completed`</li> <li>`other`</li> <li>`materials-engaged-with-offline` (new value for 2025 onwards)</li></ul> |
+| `retained-2` |  <ul class="govuk-list govuk-list--bullet"><li>`75-percent-engagement-met` (new value for 2025 onwards)</li> <li>`75-percent-engagement-met-reduced-induction` (new value for 2025 onwards)</li></ul> |
+| `retained-3` |  <ul class="govuk-list govuk-list--bullet"><li>`training-event-attended`</li> <li>`self-study-material-completed`</li> <li>`other`</li> <li>`materials-engaged-with-offline` (new value for 2025 onwards)</li></ul> |
+| `retained-4` |  <ul class="govuk-list govuk-list--bullet"><li>`training-event-attended`</li> <li>`self-study-material-completed`</li> <li>`other`</li> <li>`materials-engaged-with-offline` (new value for 2025 onwards)</li></ul> |
+| `extended-1` |  <ul class="govuk-list govuk-list--bullet"><li>`training-event-attended`</li> <li>`self-study-material-completed`</li> <li>`other`</li> <li>`materials-engaged-with-offline` (new value for 2025 onwards)</li></ul> |
+| `extended-2` |  <ul class="govuk-list govuk-list--bullet"><li>`training-event-attended`</li> <li>`self-study-material-completed`</li> <li>`other`</li> <li>`materials-engaged-with-offline` (new value for 2025 onwards)</li></ul> |
+| `extended-3` |  <ul class="govuk-list govuk-list--bullet"><li>`training-event-attended`</li> <li>`self-study-material-completed`</li> <li>`other`</li> <li>`materials-engaged-with-offline` (new value for 2025 onwards)</li></ul> |
+| `completed` |  <ul class="govuk-list govuk-list--bullet"><li>`75-percent-engagement-met` (new value for 2025 onwards)</li> <li>`75-percent-engagement-met-reduced-induction` (new value for 2025 onwards)</li> <li> `one-term-induction` (new value for 2025 onwards) </li></ul>|
+
+### Mentors
+
+| Declaration type   | Evidence held values |
+| ------------- | ------------- |
+| `started`   |  <ul class="govuk-list govuk-list--bullet"><li>`training-event-attended`</li> <li>`self-study-material-completed`</li> <li>`other`</li> <li>`materials-engaged-with-offline` (new value for 2025 onwards)</li></ul> |
+| `completed` |  <ul class="govuk-list govuk-list--bullet"><li>`75-percent-engagement-met` (new value for 2025 onwards)</li> <li>`75-percent-engagement-met-reduced-induction` (new value for 2025 onwards)</li></ul> |
+
+> New evidence types are not compatible with previous cohorts. If providers try using a new evidence type for an older cohort declaration, it will not work.
+
+### What to test ahead of 2025 registration opening in June
+
+We advise providers check their integrations can:
+
+- support all new evidence types
+- submit `one-term-induction` as `evidence_held` for `completed` ECT declarations
+- supply evidence types for `started` declarations
+
+## 3 March 2025
+
+[#bug-fix]
+
+We’ve resolved an issue in the API where a v2 declaration endpoint was inadvertently serving the v1 schema.
+
+The fix updates the `POST` action to use the correct v2 schema.
+
+The following declaration endpoint has been updated:
+
+- `POST participant-declarations`
+
+All endpoints now conform to the v2 schema specifications.
+
+## 19 February 2025
+
+[#new-feature #sandbox-release]
+
+We’ve added the schedules and contract data for the 2025/26 intake of early career teachers (ECTs) and mentors to the test (sandbox) environment.
+
+Lead providers can either add participants via the ECF interface or by using the seed data we’ve created. This will allow them to test the full end-to-end process and ensure smooth integration for any upcoming changes.
+
+When registering participants in the test environment, providers must use the following date of birth if they want the 2025/26 ECTs to appear as eligible for funding:
+
+- 25/1/1900
+
+For mentors, use the following date of birth:
+
+- 1/1/1900
+
+### Changes to mentor declarations for the 2025/6 intake
+
+We’ve removed the following declarations from the `POST participant-declarations` test environment endpoint for mentors starting in 2025/26:
+
+- `retained-1`
+- `retained-2`
+- `retained-3`
+- `retained-4`
+- `extended-1`
+- `extended-2`
+- `extended-3`
+
+This is because there’ll only be 2 mentor declarations from the 2025/26 academic year onwards, `started` and `completed`.
+
+These changes align with the updated frameworks and payment guidelines shared with lead providers.
+
+## 8 January 2025
+
+[#bug-fix]
+
+Lead providers getting participant declarations via the API endpoints will now see previous declarations attached to completed participants rather than just active participants.
+
+Before this update they could only view previous declarations of participants who had an active <code>induction_status</code> and had not completed.
+
+## 11 December 2024
+
+We’ve fixed a bug that meant providers could see declarations from participants that were not relevant to them.  They would not have been able to identify the participants with this information.
+
+Following the bug fix, providers can now only see relevant declarations.
+
+## 11 December 2024
+
+We’ve fixed a bug that caused the GET unfunded-mentors endpoint query to return incorrect or no longer valid email addresses in a small number of cases.
+
+The fix we’ve made ensures the endpoint is now surfacing the most up-to-date email in the GET request’s response.
+
+## 27 November 2024
+
+We've launched a separate API for NPQs following a 3-month test phase. All NPQ data has been successfully migrated to the new environment, which means providers can no longer make NPQ-related calls from this API.
+
+The base URL for this API continues to be:
+
+- [https://manage-training-for-early-career-teachers.education.gov.uk/](https://manage-training-for-early-career-teachers.education.gov.uk/)
+
+Providers can add the required API version and endpoint depending on what they want to do. For example, they’d add `/api/v3/participants/ecf` to the base URL if they wanted to retrieve data for multiple participants.
+
+The endpoints documentation for each version of the API is also unchanged:
+
+- [ECF API v1 documentation](https://manage-training-for-early-career-teachers.education.gov.ukreference-v1.html)
+- [ECF API v2 documentation](https://manage-training-for-early-career-teachers.education.gov.ukreference-v2.html)
+- [ECF API v3 documentation](https://manage-training-for-early-career-teachers.education.gov.ukreference-v3.html)
+
+To ensure everything runs smoothly on the ECF side of things, we recommend providers take the following post-separation actions:
+
+- check their integration supports ECF calls independently
+- make sure all data flows and integrations continue to work as expected
+- test internal processes to verify that data from the ECF environment is being handled appropriately
+- conduct full data syncs within their allocated window so that data is up to date and accurate
+
+Providers can contact us via their dedicated DfE Slack channel if they’ve got any suggestions or concerns.
+
+## 2 September 2024
+
+Providers can now see the new <code>mentor_ineligible_for_funding_reason</code> field in the API production environment's participant response bodies.
+
+For full details about the field and the values it can display, read the <a href="release-notes.html#20-august-2024">release note we published</a> when we added this functionality to the test (sandbox) environment.
+
+## 20 August 2024
+
+We’ve added a field in the API sandbox environment’s participant response bodies to show why funding for a mentor’s training has ended.
+
+This follows feedback from providers who want this information for record keeping.
+
+The new field is called <code>mentor_ineligible_for_funding_reason</code>. It’ll display 3 possible values:
+
+- <code>completed_declaration_received</code>. Providers will see this if the mentor has completed their mentor training
+- <code>completed_during-early_roll_out</code>. This means the mentor completed their training during the pilot period of the ECF (Early Career Framework) programme, so is no longer eligible for funding
+- <code>started_not_completed</code>. We’ll display this if 2 years has elapsed since a full-time mentor started training. After 2 years, they’re no longer eligible
+
+We’d welcome feedback on this sandbox update before it goes into production. Providers can contact us via the usual Slack channel if they’ve got any suggestions or concerns.
+
+## 13 August 2024
+
+We’ve launched standalone API test environments so providers can manage ECF and NPQ data separately.
+
+The merged data model that we’ve been running previously has proven challenging with bugs, unstable ID’s, issues with emails, and participants appearing and disappearing for providers.
+
+The new approach with standalone APIs will stabilise the services and simplify the domain model. Operationally, providers will benefit from faster resolution times on issues for applicants and faster deployment on requested features and policy changes.
+
+To help test the NPQ and ECF new world ahead of the full separation later in the autumn, we've launched ‘separation’ test environments with relevant seed data to replace the existing ‘sandboxes’.
+
+To make requests in the new test environments, providers must use the bearer tokens that we’ve sent them via Galaxkey. The base URLs are:
+
+- ECF test environment - [https://sp.manage-training-for-early-career-teachers.education.gov.uk](https://sp.manage-training-for-early-career-teachers.education.gov.uk)
+- NPQ test environment - [https://npq-registration-separation-web.teacherservices.cloud](https://npq-registration-separation-web.teacherservices.cloud)
+
+Providers can add the required API version and endpoint depending on what they want to test. For example, they’d add /api/v3/npq-applications to the NPQ test environment URL if they want to retrieve multiple applications.
+
+We’ve also created documentation for the new separation environment endpoints:
+
+- [ECF API v1 documentation](https://sp.manage-training-for-early-career-teachers.education.gov.ukreference-v1.html)
+- [ECF API v2 documentation](https://sp.manage-training-for-early-career-teachers.education.gov.ukreference-v2.html)
+- [ECF API v3 documentation](https://sp.manage-training-for-early-career-teachers.education.gov.ukreference-v3.html)
+- [NPQ API v1 documentation](https://npq-registration-separation-web.teacherservices.cloud/api/docs/v1)
+- [NPQ API v2 documentation](https://npq-registration-separation-web.teacherservices.cloud/api/docs/v2)
+- [NPQ API v3 documentation](https://npq-registration-separation-web.teacherservices.cloud/api/docs/v3)
+
+The existing sandbox environments will remain accessible and unchanged to allow continued testing on the current API setup.
+
+## 1 July 2024
+
+Registration has opened for the 2024/25 intake of NPQ participant applications, so we’ve added the following to the production environment:
+
+- the 2024/25 NPQ data and schedules
+- functionality which enables providers to set whether NPQ applicants are going to have their training funded by DfE
+- the new special education needs coordinator (SENCO) NPQ
+
+See the [14 June release note](release-notes.html#14-june-2024) for more details about the funded training functionality and SENCO NPQ.
+
+## 28 June 2024
+
+We’ve added some new features to help providers ahead of the closure of the funding contract for the 2021 cohort on 31 July.
+
+The main impact will be ECTs and mentors with partial declarations currently assigned to the 2021 cohort being moved to the 2024 cohort.
+
+Because these ECTs and mentors are automatically shifted from a standard to an extended schedule, we’re allowing providers to change their schedules if necessary, using the existing [change-schedule](reference-v3.html#api-v3-participants-ecf-id-change-schedule-put) endpoint.
+
+Providers can also temporarily move participants back to the 2021 cohort if they need to make any final declarations before it closes. They must be returned to the 2024 cohort to start making submissions against that year.
+
+Note that the schedule and cohort cannot be changed when a migrated participant is in the 2024 cohort if there are existing declarations in any of the following states:
+
+- submitted
+- eligible
+- payable
+- paid
+
+However, you can make changes in the 2021 cohort where participants already have declarations in these statuses.
+
+## 25 June 2024
+
+Registration is now open for the 2024/25 intake of early career teachers and mentors, so we’ve added the schedules and contract data for this academic year to the production environment.
+
+## 18 June 2024
+
+From today, schools have started moving ECTs and mentors with partial declarations currently assigned to the 2021 cohort to the 2024 cohort.
+
+This is because we’re closing the funding contract for the 2021 cohort at the end of July.
+
+Providers will be able to identify participants who’ve been moved by the new `cohort_changed_after_payments_frozen` attribute to the [participant response](reference-v3.html?#api-v3-participants-ecf-get-responses-examples) in the API v3 production environment. The value shown for these participants will be `true`.
+
+Providers will no longer be able to submit or void declarations for the 2021 cohort after the contract closes on 31 July.
+
+## 14 June 2024
+
+We’ve added the new special educational needs coordinator (SENCO) NPQ to the [test (sandbox) environment](https://sb.manage-training-for-early-career-teachers.education.gov.uk/) for the 2024 cohort.
+
+The new course’s identifier is `npq-senco`.
+
+Providers can access this within the sandbox environment for testing. Functionality will be the same as the other existing NPQ courses.
+
+We’ll notify providers when this new NPQ is available in the production environment.
+
+We're trialing new functionality in the API test ([sandbox](https://sb.manage-training-for-early-career-teachers.education.gov.uk/)) environment which will enable providers to set whether NPQ applicants are going to have their training funded by DfE.
+
+This is because from the 2024/25 academic year onwards there'll be a set maximum number of places each provider can offer per NPQ that DfE will pay for.
+
+Providers using all versions of the API can set the new `funded_place` field in the 'Accept an application' request body to true or false. They will also see the `funded_place` field in the following endpoint response bodies:
+
+- 'View all applications'
+
+- 'View a specific application'
+
+- 'View all participant data'
+
+- 'View a single participant's data'
+
+Providers who need to update a participant's funding information after an application has been accepted can do so via the 'Change funded place' endpoint.
+
+## 13 June 2024
+
+We’ve fixed an issue with the API v3 NPQ participants endpoint where performing a full sync with pagination resulted in IDs beings omitted. No other endpoint was affected.
+
+The NPQ participants endpoint and the pagination will now return all users in the NPQ GET participants endpoint.
+
+Providers are recommended to perform a full re-sync at the earliest convenience to retrieve all participant records.
+
+## 10 June 2024
+
+On 31 July we’re closing the funding contract for the 2021 cohort.
+
+This means ECTs and mentors with partial declarations currently assigned to the 2021 cohort will be moved to the 2024 cohort.
+
+Providers can now test the functionality for the migration of these ECTs and mentors.
+Participants who’ve moved can be identified by the new `cohort_changed_after_payments_frozen` attribute to the participant response in the [API v3 test (sandbox) environment](https://sb.manage-training-for-early-career-teachers.education.gov.uk/). The value shown for these participants will be `true`.
+
+Providers will be able to test future declaration submissions in the 2024 cohort but can no longer submit or void declarations for 2021 after the contract has closed.
+
+We’d welcome feedback on this sandbox update before it goes into production.
+
+## 5 June 2024
+
+We're addressing a potential confusion for providers filtering participant declarations by cohort.
+
+Currently, filtering by a participant's current cohort (for example, 2022) returns all their declarations, even those made when the participant was in an earlier cohort (for example, 2021).
+
+For instance, if a participant is in the 2022 cohort, but has declarations in both 2021 and 2022, all declarations are returned when filtering by 2022, and none when filtering by 2021.
+
+Going forward, we’ll now return only the declarations made during the specified cohort. For example:
+
+- filtering by 2021 will return only the declarations made while a participant was in the 2021 cohort
+- filtering by 2022 will return only the declarations made while a participant was in the 2022 cohort
+
+We’ve released this in the API v3 Live environment.
+
+## 24 May 2024
+
+We’ve added the schedules and contract data for the 2024/25 intake of early career teachers and mentors to the [test (sandbox) environment](https://sb.manage-training-for-early-career-teachers.education.gov.uk/).
+
+Providers can either add participants via the ECF interface or by using the seed data we’ve created. When registering participants in the test environment, providers must use the following date of birth if they want the 2024/25 ECTs to appear as eligible for funding:
+
+- 24/1/1900
+
+For mentors, use the following date of birth:
+
+- 1/1/1900
+
+Providers can also sign in to the [sandbox environment](https://sb.manage-training-for-early-career-teachers.education.gov.uk/users/sign_in) as school induction tutors, where dynamic scenarios such as transfers can be simulated.
+
+As always, we’d welcome feedback on this sandbox update before it goes into production.
+
+## 8 March 2024
+
+Lead providers can now use the new `mentor_funding_end_date` field in the Live environment’s [ECF participant endpoint](reference-v3.html#api-v3-participants-ecf-get).
+
+Further details are available in the release note of [4 March 2024](release-notes.html#4-march-2024).
+
+## 4 March 2024
+
+We’ve found and fixed a bug that meant ‘participant IDs’ had been wrongly changed for a very small subset of ECF and NPQ participants with multiple profiles. We’ve now switched all users to the right profile IDs.
+
+## 4 March 2024
+
+We're trialing new functionality in the API v3 sandbox which surfaces the `mentor_funding_end_date` field in the [ ECF participant endpoint](reference-v3.html#api-v3-participants-ecf-get).
+
+When a declaration is submitted for a mentor the completed date will equal the declaration date. When a declaration is voided the completed date will be cleared. Completed dates for early roll-out mentors will be set to 19 April 2021 regardless of any completed declarations.
+
+We'd welcome feedback on this sandbox update before it goes into production.
+
+## 16 February 2024
+
+We’ve found and fixed a bug that meant for a small number of NPQ applications the value in the `itt_provider` field was incorrectly set, so was not showing the name of the provider.
+
+The full legal name of the initial teacher training provider can now be seen on all applications impacted by this bug.
+
+## 6 February 2024
+
+We’ve done an update to ensure that early career teacher (ECT) participant records only ever appear in one cohort.
+
+Some providers had found it confusing because participants who’d moved cohort were appearing multiple times when they filtered by cohort in the ‘GET participants’ endpoint.
+
+Training providers will now only see the ECT in the latest cohort they’ve been assigned to.
+
+## 30 January 2024
+
+We’ve fixed an issue with merging duplicate user accounts that meant existing declarations were not being redirected to the newly merged account correctly.
+
+Participant records in merged accounts will now point to the right declarations in the [ECF](reference-v3.html#api-v3-participants-ecf-get) and [NPQ](/api-reference/reference-v3.html#api-v3-participants-npq-get) GET participant endpoints.
+
+This will ensure that all participant declarations are consistent.
+
+## 17 January 2024
+
+We’ve fixed a bug that had prevented some providers from changing schedules for participants they are training who have not been registered in a default partnership. In such instances they’d have seen the following 422 error message:
+
+* ‘You cannot change a participant to this cohort as you do not have a partnership with the school for the cohort. Contact the DfE for assistance.’
+
+This error message should now only apply where a lead provider is attempting to the use the [change schedule endpoint](reference-v3.html#api-v3-participants-ecf-id-change-schedule-put) to change the participant's cohort.
+
+## 28 November 2023
+
+We've fixed a bug that meant some providers were having issues finding unfunded mentor IDs when using the `updated_at` filter on the [GET unfunded mentors endpoint](reference-v3.html#api-v3-unfunded-mentors-ecf-get).
+
+The `updated_at` value of an unfunded mentor now gets touched when the mentor is linked to an ECT.
+
+An API call to the unfunded mentors endpoint filtered for any updates once the link has been made will return the unfunded mentor in the response.
+
+## 9 November 2023
+
+We're trialing new functionality in the API v3 sandbox which allows lead providers to add a participant's schedule when accepting NPQ applications.
+
+We've added the optional `schedule-identifier` field on the [NPQ accept an application request body](npq/guidance.html#example-request-body).
+
+This will prevent providers having to make manual changes if a participant has been defaulted to the wrong schedule.
+
+We'd welcome feedback on this sandbox update before it goes into production.
+
+## 6 November 2023
+
+Lead providers can now use the new `participant_id_changes` features in the Live environment.
+
+Further detail on the change is available in the release note of [6 October 2023](release-notes.html#6-october-2023).
+
+## 2 November 2023
+
+The DfE has released a fix for an issue which affected NPQ only providers using the v3 declarations endpoints. Some providers reported receiving 403 errors when attempting to POST or GET declarations. The issue was limited to v3. The fix has been released to sandbox and production environments.
+
+The fix also addresses an issue with the [cohort filter](reference-v3.html#schema-participantdeclarationsfilter), which is available for the declarations endpoint. Providers using the filter should now see that the response only returns NPQ and ECF declarations in the cohort specified. Previously, the filtering was inconsistent for NPQ declarations. The fix applies to production and sandbox environments.
+
+## 30 October 2023
+
+Lead providers will now see a 422 error code if a `completed` declaration outcome fails. In such instances, you'll be prompted to contact us for support.
+## 17 October 2023
+
+Lead providers can now test the new `participant_id_changes` feature in the sandbox.
+
+The DfE welcomes feedback and intends to deploy the change to the production environment as soon as possible.
+
+Further detail on the change is available in the release note of [6 October 2023](release-notes.html#6-october-2023).
+
+## 16 October 2023
+
+We've removed the `started-in-error` option from the [ECFWithdrawal schemas](reference-v3.html#schema-ecfwithdrawal) in all versions of the API.
+
+Note that NPQ participants can still be withdrawn for this reason.
+
+## 10 October 2023
+
+Lead providers integrated with v3 of the API can now view details of ECTs that have completed their induction.
+
+We've added a new field, `induction_end_date`, to [ECFEnrolment](reference-v3.html#schema-ecfenrolment). We populate the field with data gathered about the date an ECT completed their induction from the Database of Qualified Teachers (DQT).
+
+We check the DQT on a daily basis for data about induction completion. We'll update a participant's records when we confirm they've completed their induction. Lead providers can use the [`updated_since` filter on the GET participants endpoint](reference-v3.html#schema-ecfparticipantfilter) to check for this kind of update.
+
+Lead providers can use the field to identify participants that have completed their induction, and which may need to be placed on a [reduced schedule](ecf/schedules-and-milestone-dates.html#reduced-schedule).
+
+## 9 October 2023
+
+We've released a change to the `updated_at` functionality of the [ECFPartnershipAttributes](reference-v3.html#schema-ecfpartnershipattributes).
+
+Now, when a user (for example, a school induction tutor) challenges a partnership, the date and time of this change will populate the `updated_at` field of the partnership.
+
+In this way, providers may rely on the `updated_since` filter to identify if the partnership has been challenged since their most recent call to the API.
+
+## 6 October 2023
+
+We’ve added experimental fields to the API v3 sandbox environment to make it simpler for lead providers to identify and manage deduped participants.
+
+We’ve [previously advised](release-notes.html#15-march-2023) of the possibility that participants may be registered as duplicates with multiple participant_ids.
+
+Where we identify duplicates, we'll fix the error by ‘retiring’ one of the participant IDs, then associating all records and data under the remaining ID. To date, when this occurred, the DfE has informed providers of changes via CSVs.
+
+We’re now proposing that lead providers may manage these limited changes using some new API v3 functionality including:
+
+* a new `participant_id_changes` nested structure added to the [ECFEnrolment](reference-v3.html#schema-ecfenrolment) and [NPQEnrolment](/api-reference/reference-v3.html#schema-npqenrolment) schemas, which would each contain a `from_participant_id` and a `to_participant_id` string fields, as well a `changed_at` date value
+* a new filter for the various GET participant endpoints, so lead providers can search by a participant_id to check if it has changed, which will return the participant including their changed id. For example, **GET** `api/v3/participants/ecf?filter[from_participant_id]={your_id}`
+
+We welcome feedback on these changes and intends to release them to the sandbox and production as soon as possible. We'll provide a release note at each stage.
+
+## 2 October 2023
+
+We’ve added the new NPQ in leading primary mathematics to the production environment.
+
+The new course’s identifier is `npq-leading-primary-mathematics`. Functionality is the same as the other existing NPQ courses.
+
+Providers should ensure that any participants they accept for this course are on the correct schedule.
+
+## 13 September 2023
+
+We’ve added the new NPQ in leading primary mathematics to the sandbox environment.
+
+The new course’s identifier is `npq-leading-primary-mathematics`. Providers can access this within the sandbox environment for testing. Functionality will be the same as the other existing NPQ courses.
+
+Providers will be notified ahead of this new NPQ becoming available in the production environment.
+
+## 6 September 2023
+
+### Planned API downtime on 14 September
+
+The API will be unavailable from 6pm to 9pm on Thursday 14 September while we perform planned maintenance.
+
+Providers should pause API calls during this time. You’ll be able to start using the API again from 9pm.
+
+## 5 September 2023
+
+### New sandbox URL
+
+We will be changing the sandbox URL to [https://sb.manage-training-for-early-career-teachers.education.gov.uk/](https://sb.manage-training-for-early-career-teachers.education.gov.uk/) on Thursday 7 September.
+
+The sandbox environment will be unavailable between 5pm and 7pm on 7 September while we make this change.
+
+Providers should:
+
+* pause testing between 5pm and 7pm on 7 September
+* update their base URL for their integrations once the sandbox environment becomes available again to avoid any data loss
+
+## 24 August 2023
+
+Lead providers can now submit 'extended declarations' for ECTs that are on extended schedules in production. The change applies to all versions of the API. Previously, lead providers could only test the new functionality in the [sandbox environment](release-notes.html#17-august-2023).
+
+There is [guidance available for providers in the API documentation](ecf/schedules-and-milestone-dates.html#extended-schedules). Please note that while there are currently only three extended declarations, the number of extended declarations a provider may need to submit is not limited in the contract. The DfE may add additional extended declarations should the need arise.
+
+## 17 August 2023
+
+Lead providers can now submit 'extended declarations' for ECTs that are on extended schedules in the sandbox environment. Providers may not submit extended declarations for mentors.
+
+Qualifying ECTs will have had their induction extended as a result of having not yet met the Teachers' standards, and need additional support to meet the standards. These ECTs must be placed onto one of the available ['extended schedules'](ecf/schedules-and-milestone-dates.html#extended-schedules) for ECF.
+
+Providers may submit an extended declaration (subject to meeting the engagement criteria) for each extended term until the ECT has completed their induction, up to a maximum of three extensions. On completing induction, the provider should submit a completion declaration for the final term.
+
+For further details about how and when to use these declaration types, providers should refer to the ECF payment guidance issued by their contract manager.
+
+Providers may submit extended declarations using the following values in the `declaration_type` field on the [participant declaration request body](reference-v3.html#schema-participantdeclarationrequest):
+
+- extended-1
+- extended-2
+- extended-3
+
+Providers will be notified ahead of this functionality becoming available in the production environment.
+
+## 10 August 2023
+
+Lead providers can now ‘resume’ NPQ and ECF participants they've previously withdrawn.
+
+Lead providers should use the relevant [ecf](reference-v3.html#api-v3-participants-ecf-id-resume-put) or [npq](/api-reference/reference-v3.html#api-v3-participants-npq-id-resume-put) resume endpoints to change a given participant’s `training_status` from withdrawn to active.
+
+The DfE will monitor levels of withdrawn participants that have been resumed.
+
+## 31 July 2023
+
+Lead Providers can now change the cohort of an ECF participant, providing that:
+
+- the lead provider has a partnership with the school in the new cohort they want to move the participant into; and
+- any declarations the provider may have made for the participant have been `voided` or `clawed_back`
+
+Providers may change an ECF participant's cohort using the [change-schedule endpoint](reference-v3.html#api-v3-participants-ecf-id-change-schedule-put).
+
+If a lead provider has no partnership with a school for cohort 2022 and tries to change a participant from 2023 to 2022 cohort, then the API will return an error: `You cannot change a participant to this cohort as you do not have a partnership with the school for the cohort. Contact the DfE for assistance.`
+
+If the participant has any declarations which are in certain states - submitted, eligible, payable, paid - then the API will also return an error: `Changing schedule would invalidate existing declarations. Please void them first.`
+
+## 20 July 2023
+
+The DfE has released a fix for a bug affecting the POST partnerships endpoint. Previously, providers were unable to report, via the API, a partnership with a delivery partner where a partnership based on the same details had been challenged by the induction tutor. This issue no longer applies.
+
+The DfE has also released a fix to an issue with the user interface lead providers can access to view details on the service about their partnerships. Some lead providers may have seen more than one partnership reported for a school in the same cohort. This issue has also been fixed.
+
+## 13 July 2023
+
+Providers may now filter outcomes by created_since date. For example:
+
+* GET /api/v1/participants/npq/outcomes?filter[created_since]=2023-04-17T23:11:18Z
+
+The change applies to all API versions.
+
+Providers can now filter ECF and NPQ participants by training_status, for example:
+
+* GET /api/v3/participants/ecf?filter[training_status]=deferred
+* GET /api/v3/participants/npq?filter[training_status]=active
+
+The filter is optional and only applies to v3 of the API. More detail is available in the [NPQ](reference-v3.html#api-v3-participants-npq-get) and [ECF](/api-reference/reference-v3.html#api-v3-participants-ecf-get) specifications.
+
+## 12 July 2023
+
+DfE has changed functionality around the endpoint `PUT /api/v1/participants/npq/{id}/defer`
+
+Providers may not defer an NPQ participant unless the participant has at least a `started` declaration and which has not been voided. This is in line with the NPQ withdrawal endpoint and contractual requirements. The change applies to all versions of the API.
+
+If a provider wishes to defer a participant without a started declaration then they should contact the DfE which can undo the application.
+
+## 7 July 2023
+
+Providers can now see the name of the lead provider which submitted a given declaration. Providers can find more detail on the new attribute `lead_provider_name` in the [v3 specification](reference-v3.html#schema-participantdeclarationresponse).
+
+Providers may see declarations submitted by another provider where an ECF participant has transferred. A provider may not void a declaration submitted by another provider.
+
+The change only applies to v3 and will apply to ECF and NPQ declarations.
+
+## 5 July 2023
+
+The DfE has updated error messages for several endpoints. There has been no change to functionality, error codes, or the scenarios which result in an error. The changes only involve an update to the `detail` part of the error message.
+
+## 3 July 2023
+
+The DfE has added a new possible value to the NPQ withdrawal_reason field.
+
+When submitting a withdrawal request for an NPQ participant, providers may now include the following value:
+
+* `expected-commitment-unclear`
+
+Providers can view details about NPQ participant [withdrawal request schema](reference-v1.html#schema-npqparticipantwithdrawattributes) in the API specification.
+
+## 2 June 2023
+
+Providers can now make calls to API 3.0.0 in the production environment.
+
+Based on feedback from testing in the sandbox, the following updates have been made:
+
+* API v3 endpoints will order responses by `created_at` by default
+* an `updated_at` attribute has been added to the ECF statement response
+* `updated_since` filter parameters can be used when [viewing ECF statements](ecf/guidance.html#view-financial-statement-payment-dates) and [viewing ECF schools](/api-reference/ecf/guidance.html#find-schools-delivering-ecf-based-training-in-a-given-cohort)
+* an `id` parameter has been added to the [endpoint specifications for ECF schools](reference-v3.html#api-v3-schools-ecf-id-get)
+* the formatting of the `completion_date` attribute has amended to follow ISO 8601 format in the [specifications for NPQ outcomes](reference-v3.html#schema-npqoutcomeattributes)
+
+To improve sandbox performance, queries underpinning key endpoints have been optimised. Providers should notice a reduction in slower response times when testing in the sandbox.
+
+**Note:**
+
+* providers are not expected to integrate with API v3 if taking part in the upcoming ECF pilot. The DfE will continue to support v1 and v2 of the API until further notice
+* if providers do wish to integrate with v3 and would like to sync historical records, providers must coordinate with the DfE to manage load on the service
+
+Providers are invited to give feedback on the API. Feedback can include, for example, the addition of new filters or functionality.
+
+## 1 June 2023
+
+School induction tutors are now able to register ECT as mentors at their school. To see how this affects data given via API v3, providers can test this induction tutor functionality in the sandbox.
+
+Note, induction tutors are not yet able to register ECTs as mentors at different schools.
+
+[Watch a demonstration of how to register an ECT as a mentor.](https://www.loom.com/share/7f45563f846a46aba30c713f1b0a7cce)
+
+[View API v3 specifications for the ‘nested’ participant response.](reference-v3.html#api-v3-participants-ecf-get)
+
+See the [13th April 2023 release note](release-notes.html#13th-april-2023) for details on how the API handles ECT-mentors depending on provider integrations with API versions 1 or 2 and version 3.
+
+## 19 May 2023
+
+Providers can now test API v3.0.0.0. integrations in the sandbox environment. Additional seed data has been added to sandbox to enable the testing of new scenarios.
+
+Feedback from providers is invited via the usual channels. All feedback will be considered ahead API v3 release to production environment.
+
+Changes to the [API v3 spec](reference-v3.html) have been implemented since the original draft was shared. Based on provider feedback and continual improvement, these include:
+
+* the addition of a URN filter for when providers [find schools delivering ECF-based training in a given cohort](reference-v3.html#api-v3-schools-ecf-get)
+
+* pagination parameter functionality on multiple GET endpoints which, for example, do not include an `{id}` parameter
+
+* the addition of a date attribute which allows providers to view and update when a participant has deferred [from their ECF-based training](reference-v3.html#schema-ecfdeferral) or [from their NPQ course](/api-reference/reference-v3.html#schema-npqdeferral)
+
+* an update on where participant email addresses are included within participant responses to reduce confusion if, for example, a participant uses different email addresses when registering as an ECT and mentor
+
+* the removal of the `validation_status` attribute from the [ECF participant response](reference-v3.html#schema-ecfparticipant). New attribute options will be tested and added at a later stage, to meet provider and delivery partner needs
+
+### Test dynamic scenarios
+
+Providers will also be able to [sign into the sandbox environment](https://sb.manage-training-for-early-career-teachers.education.gov.uk/users/sign_in) as school induction tutors. Scenarios, such as transfers, can be simulated. Providers will be contacted shortly with login instructions.
+
+**Note,** when registering participants in the sandbox environment, providers must use the following dates of birth if they want to the participants to appear as **eligible for funding**:
+
+* ECT, 2022 cohort – date of birth 22/1/1900
+* ECT, 2023 cohort – date of birth 23/1/1900
+* Mentor, 2023 cohort – date of birth 1/1/1900
+
+### Watch video demos
+
+Watch videos on how to test the behaviour of the API in the scenario where:
+
+* [a participant is leaving a school, transferring to another](https://www.loom.com/share/7513dd3980814230bf4221e3976a2033)
+* [a participant is joining a school, transferring from another]( https://www.loom.com/share/d4d8a9f8f7254f0ca36ad63028ba4178)
+* [a school induction tutor assigns an ECT to an ‘unfunded mentor’](https://www.loom.com/share/7c17218248234a23aec5591cc74d0adb)
+* [a school induction tutor confirms a partnership will continue into the next cohort]( https://www.loom.com/share/bfbad349fe2c470d89e6949d78e43fc8)
+* [a school induction tutor challenges an existing partnership]( https://www.loom.com/share/af0ad15980cf434d8361da5633d730c6)
+
+## 15 May 2023
+
+To support providers with their integrations with API v3.0.0.0, the API guidance has been updated.
+
+Original instruction has been replaced with the following guidance:
+
+* [About the API](/api-reference) - an overview of the API’s core functionality and version control
+* [Get started](get-started) - instruction on how to connect to the API
+* [ECF-based training management](ecf) - an overview key ECF concepts, instruction on new and existing endpoints, and schedule dates
+* [NPQ course management](npq) - an overview of key NPQ concepts, instruction on new and existing endpoints, and schedule identifiers
+
+Providers are invited to feedback ahead of the API v3 release to the production environment. Updates to the guidance will be made as needed.
+
+Note, API v3.0.0.0 is not yet available in either sandbox or production environments.
+
+## 13 April 2023
+
+To enable the scenario where a participant needs to be registered as a mentor after having already been trained as an ECT by a given provider, a new `training_record_id` attribute has been added to the [ECF participant schema](reference-v1.html#schema-ecfparticipant).
+
+The `training_record_id` value will be unique to each registration that a participant has for ECF-based training, as either an ECT or mentor.
+
+Induction tutors have not yet been able to register participants as mentors if they were already registered as ECTs. Given the likely scenario that ECTs will go on to become mentors, the `training_record_id` attribute will soon allow the service to recognise and differentiate registrations. Note, DfE does not expect induction tutors to begin registering ECTs as mentors until June.
+
+For the moment, we have added examples to provider sandbox environments:
+
+* when using the endpoint GET /api/v1/participants/ecf, providers will receive an API response with all the ECF-based training registrations. Where a given participant is registered as both an ECT and a mentor, they will see multiple responses that each have the same participant_id, but which have unique `training_record_ids` for the mentor and ECT response
+* when using the endpoint GET /api/v1/participants/ecf/{id}, providers will only receive a single response for a given participant. Where a given participant is registered as both an ECT and a mentor, this will be associated with the participant’s ECT registration, not their mentor registration. Note, when API version 3.0.0 is released and integrated with, providers will receive all registrations for the participant ‘nested’ under the relevant `training_record_id`
+
+Specifications for the `‘nested’ participant response` can be found in the [draft API version 3.0.0. documentation](reference-v3.html#api-v3-participants-ecf-get).
+
+Note, if the DfE has been in touch regarding consolidating inconsistent participant_ids (see the [release note on 15 March 2023](release-notes.html#15th-march-2023)), the `training_record_id` would not change as it is unique to a registration.
+
+## 15 March 2023
+
+Providers will see reduced errors and inconsistencies associated with `participant_id` values.
+
+Providers have previously reported seeing different `participant_id` values associated with a single participant. For example, an NPQ provider may have seen a `participant_id` value of XXX via the applications endpoint, but when submitting a declaration for the same participant, the response body returned a `participant_id` value of YYY.
+
+These types of inconsistencies were appearing because the API was exposing the underpinning ECF and NPQ programme data models. The DfE has now updated the API logic to align `participant_id` values across various API endpoints and prevent related issues.
+
+Note, providers may need to update IDs held on their systems. The DfE will contact providers with further instruction if:
+
+- they need to reconcile multiple `participant_ids` into a single true `participant_id`
+- they need to replace a `participant_id` as a result of this API release
+
+While the expected volume of future instances is expected to be very low (where single participants are registered with multiple `participant_ids`), providers who identify issues should contact the DfE via existing support channels. The DfE will fix errors by 'retiring' one of the IDs, then associating all records and data under the remaining ID. The DfE will inform providers as to which `participant_id` they will need to record on their systems.
+
+## 14 March 2023
+
+DfE has updated the definition of the cohort attribute in the API guidance and schema definitions for ECF and NPQ. Note, this update is limited to definitions and guidance. There has been no change to API functionality or business rules.
+
+This update ensures API documentation is properly aligned with contractual terms and the way the attribute is used and understood by providers.
+
+Cohorts are now defined as the value indicating which call-off contract funds a given participant’s training. For example, 2021 indicates a participant that has started, or will start, their funded training in the 2021/22 academic year.
+
+[Read guidance around cohorts for ECF providers](ecf-usage.html#notifying-of-schedule-ecf-cohort-attribute)
+
+[Read guidance around cohorts for NPQ providers](npq-usage.html#notifying-of-schedule-npq-cohort-attribute)
+
+## 28 February 2023
+
+Providers can now review updated draft documentation for API version 3.0.0. Presentations and further feedback sessions on the proposed changes will be arranged with providers directly.
+
+Note, providers are not yet able to use API version 3.0.0 in any environment. Functionality should be available in the sandbox environment in May 2023, and in the live production environment in June 2023.
+
+Initial API draft documentation was shared with providers in Summer 2022. Following workshops with providers in November and December, DfE have gathered insights and incorporated feedback into the newly published draft documentation.
+
+### Important changes to be aware of for API version 3.0.0
+
+#### New endpoints will become available
+
+To address feedback from providers, DfE will avoid adding new attributes to existing endpoints (and their response bodies) where possible, and will instead create new endpoints to meet provider needs.
+
+#### ECF providers will receive nested participant responses
+
+To support the need to see participant details for those that train as an ECT and/then as a mentor with the same provider, the API will present nested data for ECF participant responses.
+
+#### ECF providers will be able to view transfer details
+
+New endpoints will allow providers to view details for any participants (who they train or will train) who have transferred to new schools. Existing ECF participant endpoints will present a `participant_status` attribute which will identify participants that are leaving or joining.
+
+#### ECF providers will be able to view details for ‘unfunded’ mentors
+
+New endpoints will allow providers to view details for mentors linked to ECTs, but who are not eligible for DfE funding.
+
+#### ECF providers will be able to identify schools they could partner with
+
+New endpoints will allow providers to view details for schools they could contact to partner with.
+
+#### ECF and NPQ providers will see new attributes when using declaration endpoints
+
+The API will continue to support NPQ and ECF declarations via existing endpoints. Providers may therefore see `null` values for attributes that do not apply to their declaration’s course type. For example, the `delivery_partner_id` attribute for an NPQ declaration will always be `null`.
+
+## 24 February 2023
+
+When [submitting completed ECF declarations](ecf-usage.html#declaring-that-an-ecf-participant-has-completed-their-course), providers should note that `evidence_held` is a mandatory attribute and must be included in the request body. API documentation has been updated in line with contractual requirements.
+
+Providers can only submit accepted `evidence_held` values. These signify the type of evidence held by a provider to demonstrate that a participant has met the retention criteria for the milestone period. The accepted values are:
+
+* `"evidence_held": training-event-attended`
+* `"evidence_held": self-study-material-completed`
+* `"evidence_held": other`
+
+Note, other mandatory attributes to include in the request body for completed ECF declaration submissions are `participant_id`, `declaration_type`, `declaration_date` and `course_identifier`.
+
+## 23 February 2023
+
+Initial teacher training (ITT) lead mentors who are not employed by schools are now eligible for DfE funding.
+
+During their registration journey, applicants for the leading teacher development NPQ will enter data to identify themselves as ITT lead mentors and validate their funding eligibility.
+
+Providers will see two new data attributes when viewing application data via the endpoint `GET /api/v1/npq-applications`:
+
+* `lead_mentor` - This signifies whether an applicant is a lead mentor (`"lead_mentor": true`) or not (`"lead_mentor": false`)
+* `itt_provider` - This will show the name of the accredited provider
+
+Note, unlike other NPQ applicants, ITT lead mentors do not need to enter some information on their registration journey. The following attributes will have null values:
+
+* `employer_name`
+* `employment_role`
+* `school_urn`
+
+## 26 January 2023
+
+Providers are now able to submit, view and update NPQ participant outcomes in the production environment.
+
+When an NPQ participant completes their course, their final assessment will determine a pass or fail outcome. Providers are required to notify DfE of outcomes, and provide updated outcomes as required.
+
+DfE will then notify the TRA who will issue certificates to any participants who have passed their NPQ course.
+
+Note, this functionality became available in the sandbox environment on 16 January 2023. Read more detailed guidance below on:
+
+* [Submitting NPQ outcomes in 'completed' declarations](#submitting-npq-outcomes)
+* [Updating NPQ outcomes](#updating-npq-outcomes)
+* [Viewing NPQ outcomes for participants](#viewing-npq-outcomes)
+
+## 16 January 2023
+
+Providers are now able to submit, view and update NPQ participant outcomes in the sandbox environment. Note, providers will be notified ahead of this functionality becoming available in the production environment.
+
+When an NPQ participant completes their course, their final assessment will determine a pass or fail outcome. Providers are now required to notify DfE of outcomes as part of `completed` declaration submissions, and provide updated outcomes as required.
+
+The DfE will then notify the TRA who will issue certificates to any participants who have passed their NPQ course.
+
+### Submitting NPQ outcomes in 'completed' declarations
+
+Providers must include participant outcomes as part of NPQ `completed` declaration submissions. The mandatory `has_passed` attribute must be included as part of the request body for the following endpoint:
+
+```
+POST /api/v1/participant-declarations
+```
+
+Providers can submit `has_passed` values as follows:
+
+* `"has_passed": true` - this signifies a participant has passed their course
+* `"has_passed": false` - this signifies a participant has failed their course
+
+`completed` declaration submissions which do not include outcomes will be rejected as invalid requests.
+
+If providers void `completed` declarations where a participant had passed assessment (`"has_passed": true`), then this outcome will also be retracted and the participants will be notified.
+
+### Updating NPQ outcomes
+
+Providers can update participant outcomes (defined by the `state` attribute) if they made an error in the data originally submitted, or if the participant fails, retakes and goes on to pass their assessment.
+
+Providers should include updated values for the NPQ `state` and `completion_date`, as well as the explicit `course_identifier` for the new endpoint:
+
+```
+POST /api/v1/participants/npq/{participant_id}/outcomes
+```
+
+Providers can submit `state` values as follows:
+
+* `"state": passed` - this will update the record to signify a participant has passed their course
+* `"state": failed` - this will update the record to signify a participant has failed their course
+
+### Viewing NPQ outcomes for all participants
+
+Providers can view all outcomes submitted for NPQ participants by using the following endpoints. Outcomes will be defined in the responses by the state attribute with values including:
+
+* `"state": passed` - this signifies a participant has passed their course
+* `"state": failed` - this signifies a participant has failed their course
+* `"state": voided` - this signifies a `completed` declaration has since been voided and therefore the associated outcome retracted
+
+Providers can view outcomes for all NPQ participants by using the new endpoint:
+
+```
+GET /api/v1/participants/npq/outcomes
+```
+
+Providers can view outcomes for a specific NPQ participant by using the new endpoint:
+
+```
+GET /api/v1/participants/npq/{participant_id}/outcomes
+```
+
+## 21 September 2022
+
+Providers may need to consider funding and administrative implications of non-UK participants registering for NPQs. Providers can now identify non-UK registrations using three new participant data fields in the API:
+
+1. `teacher_catchment` - this field will indicate whether or not the participant is UK-based:
+  * if `true` then the registration relates to a participant who is UK-based
+  * if `false` then the registration relates to a participant who is not UK-based
+2. `teacher_catchment_iso_country_code` - this field identifies which non-UK country the participant has registered from. The API uses [ISO 3166 alpha-3 codes](https://www.iso.org/iso-3166-country-codes.html), three-letter codes published by the International Organization for Standardization (ISO) to represent countries, dependent territories, and special areas of geographical interest.
+3. `teacher_catchment_country` - this field shows the text entered by the participant during their NPQ online registration.
+
+### Example
+
+A teacher from a country outside the UK uses the DfE’s digital service to register for an NPQ. The provider wants to identify the country the participant is registering from, so checks the API and finds:
+
+* `"teacher_catchment": false` - this means the participant is not UK-based
+* `"teacher_catchment_iso_country_code": "FRA"` - the provider investigates the result and identifies the participant is based in France
+* `"teacher_catchment_country": "France"` - the provider views the text the participant has entered in their online registration
+
+## 14 September 2022
+
+The API will now return a 422 error message to highlight invalid ECF or NPQ `course_identifier` entries.
+
+Invalid entries include:
+
+* spelling errors
+* unrecognised values not included in the schema, or a value included in the schema but not associated with the participant
+
+### Example
+
+When updating a participant record, an ECF provider enters an invalid `course_identifier`:
+
+* a provider enters `"course_identifier": "ecf-induction"` when the participant is actually an `ecf-mentor`
+* the API will check the `course_identifier` is valid against the `participant_id`
+* this will identify whether or not the participant is registered for the given training
+* the API will recognise that the `course_identifier` entered by the provider is invalid (as it should be `"course_identifier": "ecf-mentor"`)
+* the API will return a 422 error message: `“The property '#/course_identifier' must be an available course to '#/participant_id'”`
+* the provider will know to update the `course_identifier` entered
+
+## 24 August 2022
+
+ECF and NPQ lead providers can now trigger clawbacks of declarations which the DfE has paid to them.
+
+To do this, use the void endpoint. This can be done for both API versions (1.0.0 and 2.0.0):
+
+* a provider uses the void endpoint to void a declaration that was in the paid state
+* the state of the declaration will then become awaiting_clawback
+* on the next statement the DfE will then clawback the value of the declaration, including any associated uplift fee
+
+## 17 August 2022
+
+Added non-standard ECF schedules to 2022 cohort:
+
+* ecf-extended-september
+* ecf-extended-january
+* ecf-extended-april
+* ecf-reduced-september
+* ecf-reduced-january
+* ecf-reduced-april
+* ecf-replacement-september
+* ecf-replacement-january
+* ecf-replacement-april
+
+These non-standard schedules start on the first day of the month of the given schedule name. For example, 'ecf-extended-january' starts on 1 January 2023.
+
+## 9 August 2022
+
+Added `targeted_delivery_funding_eligibility` to NPQ applications.
+
+## 2 August 2022
+
+Removed the logic where the API would nullify the `email` field on the ECF and NPQ participant responses where the `status` is withdrawn. Now, where `status` is withdrawn, we will continue to display the participant’s `email`. Generally, the `status` will show withdrawn when a School Induction Tutor has withdrawn or “deleted” a participant in the schools user interface or “portal”. Where `email` was nullified, they will now be visible again.
+
+## 24 June 2022
+
+Added new declaration states `awaiting-clawback` and `clawed-back`.
+
+## 6 June 2022
+
+With this release we've:
+
+* added `cohort` to NPQ applications
+* added ability to filter by `cohort` on NPQ applications
+* added `ineligible_for_funding_reason` on NPQ applications
+* updated `eligible_for_funding` on NPQ applications to take previous accepted applications into consideration
+
+## 11 May 2022
+
+Added `yes_in_first_five_years` and `yes_over_five_years` to `headteacher_status` for NPQ applications.
+
+## 21 April 2022
+
+Added `works_in_school`, `employer_name`, and `employment_role` to `NPQApplicationAttributes` API entities. Definitions available at `reference-v1.html#schema-npqapplication`.
+
+## 12 April 2022
+
+When fetching participant declarations it will now return any declarations made by previous providers. This will allow you to determine what declarations you should be posting next.
+
+## 8 March 2022
+
+In the documentation `reference.html` has been moved to `/api-reference/reference-v1.html`.
+
+## 12 January 2022
+
+`change-schedule` API endpoints now accept a `cohort` attribute in the request body. This defaults to the current cohort if it is not specified.
+
+## 11 January 2022
+
+Added new API endpoint `/api/v1/participants/ecf/{participant_id}/change-schedule`.
+
+## 7 January 2022
+
+Added schedule with identifier `ecf-standard-april`.
+
+## 6 January 2022
+
+Schedule identifier has been renamed from `ecf-september-standard-2021` to `ecf-standard-september`.
+
+Schedule identifier has been renamed from `ecf-january-standard-2021` to `ecf-standard-january`.
+
+## 3 December 2021
+
+Return JSON responses for 404 and 401 errors rather than `text/plain`.
+
+## 4 November 2021
+
+With this release we've:
+
+* added ability to defer an NPQ participant from a given course. `PUT /api/v1/participants/npq/{id}/defer`
+* added the new endpoint to defer an NPQ participant from a given course. `PUT /api/v1/participants/npq/{id}/defer`
+* added ability to resume an NPQ participant from a given course. `PUT /api/v1/participants/npq/{id}/resume`
+* added the new endpoint to resume an NPQ participant from a given course. `PUT /api/v1/participants/npq/{id}/resume`
+* added 'updated_at' date to NPQ applications, NPQ participants, participants, and participant declarations (GET endpoints)
+
+## 27 October 2021
+
+Added created_at date to NPQ applications (GET endpoints).
+
+## 25 October 2021
+
+Add `employer` as possible option for NPQ `funding_choice`.
+
+## 19 October 2021
+
+With this release we've:
+
+* added ability to withdraw an NPQ participant from a given course. `PUT /api/v1/participants/npq/{id}/withdraw`
+* added the new endpoint to withdraw an NPQ participant from a given course. `PUT /api/v1/participants/npq/{id}/withdraw`
+
+The previous endpoint `PUT /api/v1/participants/npq/{id}/withdraw` is deprecated and will be removed in a later version of the API.
+
+## 5 October 2021
+
+Update withdrawal and deferral reason codes.
+
+Added created_at date to NPQ applications (GET endpoints).
+
+## 29 September 2021
+
+Added `GET /api/v1/participants/npq` endpoint.
+
+## 22 September 2021
+
+Prevent changing schedule if the new schedule makes existing pending declaration invalid.
+
+## 17 September 2021
+
+Add `GET /api/v1/participants/ecf` endpoint.
+
+## 16 September 2021
+
+Share `pupil_premium_uplift` and `sparsity_uplift` values for ECF participants.
+
+## 15 September 2021
+
+Ability to void participant declarations.
+
+## 10 September 2021
+
+Ability to resume participants on a course.
+
+## 9 September 2021
+
+Added new action to retrieve a single participant declaration by ID.
+
+## 8 September 2021
+
+Ability to defer participants on a course.
+
+## 7 September 2021
+
+Standardise date filtering parameters between different API endpoints.
+
+## 19 July 2021
+
+Initial release of the NPQ usage guide.
+
+## 1 July 2021
+
+Initial release of the API reference documentation.

--- a/documentation/ecf1_guidance/release-notes.md
+++ b/documentation/ecf1_guidance/release-notes.md
@@ -30,7 +30,7 @@ Providers can now submit declarations for these participants as expected.
 
 Registration is now open for the 2025/26 intake of early career teachers and mentors, so we’ve added the schedules and contract data for this academic year to the production environment.
 
-For more details, [view our guidance on changes for the 2025/26 academic year](changes-for-the-2025-2026-academic-year).
+For more details, [view our guidance on changes for the 2025/26 academic year](changes-for-the-2025-2026-academic-year.md).
 
 ## 23 April 2025
 
@@ -71,7 +71,7 @@ We’ll contact providers directly to ensure their integrations can support the 
 
 We’ve set up dummy data/contracts and milestones in the [API v3 test (sandbox) environment](https://sb.manage-training-for-early-career-teachers.education.gov.uk/) to support providers ahead of the closure of the 2022 ECF cohort at the end of July.
 
-[View detailed guidance about the closure of the 2022 cohort](2022-cohort-closure-information-for-lead-providers)
+[View detailed guidance about the closure of the 2022 cohort](2022-cohort-closure-information-for-lead-providers.md)
 
 ### How we’ll handle participants who haven’t completed their training by 31 July
 
@@ -104,7 +104,7 @@ We recommend providers use the dummy data we’ve set up in the test environment
 - check their CRM to make sure they can handle an enrolment in a new cohort with declarations spanning across 2022 and 2024
 - familiarise themselves with the `cohort_changed_after_payments_frozen` field in the `GET participant` endpoint response
 - check they can see historically submitted declarations made in a previous cohort in the `GET participant-declarations` endpoint when using the cohort filter
-- attempt some [future declarations](ecf/guidance/?#test-the-ability-to-submit-declarations-in-sandbox-ahead-of-time) and ensure they’re recorded and handled safely in their CRM
+- attempt some [future declarations](ecf/guidance.md#how-providers-can-test-theyre-able-to-submit-declarations) and ensure they’re recorded and handled safely in their CRM
 
 ## 14 March 2025
 
@@ -225,9 +225,9 @@ Providers can add the required API version and endpoint depending on what they w
 
 The endpoints documentation for each version of the API is also unchanged:
 
-- [ECF API v1 documentation](https://manage-training-for-early-career-teachers.education.gov.ukreference-v1.html)
-- [ECF API v2 documentation](https://manage-training-for-early-career-teachers.education.gov.ukreference-v2.html)
-- [ECF API v3 documentation](https://manage-training-for-early-career-teachers.education.gov.ukreference-v3.html)
+- [ECF API v1 documentation](reference-v1.md)
+- [ECF API v2 documentation](reference-v2.md)
+- [ECF API v3 documentation](reference-v3.md)
 
 To ensure everything runs smoothly on the ECF side of things, we recommend providers take the following post-separation actions:
 
@@ -242,7 +242,7 @@ Providers can contact us via their dedicated DfE Slack channel if they’ve got 
 
 Providers can now see the new <code>mentor_ineligible_for_funding_reason</code> field in the API production environment's participant response bodies.
 
-For full details about the field and the values it can display, read the <a href="release-notes.html#20-august-2024">release note we published</a> when we added this functionality to the test (sandbox) environment.
+For full details about the field and the values it can display, read the [release notes we published](#20-august-2024) when we added this functionality to the test (sandbox) environment.
 
 ## 20 August 2024
 
@@ -277,9 +277,9 @@ Providers can add the required API version and endpoint depending on what they w
 
 We’ve also created documentation for the new separation environment endpoints:
 
-- [ECF API v1 documentation](https://sp.manage-training-for-early-career-teachers.education.gov.ukreference-v1.html)
-- [ECF API v2 documentation](https://sp.manage-training-for-early-career-teachers.education.gov.ukreference-v2.html)
-- [ECF API v3 documentation](https://sp.manage-training-for-early-career-teachers.education.gov.ukreference-v3.html)
+- [ECF API v1 documentation](reference-v1.md)
+- [ECF API v2 documentation](reference-v2.md)
+- [ECF API v3 documentation](reference-v3.md)
 - [NPQ API v1 documentation](https://npq-registration-separation-web.teacherservices.cloud/api/docs/v1)
 - [NPQ API v2 documentation](https://npq-registration-separation-web.teacherservices.cloud/api/docs/v2)
 - [NPQ API v3 documentation](https://npq-registration-separation-web.teacherservices.cloud/api/docs/v3)
@@ -294,7 +294,7 @@ Registration has opened for the 2024/25 intake of NPQ participant applications, 
 - functionality which enables providers to set whether NPQ applicants are going to have their training funded by DfE
 - the new special education needs coordinator (SENCO) NPQ
 
-See the [14 June release note](release-notes.html#14-june-2024) for more details about the funded training functionality and SENCO NPQ.
+See the [14 June release note](#14-june-2024) for more details about the funded training functionality and SENCO NPQ.
 
 ## 28 June 2024
 
@@ -302,7 +302,7 @@ We’ve added some new features to help providers ahead of the closure of the fu
 
 The main impact will be ECTs and mentors with partial declarations currently assigned to the 2021 cohort being moved to the 2024 cohort.
 
-Because these ECTs and mentors are automatically shifted from a standard to an extended schedule, we’re allowing providers to change their schedules if necessary, using the existing [change-schedule](reference-v3.html#api-v3-participants-ecf-id-change-schedule-put) endpoint.
+Because these ECTs and mentors are automatically shifted from a standard to an extended schedule, we’re allowing providers to change their schedules if necessary, using the existing [change-schedule](reference-v3.md#put-api-v3-participants-ecf-id-change-schedule) endpoint.
 
 Providers can also temporarily move participants back to the 2021 cohort if they need to make any final declarations before it closes. They must be returned to the 2024 cohort to start making submissions against that year.
 
@@ -325,7 +325,7 @@ From today, schools have started moving ECTs and mentors with partial declaratio
 
 This is because we’re closing the funding contract for the 2021 cohort at the end of July.
 
-Providers will be able to identify participants who’ve been moved by the new `cohort_changed_after_payments_frozen` attribute to the [participant response](reference-v3.html?#api-v3-participants-ecf-get-responses-examples) in the API v3 production environment. The value shown for these participants will be `true`.
+Providers will be able to identify participants who’ve been moved by the new `cohort_changed_after_payments_frozen` attribute to the [participant response](reference-v3.md#api-v3-participants-ecf-get-responses-examples) in the API v3 production environment. The value shown for these participants will be `true`.
 
 Providers will no longer be able to submit or void declarations for the 2021 cohort after the contract closes on 31 July.
 
@@ -409,9 +409,9 @@ As always, we’d welcome feedback on this sandbox update before it goes into pr
 
 ## 8 March 2024
 
-Lead providers can now use the new `mentor_funding_end_date` field in the Live environment’s [ECF participant endpoint](reference-v3.html#api-v3-participants-ecf-get).
+Lead providers can now use the new `mentor_funding_end_date` field in the Live environment’s [ECF participant endpoint](reference-v3.md#get-api-v3-participants-ecf).
 
-Further details are available in the release note of [4 March 2024](release-notes.html#4-march-2024).
+Further details are available in the release note of [4 March 2024](#4-march-2024).
 
 ## 4 March 2024
 
@@ -419,7 +419,7 @@ We’ve found and fixed a bug that meant ‘participant IDs’ had been wrongly 
 
 ## 4 March 2024
 
-We're trialing new functionality in the API v3 sandbox which surfaces the `mentor_funding_end_date` field in the [ ECF participant endpoint](reference-v3.html#api-v3-participants-ecf-get).
+We're trialing new functionality in the API v3 sandbox which surfaces the `mentor_funding_end_date` field in the [ ECF participant endpoint](reference-v3.md#get-api-v3-participants-ecf).
 
 When a declaration is submitted for a mentor the completed date will equal the declaration date. When a declaration is voided the completed date will be cleared. Completed dates for early roll-out mentors will be set to 19 April 2021 regardless of any completed declarations.
 
@@ -443,7 +443,7 @@ Training providers will now only see the ECT in the latest cohort they’ve been
 
 We’ve fixed an issue with merging duplicate user accounts that meant existing declarations were not being redirected to the newly merged account correctly.
 
-Participant records in merged accounts will now point to the right declarations in the [ECF](reference-v3.html#api-v3-participants-ecf-get) and [NPQ](/api-reference/reference-v3.html#api-v3-participants-npq-get) GET participant endpoints.
+Participant records in merged accounts will now point to the right declarations in the [ECF](reference-v3.md#get-api-v3-participants-ecf) and [NPQ](reference-v3.md#get-api-v3-participants-npq) GET participant endpoints.
 
 This will ensure that all participant declarations are consistent.
 
@@ -453,11 +453,11 @@ We’ve fixed a bug that had prevented some providers from changing schedules fo
 
 * ‘You cannot change a participant to this cohort as you do not have a partnership with the school for the cohort. Contact the DfE for assistance.’
 
-This error message should now only apply where a lead provider is attempting to the use the [change schedule endpoint](reference-v3.html#api-v3-participants-ecf-id-change-schedule-put) to change the participant's cohort.
+This error message should now only apply where a lead provider is attempting to the use the [change schedule endpoint](reference-v3.md#put-api-v3-participants-ecf-id-change-schedule) to change the participant's cohort.
 
 ## 28 November 2023
 
-We've fixed a bug that meant some providers were having issues finding unfunded mentor IDs when using the `updated_at` filter on the [GET unfunded mentors endpoint](reference-v3.html#api-v3-unfunded-mentors-ecf-get).
+We've fixed a bug that meant some providers were having issues finding unfunded mentor IDs when using the `updated_at` filter on the [GET unfunded mentors endpoint](reference-v3.md#get-api-v3-unfunded-mentors-ecf).
 
 The `updated_at` value of an unfunded mentor now gets touched when the mentor is linked to an ECT.
 
@@ -467,7 +467,7 @@ An API call to the unfunded mentors endpoint filtered for any updates once the l
 
 We're trialing new functionality in the API v3 sandbox which allows lead providers to add a participant's schedule when accepting NPQ applications.
 
-We've added the optional `schedule-identifier` field on the [NPQ accept an application request body](npq/guidance.html#example-request-body).
+We've added the optional `schedule-identifier` field on the [NPQ accept an application request body](npq/guidance.md#example-request-body).
 
 This will prevent providers having to make manual changes if a participant has been defaulted to the wrong schedule.
 
@@ -477,13 +477,13 @@ We'd welcome feedback on this sandbox update before it goes into production.
 
 Lead providers can now use the new `participant_id_changes` features in the Live environment.
 
-Further detail on the change is available in the release note of [6 October 2023](release-notes.html#6-october-2023).
+Further detail on the change is available in the release note of [6 October 2023](release-notes.md#6-october-2023).
 
 ## 2 November 2023
 
 The DfE has released a fix for an issue which affected NPQ only providers using the v3 declarations endpoints. Some providers reported receiving 403 errors when attempting to POST or GET declarations. The issue was limited to v3. The fix has been released to sandbox and production environments.
 
-The fix also addresses an issue with the [cohort filter](reference-v3.html#schema-participantdeclarationsfilter), which is available for the declarations endpoint. Providers using the filter should now see that the response only returns NPQ and ECF declarations in the cohort specified. Previously, the filtering was inconsistent for NPQ declarations. The fix applies to production and sandbox environments.
+The fix also addresses an issue with the [cohort filter](reference-v3.md#schema-participantdeclarationsfilter), which is available for the declarations endpoint. Providers using the filter should now see that the response only returns NPQ and ECF declarations in the cohort specified. Previously, the filtering was inconsistent for NPQ declarations. The fix applies to production and sandbox environments.
 
 ## 30 October 2023
 
@@ -494,11 +494,11 @@ Lead providers can now test the new `participant_id_changes` feature in the sand
 
 The DfE welcomes feedback and intends to deploy the change to the production environment as soon as possible.
 
-Further detail on the change is available in the release note of [6 October 2023](release-notes.html#6-october-2023).
+Further detail on the change is available in the release note of [6 October 2023](release-notes.md#6-october-2023).
 
 ## 16 October 2023
 
-We've removed the `started-in-error` option from the [ECFWithdrawal schemas](reference-v3.html#schema-ecfwithdrawal) in all versions of the API.
+We've removed the `started-in-error` option from the [ECFWithdrawal schemas](reference-v3.md#schema-ecfwithdrawal) in all versions of the API.
 
 Note that NPQ participants can still be withdrawn for this reason.
 
@@ -506,15 +506,15 @@ Note that NPQ participants can still be withdrawn for this reason.
 
 Lead providers integrated with v3 of the API can now view details of ECTs that have completed their induction.
 
-We've added a new field, `induction_end_date`, to [ECFEnrolment](reference-v3.html#schema-ecfenrolment). We populate the field with data gathered about the date an ECT completed their induction from the Database of Qualified Teachers (DQT).
+We've added a new field, `induction_end_date`, to [ECFEnrolment](reference-v3.md#schema-ecfenrolment). We populate the field with data gathered about the date an ECT completed their induction from the Database of Qualified Teachers (DQT).
 
-We check the DQT on a daily basis for data about induction completion. We'll update a participant's records when we confirm they've completed their induction. Lead providers can use the [`updated_since` filter on the GET participants endpoint](reference-v3.html#schema-ecfparticipantfilter) to check for this kind of update.
+We check the DQT on a daily basis for data about induction completion. We'll update a participant's records when we confirm they've completed their induction. Lead providers can use the [`updated_since` filter on the GET participants endpoint](reference-v3.md#schema-ecfparticipantfilter) to check for this kind of update.
 
-Lead providers can use the field to identify participants that have completed their induction, and which may need to be placed on a [reduced schedule](ecf/schedules-and-milestone-dates.html#reduced-schedule).
+Lead providers can use the field to identify participants that have completed their induction, and which may need to be placed on a [reduced schedule](ecf/schedules-and-milestone-dates.md#reduced-schedule).
 
 ## 9 October 2023
 
-We've released a change to the `updated_at` functionality of the [ECFPartnershipAttributes](reference-v3.html#schema-ecfpartnershipattributes).
+We've released a change to the `updated_at` functionality of the [ECFPartnershipAttributes](reference-v3.md#schema-ecfpartnershipattributes).
 
 Now, when a user (for example, a school induction tutor) challenges a partnership, the date and time of this change will populate the `updated_at` field of the partnership.
 
@@ -524,13 +524,13 @@ In this way, providers may rely on the `updated_since` filter to identify if the
 
 We’ve added experimental fields to the API v3 sandbox environment to make it simpler for lead providers to identify and manage deduped participants.
 
-We’ve [previously advised](release-notes.html#15-march-2023) of the possibility that participants may be registered as duplicates with multiple participant_ids.
+We’ve [previously advised](release-notes.md#15-march-2023) of the possibility that participants may be registered as duplicates with multiple participant_ids.
 
 Where we identify duplicates, we'll fix the error by ‘retiring’ one of the participant IDs, then associating all records and data under the remaining ID. To date, when this occurred, the DfE has informed providers of changes via CSVs.
 
 We’re now proposing that lead providers may manage these limited changes using some new API v3 functionality including:
 
-* a new `participant_id_changes` nested structure added to the [ECFEnrolment](reference-v3.html#schema-ecfenrolment) and [NPQEnrolment](/api-reference/reference-v3.html#schema-npqenrolment) schemas, which would each contain a `from_participant_id` and a `to_participant_id` string fields, as well a `changed_at` date value
+* a new `participant_id_changes` nested structure added to the [ECFEnrolment](reference-v3.md#schema-ecfenrolment) and [NPQEnrolment](reference-v3.md#schema-npqenrolment) schemas, which would each contain a `from_participant_id` and a `to_participant_id` string fields, as well a `changed_at` date value
 * a new filter for the various GET participant endpoints, so lead providers can search by a participant_id to check if it has changed, which will return the participant including their changed id. For example, **GET** `api/v3/participants/ecf?filter[from_participant_id]={your_id}`
 
 We welcome feedback on these changes and intends to release them to the sandbox and production as soon as possible. We'll provide a release note at each stage.
@@ -574,21 +574,21 @@ Providers should:
 
 ## 24 August 2023
 
-Lead providers can now submit 'extended declarations' for ECTs that are on extended schedules in production. The change applies to all versions of the API. Previously, lead providers could only test the new functionality in the [sandbox environment](release-notes.html#17-august-2023).
+Lead providers can now submit 'extended declarations' for ECTs that are on extended schedules in production. The change applies to all versions of the API. Previously, lead providers could only test the new functionality in the [sandbox environment](release-notes.md#17-august-2023).
 
-There is [guidance available for providers in the API documentation](ecf/schedules-and-milestone-dates.html#extended-schedules). Please note that while there are currently only three extended declarations, the number of extended declarations a provider may need to submit is not limited in the contract. The DfE may add additional extended declarations should the need arise.
+There is [guidance available for providers in the API documentation](ecf/schedules-and-milestone-dates.md#extended-schedules). Please note that while there are currently only three extended declarations, the number of extended declarations a provider may need to submit is not limited in the contract. The DfE may add additional extended declarations should the need arise.
 
 ## 17 August 2023
 
 Lead providers can now submit 'extended declarations' for ECTs that are on extended schedules in the sandbox environment. Providers may not submit extended declarations for mentors.
 
-Qualifying ECTs will have had their induction extended as a result of having not yet met the Teachers' standards, and need additional support to meet the standards. These ECTs must be placed onto one of the available ['extended schedules'](ecf/schedules-and-milestone-dates.html#extended-schedules) for ECF.
+Qualifying ECTs will have had their induction extended as a result of having not yet met the Teachers' standards, and need additional support to meet the standards. These ECTs must be placed onto one of the available ['extended schedules'](ecf/schedules-and-milestone-dates.md#extended-schedules) for ECF.
 
 Providers may submit an extended declaration (subject to meeting the engagement criteria) for each extended term until the ECT has completed their induction, up to a maximum of three extensions. On completing induction, the provider should submit a completion declaration for the final term.
 
 For further details about how and when to use these declaration types, providers should refer to the ECF payment guidance issued by their contract manager.
 
-Providers may submit extended declarations using the following values in the `declaration_type` field on the [participant declaration request body](reference-v3.html#schema-participantdeclarationrequest):
+Providers may submit extended declarations using the following values in the `declaration_type` field on the [participant declaration request body](reference-v3.md#schema-participantdeclarationrequest):
 
 - extended-1
 - extended-2
@@ -600,7 +600,7 @@ Providers will be notified ahead of this functionality becoming available in the
 
 Lead providers can now ‘resume’ NPQ and ECF participants they've previously withdrawn.
 
-Lead providers should use the relevant [ecf](reference-v3.html#api-v3-participants-ecf-id-resume-put) or [npq](/api-reference/reference-v3.html#api-v3-participants-npq-id-resume-put) resume endpoints to change a given participant’s `training_status` from withdrawn to active.
+Lead providers should use the relevant [ecf](reference-v3.md#put-api-v3-participants-ecf-id-resume) or [npq](reference-v3.md#put-api-v3-participants-npq-id-resume) resume endpoints to change a given participant’s `training_status` from withdrawn to active.
 
 The DfE will monitor levels of withdrawn participants that have been resumed.
 
@@ -611,7 +611,7 @@ Lead Providers can now change the cohort of an ECF participant, providing that:
 - the lead provider has a partnership with the school in the new cohort they want to move the participant into; and
 - any declarations the provider may have made for the participant have been `voided` or `clawed_back`
 
-Providers may change an ECF participant's cohort using the [change-schedule endpoint](reference-v3.html#api-v3-participants-ecf-id-change-schedule-put).
+Providers may change an ECF participant's cohort using the [change-schedule endpoint](reference-v3.md#put-api-v3-participants-ecf-id-change-schedule).
 
 If a lead provider has no partnership with a school for cohort 2022 and tries to change a participant from 2023 to 2022 cohort, then the API will return an error: `You cannot change a participant to this cohort as you do not have a partnership with the school for the cohort. Contact the DfE for assistance.`
 
@@ -636,7 +636,7 @@ Providers can now filter ECF and NPQ participants by training_status, for exampl
 * GET /api/v3/participants/ecf?filter[training_status]=deferred
 * GET /api/v3/participants/npq?filter[training_status]=active
 
-The filter is optional and only applies to v3 of the API. More detail is available in the [NPQ](reference-v3.html#api-v3-participants-npq-get) and [ECF](/api-reference/reference-v3.html#api-v3-participants-ecf-get) specifications.
+The filter is optional and only applies to v3 of the API. More detail is available in the [NPQ](reference-v3.md#get-api-v3-participants-npq) and [ECF](reference-v3.md#get-api-v3-participants-ecf) specifications.
 
 ## 12 July 2023
 
@@ -648,7 +648,7 @@ If a provider wishes to defer a participant without a started declaration then t
 
 ## 7 July 2023
 
-Providers can now see the name of the lead provider which submitted a given declaration. Providers can find more detail on the new attribute `lead_provider_name` in the [v3 specification](reference-v3.html#schema-participantdeclarationresponse).
+Providers can now see the name of the lead provider which submitted a given declaration. Providers can find more detail on the new attribute `lead_provider_name` in the [v3 specification](reference-v3.md#participantdeclarationresponse).
 
 Providers may see declarations submitted by another provider where an ECF participant has transferred. A provider may not void a declaration submitted by another provider.
 
@@ -666,7 +666,7 @@ When submitting a withdrawal request for an NPQ participant, providers may now i
 
 * `expected-commitment-unclear`
 
-Providers can view details about NPQ participant [withdrawal request schema](reference-v1.html#schema-npqparticipantwithdrawattributes) in the API specification.
+Providers can view details about NPQ participant [withdrawal request schema](reference-v1.md#npqparticipantwithdrawattributes) in the API specification.
 
 ## 2 June 2023
 
@@ -676,9 +676,9 @@ Based on feedback from testing in the sandbox, the following updates have been m
 
 * API v3 endpoints will order responses by `created_at` by default
 * an `updated_at` attribute has been added to the ECF statement response
-* `updated_since` filter parameters can be used when [viewing ECF statements](ecf/guidance.html#view-financial-statement-payment-dates) and [viewing ECF schools](/api-reference/ecf/guidance.html#find-schools-delivering-ecf-based-training-in-a-given-cohort)
-* an `id` parameter has been added to the [endpoint specifications for ECF schools](reference-v3.html#api-v3-schools-ecf-id-get)
-* the formatting of the `completion_date` attribute has amended to follow ISO 8601 format in the [specifications for NPQ outcomes](reference-v3.html#schema-npqoutcomeattributes)
+* `updated_since` filter parameters can be used when [viewing ECF statements](ecf/guidance.md#view-financial-statement-payment-dates) and [viewing ECF schools](ecf/guidance.md#find-schools-delivering-ecf-based-training-in-a-given-cohort)
+* an `id` parameter has been added to the [endpoint specifications for ECF schools](reference-v3.md#get-api-v3-schools-ecf-id)
+* the formatting of the `completion_date` attribute has amended to follow ISO 8601 format in the [specifications for NPQ outcomes](reference-v3.md#schema-npqoutcomeattributes)
 
 To improve sandbox performance, queries underpinning key endpoints have been optimised. Providers should notice a reduction in slower response times when testing in the sandbox.
 
@@ -697,9 +697,9 @@ Note, induction tutors are not yet able to register ECTs as mentors at different
 
 [Watch a demonstration of how to register an ECT as a mentor.](https://www.loom.com/share/7f45563f846a46aba30c713f1b0a7cce)
 
-[View API v3 specifications for the ‘nested’ participant response.](reference-v3.html#api-v3-participants-ecf-get)
+[View API v3 specifications for the ‘nested’ participant response.](reference-v3.md#get-api-v3-participants-ecf)
 
-See the [13th April 2023 release note](release-notes.html#13th-april-2023) for details on how the API handles ECT-mentors depending on provider integrations with API versions 1 or 2 and version 3.
+See the [13th April 2023 release note](#13th-april-2023) for details on how the API handles ECT-mentors depending on provider integrations with API versions 1 or 2 and version 3.
 
 ## 19 May 2023
 
@@ -707,17 +707,17 @@ Providers can now test API v3.0.0.0. integrations in the sandbox environment. Ad
 
 Feedback from providers is invited via the usual channels. All feedback will be considered ahead API v3 release to production environment.
 
-Changes to the [API v3 spec](reference-v3.html) have been implemented since the original draft was shared. Based on provider feedback and continual improvement, these include:
+Changes to the [API v3 spec](reference-v3.md) have been implemented since the original draft was shared. Based on provider feedback and continual improvement, these include:
 
-* the addition of a URN filter for when providers [find schools delivering ECF-based training in a given cohort](reference-v3.html#api-v3-schools-ecf-get)
+* the addition of a URN filter for when providers [find schools delivering ECF-based training in a given cohort](reference-v3.md#get-api-v3-schools-ecf)
 
 * pagination parameter functionality on multiple GET endpoints which, for example, do not include an `{id}` parameter
 
-* the addition of a date attribute which allows providers to view and update when a participant has deferred [from their ECF-based training](reference-v3.html#schema-ecfdeferral) or [from their NPQ course](/api-reference/reference-v3.html#schema-npqdeferral)
+* the addition of a date attribute which allows providers to view and update when a participant has deferred [from their ECF-based training](reference-v3.md#ecfdeferral) or [from their NPQ course](reference-v3.md#npqdeferral)
 
 * an update on where participant email addresses are included within participant responses to reduce confusion if, for example, a participant uses different email addresses when registering as an ECT and mentor
 
-* the removal of the `validation_status` attribute from the [ECF participant response](reference-v3.html#schema-ecfparticipant). New attribute options will be tested and added at a later stage, to meet provider and delivery partner needs
+* the removal of the `validation_status` attribute from the [ECF participant response](reference-v3.md#schema-ecfparticipant). New attribute options will be tested and added at a later stage, to meet provider and delivery partner needs
 
 ### Test dynamic scenarios
 
@@ -756,7 +756,7 @@ Note, API v3.0.0.0 is not yet available in either sandbox or production environm
 
 ## 13 April 2023
 
-To enable the scenario where a participant needs to be registered as a mentor after having already been trained as an ECT by a given provider, a new `training_record_id` attribute has been added to the [ECF participant schema](reference-v1.html#schema-ecfparticipant).
+To enable the scenario where a participant needs to be registered as a mentor after having already been trained as an ECT by a given provider, a new `training_record_id` attribute has been added to the [ECF participant schema](reference-v1.md#schema-ecfparticipant).
 
 The `training_record_id` value will be unique to each registration that a participant has for ECF-based training, as either an ECT or mentor.
 
@@ -767,9 +767,9 @@ For the moment, we have added examples to provider sandbox environments:
 * when using the endpoint GET /api/v1/participants/ecf, providers will receive an API response with all the ECF-based training registrations. Where a given participant is registered as both an ECT and a mentor, they will see multiple responses that each have the same participant_id, but which have unique `training_record_ids` for the mentor and ECT response
 * when using the endpoint GET /api/v1/participants/ecf/{id}, providers will only receive a single response for a given participant. Where a given participant is registered as both an ECT and a mentor, this will be associated with the participant’s ECT registration, not their mentor registration. Note, when API version 3.0.0 is released and integrated with, providers will receive all registrations for the participant ‘nested’ under the relevant `training_record_id`
 
-Specifications for the `‘nested’ participant response` can be found in the [draft API version 3.0.0. documentation](reference-v3.html#api-v3-participants-ecf-get).
+Specifications for the `‘nested’ participant response` can be found in the [draft API version 3.0.0. documentation](reference-v3.md#get-api-v3-participants-ecf).
 
-Note, if the DfE has been in touch regarding consolidating inconsistent participant_ids (see the [release note on 15 March 2023](release-notes.html#15th-march-2023)), the `training_record_id` would not change as it is unique to a registration.
+Note, if the DfE has been in touch regarding consolidating inconsistent participant_ids (see the [release note on 15 March 2023](#15th-march-2023)), the `training_record_id` would not change as it is unique to a registration.
 
 ## 15 March 2023
 
@@ -794,9 +794,9 @@ This update ensures API documentation is properly aligned with contractual terms
 
 Cohorts are now defined as the value indicating which call-off contract funds a given participant’s training. For example, 2021 indicates a participant that has started, or will start, their funded training in the 2021/22 academic year.
 
-[Read guidance around cohorts for ECF providers](ecf-usage.html#notifying-of-schedule-ecf-cohort-attribute)
+[Read guidance around cohorts for ECF providers](ecf-usage.md#notifying-of-schedule-ecf-cohort-attribute)
 
-[Read guidance around cohorts for NPQ providers](npq-usage.html#notifying-of-schedule-npq-cohort-attribute)
+[Read guidance around cohorts for NPQ providers](npq-usage.md#notifying-of-schedule-npq-cohort-attribute)
 
 ## 28 February 2023
 
@@ -834,7 +834,7 @@ The API will continue to support NPQ and ECF declarations via existing endpoints
 
 ## 24 February 2023
 
-When [submitting completed ECF declarations](ecf-usage.html#declaring-that-an-ecf-participant-has-completed-their-course), providers should note that `evidence_held` is a mandatory attribute and must be included in the request body. API documentation has been updated in line with contractual requirements.
+When [submitting completed ECF declarations](ecf-usage.md#declaring-that-an-ecf-participant-has-completed-their-course), providers should note that `evidence_held` is a mandatory attribute and must be included in the request body. API documentation has been updated in line with contractual requirements.
 
 Providers can only submit accepted `evidence_held` values. These signify the type of evidence held by a provider to demonstrate that a participant has met the retention criteria for the milestone period. The accepted values are:
 
@@ -942,7 +942,7 @@ Providers may need to consider funding and administrative implications of non-UK
 1. `teacher_catchment` - this field will indicate whether or not the participant is UK-based:
   * if `true` then the registration relates to a participant who is UK-based
   * if `false` then the registration relates to a participant who is not UK-based
-2. `teacher_catchment_iso_country_code` - this field identifies which non-UK country the participant has registered from. The API uses [ISO 3166 alpha-3 codes](https://www.iso.org/iso-3166-country-codes.html), three-letter codes published by the International Organization for Standardization (ISO) to represent countries, dependent territories, and special areas of geographical interest.
+2. `teacher_catchment_iso_country_code` - this field identifies which non-UK country the participant has registered from. The API uses [ISO 3166 alpha-3 codes](https://www.iso.org/iso-3166-country-codes.md), three-letter codes published by the International Organization for Standardization (ISO) to represent countries, dependent territories, and special areas of geographical interest.
 3. `teacher_catchment_country` - this field shows the text entered by the participant during their NPQ online registration.
 
 ### Example
@@ -1026,7 +1026,7 @@ Added `yes_in_first_five_years` and `yes_over_five_years` to `headteacher_status
 
 ## 21 April 2022
 
-Added `works_in_school`, `employer_name`, and `employment_role` to `NPQApplicationAttributes` API entities. Definitions available at `reference-v1.html#schema-npqapplication`.
+Added `works_in_school`, `employer_name`, and `employment_role` to `NPQApplicationAttributes` API entities. Definitions available at `reference-v1.md#schema-npqapplication`.
 
 ## 12 April 2022
 
@@ -1034,7 +1034,7 @@ When fetching participant declarations it will now return any declarations made 
 
 ## 8 March 2022
 
-In the documentation `reference.html` has been moved to `/api-reference/reference-v1.html`.
+In the documentation `reference.md` has been moved to `reference-v1.md`.
 
 ## 12 January 2022
 


### PR DESCRIPTION
### Context

Convert and move the ECF1 guidance docs to the RECT so we have a copy available (especially as some were generated from templated code and had to be "scraped" from a running ECF1 instance) should we need them for reference.

### Changes proposed in this pull request

Adds ECF1 docs in markdown format

### Guidance to review

Probably best to use the "View file" functionality on Github to see the rendered view and be able to navigate links etc.
Note that not all links go anywhere, I guess over time things have changed and this hasn't been updated as they don't go anywhere on the ECF1 original either (the `<schemaobject>/items` links for instance)