### PR TITLE
[3404] Add contract period and partnership selection steps (Slice 1)

### DIFF
--- a/app/controllers/admin/teachers/training_periods/change_contract_period_wizard_controller.rb
+++ b/app/controllers/admin/teachers/training_periods/change_contract_period_wizard_controller.rb
@@ -46,7 +46,10 @@ module Admin
         end
 
         def ensure_changeable_training_period
-          raise ActionController::BadRequest, "Training period is not eligible for contract period change" unless ChangeContractPeriod::Eligibility.new(training_period: @training_period).eligible?
+          unless ChangeContractPeriod::Eligibility.new(training_period: @training_period).eligible?
+            raise ActionController::BadRequest,
+                  "Training period is not eligible for contract period change"
+          end
         end
 
         def check_allowed_step

--- a/app/controllers/admin/teachers/training_periods/change_contract_period_wizard_controller.rb
+++ b/app/controllers/admin/teachers/training_periods/change_contract_period_wizard_controller.rb
@@ -1,0 +1,101 @@
+module Admin
+  module Teachers
+    module TrainingPeriods
+      class ChangeContractPeriodWizardController < AdminController
+        layout "full"
+
+        FORM_KEY_PREFIX = "admin_teachers_training_periods_change_contract_period_wizard"
+
+        include WizardStoreRescuable
+
+        before_action :set_teacher
+        before_action :set_training_period
+        before_action :ensure_changeable_training_period
+        before_action :initialize_wizard
+        before_action :check_allowed_step
+        before_action :reset_store_on_entry
+
+        def new
+          render current_step
+        end
+
+        def create
+          if @wizard.valid_step?
+            @wizard.current_step.save!
+
+            if current_step == :select_partnership
+              render current_step
+            else
+              redirect_to @wizard.next_step_path
+            end
+          else
+            render current_step, status: :unprocessable_content
+          end
+        end
+
+      private
+
+        def set_teacher
+          @teacher = Teacher.find(params[:teacher_id])
+        end
+
+        def set_training_period
+          @training_period = TrainingPeriod.find(params[:training_period_id])
+
+          raise ActiveRecord::RecordNotFound unless @training_period.teacher_id == @teacher.id
+        end
+
+        def ensure_changeable_training_period
+          raise ActionController::BadRequest, "Training period is not eligible for contract period change" unless ChangeContractPeriod::Eligibility.new(training_period: @training_period).eligible?
+        end
+
+        def check_allowed_step
+          redirect_to @wizard.allowed_step_path unless @wizard.allowed_step?
+        end
+
+        def store
+          @store ||= SessionRepository.new(session:, form_key:)
+        end
+
+        def form_key
+          "#{FORM_KEY_PREFIX}_#{@teacher.id}_#{@training_period.id}"
+        end
+
+        def current_step
+          @current_step ||= begin
+            step = step_name_from_path
+            return :not_found unless wizard_class.step?(step)
+
+            step
+          end
+        end
+
+        def step_name_from_path
+          request.path.split("/").last.underscore.to_sym
+        end
+
+        def initialize_wizard
+          @wizard = wizard_class.new(
+            current_step:,
+            step_params: params,
+            author: current_user,
+            teacher_id: @teacher.id,
+            training_period_id: @training_period.id,
+            store:
+          )
+        end
+
+        def wizard_class
+          Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Wizard
+        end
+
+        def reset_store_on_entry
+          return unless current_step == :select_contract_period
+          return if request.referer.to_s.include?("/contract-period/change/")
+
+          store.reset
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/admin/teachers/training_periods/change_contract_period_wizard_controller.rb
+++ b/app/controllers/admin/teachers/training_periods/change_contract_period_wizard_controller.rb
@@ -11,9 +11,9 @@ module Admin
         before_action :set_teacher
         before_action :set_training_period
         before_action :ensure_changeable_training_period
+        before_action :reset_store_on_entry
         before_action :initialize_wizard
         before_action :check_allowed_step
-        before_action :reset_store_on_entry
 
         def new
           render current_step

--- a/app/forms/admin/teachers/change_training_partnership_form.rb
+++ b/app/forms/admin/teachers/change_training_partnership_form.rb
@@ -15,7 +15,7 @@ module Admin
       def save(author:)
         return false unless valid?
 
-        TrainingPeriods::ChangePartnership.new(training_period:, school_partnership:, author:).call
+        ::TrainingPeriods::ChangePartnership.new(training_period:, school_partnership:, author:).call
         true
       rescue ActiveRecord::RecordInvalid => e
         errors.add(:base, e.record.errors.full_messages.to_sentence)

