### PR TITLE
[4038] Service to destroy mentor periods

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -41,6 +41,7 @@ class Event < ApplicationRecord
     teacher_registered_as_ect
     teacher_left_school_as_ect
     teacher_ect_at_school_period_deleted
+    teacher_mentor_at_school_period_deleted
     teacher_registered_as_mentor
     teacher_left_school_as_mentor
     teacher_starts_being_mentored

--- a/app/services/appropriate_bodies/close_induction.rb
+++ b/app/services/appropriate_bodies/close_induction.rb
@@ -85,7 +85,7 @@ module AppropriateBodies
     end
 
     def destroy_unstarted_ect_period!
-      ECTAtSchoolPeriods::Destroy.call(ect_at_school_period:, author:)
+      ECTAtSchoolPeriods::Destroy.call(ect_at_school_period:, author:, actioned_at: Date.current)
     end
 
     def mentorship_period

--- a/app/services/concerns/periods/destroyable.rb
+++ b/app/services/concerns/periods/destroyable.rb
@@ -1,0 +1,56 @@
+module Periods
+  module Destroyable
+    extend ActiveSupport::Concern
+
+    included do
+      attr_reader :period, :author
+    end
+
+    class_methods do
+      def call(**args)
+        new(**args).call
+      end
+    end
+
+    def call
+      return unless period
+      return if period_started?
+
+      ActiveRecord::Base.transaction do
+        record_unstarted_period_deleted_event!
+        destroy_mentorship_period_events!
+        destroy_training_period_events!
+        destroy_period_events!
+        period.destroy!
+      end
+    end
+
+  private
+
+    def period_started?
+      started_on < Time.zone.today
+    end
+
+    def destroy_mentorship_period_events!
+      mentorship_periods.each do |mentorship_period|
+        mentorship_period.events.each(&:destroy!)
+      end
+    end
+
+    def destroy_training_period_events!
+      training_periods.each do |training_period|
+        training_period.events.each(&:destroy!)
+      end
+    end
+
+    def destroy_period_events!
+      period.events.each(&:destroy!)
+    end
+
+    def record_unstarted_period_deleted_event!
+      raise NotImplementedError
+    end
+
+    delegate :started_on, :school, :teacher, :training_periods, :mentorship_periods, to: :period
+  end
+end

--- a/app/services/concerns/periods/destroyable.rb
+++ b/app/services/concerns/periods/destroyable.rb
@@ -2,8 +2,10 @@ module Periods
   module Destroyable
     extend ActiveSupport::Concern
 
+    class InvalidDate < StandardError; end
+
     included do
-      attr_reader :period, :author
+      attr_reader :period, :author, :actioned_at
     end
 
     class_methods do
@@ -13,6 +15,9 @@ module Periods
     end
 
     def call
+      raise InvalidDate, "Date must be present" unless actioned_at
+      raise InvalidDate, "Date cannot be in the future" if actioned_at > Date.current
+
       return unless period
       return if period_started?
 
@@ -28,7 +33,7 @@ module Periods
   private
 
     def period_started?
-      started_on < Time.zone.today
+      started_on < actioned_at
     end
 
     def destroy_mentorship_period_events!

--- a/app/services/ect_at_school_periods/destroy.rb
+++ b/app/services/ect_at_school_periods/destroy.rb
@@ -2,7 +2,7 @@ module ECTAtSchoolPeriods
   class Destroy
     include Periods::Destroyable
 
-    def initialize(ect_at_school_period:, author:, actioned_at: Date.current)
+    def initialize(ect_at_school_period:, author:, actioned_at:)
       @period = ect_at_school_period
       @author = author
       @actioned_at = actioned_at

--- a/app/services/ect_at_school_periods/destroy.rb
+++ b/app/services/ect_at_school_periods/destroy.rb
@@ -1,73 +1,16 @@
 module ECTAtSchoolPeriods
   class Destroy
-    attr_reader :ect_at_school_period, :author
+    include Periods::Destroyable
 
     def initialize(ect_at_school_period:, author:)
-      @ect_at_school_period = ect_at_school_period
+      @period = ect_at_school_period
       @author = author
-    end
-
-    def self.call(**args)
-      new(**args).call
-    end
-
-    def call
-      return unless ect_at_school_period
-      return if ect_at_school_period_started?
-
-      ActiveRecord::Base.transaction do
-        record_unstarted_ect_period_deleted_event!
-        destroy_mentorship_period_events!
-        destroy_training_period_events!
-        destroy_ect_at_school_period_events!
-        ect_at_school_period.destroy!
-      end
     end
 
   private
 
