### PR TITLE
Add schedule lookup across contract periods (Admin change contract period journey)

### DIFF
--- a/app/services/schedules/equivalent_schedule.rb
+++ b/app/services/schedules/equivalent_schedule.rb
@@ -1,0 +1,17 @@
+module Schedules
+  class EquivalentSchedule
+    attr_reader :source_schedule, :target_contract_period
+
+    def initialize(source_schedule:, target_contract_period:)
+      @source_schedule = source_schedule
+      @target_contract_period = target_contract_period
+    end
+
+    def schedule
+      Schedule.find_by(
+        identifier: source_schedule.identifier,
+        contract_period: target_contract_period
+      )
+    end
+  end
+end

--- a/spec/services/schedules/equivalent_schedule_spec.rb
+++ b/spec/services/schedules/equivalent_schedule_spec.rb
@@ -1,0 +1,46 @@
+RSpec.describe Schedules::EquivalentSchedule do
+  subject(:equivalent_schedule) do
+    described_class.new(
+      source_schedule:,
+      target_contract_period:
+    ).schedule
+  end
+
+  let(:source_contract_period) { FactoryBot.create(:contract_period, year: 2025) }
+  let(:target_contract_period) { FactoryBot.create(:contract_period, year: 2026) }
+  let(:source_schedule) do
+    FactoryBot.create(
+      :schedule,
+      contract_period: source_contract_period,
+      identifier: "ecf-standard-april"
+    )
+  end
+
+  context "when a schedule with the same identifier exists in the target contract period" do
+    let!(:target_schedule) do
+      FactoryBot.create(
+        :schedule,
+        contract_period: target_contract_period,
+        identifier: source_schedule.identifier
+      )
+    end
+
+    it "returns the matching schedule" do
+      expect(equivalent_schedule).to eq(target_schedule)
+    end
+  end
+
+  context "when no schedule with the same identifier exists in the target contract period" do
+    before do
+      FactoryBot.create(
+        :schedule,
+        contract_period: target_contract_period,
+        identifier: "ecf-standard-september"
+      )
+    end
+
+    it "returns nil" do
+      expect(equivalent_schedule).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
### Summary

Add `TrainingPeriods::MatchingSchedule`, a query object for finding schedules with the same identifier across contract periods.

### Why?

This logic will be needed by the [upcoming contract period change journey](https://github.com/DFE-Digital/register-ects-project-board/issues/3404) and is extracted here to keep the lookup in a single place.