--- a/app/services/admin/teachers/training_periods/change_contract_period/eligibility.rb
+++ b/app/services/admin/teachers/training_periods/change_contract_period/eligibility.rb
@@ -1,0 +1,49 @@
+module Admin
+  module Teachers
+    module TrainingPeriods
+      module ChangeContractPeriod
+        class Eligibility
+          attr_reader :training_period
+
+          def initialize(training_period:)
+            @training_period = training_period
+          end
+
+          def eligible?
+            return false unless training_period.provider_led_training_programme?
+            return false if training_period.school_partnership.blank?
+            return false if finished_before_today?
+
+            return current_active_period == training_period if future_periods.empty?
+            return future_periods == [training_period] if current_active_period.blank?
+
+            future_periods.include?(training_period) && same_lead_provider_delivery_partnership?(current_active_period, training_period)
+          end
+
+        private
+
+          def relationships
+            @relationships ||= ::TrainingPeriods::PeriodRelationships.new(training_period:)
+          end
+
+          def current_active_period
+            relationships.current_active_period
+          end
+
+          def future_periods
+            @future_periods ||= relationships.future_periods.to_a
+          end
+
+          def same_lead_provider_delivery_partnership?(period, other_period)
+            period.lead_provider_delivery_partnership.present? &&
+              period.lead_provider_delivery_partnership == other_period.lead_provider_delivery_partnership
+          end
+
+          def finished_before_today?
+            training_period.complete? && !training_period.leaving_today_or_in_future?
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/admin/teachers/training_periods/change_contract_period/eligibility.rb
+++ b/app/services/admin/teachers/training_periods/change_contract_period/eligibility.rb
@@ -23,7 +23,7 @@ module Admin
         private
 
           def relationships
-            @relationships ||= ::TrainingPeriods::PeriodRelationships.new(training_period:)
+            @relationships ||= ::TrainingPeriods::RelatedPeriods.new(training_period:)
           end
 
           def current_active_period

--- a/app/views/admin/teachers/training_periods/change_contract_period_wizard/select_contract_period.html.erb
+++ b/app/views/admin/teachers/training_periods/change_contract_period_wizard/select_contract_period.html.erb
@@ -1,0 +1,29 @@
+<% page_data(
+  title: "Select new contract period for #{@wizard.teacher_name}",
+  error: @wizard.current_step.errors.present?,
+  backlink_href: admin_teacher_training_path(@teacher)
+) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
+      <%= content_for(:error_summary) { f.govuk_error_summary } %>
+
+      <%= f.govuk_radio_buttons_fieldset(
+        :contract_period_year,
+        legend: { text: "Select new contract period for #{@wizard.teacher_name}", hidden: true }
+      ) do %>
+        <% @wizard.contract_periods.each_with_index do |contract_period, index| %>
+          <%= f.govuk_radio_button(
+            :contract_period_year,
+            contract_period.year,
+            label: { text: contract_period.year.to_s },
+            link_errors: index.zero?
+          ) %>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_submit "Continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/teachers/training_periods/change_contract_period_wizard/select_partnership.html.erb
+++ b/app/views/admin/teachers/training_periods/change_contract_period_wizard/select_partnership.html.erb
@@ -1,5 +1,5 @@
 <% page_data(
-  title: "Select partnership for #{@wizard.selected_contract_period.year} for #{@wizard.teacher_name}",
+  title: "Select #{@wizard.selected_contract_period.year} partnership for #{@wizard.teacher_name}",
   error: @wizard.current_step.errors.present?,
   backlink_href: @wizard.previous_step_path
 ) %>