-    def destroy_mentorship_period_events!
-      mentorship_periods.each do |mentorship_period|
-        mentorship_period.events.each(&:destroy!)
-      end
-    end
-
-    def destroy_training_period_events!
-      training_periods.each do |training_period|
-        training_period.events.each(&:destroy!)
-      end
-    end
-
-    def mentorship_periods
-      ect_at_school_period.mentorship_periods
-    end
-
-    def training_periods
-      ect_at_school_period.training_periods
-    end
-
-    def destroy_ect_at_school_period_events!
-      ect_at_school_period.events.each(&:destroy!)
-    end
-
-    def record_unstarted_ect_period_deleted_event!
+    def record_unstarted_period_deleted_event!
       Events::Record.record_teacher_ect_at_school_period_deleted!(author:, teacher:, school:, started_on:)
-    end
-
-    def teacher
-      ect_at_school_period.teacher
-    end
-
-    def school
-      ect_at_school_period.school
-    end
-
-    def ect_at_school_period_started?
-      started_on < Time.zone.today
-    end
-
-    def started_on
-      ect_at_school_period.started_on
     end
   end
 end

--- a/app/services/ect_at_school_periods/destroy.rb
+++ b/app/services/ect_at_school_periods/destroy.rb
@@ -2,15 +2,16 @@ module ECTAtSchoolPeriods
   class Destroy
     include Periods::Destroyable
 
-    def initialize(ect_at_school_period:, author:)
+    def initialize(ect_at_school_period:, author:, actioned_at: Date.current)
       @period = ect_at_school_period
       @author = author
+      @actioned_at = actioned_at
     end
 
   private
 
     def record_unstarted_period_deleted_event!
-      Events::Record.record_teacher_ect_at_school_period_deleted!(author:, teacher:, school:, started_on:)
+      Events::Record.record_teacher_ect_at_school_period_deleted!(author:, teacher:, school:, started_on:, happened_at: actioned_at)
     end
   end
 end

--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -327,7 +327,15 @@ module Events
     def self.record_teacher_ect_at_school_period_deleted!(author:, teacher:, school:, started_on:, happened_at: Time.zone.now)
       event_type = :teacher_ect_at_school_period_deleted
       teacher_name = Teachers::Name.new(teacher).full_name
-      heading = "#{teacher_name}'s ECT at school period which was due to start on #{started_on} was deleted"
+      heading = "#{teacher_name}'s ECT at school period which was due to start on #{started_on} at #{school.name} was deleted"
+
+      new(event_type:, author:, heading:, teacher:, school:, happened_at:).record_event!
+    end
+
+    def self.record_teacher_mentor_at_school_period_deleted!(author:, teacher:, school:, started_on:, happened_at: Time.zone.now)
+      event_type = :teacher_mentor_at_school_period_deleted
+      teacher_name = Teachers::Name.new(teacher).full_name
+      heading = "#{teacher_name}'s Mentor at school period which was due to start on #{started_on} at #{school.name} was deleted"
 
       new(event_type:, author:, heading:, teacher:, school:, happened_at:).record_event!
     end

--- a/app/services/mentor_at_school_periods/destroy.rb
+++ b/app/services/mentor_at_school_periods/destroy.rb
@@ -1,0 +1,16 @@
+module MentorAtSchoolPeriods
+  class Destroy
+    include Periods::Destroyable
+
+    def initialize(mentor_at_school_period:, author:)
+      @period = mentor_at_school_period
+      @author = author
+    end
+
+  private
+
+    def record_unstarted_period_deleted_event!
+      Events::Record.record_teacher_mentor_at_school_period_deleted!(author:, teacher:, school:, started_on:)
+    end
+  end
+end

--- a/app/services/mentor_at_school_periods/destroy.rb
+++ b/app/services/mentor_at_school_periods/destroy.rb
@@ -2,7 +2,7 @@ module MentorAtSchoolPeriods
   class Destroy
     include Periods::Destroyable
 
-    def initialize(mentor_at_school_period:, author:, actioned_at: Date.current)
+    def initialize(mentor_at_school_period:, author:, actioned_at:)
       @period = mentor_at_school_period
       @author = author
       @actioned_at = actioned_at

--- a/app/services/mentor_at_school_periods/destroy.rb
+++ b/app/services/mentor_at_school_periods/destroy.rb
@@ -2,15 +2,16 @@ module MentorAtSchoolPeriods
   class Destroy
     include Periods::Destroyable
 
