### PR TITLE
Make teacher overview summary list wider

### DIFF
--- a/app/components/admin/teachers/overview_summary_component.rb
+++ b/app/components/admin/teachers/overview_summary_component.rb
@@ -10,7 +10,7 @@ module Admin
       end
 
       def call
-        govuk_summary_list do |summary_list|
+        govuk_summary_list(actions: false) do |summary_list|
           rows.each do |row|
             summary_list.with_row do |summary_row|
               summary_row.with_key(text: row[:key])


### PR DESCRIPTION
There are no actions on this summary list so we can suppress the actions column with `actions: false`.

| Before | After |
| ------ | ------ |
| <img width="753" height="554" alt="Screenshot From 2026-06-11 13-57-13" src="https://github.com/user-attachments/assets/c017e40b-b218-4d3b-be4d-d3090b450e22" /> | <img width="753" height="554" alt="Screenshot From 2026-06-11 13-57-22" src="https://github.com/user-attachments/assets/77b118aa-81b8-4f44-9226-63be7fd5bc3e" /> |