--- a/app/views/admin/teachers/training_periods/change_contract_period_wizard/select_partnership.html.erb
+++ b/app/views/admin/teachers/training_periods/change_contract_period_wizard/select_partnership.html.erb
@@ -1,0 +1,31 @@
+<% page_data(
+  title: "Select partnership for #{@wizard.selected_contract_period.year} for #{@wizard.teacher_name}",
+  error: @wizard.current_step.errors.present?,
+  backlink_href: @wizard.previous_step_path
+) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
+      <%= content_for(:error_summary) { f.govuk_error_summary } %>
+
+      <%= f.govuk_collection_radio_buttons(
+        :school_partnership_id,
+        @wizard.partnership_options,
+        :id,
+        :name,
+        legend: {
+          text: "Select partnership",
+          hidden: true,
+        }
+      ) %>
+
+      <%= govuk_inset_text do %>
+        If you need to add a new partnership, go to
+        <%= govuk_link_to("school partnerships", admin_school_partnerships_path(@wizard.school.urn)) %>.
+      <% end %>
+
+      <%= f.govuk_submit "Continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/select_contract_period_step.rb
+++ b/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/select_contract_period_step.rb
@@ -1,0 +1,33 @@
+module Admin
+  module Teachers
+    module TrainingPeriods
+      module ChangeContractPeriodWizard
+        class SelectContractPeriodStep < Step
+          attribute :contract_period_year, :integer
+
+          validates :contract_period_year, presence: { message: "Select a new contract period" }
+          validate :contract_period_available
+
+          def self.permitted_params = %i[contract_period_year]
+
+          def next_step = :select_partnership
+
+        private
+
+          def persist
+            value = step_params["contract_period_year"] || contract_period_year
+            store.contract_period_year = value
+            store.school_partnership_id = nil
+          end
+
+          def contract_period_available
+            return if contract_period_year.blank?
+            return if wizard.contract_periods.where(year: contract_period_year).exists?
+
+            errors.add(:contract_period_year, "Select a new contract period")
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/select_partnership_step.rb
+++ b/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/select_partnership_step.rb
@@ -1,0 +1,32 @@
+module Admin
+  module Teachers
+    module TrainingPeriods
+      module ChangeContractPeriodWizard
+        class SelectPartnershipStep < Step
+          attribute :school_partnership_id, :integer
+
+          validates :school_partnership_id, presence: { message: "Select a partnership" }
+          validate :school_partnership_available
+
+          def self.permitted_params = %i[school_partnership_id]
+
+          def previous_step = :select_contract_period
+
+        private
+
+          def persist
+            value = step_params["school_partnership_id"] || school_partnership_id
+            store.school_partnership_id = value
+          end
+
+          def school_partnership_available
+            return if school_partnership_id.blank?
+            return if wizard.school_partnerships.where(id: school_partnership_id).exists?
+
+            errors.add(:school_partnership_id, "Select a partnership")
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/step.rb
+++ b/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/step.rb
@@ -1,0 +1,28 @@
+module Admin
+  module Teachers
+    module TrainingPeriods
+      module ChangeContractPeriodWizard
+        class Step < ApplicationWizardStep
+          def self.permitted_params = []
+
+          def save!
+            persist if wizard.valid_step?
+          end
+
+        private
+
+          def pre_populate_attributes
+            self.class.permitted_params.each do |key|
+              value = wizard.store.public_send(key)
+              public_send("#{key}=", value) if value.present?
+            end
+          end
+
+          def step_params
+            @step_params ||= wizard.step_params.to_h.slice(*self.class.permitted_params.map(&:to_s))
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard.rb
+++ b/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard.rb
@@ -3,6 +3,8 @@ module Admin
     module TrainingPeriods
       module ChangeContractPeriodWizard
         class Wizard < ApplicationWizard
+          class UnexpectedTrainingPeriodTypeError < StandardError; end
+
           PartnershipOption = Data.define(:id, :name)
 
           attr_accessor :store, :teacher_id, :training_period_id, :author
@@ -99,7 +101,7 @@ module Admin
             elsif training_period.for_mentor?
               teacher.mentor_payments_frozen_year
             else
-              raise ArgumentError, "Expected training period to be ECT or Mentor"
+              raise UnexpectedTrainingPeriodTypeError, "Training period was neither ECT nor Mentor"
             end
           end
 