-    def initialize(mentor_at_school_period:, author:)
+    def initialize(mentor_at_school_period:, author:, actioned_at: Date.current)
       @period = mentor_at_school_period
       @author = author
+      @actioned_at = actioned_at
     end
 
   private
 
     def record_unstarted_period_deleted_event!
-      Events::Record.record_teacher_mentor_at_school_period_deleted!(author:, teacher:, school:, started_on:)
+      Events::Record.record_teacher_mentor_at_school_period_deleted!(author:, teacher:, school:, started_on:, happened_at: actioned_at)
     end
   end
 end

--- a/spec/services/ect_at_school_periods/destroy_spec.rb
+++ b/spec/services/ect_at_school_periods/destroy_spec.rb
@@ -1,5 +1,5 @@
 describe ECTAtSchoolPeriods::Destroy do
-  subject { ECTAtSchoolPeriods::Destroy.call(ect_at_school_period:, author:) }
+  subject { ECTAtSchoolPeriods::Destroy.call(ect_at_school_period:, author:, actioned_at: Date.current) }
 
   let(:started_on) { Date.tomorrow }
   let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, school:, started_on: 1.week.ago) }
@@ -154,7 +154,7 @@ describe ECTAtSchoolPeriods::Destroy do
           expect { subject }.not_to(change(MentorshipPeriod, :count))
         end
 
-        it "destroys any events associated with the mentorship periods" do
+        it "does not destroy any events associated with the mentorship periods" do
           expect { subject }.not_to(change(Event, :count))
         end
       end
@@ -248,7 +248,7 @@ describe ECTAtSchoolPeriods::Destroy do
             expect { subject }.not_to(change(MentorshipPeriod, :count))
           end
 
-          it "destroys any events associated with the mentorship periods" do
+          it "does not destroy any events associated with the mentorship periods" do
             expect { subject }.not_to(change(Event, :count))
           end
         end

--- a/spec/services/ect_at_school_periods/destroy_spec.rb
+++ b/spec/services/ect_at_school_periods/destroy_spec.rb
@@ -46,7 +46,8 @@ describe ECTAtSchoolPeriods::Destroy do
           author:,
           teacher:,
           school:,
-          started_on:
+          started_on:,
+          happened_at: Date.current
         )
 
         subject
@@ -82,7 +83,7 @@ describe ECTAtSchoolPeriods::Destroy do
     end
 
     context "when the ECT at school period has started today" do
-      let(:started_on) { Time.zone.today }
+      let(:started_on) { Date.current }
 
       it "destroys the ECT at school period" do
         expect { subject }.to change(ECTAtSchoolPeriod, :count).from(1).to(0)
@@ -98,7 +99,8 @@ describe ECTAtSchoolPeriods::Destroy do
           author:,
           teacher:,
           school:,
-          started_on:
+          started_on:,
+          happened_at: Date.current
         )
 
         subject
@@ -168,6 +170,170 @@ describe ECTAtSchoolPeriods::Destroy do
         it "does not destroy any events associated with the training periods" do
           expect { subject }.not_to(change(Event, :count))
         end