--- a/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard.rb
+++ b/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard.rb
@@ -1,0 +1,124 @@
+module Admin
+  module Teachers
+    module TrainingPeriods
+      module ChangeContractPeriodWizard
+        class Wizard < ApplicationWizard
+          PartnershipOption = Data.define(:id, :name)
+
+          attr_accessor :store, :teacher_id, :training_period_id, :author
+
+          steps do
+            [{
+              select_contract_period: SelectContractPeriodStep,
+              select_partnership: SelectPartnershipStep
+            }]
+          end
+
+          def self.step?(step_name) = Array(steps).first[step_name].present?
+
+          def allowed_steps
+            steps = [:select_contract_period]
+            return steps unless selected_contract_period_allowed?
+
+            steps << :select_partnership
+          end
+
+          def allowed_step_path
+            step_path(allowed_steps.last)
+          end
+
+          def teacher
+            @teacher ||= Teacher.find(teacher_id)
+          end
+
+          def training_period
+            @training_period ||= TrainingPeriod.find(training_period_id)
+          end
+
+          def teacher_name
+            ::Teachers::Name.new(teacher).full_name
+          end
+
+          delegate :school, to: :training_period
+
+          def contract_periods
+            scope = ContractPeriod.enabled.most_recent_first
+            scope = scope.where.not(year: current_contract_period.year) if current_contract_period
+
+            if original_frozen_contract_period_year.in?([2021, 2022])
+              scope.where.not(year: [2021, 2022] - [original_frozen_contract_period_year])
+            else
+              scope.where.not(year: [2021, 2022])
+            end
+          end
+
+          def selected_contract_period
+            return if store.contract_period_year.blank?
+
+            @selected_contract_period ||= ContractPeriod.find_by(year: store.contract_period_year)
+          end
+
+          def school_partnerships
+            return SchoolPartnership.none unless selected_contract_period
+
+            SchoolPartnerships::Search
+              .new(school:, contract_period: selected_contract_period)
+              .school_partnerships
+          end
+
+          def partnership_options
+            school_partnerships.map do |partnership|
+              PartnershipOption.new(
+                id: partnership.id,
+                name: "#{partnership.lead_provider.name} & #{partnership.delivery_partner.name}"
+              )
+            end
+          end
+
+          def current_step_path
+            step_path(current_step_name)
+          end
+
+          def next_step_path
+            step_path(current_step.next_step)
+          end
+
+          def previous_step_path
+            step_path(current_step.previous_step)
+          end
+
+        private
+
+          def current_contract_period
+            training_period.contract_period
+          end
+
+          def original_frozen_contract_period_year
+            if training_period.for_ect?
+              teacher.ect_payments_frozen_year
+            elsif training_period.for_mentor?
+              teacher.mentor_payments_frozen_year
+            else
+              raise ArgumentError, "Expected training period to be ECT or Mentor"
+            end
+          end
+
+          def selected_contract_period_allowed?
+            store.contract_period_year.present? &&
+              contract_periods.where(year: store.contract_period_year).exists?
+          end
+
+          def step_path(step_name)
+            return if step_name.blank?
+
+            Rails.application.routes.url_helpers.public_send(
+              "admin_teacher_training_period_change_contract_period_wizard_#{step_name}_path",
+              teacher_id,
+              training_period_id
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard.rb
+++ b/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard.rb
@@ -57,7 +57,7 @@ module Admin
           def selected_contract_period
             return if store.contract_period_year.blank?
 
-            @selected_contract_period ||= ContractPeriod.find_by(year: store.contract_period_year)
+            @selected_contract_period ||= contract_periods.find_by(year: store.contract_period_year)
           end
 
           def school_partnerships

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -61,6 +61,12 @@ namespace :admin do
         resource :partnership, only: %i[new create], controller: :training_partnerships do
           get :no_other_partnerships, path: "no-other-partnerships"
         end
+
+        namespace :change_contract_period_wizard,
+                  path: "contract-period/change",
+                  controller: "/admin/teachers/training_periods/change_contract_period_wizard" do
+          concerns :wizardable, wizard: Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard
+        end
       end
     end
     resources :induction_periods, only: %i[new create edit update destroy], path: "induction-periods" do

--- a/spec/requests/admin/teachers/training_periods/change_contract_period_wizard_spec.rb
+++ b/spec/requests/admin/teachers/training_periods/change_contract_period_wizard_spec.rb
@@ -1,0 +1,119 @@
+RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardController", type: :request do
+  include_context "sign in as DfE user"
+
+  let(:today) { Date.new(2026, 2, 1) }
+  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:school) { FactoryBot.create(:school) }
+  let(:current_contract_period) { FactoryBot.create(:contract_period, year: 2025) }
+  let!(:target_contract_period) { FactoryBot.create(:contract_period, year: 2026) }
+  let(:school_partnership) do
+    FactoryBot.create(
+      :school_partnership,
+      :for_year,
+      year: current_contract_period.year,
+      school:
+    )
+  end
+  let(:target_school_partnership) do
+    FactoryBot.create(
+      :school_partnership,
+      :for_year,
+      year: target_contract_period.year,
+      school:
+    )
+  end
+  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:) }
+  let(:schedule) { FactoryBot.create(:schedule, contract_period: current_contract_period) }
+  let(:training_period) do
+    FactoryBot.create(
+      :training_period,
+      :ongoing,
+      ect_at_school_period:,
+      school_partnership:,
+      schedule:,
+      started_on: today.prev_month
+    )
+  end
+  let(:teacher_name) { Teachers::Name.new(teacher).full_name }
+
+  around do |example|
+    travel_to(today) { example.run }
+  end
+
+  describe "GET select-contract-period" do
+    it "renders the contract period selection page" do
+      get path_for_step("select-contract-period")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Select new contract period for #{teacher_name}")
+      expect(response.body).to include(target_contract_period.year.to_s)
+      expect(response.body).not_to include(current_contract_period.year.to_s)
+    end
+
+    it "returns not found when the training period does not belong to the teacher" do
+      other_teacher = FactoryBot.create(:teacher)
+
+      get path_for_step("select-contract-period", teacher: other_teacher)
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "returns bad request when the training period is not eligible" do
+      training_period.update!(finished_on: today.yesterday)
+
+      get path_for_step("select-contract-period")
+
+      expect(response).to have_http_status(:bad_request)
+    end
+  end
+
+  describe "POST select-contract-period" do
+    it "validates the selection" do
+      post(
+        path_for_step("select-contract-period"),
+        params: { select_contract_period: { contract_period_year: "" } }
+      )
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include("Select a new contract period")
+    end
+
+    it "redirects to select partnership when the selection is valid" do
+      post(
+        path_for_step("select-contract-period"),
+        params: { select_contract_period: { contract_period_year: target_contract_period.year } }
+      )
+
+      expect(response).to redirect_to(path_for_step("select-partnership"))
+    end
+  end
+
+  describe "GET select-partnership" do
+    it "redirects to select contract period when no contract period has been selected" do
+      get path_for_step("select-partnership")
+
+      expect(response).to redirect_to(path_for_step("select-contract-period"))
+    end
+
+    it "renders the partnership selection page after a contract period has been selected" do
+      target_school_partnership
+
+      post(
+        path_for_step("select-contract-period"),
+        params: { select_contract_period: { contract_period_year: target_contract_period.year } }
+      )
+      follow_redirect!
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Select partnership for #{target_contract_period.year} for #{teacher_name}")
+      expect(response.body).to include("#{target_school_partnership.lead_provider.name} &amp; #{target_school_partnership.delivery_partner.name}")
+      expect(response.body).to include(admin_school_partnerships_path(school.urn))
+    end
+  end
+
+private
+
+  def path_for_step(step, teacher: self.teacher, training_period: self.training_period)
+    "/admin/teachers/#{teacher.id}/training-periods/#{training_period.id}/contract-period/change/#{step}"
+  end
+end

--- a/spec/requests/admin/teachers/training_periods/change_contract_period_wizard_spec.rb
+++ b/spec/requests/admin/teachers/training_periods/change_contract_period_wizard_spec.rb
@@ -78,6 +78,18 @@ RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardCont
       expect(response.body).to include("Select a new contract period")
     end
 
+    it "validates the selected contract period is available" do
+      unavailable_contract_period = FactoryBot.create(:contract_period, year: 2027, enabled: false)
+
+      post(
+        path_for_step("select-contract-period"),
+        params: { select_contract_period: { contract_period_year: unavailable_contract_period.year } }
+      )
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include("Select a new contract period")
+    end
+
     it "redirects to select partnership when the selection is valid" do
       post(
         path_for_step("select-contract-period"),

--- a/spec/requests/admin/teachers/training_periods/change_contract_period_wizard_spec.rb
+++ b/spec/requests/admin/teachers/training_periods/change_contract_period_wizard_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardCont
       follow_redirect!
 
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include("Select partnership for #{target_contract_period.year} for #{teacher_name}")
+      expect(response.body).to include("Select #{target_contract_period.year} partnership for #{teacher_name}")
       expect(response.body).to include("#{target_school_partnership.lead_provider.name} &amp; #{target_school_partnership.delivery_partner.name}")
       expect(response.body).to include(admin_school_partnerships_path(school.urn))
     end

--- a/spec/services/admin/teachers/training_periods/change_contract_period/eligibility_spec.rb
+++ b/spec/services/admin/teachers/training_periods/change_contract_period/eligibility_spec.rb
@@ -1,0 +1,220 @@
+RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriod::Eligibility do
+  subject(:eligibility) { described_class.new(training_period:) }
+
+  let(:today) { Date.new(2026, 2, 1) }
+  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:school) { FactoryBot.create(:school) }
+  let(:current_school) { FactoryBot.create(:school) }
+  let(:lead_provider) { FactoryBot.create(:lead_provider) }
+  let(:delivery_partner) { FactoryBot.create(:delivery_partner) }
+  let(:contract_period) { FactoryBot.create(:contract_period, year: 2026) }
+  let(:lead_provider_delivery_partnership) do
+    FactoryBot.create(
+      :lead_provider_delivery_partnership,
+      :for_year,
+      year: contract_period.year,
+      lead_provider:,
+      delivery_partner:
+    )
+  end
+  let(:school_partnership) do
+    FactoryBot.create(
+      :school_partnership,
+      school:,
+      lead_provider_delivery_partnership:
+    )
+  end
+  let(:started_on) { today.prev_month }
+  let(:finished_on) { nil }
+  let(:current_started_on) { today.prev_month }
+  let(:current_finished_on) { nil }
+  let(:current_school_partnership) do
+    FactoryBot.create(
+      :school_partnership,
+      school: current_school,
+      lead_provider_delivery_partnership:
+    )
+  end
+  let(:ect_at_school_period) do
+    FactoryBot.create(
+      :ect_at_school_period,
+      teacher:,
+      school:,
+      started_on:,
+      finished_on:
+    )
+  end
+  let(:training_period) do
+    FactoryBot.create(
+      :training_period,
+      ect_at_school_period:,
+      school_partnership:,
+      started_on:,
+      finished_on:
+    )
+  end
+  let(:current_ect_at_school_period) do
+    FactoryBot.create(
+      :ect_at_school_period,
+      teacher:,
+      school: current_school,
+      started_on: current_started_on,
+      finished_on: current_finished_on
+    )
+  end
+  let(:current_training_period) do
+    FactoryBot.create(
+      :training_period,
+      ect_at_school_period: current_ect_at_school_period,
+      school_partnership: current_school_partnership,
+      started_on: current_started_on,
+      finished_on: current_finished_on
+    )
+  end
+
+  around do |example|
+    travel_to(today) { example.run }
+  end
+
+  it "is eligible for a provider-led active current period with no future periods" do
+    expect(eligibility).to be_eligible
+  end
+
+  context "when the training period is not provider-led" do
+    let(:training_period) do
+      FactoryBot.create(
+        :training_period,
+        :school_led,
+        ect_at_school_period:,
+        started_on:,
+        finished_on:
+      )
+    end
+
+    it "is not eligible" do
+      expect(eligibility).not_to be_eligible
+    end
+  end
+
+  context "when the training period has no partnership" do
+    let(:training_period) do
+      FactoryBot.create(
+        :training_period,
+        :with_only_expression_of_interest,
+        ect_at_school_period:,
+        started_on:,
+        finished_on:
+      )
+    end
+
+    it "is not eligible" do
+      expect(eligibility).not_to be_eligible
+    end
+  end
+
+  context "when the training period has ended" do
+    let(:started_on) { today.prev_year }
+    let(:finished_on) { today.yesterday }
+
+    it "is not eligible" do
+      expect(eligibility).not_to be_eligible
+    end
+  end
+
+  context "when there is only one future period and no current active period" do
+    let(:started_on) { today.next_month }
+
+    it "is eligible" do
+      expect(eligibility).to be_eligible
+    end
+  end
+
+  context "when there is more than one future period and no current active period" do
+    let(:started_on) { today.next_month }
+    let(:second_future_started_on) { started_on.next_month }
+    let(:finished_on) { second_future_started_on.yesterday }
+
+    before do
+      FactoryBot.create(
+        :training_period,
+        ect_at_school_period: FactoryBot.create(
+          :ect_at_school_period,
+          teacher:,
+          school:,
+          started_on: second_future_started_on,
+          finished_on: nil
+        ),
+        school_partnership:,
+        started_on: second_future_started_on,
+        finished_on: nil
+      )
+    end
+
+    it "is not eligible" do
+      expect(eligibility).not_to be_eligible
+    end
+  end
+
+  context "when the future period has the same lead provider and delivery partner as the current active period" do
+    let(:started_on) { today.next_month }
+    let(:current_finished_on) { started_on.yesterday }
+
+    before do
+      current_training_period
+    end
+
+    it "is eligible" do
+      expect(eligibility).to be_eligible
+    end
+  end
+
+  context "when the future period has a different lead provider" do
+    let(:other_lead_provider) { FactoryBot.create(:lead_provider) }
+    let(:future_school_partnership) do
+      FactoryBot.create(
+        :school_partnership,
+        :for_year,
+        year: contract_period.year,
+        school:,
+        lead_provider: other_lead_provider,
+        delivery_partner:
+      )
+    end
+    let(:started_on) { today.next_month }
+    let(:current_finished_on) { started_on.yesterday }
+    let(:school_partnership) { future_school_partnership }
+
+    before do
+      current_training_period
+    end
+
+    it "is not eligible" do
+      expect(eligibility).not_to be_eligible
+    end
+  end
+
+  context "when the future period has a different delivery partner" do
+    let(:other_delivery_partner) { FactoryBot.create(:delivery_partner) }
+    let(:future_school_partnership) do
+      FactoryBot.create(
+        :school_partnership,
+        :for_year,
+        year: contract_period.year,
+        school:,
+        lead_provider:,
+        delivery_partner: other_delivery_partner
+      )
+    end
+    let(:started_on) { today.next_month }
+    let(:current_finished_on) { started_on.yesterday }
+    let(:school_partnership) { future_school_partnership }
+
+    before do
+      current_training_period
+    end
+
+    it "is not eligible" do
+      expect(eligibility).not_to be_eligible
+    end
+  end
+end