+      end
+    end
+
+    context "when actioned_at is in the past" do
+      subject { ECTAtSchoolPeriods::Destroy.call(ect_at_school_period:, author:, actioned_at: Date.yesterday) }
+
+      context "when the ECT at school period started after actioned_at" do
+        let(:started_on) { Date.current }
+
+        it "destroys the ECT at school period" do
+          expect { subject }.to change(ECTAtSchoolPeriod, :count).from(1).to(0)
+        end
+
+        it "destroys any events associated with the ECT at school period" do
+          subject
+          expect(Event).not_to exist(ect_at_school_period_id: ect_at_school_period.id)
+        end
+
+        it "records an event for the deletion of the unstarted ECT at school period" do
+          expect(Events::Record).to receive(:record_teacher_ect_at_school_period_deleted!).with(
+            author:,
+            teacher:,
+            school:,
+            started_on:,
+            happened_at: Date.yesterday
+          )
+
+          subject
+        end
+
+        context "with associated mentorship periods" do
+          let!(:mentorship_period) { FactoryBot.create(:mentorship_period, mentee: ect_at_school_period, mentor: mentor_at_school_period, started_on:) }
+          let!(:event) { FactoryBot.create(:event, :with_mentorship_period, mentorship_period:) }
+
+          it "destroys any associated mentorship periods" do
+            expect { subject }.to change(MentorshipPeriod, :count).from(1).to(0)
+          end
+
+          it "destroys any events associated with the mentorship periods" do
+            subject
+            expect(Event).not_to exist(mentorship_period_id: mentorship_period.id)
+          end
+        end
+
+        context "with associated training periods" do
+          let!(:training_period) { FactoryBot.create(:training_period, ect_at_school_period:) }
+          let!(:event) { FactoryBot.create(:event, :with_training_period, training_period:) }
+
+          it "destroys the periods" do
+            expect { subject }.to change(TrainingPeriod, :count).from(1).to(0)
+          end
+
+          it "destroys any events associated with the training periods" do
+            subject
+            expect(Event).not_to exist(training_period_id: training_period.id)
+          end
+        end
+      end
+
+      context "when the ECT at school period has started before actioned_at" do
+        let(:started_on) { 2.days.ago.to_date }
+
+        it "does not destroy the ECT at school period" do
+          expect { subject }.not_to(change { ECTAtSchoolPeriod.exists?(ect_at_school_period.id) })
+        end
+
+        it "does not create or destroy any events" do
+          expect { subject }.not_to(change(Event, :count))
+        end
+
+        context "with associated mentorship periods" do
+          let!(:mentorship_period) { FactoryBot.create(:mentorship_period, mentee: ect_at_school_period, mentor: mentor_at_school_period, started_on:) }
+          let!(:event) { FactoryBot.create(:event, :with_mentorship_period, mentorship_period:) }
+
+          it "does not destroy any associated mentorship periods" do
+            expect { subject }.not_to(change(MentorshipPeriod, :count))
+          end
+
+          it "destroys any events associated with the mentorship periods" do
+            expect { subject }.not_to(change(Event, :count))
+          end
+        end
+
+        context "with associated training periods" do
+          let!(:training_period) { FactoryBot.create(:training_period, ect_at_school_period:) }
+          let!(:event) { FactoryBot.create(:event, :with_training_period, training_period:) }
+
+          it "does not destroy the periods" do
+            expect { subject }.not_to(change(TrainingPeriod, :count))
+          end
+
+          it "does not destroy any events associated with the training periods" do
+            expect { subject }.not_to(change(Event, :count))
+          end
+        end
+      end
+
+      context "when the ECT at school period started on actioned_at" do
+        let(:started_on) { Date.yesterday }
+
+        it "destroys the ECT at school period" do
+          expect { subject }.to change(ECTAtSchoolPeriod, :count).from(1).to(0)
+        end
+
+        it "destroys any events associated with the ECT at school period" do
+          subject
+          expect(Event).not_to exist(ect_at_school_period_id: ect_at_school_period.id)
+        end
+
+        it "records an event for the deletion of the unstarted ECT at school period" do
+          expect(Events::Record).to receive(:record_teacher_ect_at_school_period_deleted!).with(
+            author:,
+            teacher:,
+            school:,
+            started_on:,
+            happened_at: Date.yesterday
+          )
+
+          subject
+        end
+
+        context "with associated mentorship periods" do
+          let!(:mentorship_period) { FactoryBot.create(:mentorship_period, mentee: ect_at_school_period, mentor: mentor_at_school_period, started_on:) }
+          let!(:event) { FactoryBot.create(:event, :with_mentorship_period, mentorship_period:) }
+
+          it "destroys any associated mentorship periods" do
+            expect { subject }.to change(MentorshipPeriod, :count).from(1).to(0)
+          end
+
+          it "destroys any events associated with the mentorship periods" do
+            subject
+            expect(Event).not_to exist(mentorship_period_id: mentorship_period.id)
+          end
+        end
+
+        context "with associated training periods" do
+          let!(:training_period) { FactoryBot.create(:training_period, ect_at_school_period:) }
+          let!(:event) { FactoryBot.create(:event, :with_training_period, training_period:) }
+
+          it "destroys the periods" do
+            expect { subject }.to change(TrainingPeriod, :count).from(1).to(0)
+          end
+
+          it "destroys any events associated with the training periods" do
+            subject
+            expect(Event).not_to exist(training_period_id: training_period.id)
+          end
+        end
+      end
+    end
+
+    context "when actioned_at is nil" do
+      subject { ECTAtSchoolPeriods::Destroy.call(ect_at_school_period:, author:, actioned_at: nil) }
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Periods::Destroyable::InvalidDate, "Date must be present")
+      end
+    end
+
+    context "when actioned_at is in the future" do
+      subject { ECTAtSchoolPeriods::Destroy.call(ect_at_school_period:, author:, actioned_at: Date.tomorrow) }
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Periods::Destroyable::InvalidDate, "Date cannot be in the future")
       end
     end
   end

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -770,7 +770,7 @@ RSpec.describe Events::Record do
     end
   end
 