--- a/spec/services/admin/teachers/training_periods/change_contract_period/eligibility_spec.rb
+++ b/spec/services/admin/teachers/training_periods/change_contract_period/eligibility_spec.rb
@@ -121,6 +121,15 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriod::Eligibili
     end
   end
 
+  context "when the training period ends today" do
+    let(:started_on) { today.prev_year }
+    let(:finished_on) { today }
+
+    it "is eligible" do
+      expect(eligibility).to be_eligible
+    end
+  end
+
   context "when there is only one future period and no current active period" do
     let(:started_on) { today.next_month }
 

--- a/spec/services/admin/teachers/training_periods/change_contract_period/eligibility_spec.rb
+++ b/spec/services/admin/teachers/training_periods/change_contract_period/eligibility_spec.rb
@@ -160,11 +160,16 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriod::Eligibili
     let(:current_finished_on) { started_on.yesterday }
 
     before do
+      training_period
       current_training_period
     end
 
     it "is eligible" do
       expect(eligibility).to be_eligible
+    end
+
+    it "does not make the current active period eligible" do
+      expect(described_class.new(training_period: current_training_period)).not_to be_eligible
     end
   end
 

--- a/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/select_contract_period_step_spec.rb
+++ b/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/select_contract_period_step_spec.rb
@@ -1,0 +1,73 @@
+RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::SelectContractPeriodStep do
+  subject(:step) { described_class.new(wizard:, contract_period_year:) }
+
+  let(:wizard) do
+    instance_double(
+      Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Wizard,
+      store:,
+      contract_periods:
+    )
+  end
+  let(:store) { FactoryBot.build(:session_repository) }
+  let(:available_contract_period) { FactoryBot.create(:contract_period, year: 2026) }
+  let(:other_contract_period) { FactoryBot.create(:contract_period, year: 2027) }
+  let(:contract_periods) { ContractPeriod.where(year: available_contract_period.year) }
+  let(:contract_period_year) { available_contract_period.year }
+
+  before do
+    allow(wizard).to receive(:valid_step?) { step.valid? }
+    allow(wizard).to receive(:step_params)
+      .and_return(ActionController::Parameters.new(contract_period_year:).permit(:contract_period_year))
+  end
+
+  describe "#save!" do
+    before do
+      store.school_partnership_id = "123"
+    end
+
+    it "stores the selected contract period year and clears the selected partnership" do
+      expect { step.save! }
+        .to change(store, :contract_period_year)
+        .from(nil)
+        .to(available_contract_period.year)
+
+      expect(store.school_partnership_id).to be_nil
+    end
+
+    context "when invalid" do
+      let(:contract_period_year) { nil }
+
+      it "returns false without changing the stored selections" do
+        result = step.save!
+
+        expect(result).to be_falsey
+        expect(store.contract_period_year).to be_nil
+        expect(store.school_partnership_id).to eq("123")
+      end
+    end
+  end
+
+  describe "validations" do
+    context "when contract period is not present" do
+      let(:contract_period_year) { nil }
+
+      it "is invalid with the correct error message" do
+        expect(step).not_to be_valid
+        expect(step.errors[:contract_period_year].map(&:squish)).to include("Select a new contract period")
+      end
+    end
+
+    context "when contract period is not available" do
+      let(:contract_period_year) { other_contract_period.year }
+
+      it "is invalid with the correct error message" do
+        expect(step).not_to be_valid
+        expect(step.errors[:contract_period_year].map(&:squish)).to include("Select a new contract period")
+      end
+    end
+
+    context "when contract period is available" do
+      it { is_expected.to be_valid }
+    end
+  end
+end

--- a/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/select_partnership_step_spec.rb
+++ b/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/select_partnership_step_spec.rb
@@ -1,0 +1,66 @@
+RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::SelectPartnershipStep do
+  subject(:step) { described_class.new(wizard:, school_partnership_id:) }
+
+  let(:wizard) do
+    instance_double(
+      Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Wizard,
+      store:,
+      school_partnerships:
+    )
+  end
+  let(:store) { FactoryBot.build(:session_repository) }
+  let(:available_school_partnership) { FactoryBot.create(:school_partnership) }
+  let(:other_school_partnership) { FactoryBot.create(:school_partnership) }
+  let(:school_partnerships) { SchoolPartnership.where(id: available_school_partnership.id) }
+  let(:school_partnership_id) { available_school_partnership.id }
+
+  before do
+    allow(wizard).to receive(:valid_step?) { step.valid? }
+    allow(wizard).to receive(:step_params)
+      .and_return(ActionController::Parameters.new(school_partnership_id:).permit(:school_partnership_id))
+  end
+
+  describe "#save!" do
+    it "stores the selected partnership" do
+      expect { step.save! }
+        .to change(store, :school_partnership_id)
+        .from(nil)
+        .to(available_school_partnership.id)
+    end
+
+    context "when invalid" do
+      let(:school_partnership_id) { nil }
+
+      it "returns false without changing the stored selection" do
+        result = step.save!
+
+        expect(result).to be_falsey
+        expect(store.school_partnership_id).to be_nil
+      end
+    end
+  end
+
+  describe "validations" do
+    context "when partnership is not present" do
+      let(:school_partnership_id) { nil }
+
+      it "is invalid with the correct error message" do
+        expect(step).not_to be_valid
+        expect(step.errors[:school_partnership_id].map(&:squish)).to include("Select a partnership")
+      end
+    end
+
+    context "when partnership is not available" do
+      let(:school_partnership_id) { other_school_partnership.id }
+
+      it "is invalid with the correct error message" do
+        expect(step).not_to be_valid
+        expect(step.errors[:school_partnership_id].map(&:squish)).to include("Select a partnership")
+      end
+    end
+
+    context "when partnership is available" do
+      it { is_expected.to be_valid }
+    end
+  end
+end