-  describe ".record_teacher_mentor_at_school_period_deleted" do
+  describe ".record_teacher_mentor_at_school_period_deleted!" do
     let(:school) { FactoryBot.create(:school) }
     let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher:, school:, started_on:) }
     let(:started_on) { Date.tomorrow }

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -761,8 +761,29 @@ RSpec.describe Events::Record do
         expect(RecordEventJob).to have_received(:perform_later).with(
           teacher:,
           school:,
-          heading: "Rhys Ifans's ECT at school period which was due to start on #{started_on} was deleted",
+          heading: "Rhys Ifans's ECT at school period which was due to start on #{started_on} at #{school.name} was deleted",
           event_type: :teacher_ect_at_school_period_deleted,
+          happened_at: Time.zone.now,
+          **author_params
+        )
+      end
+    end
+  end
+
+  describe ".record_teacher_mentor_at_school_period_deleted" do
+    let(:school) { FactoryBot.create(:school) }
+    let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher:, school:, started_on:) }
+    let(:started_on) { Date.tomorrow }
+
+    it "queues a RecordEventJob with the correct values" do
+      freeze_time do
+        Events::Record.record_teacher_mentor_at_school_period_deleted!(author:, teacher:, school:, started_on:)
+
+        expect(RecordEventJob).to have_received(:perform_later).with(
+          teacher:,
+          school:,
+          heading: "Rhys Ifans's Mentor at school period which was due to start on #{started_on} at #{school.name} was deleted",
+          event_type: :teacher_mentor_at_school_period_deleted,
           happened_at: Time.zone.now,
           **author_params
         )

--- a/spec/services/mentor_at_school_periods/destroy_spec.rb
+++ b/spec/services/mentor_at_school_periods/destroy_spec.rb
@@ -1,0 +1,174 @@
+describe MentorAtSchoolPeriods::Destroy do
+  subject { MentorAtSchoolPeriods::Destroy.call(mentor_at_school_period:, author:) }
+
+  let(:started_on) { Date.tomorrow }
+  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, school:, started_on: 1.week.ago) }
+  let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, started_on:) }
+
+  let(:school) { mentor_at_school_period.school }
+  let(:author) { FactoryBot.build(:school_user, school_urn: school.urn) }
+  let(:teacher) { mentor_at_school_period.teacher }
+  let(:event_mentor) { FactoryBot.create(:event, :with_mentor_at_school_period, mentor_at_school_period:) }
+
+  describe "#call!" do
+    context "when the Mentor at school period does not exist" do
+      let(:mentor_at_school_period) { nil }
+      let(:school) { FactoryBot.create(:school) }
+      let(:teacher) { nil }
+
+      it "does not raise an error" do
+        expect { subject }.not_to raise_error
+      end
+
+      it "does not delete anything" do
+        expect { subject }.not_to(change(MentorAtSchoolPeriod, :count))
+      end
+
+      it "does not create any events" do
+        expect { subject }.not_to(change(Event, :count))
+      end
+    end
+
+    context "when the Mentor at school period has not started yet" do
+      let(:started_on) { Date.tomorrow }
+
+      it "destroys the Mentor at school period" do
+        expect { subject }.to change(MentorAtSchoolPeriod, :count).from(1).to(0)
+      end
+
+      it "destroys any events associated with the Mentor at school period" do
+        subject
+        expect(Event).not_to exist(mentor_at_school_period_id: mentor_at_school_period.id)
+      end
+
+      it "records an event for the deletion of the unstarted Mentor at school period" do
+        expect(Events::Record).to receive(:record_teacher_mentor_at_school_period_deleted!).with(
+          author:,
+          teacher:,
+          school:,
+          started_on:
+        )
+
+        subject
+      end
+
+      context "with associated mentorship periods" do
+        let!(:mentorship_period) { FactoryBot.create(:mentorship_period, mentee: ect_at_school_period, mentor: mentor_at_school_period, started_on:) }
+        let!(:event) { FactoryBot.create(:event, :with_mentorship_period, mentorship_period:) }
+
+        it "destroys any associated mentorship periods" do
+          expect { subject }.to change(MentorshipPeriod, :count).from(1).to(0)
+        end
+
+        it "destroys any events associated with the mentorship periods" do
+          subject
+          expect(Event).not_to exist(mentorship_period_id: mentorship_period.id)
+        end
+      end
+
+      context "with associated training periods" do
+        let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, mentor_at_school_period:) }
+        let!(:event) { FactoryBot.create(:event, :with_training_period, training_period:) }
+
+        it "destroys the periods" do
+          expect { subject }.to change(TrainingPeriod, :count).from(1).to(0)
+        end
+
+        it "destroys any events associated with the training periods" do
+          subject
+          expect(Event).not_to exist(training_period_id: training_period.id)
+        end
+      end
+    end
+
+    context "when the Mentor at school period has started today" do
+      let(:started_on) { Time.zone.today }
+
+      it "destroys the Mentor at school period" do
+        expect { subject }.to change(MentorAtSchoolPeriod, :count).from(1).to(0)
+      end
+
+      it "destroys any events associated with the Mentor at school period" do
+        subject
+        expect(Event).not_to exist(mentor_at_school_period_id: mentor_at_school_period.id)
+      end
+
+      it "records an event for the deletion of the unstarted Mentor at school period" do
+        expect(Events::Record).to receive(:record_teacher_mentor_at_school_period_deleted!).with(
+          author:,
+          teacher:,
+          school:,
+          started_on:
+        )
+
+        subject
+      end
+
+      context "with associated mentorship periods" do
+        let!(:mentorship_period) { FactoryBot.create(:mentorship_period, mentee: ect_at_school_period, mentor: mentor_at_school_period, started_on:) }
+        let!(:event) { FactoryBot.create(:event, :with_mentorship_period, mentorship_period:) }
+
+        it "destroys any associated mentorship periods" do
+          expect { subject }.to change(MentorshipPeriod, :count).from(1).to(0)
+        end
+
+        it "destroys any events associated with the mentorship periods" do
+          subject
+          expect(Event).not_to exist(mentorship_period_id: mentorship_period.id)
+        end
+      end
+
+      context "with associated training periods" do
+        let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, mentor_at_school_period:) }
+        let!(:event) { FactoryBot.create(:event, :with_training_period, training_period:) }
+
+        it "destroys the periods" do
+          expect { subject }.to change(TrainingPeriod, :count).from(1).to(0)
+        end
+
+        it "destroys any events associated with the training periods" do
+          subject
+          expect(Event).not_to exist(training_period_id: training_period.id)
+        end
+      end
+    end
+
+    context "when the Mentor at school period has started in the past" do
+      let(:started_on) { Date.yesterday }
+
+      it "does not destroy the Mentor at school period" do
+        expect { subject }.not_to(change { MentorAtSchoolPeriod.exists?(mentor_at_school_period.id) })
+      end
+
+      it "does not create or destroy any events" do
+        expect { subject }.not_to(change(Event, :count))
+      end
+
+      context "with associated mentorship periods" do
+        let!(:mentorship_period) { FactoryBot.create(:mentorship_period, mentee: ect_at_school_period, mentor: mentor_at_school_period, started_on:) }
+        let!(:event) { FactoryBot.create(:event, :with_mentorship_period, mentorship_period:) }
+
+        it "does not destroy any associated mentorship periods" do
+          expect { subject }.not_to(change(MentorshipPeriod, :count))
+        end
+
+        it "destroys any events associated with the mentorship periods" do
+          expect { subject }.not_to(change(Event, :count))
+        end
+      end
+
+      context "with associated training periods" do
+        let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, mentor_at_school_period:) }
+        let!(:event) { FactoryBot.create(:event, :with_training_period, training_period:) }
+
+        it "does not destroy the periods" do
+          expect { subject }.not_to(change(TrainingPeriod, :count))
+        end
+
+        it "does not destroy any events associated with the training periods" do
+          expect { subject }.not_to(change(Event, :count))
+        end
+      end
+    end
+  end
+end

--- a/spec/services/mentor_at_school_periods/destroy_spec.rb
+++ b/spec/services/mentor_at_school_periods/destroy_spec.rb
@@ -46,7 +46,8 @@ describe MentorAtSchoolPeriods::Destroy do
           author:,
           teacher:,
           school:,
-          started_on:
+          started_on:,
+          happened_at: Date.current
         )
 
         subject
@@ -82,7 +83,7 @@ describe MentorAtSchoolPeriods::Destroy do
     end
 
     context "when the Mentor at school period has started today" do