--- a/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard_spec.rb
+++ b/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard_spec.rb
@@ -1,0 +1,150 @@
+RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Wizard do
+  let(:store) { FactoryBot.build(:session_repository) }
+  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:school) { FactoryBot.create(:school) }
+  let(:current_contract_period) { FactoryBot.create(:contract_period, year: 2025) }
+  let(:target_contract_period) { FactoryBot.create(:contract_period, year: 2026) }
+  let(:other_contract_period) { FactoryBot.create(:contract_period, year: 2027) }
+  let(:school_partnership) do
+    FactoryBot.create(
+      :school_partnership,
+      :for_year,
+      year: current_contract_period.year,
+      school:
+    )
+  end
+  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:) }
+  let(:schedule) { FactoryBot.create(:schedule, contract_period: current_contract_period) }
+  let(:training_period) do
+    FactoryBot.create(
+      :training_period,
+      :ongoing,
+      ect_at_school_period:,
+      school_partnership:,
+      schedule:
+    )
+  end
+  let(:current_step) { :select_contract_period }
+  let(:wizard) do
+    described_class.new(
+      store:,
+      teacher_id: teacher.id,
+      training_period_id: training_period.id,
+      current_step:
+    )
+  end
+
+  describe "#allowed_steps" do
+    subject { wizard.allowed_steps }
+
+    context "when no contract period has been selected" do
+      it { is_expected.to eq([:select_contract_period]) }
+    end
+
+    context "when an available contract period has been selected" do
+      before { store.contract_period_year = target_contract_period.year }
+
+      it { is_expected.to eq(%i[select_contract_period select_partnership]) }
+    end
+
+    context "when an unavailable contract period has been selected" do
+      before { store.contract_period_year = current_contract_period.year }
+
+      it { is_expected.to eq([:select_contract_period]) }
+    end
+  end
+
+  describe "#contract_periods" do
+    let!(:contract_period_2021) { FactoryBot.create(:contract_period, year: 2021) }
+    let!(:contract_period_2022) { FactoryBot.create(:contract_period, year: 2022) }
+    let!(:disabled_contract_period) { FactoryBot.create(:contract_period, year: 2028, enabled: false) }
+
+    it "returns enabled contract periods excluding the current and frozen years" do
+      expect(wizard.contract_periods).to contain_exactly(target_contract_period, other_contract_period)
+    end
+
+    context "when the original frozen contract period is 2021" do
+      before do
+        teacher.update!(ect_payments_frozen_year: contract_period_2021.year)
+      end
+
+      it "keeps the original frozen contract period" do
+        expect(wizard.contract_periods)
+          .to contain_exactly(contract_period_2021, target_contract_period, other_contract_period)
+      end
+    end
+
+    context "when the original frozen contract period is 2022" do
+      before do
+        teacher.update!(ect_payments_frozen_year: contract_period_2022.year)
+      end
+
+      it "keeps the original frozen contract period" do
+        expect(wizard.contract_periods)
+          .to contain_exactly(contract_period_2022, target_contract_period, other_contract_period)
+      end
+    end
+  end
+
+  describe "#school_partnerships" do
+    let(:lead_provider) { FactoryBot.create(:lead_provider, name: "Target lead provider") }
+    let(:delivery_partner) { FactoryBot.create(:delivery_partner, name: "Target delivery partner") }
+    let!(:target_school_partnership) do
+      FactoryBot.create(
+        :school_partnership,
+        :for_year,
+        year: target_contract_period.year,
+        school:,
+        lead_provider:,
+        delivery_partner:
+      )
+    end
+
+    before do
+      FactoryBot.create(:school_partnership, :for_year, year: target_contract_period.year)
+      FactoryBot.create(:school_partnership, :for_year, year: other_contract_period.year, school:)
+    end
+
+    context "when no contract period has been selected" do
+      it "returns no school partnerships" do
+        expect(wizard.school_partnerships).to be_empty
+      end
+    end
+
+    context "when a contract period has been selected" do
+      before { store.contract_period_year = target_contract_period.year }
+
+      it "returns school partnerships for the selected contract period and school" do
+        expect(wizard.school_partnerships).to contain_exactly(target_school_partnership)
+      end
+    end
+  end
+
+  describe "#partnership_options" do
+    let(:lead_provider) { FactoryBot.create(:lead_provider, name: "Target lead provider") }
+    let(:delivery_partner) { FactoryBot.create(:delivery_partner, name: "Target delivery partner") }
+    let!(:target_school_partnership) do
+      FactoryBot.create(
+        :school_partnership,
+        :for_year,
+        year: target_contract_period.year,
+        school:,
+        lead_provider:,
+        delivery_partner:
+      )
+    end
+
+    before do
+      store.contract_period_year = target_contract_period.year
+    end
+
+    it "returns options for the available partnerships" do
+      expect(wizard.partnership_options).to contain_exactly(
+        have_attributes(
+          id: target_school_partnership.id,
+          name: "Target lead provider & Target delivery partner"
+        )
+      )
+    end
+  end
+end


### PR DESCRIPTION
## What

This is the first vertical slice of the contract period change journey for admins.

This introduces:

- eligibility rules for determining when a training period can start the contract period change journey
- the contract period selection step
- the partnership selection step
- admin routes and controller flow for the wizard
- contract period and partnership selection pages

## Screenshots

| `/select-contract-period` | `/select-partnership` |
|--------|-------|
|<img width="860" height="569" alt="image" src="https://github.com/user-attachments/assets/ca641fb4-519e-4dd4-91fa-4d00c36d0a8a" />|<img width="857" height="504" alt="image" src="https://github.com/user-attachments/assets/fb1ccccf-609c-4de1-ae6a-ddb62877550a" />|
## Not included

This PR does not:

- display the Change link on the Training tab
- include the check answers page
- apply the contract period change
- create or update training periods