-      let(:started_on) { Time.zone.today }
+      let(:started_on) { Date.current }
 
       it "destroys the Mentor at school period" do
         expect { subject }.to change(MentorAtSchoolPeriod, :count).from(1).to(0)
@@ -98,7 +99,8 @@ describe MentorAtSchoolPeriods::Destroy do
           author:,
           teacher:,
           school:,
-          started_on:
+          started_on:,
+          happened_at: Date.current
         )
 
         subject
@@ -168,6 +170,170 @@ describe MentorAtSchoolPeriods::Destroy do
         it "does not destroy any events associated with the training periods" do
           expect { subject }.not_to(change(Event, :count))
         end
+      end
+    end
+
+    context "when actioned_at is in the past" do
+      subject { MentorAtSchoolPeriods::Destroy.call(mentor_at_school_period:, author:, actioned_at: Date.yesterday) }
+
+      context "when the mentor at school period started after actioned_at" do
+        let(:started_on) { Date.tomorrow }
+
+        it "destroys the Mentor at school period" do
+          expect { subject }.to change(MentorAtSchoolPeriod, :count).from(1).to(0)
+        end
+
+        it "destroys any events associated with the Mentor at school period" do
+          subject
+          expect(Event).not_to exist(mentor_at_school_period_id: mentor_at_school_period.id)
+        end
+
+        it "records an event for the deletion of the unstarted Mentor at school period" do
+          expect(Events::Record).to receive(:record_teacher_mentor_at_school_period_deleted!).with(
+            author:,
+            teacher:,
+            school:,
+            started_on:,
+            happened_at: Date.yesterday
+          )
+
+          subject
+        end
+
+        context "with associated mentorship periods" do
+          let!(:mentorship_period) { FactoryBot.create(:mentorship_period, mentee: ect_at_school_period, mentor: mentor_at_school_period, started_on:) }
+          let!(:event) { FactoryBot.create(:event, :with_mentorship_period, mentorship_period:) }
+
+          it "destroys any associated mentorship periods" do
+            expect { subject }.to change(MentorshipPeriod, :count).from(1).to(0)
+          end
+
+          it "destroys any events associated with the mentorship periods" do
+            subject
+            expect(Event).not_to exist(mentorship_period_id: mentorship_period.id)
+          end
+        end
+
+        context "with associated training periods" do
+          let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, mentor_at_school_period:) }
+          let!(:event) { FactoryBot.create(:event, :with_training_period, training_period:) }
+
+          it "destroys the periods" do
+            expect { subject }.to change(TrainingPeriod, :count).from(1).to(0)
+          end
+
+          it "destroys any events associated with the training periods" do
+            subject
+            expect(Event).not_to exist(training_period_id: training_period.id)
+          end
+        end
+      end
+
+      context "when the mentor at school period started before actioned_at" do
+        let(:started_on) { 2.days.ago.to_date }
+
+        it "does not destroy the Mentor at school period" do
+          expect { subject }.not_to(change { MentorAtSchoolPeriod.exists?(mentor_at_school_period.id) })
+        end
+
+        it "does not create or destroy any events" do
+          expect { subject }.not_to(change(Event, :count))
+        end
+
+        context "with associated mentorship periods" do
+          let!(:mentorship_period) { FactoryBot.create(:mentorship_period, mentee: ect_at_school_period, mentor: mentor_at_school_period, started_on:) }
+          let!(:event) { FactoryBot.create(:event, :with_mentorship_period, mentorship_period:) }
+
+          it "does not destroy any associated mentorship periods" do
+            expect { subject }.not_to(change(MentorshipPeriod, :count))
+          end
+
+          it "destroys any events associated with the mentorship periods" do
+            expect { subject }.not_to(change(Event, :count))
+          end
+        end
+
+        context "with associated training periods" do
+          let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, mentor_at_school_period:) }
+          let!(:event) { FactoryBot.create(:event, :with_training_period, training_period:) }
+
+          it "does not destroy the periods" do
+            expect { subject }.not_to(change(TrainingPeriod, :count))
+          end
+
+          it "does not destroy any events associated with the training periods" do
+            expect { subject }.not_to(change(Event, :count))
+          end
+        end
+      end
+
+      context "when the mentor at school period started on actioned_at" do
+        let(:started_on) { Date.yesterday }
+
+        it "destroys the Mentor at school period" do
+          expect { subject }.to change(MentorAtSchoolPeriod, :count).from(1).to(0)
+        end
+
+        it "destroys any events associated with the Mentor at school period" do
+          subject
+          expect(Event).not_to exist(mentor_at_school_period_id: mentor_at_school_period.id)
+        end
+
+        it "records an event for the deletion of the unstarted Mentor at school period" do
+          expect(Events::Record).to receive(:record_teacher_mentor_at_school_period_deleted!).with(
+            author:,
+            teacher:,
+            school:,
+            started_on:,
+            happened_at: Date.yesterday
+          )
+
+          subject
+        end
+
+        context "with associated mentorship periods" do
+          let!(:mentorship_period) { FactoryBot.create(:mentorship_period, mentee: ect_at_school_period, mentor: mentor_at_school_period, started_on:) }
+          let!(:event) { FactoryBot.create(:event, :with_mentorship_period, mentorship_period:) }
+
+          it "destroys any associated mentorship periods" do
+            expect { subject }.to change(MentorshipPeriod, :count).from(1).to(0)
+          end
+
+          it "destroys any events associated with the mentorship periods" do
+            subject
+            expect(Event).not_to exist(mentorship_period_id: mentorship_period.id)
+          end
+        end
+
+        context "with associated training periods" do
+          let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, mentor_at_school_period:) }
+          let!(:event) { FactoryBot.create(:event, :with_training_period, training_period:) }
+
+          it "destroys the periods" do
+            expect { subject }.to change(TrainingPeriod, :count).from(1).to(0)
+          end
+
+          it "destroys any events associated with the training periods" do
+            subject
+            expect(Event).not_to exist(training_period_id: training_period.id)
+          end
+        end
+      end
+    end
+
+    context "when actioned_at is nil" do
+      subject { MentorAtSchoolPeriods::Destroy.call(mentor_at_school_period:, author:, actioned_at: nil) }
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Periods::Destroyable::InvalidDate, "Date must be present")
+      end
+    end
+
+    context "when actioned_at is in the future" do
+      subject { MentorAtSchoolPeriods::Destroy.call(mentor_at_school_period:, author:, actioned_at: Date.tomorrow) }
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Periods::Destroyable::InvalidDate, "Date cannot be in the future")
       end
     end
   end

--- a/spec/services/mentor_at_school_periods/destroy_spec.rb
+++ b/spec/services/mentor_at_school_periods/destroy_spec.rb
@@ -1,5 +1,5 @@
 describe MentorAtSchoolPeriods::Destroy do
-  subject { MentorAtSchoolPeriods::Destroy.call(mentor_at_school_period:, author:) }
+  subject { MentorAtSchoolPeriods::Destroy.call(mentor_at_school_period:, author:, actioned_at: Date.current) }
 
   let(:started_on) { Date.tomorrow }
   let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, school:, started_on: 1.week.ago) }
@@ -154,7 +154,7 @@ describe MentorAtSchoolPeriods::Destroy do
           expect { subject }.not_to(change(MentorshipPeriod, :count))
         end
 
-        it "destroys any events associated with the mentorship periods" do
+        it "does not destroy any events associated with the mentorship periods" do
           expect { subject }.not_to(change(Event, :count))
         end
       end
@@ -248,7 +248,7 @@ describe MentorAtSchoolPeriods::Destroy do
             expect { subject }.not_to(change(MentorshipPeriod, :count))
           end
 
-          it "destroys any events associated with the mentorship periods" do
+          it "does not destroy any events associated with the mentorship periods" do
             expect { subject }.not_to(change(Event, :count))
           end
         end

--- a/spec/support/shared_examples/close_induction.rb
+++ b/spec/support/shared_examples/close_induction.rb
@@ -104,7 +104,8 @@ RSpec.shared_context "it closes an induction period and finishes any related per
       expect(ECTAtSchoolPeriods::Destroy)
       .to have_received(:call).with(
         ect_at_school_period:,
-        author:
+        author:,
+        actioned_at: Date.current
       )
 
       expect(ECTAtSchoolPeriod).not_to exist(ect_at_school_period.id)


### PR DESCRIPTION
### Context
In order to close a school when its status in GIAS changes to closed, we need to finish all open periods on the closure date.  However if any of these periods, or their associated training or mentorship periods start in the future that will cause an error.  So these periods will need to be deleted.  


### Changes proposed in this pull request
Currently there is only a service to destroy ect_at_school_periods.  This abstracts this to a module, which can then be used to build the mentor service.
Additionally, because we have schools in the past, we will need to be able to run this service for a particular date in the past.


### Guidance to review
This adds a service class which could be reviewed from the console.  However we could try running some of the wizard journeys which destroy ECT periods in the future.
