### PR TITLE
[4026] add milestone date validations

### DIFF
--- a/app/models/milestone.rb
+++ b/app/models/milestone.rb
@@ -39,14 +39,14 @@ class Milestone < ApplicationRecord
 
 private
 
-  # Contract periods start on 1st June
+  # NB: Contract periods typically start on 15th June, 2 weeks after the milestone start date.
   def start_date_within_contract_period
     return unless schedule&.contract_period
 
-    contract_start = schedule.contract_period.started_on
+    contract_start = Date.new(schedule.contract_period_year, 6, 1)
 
     return if start_date >= contract_start
 
-    errors.add(:start_date, "The start date must be on or after the contract start date (#{contract_start.to_fs(:govuk)})")
+    errors.add(:start_date, "The start date must be on or after the #{contract_start.to_fs(:govuk)}")
   end
 end

--- a/app/models/milestone.rb
+++ b/app/models/milestone.rb
@@ -15,13 +15,15 @@ class Milestone < ApplicationRecord
 
   belongs_to :schedule
 
+  # Validations
   validates :schedule_id, presence: { message: "Choose a schedule" }
-
-  validates :start_date,
-            presence: { message: "Enter a start date" }
+  validates :start_date, presence: { message: "Enter a start date" }
 
   validates :milestone_date,
-            comparison: { greater_than: :start_date, message: "Milestone date must be after the start date" },
+            comparison: {
+              greater_than: :start_date,
+              message: "Milestone date must be after the start date"
+            },
             if: -> { start_date.present? },
             allow_nil: true
 
@@ -30,6 +32,21 @@ class Milestone < ApplicationRecord
               message: "Can be used once per schedule",
               scope: :schedule_id
             }
+  validate :start_date_within_contract_period,
+           if: -> { start_date.present? }
 
   scope :in_declaration_order, -> { order(declaration_type: "asc") }
+
+private
+
+  # Contract periods start on 1st June
+  def start_date_within_contract_period
+    return unless schedule&.contract_period
+
+    contract_start = schedule.contract_period.started_on
+
+    return if start_date >= contract_start
+
+    errors.add(:start_date, "The start date must be on or after the contract start date (#{contract_start.to_fs(:govuk)})")
+  end
 end

--- a/spec/factories/active_lead_provider_factory.rb
+++ b/spec/factories/active_lead_provider_factory.rb
@@ -8,7 +8,9 @@ FactoryBot.define do
     end
 
     trait :for_year do
-      transient { year { 2025 } }
+      transient do
+        year { 2025 }
+      end
       contract_period { association :contract_period, year: }
     end
   end

--- a/spec/factories/contract_period_factory.rb
+++ b/spec/factories/contract_period_factory.rb
@@ -29,7 +29,7 @@ FactoryBot.define do
     uplift_fees_enabled { true }
 
     initialize_with do
-      ContractPeriod.find_or_create_by(year:)
+      ContractPeriod.find_or_initialize_by(year:)
     end
 
     trait :with_schedules do

--- a/spec/factories/metadata/school_contract_period_factory.rb
+++ b/spec/factories/metadata/school_contract_period_factory.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     end
 
     initialize_with do
-      Metadata::SchoolContractPeriod.find_or_create_by(school:, contract_period:)
+      Metadata::SchoolContractPeriod.find_or_initialize_by(school:, contract_period:)
     end
 
     updated_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }

--- a/spec/factories/metadata/school_lead_provider_contract_period_factory.rb
+++ b/spec/factories/metadata/school_lead_provider_contract_period_factory.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     end
 
     initialize_with do
-      Metadata::SchoolLeadProviderContractPeriod.find_or_create_by(school:, contract_period:, lead_provider:)
+      Metadata::SchoolLeadProviderContractPeriod.find_or_initialize_by(school:, contract_period:, lead_provider:)
     end
 
     updated_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }

--- a/spec/factories/metadata/teacher_lead_provider_factory.rb
+++ b/spec/factories/metadata/teacher_lead_provider_factory.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     end
 
     initialize_with do
-      Metadata::TeacherLeadProvider.find_or_create_by(teacher:, lead_provider:)
+      Metadata::TeacherLeadProvider.find_or_initialize_by(teacher:, lead_provider:)
     end
 
     transient do

--- a/spec/factories/milestone_factory.rb
+++ b/spec/factories/milestone_factory.rb
@@ -1,13 +1,13 @@
 FactoryBot.define do
   factory(:milestone) do
     association :schedule
-    declaration_type { "started" }
-
-    start_date { Date.new(2024, 9, 1) }
-    milestone_date { Date.new(2024, 10, 1) }
 
     initialize_with do
-      Milestone.find_or_create_by(schedule:, declaration_type:)
+      Milestone.find_or_initialize_by(schedule:, declaration_type:)
     end
+
+    declaration_type { "started" }
+    start_date { schedule&.contract_period&.started_on }
+    milestone_date { 1.month.after(start_date) }
   end
 end

--- a/spec/factories/schedule_factory.rb
+++ b/spec/factories/schedule_factory.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     identifier { "ecf-standard-september" }
 
     initialize_with do
-      Schedule.find_or_create_by(contract_period:, identifier:)
+      Schedule.find_or_initialize_by(contract_period:, identifier:)
     end
 
     trait :replacement_schedule do
@@ -20,7 +20,7 @@ FactoryBot.define do
     end
 
     trait :with_milestones do
-      after(:build) do |schedule|
+      after :create do |schedule|
         year = schedule.contract_period.year
         _, type, period = schedule.identifier.split("-")
 

--- a/spec/factories/training_period_factory.rb
+++ b/spec/factories/training_period_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory(:training_period) do
+  factory :training_period do
     transient do
       # default start date to be a realistic past date
       period_start_date { ect_at_school_period&.started_on || mentor_at_school_period&.started_on || rand(2.years.ago..6.months.ago) }
@@ -7,7 +7,7 @@ FactoryBot.define do
       period_end_date { started_on.tomorrow || ect_at_school_period&.finished_on&.tomorrow || mentor_at_school_period&.finished_on&.tomorrow || period_start_date + 1.year }
     end
 
-    before(:create) do |training_period|
+    before :create do |training_period|
       school_partnership = training_period.school_partnership
 
       # Ensure the associated `ect_at_school_period` and `mentor_at_school_period` have the same school
@@ -42,14 +42,14 @@ FactoryBot.define do
       finished_on { ect_at_school_period&.started_on&.+(1.month) || mentor_at_school_period&.started_on&.+(1.month) || 2.weeks.ago }
     end
 
-    trait(:school_led) do
+    trait :school_led do
       training_programme { "school_led" }
       school_partnership { nil }
       expression_of_interest { nil }
       schedule { nil }
     end
 
-    trait(:provider_led) do
+    trait :provider_led do
       training_programme { "provider_led" }
     end
 
@@ -58,43 +58,49 @@ FactoryBot.define do
         at_school_period { ect_at_school_period.presence || mentor_at_school_period }
       end
 
-      school_partnership { association :school_partnership, school: at_school_period&.school || FactoryBot.create(:school) }
+      transient do
+        school_period_school { at_school_period&.school || FactoryBot.create(:school) }
+      end
+
+      school_partnership do
+        association :school_partnership,
+                    school: school_period_school
+      end
     end
 
     trait :with_active_lead_provider do
+      with_school_partnership
+
       transient do
         active_lead_provider { association :active_lead_provider }
       end
 
       school_partnership do
-        association :school_partnership,
-                    :with_active_lead_provider,
+        association :school_partnership, :with_active_lead_provider,
                     active_lead_provider:,
-                    school: at_school_period&.school || FactoryBot.create(:school)
+                    school: school_period_school
       end
     end
 
     trait :with_schedule do
       transient do
-        schedule do
-          FactoryBot.build(:schedule, contract_period: contract_period || expression_of_interest_contract_period)
+        contract_period do
+          school_partnership&.contract_period ||
+            expression_of_interest&.contract_period ||
+            FactoryBot.create(:contract_period)
         end
       end
 
-      after(:build) do |training_period, evaluator|
-        training_period.schedule = evaluator.schedule
+      schedule do
+        association :schedule, contract_period:
       end
     end
 
     trait :with_schedule_and_milestones do
-      transient do
-        schedule do
-          FactoryBot.build(:schedule, :with_milestones, contract_period: school_partnership&.contract_period || expression_of_interest_contract_period)
-        end
-      end
+      with_schedule
 
-      after(:build) do |training_period, evaluator|
-        training_period.schedule = evaluator.schedule
+      schedule do
+        association :schedule, :with_milestones, contract_period:
       end
     end
 
@@ -103,18 +109,18 @@ FactoryBot.define do
     end
 
     trait :with_expression_of_interest do
-      after(:build) do |training_period|
-        training_period.expression_of_interest = FactoryBot.create(:active_lead_provider,
-                                                                   contract_period: training_period.contract_period ||
-                                                                   FactoryBot.create(:contract_period, :current))
+      after :build do |training_period|
+        contract_period = training_period.school_partnership&.contract_period ||
+          training_period.contract_period ||
+          FactoryBot.create(:contract_period, :current)
+        training_period.expression_of_interest = FactoryBot.create(:active_lead_provider, contract_period:)
       end
     end
 
     trait :with_only_expression_of_interest do
+      with_schedule
       school_partnership { nil }
       association :expression_of_interest, factory: :active_lead_provider
-
-      with_schedule
     end
 
     trait :ongoing do

--- a/spec/features/schools/ects/register/edge_cases/moving_school_backdated_start_date_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/moving_school_backdated_start_date_spec.rb
@@ -307,14 +307,16 @@ RSpec.describe "Moving School - backdated start spec" do
 
     @alp_current_year = FactoryBot.create(
       :active_lead_provider,
-      lead_provider: @orange_institute_lead_provider,
-      contract_period_year: @current_contract_year
+      :for_year,
+      year: @current_contract_year,
+      lead_provider: @orange_institute_lead_provider
     )
 
     @alp_previous_year = FactoryBot.create(
       :active_lead_provider,
-      lead_provider: @orange_institute_lead_provider,
-      contract_period_year: @previous_contract_year
+      :for_year,
+      year: @previous_contract_year,
+      lead_provider: @orange_institute_lead_provider
     )
 
     @lpdp_current_year = FactoryBot.create(

--- a/spec/models/milestone_spec.rb
+++ b/spec/models/milestone_spec.rb
@@ -5,7 +5,7 @@ describe Milestone do
     it { is_expected.to belong_to(:schedule) }
   end
 
-  describe "validation" do
+  describe "validations" do
     subject { FactoryBot.build(:milestone) }
 
     it { is_expected.to validate_presence_of(:schedule_id).with_message("Choose a schedule") }
@@ -13,12 +13,56 @@ describe Milestone do
     it { is_expected.to validate_inclusion_of(:declaration_type).in_array(declaration_types).with_message("Choose a valid declaration type") }
     it { is_expected.to validate_comparison_of(:milestone_date).is_greater_than(:start_date).with_message("Milestone date must be after the start date").allow_nil }
 
-    it "ensures uniqueness of declaration_types and schedule_ids" do
-      original = FactoryBot.create(:milestone)
-      duplicate = original.dup
+    describe "declaration uniqueness" do
+      subject(:milestone) { original.dup }
 
-      expect(duplicate).not_to be_valid
-      expect(duplicate.errors.messages.fetch(:declaration_type)).to include("Can be used once per schedule")
+      let(:original) { FactoryBot.create(:milestone) }
+
+      it "ensures declaration_type is used once per schedule" do
+        expect(milestone).not_to be_valid
+        expect(milestone.errors.messages.fetch(:declaration_type)).to include("Can be used once per schedule")
+      end
+    end
+
+    describe "start date" do
+      subject(:milestone) { FactoryBot.build(:milestone, schedule:, start_date:) }
+
+      let(:contract_period) { FactoryBot.create(:contract_period, :next) }
+      let(:schedule) { FactoryBot.create(:schedule, contract_period:) }
+
+      context "when start date is before the contract period start date" do
+        let(:start_date) { contract_period.started_on.prev_day }
+
+        it "is invalid" do
+          expect(milestone).not_to be_valid
+          expect(milestone.errors.messages.fetch(:start_date)).to include("The start date must be on or after the contract start date (1 June #{contract_period.year})")
+        end
+      end
+
+      context "when start date is on the contract period start date" do
+        let(:start_date) { contract_period.started_on }
+
+        it { is_expected.to be_valid }
+      end
+
+      context "when start date is after the contract period start date" do
+        let(:start_date) { contract_period.started_on.next_day }
+
+        it { is_expected.to be_valid }
+      end
+    end
+
+    describe "milestone date" do
+      subject(:milestone) do
+        FactoryBot.build(:milestone,
+                         start_date: Date.tomorrow,
+                         milestone_date: Time.zone.today)
+      end
+
+      it "ensures milestone date is later than the start date" do
+        expect(milestone).not_to be_valid
+        expect(milestone.errors.messages.fetch(:milestone_date)).to include("Milestone date must be after the start date")
+      end
     end
   end
 

--- a/spec/models/milestone_spec.rb
+++ b/spec/models/milestone_spec.rb
@@ -30,22 +30,22 @@ describe Milestone do
       let(:contract_period) { FactoryBot.create(:contract_period, :next) }
       let(:schedule) { FactoryBot.create(:schedule, contract_period:) }
 
-      context "when start date is before the contract period start date" do
+      context "when start date is before June 1st of the contract period year" do
         let(:start_date) { contract_period.started_on.prev_day }
 
         it "is invalid" do
           expect(milestone).not_to be_valid
-          expect(milestone.errors.messages.fetch(:start_date)).to include("The start date must be on or after the contract start date (1 June #{contract_period.year})")
+          expect(milestone.errors.messages.fetch(:start_date)).to include("The start date must be on or after the 1 June #{contract_period.year}")
         end
       end
 
-      context "when start date is on the contract period start date" do
+      context "when start date is on June 1st of the contract period year" do
         let(:start_date) { contract_period.started_on }
 
         it { is_expected.to be_valid }
       end
 
-      context "when start date is after the contract period start date" do
+      context "when start date is after June 1st of the contract period year" do
         let(:start_date) { contract_period.started_on.next_day }
 
         it { is_expected.to be_valid }

--- a/spec/requests/admin/finance/contract_periods/milestones_spec.rb
+++ b/spec/requests/admin/finance/contract_periods/milestones_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "Admin finance milestones", type: :request do
   describe "POST /admin/finance/contract-periods/:contract_period_id/schedules/:schedule_id/milestones/:id", :enable_finance_contract_periods do
     let(:index_path) { admin_contract_period_schedule_milestones_path(contract_period, schedule) }
 
-    let(:start_date) { Time.zone.now }
+    let(:start_date) { 1.day.after(contract_period.started_on) }
     let(:params) do
       {
         contract_period_id: contract_period.id,

--- a/spec/requests/admin/teachers/trainings_spec.rb
+++ b/spec/requests/admin/teachers/trainings_spec.rb
@@ -189,6 +189,7 @@ RSpec.describe "Admin::Teachers::Training", type: :request do
 
           before do
             newer_training_period.school_partnership = older_training_period.school_partnership
+            newer_training_period.schedule = FactoryBot.create(:schedule, contract_period: older_training_period.school_partnership.contract_period)
             newer_training_period.save!
           end
 

--- a/spec/requests/api/v3/declarations_spec.rb
+++ b/spec/requests/api/v3/declarations_spec.rb
@@ -55,12 +55,15 @@ RSpec.describe "Declarations API", :with_metadata, :with_touches, type: :request
     let(:path) { api_v3_declarations_path }
     let(:service) { API::Declarations::Create }
     let(:resource_type) { Declaration }
+    let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, :for_year, year: 2024) }
     let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
     let(:school_partnership) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:) }
     let(:teacher) { FactoryBot.create(:teacher) }
     let(:schedule) { FactoryBot.create(:schedule, contract_period: school_partnership.contract_period) }
     let(:milestone) { FactoryBot.create(:milestone, declaration_type: :started, schedule:) }
-    let(:declaration_date) { Faker::Date.between(from: milestone.start_date, to: milestone.milestone_date) }
+    let(:declaration_date) do
+      Faker::Date.between(from: milestone.start_date, to: milestone.milestone_date)
+    end
 
     let(:service_args) do
       {
@@ -91,8 +94,20 @@ RSpec.describe "Declarations API", :with_metadata, :with_touches, type: :request
 
     %i[ect mentor].each do |teacher_type|
       context "for #{teacher_type}" do
-        let(:at_school_period) { FactoryBot.create(:"#{teacher_type}_at_school_period", started_on: 6.months.ago, finished_on: 2.weeks.from_now, teacher:) }
-        let!(:training_period) { FactoryBot.create(:training_period, :"for_#{teacher_type}", :active, "#{teacher_type}_at_school_period": at_school_period, started_on: at_school_period.started_on.tomorrow, finished_on: at_school_period.finished_on, school_partnership:, schedule:) }
+        let(:at_school_period) do
+          FactoryBot.create(:"#{teacher_type}_at_school_period",
+                            started_on: 6.months.ago,
+                            finished_on: 2.weeks.from_now,
+                            teacher:)
+        end
+        let!(:training_period) do
+          FactoryBot.create(:training_period, :"for_#{teacher_type}", :active,
+                            "#{teacher_type}_at_school_period": at_school_period,
+                            started_on: at_school_period.started_on.tomorrow,
+                            finished_on: at_school_period.finished_on,
+                            school_partnership:,
+                            schedule:)
+        end
         let(:course_identifier) { teacher_type == :ect ? "ecf-induction" : "ecf-mentor" }
         let(:teacher_type) { teacher_type }
 

--- a/spec/serializers/api/teacher_serializer_spec.rb
+++ b/spec/serializers/api/teacher_serializer_spec.rb
@@ -129,6 +129,10 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
           )
         end
 
+        before do
+          school_partnership.contract_period.update!(uplift_fees_enabled: true)
+        end
+
         it { expect(ecf_enrolments.count).to eq(2) }
 
         describe "ECT enrolment" do

--- a/spec/services/api/declarations/create_spec.rb
+++ b/spec/services/api/declarations/create_spec.rb
@@ -10,25 +10,43 @@ RSpec.describe API::Declarations::Create, type: :model do
     )
   end
 
+  let(:school_partnership) { FactoryBot.create(:school_partnership, :for_year, year: 2024) }
+
   let(:lead_provider) { training_period.lead_provider }
   let(:lead_provider_id) { lead_provider.id }
   let(:teacher) { training_period.teacher }
   let(:teacher_api_id) { teacher.api_id }
-  let(:school_partnership) { training_period.school_partnership }
   let(:contract_period) { training_period.contract_period }
   let(:declaration_type) { "started" }
   let(:evidence_type) { "training-event-attended" }
   let(:schedule) { training_period.schedule }
-  let!(:milestone) { FactoryBot.create(:milestone, declaration_type:, schedule:, start_date: Date.new(2024, 11, 1), milestone_date: Date.new(2024, 12, 1)) }
   let(:declaration_datetime) { Faker::Time.between(from: milestone.start_date, to: milestone.milestone_date) }
   let(:declaration_date) { declaration_datetime.rfc3339 }
   let(:active_lead_provider) { training_period.active_lead_provider }
 
+  let!(:milestone) do
+    FactoryBot.create(:milestone,
+                      declaration_type:,
+                      schedule:,
+                      start_date: Date.new(contract_period.year, 11, 1),
+                      milestone_date: Date.new(contract_period.year, 12, 1))
+  end
+
   describe "validations" do
     %i[ect mentor].each do |trainee_type|
       context "for #{trainee_type}" do
-        let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", started_on: 6.months.ago, finished_on: 2.months.from_now) }
-        let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :active, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on, finished_on: 1.week.from_now) }
+        let(:at_school_period) do
+          FactoryBot.create(:"#{trainee_type}_at_school_period",
+                            started_on: 6.months.ago,
+                            finished_on: 2.months.from_now)
+        end
+        let!(:training_period) do
+          FactoryBot.create(:training_period, :"for_#{trainee_type}", :active,
+                            "#{trainee_type}_at_school_period": at_school_period,
+                            school_partnership:,
+                            started_on: at_school_period.started_on,
+                            finished_on: at_school_period.finished_on - 1.day)
+        end
         let(:teacher_type) { trainee_type }
 
         it { is_expected.to be_valid }
@@ -130,14 +148,14 @@ RSpec.describe API::Declarations::Create, type: :model do
         end
 
         context "when declaration date does not match the milestone start date" do
-          let(:declaration_date) { Date.new(2024, 10, 25).rfc3339 }
+          let(:declaration_date) { (milestone.start_date - 1.day).rfc3339 }
 
           it { is_expected.to have_one_error_only }
           it { is_expected.to have_error(:declaration_date, "Declaration date must be on or after the milestone start date for the same declaration type.") }
         end
 
         context "when declaration date does not match the milestone date" do
-          let(:declaration_date) { Date.new(2024, 12, 25).rfc3339 }
+          let(:declaration_date) { (milestone.milestone_date + 1.day).rfc3339 }
 
           it { is_expected.to have_one_error_only }
           it { is_expected.to have_error(:declaration_date, "Declaration date must be on or before the milestone date for the same declaration type.") }
@@ -245,34 +263,24 @@ RSpec.describe API::Declarations::Create, type: :model do
 
             let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :ongoing, started_on: 6.months.ago) }
             let!(:training_period) do
-              FactoryBot.create(
-                :training_period,
-                :"for_#{trainee_type}",
-                :active,
-                "#{trainee_type}_at_school_period": at_school_period,
-                started_on: at_school_period.started_on,
-                finished_on: 2.months.ago
-              )
+              FactoryBot.create(:training_period, :"for_#{trainee_type}", :active,
+                                "#{trainee_type}_at_school_period": at_school_period,
+                                started_on: at_school_period.started_on,
+                                finished_on: 2.months.ago)
             end
 
             let(:frozen_contract_period) { FactoryBot.create(:contract_period, :with_payments_frozen) }
             let(:frozen_active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:, contract_period: frozen_contract_period) }
             let(:frozen_school_partnership) do
-              FactoryBot.create(
-                :school_partnership,
-                active_lead_provider: frozen_active_lead_provider,
-                school: at_school_period.school
-              )
+              FactoryBot.create(:school_partnership,
+                                active_lead_provider: frozen_active_lead_provider,
+                                school: at_school_period.school)
             end
             let!(:frozen_training_period) do
-              FactoryBot.create(
-                :training_period,
-                :"for_#{trainee_type}",
-                :ongoing,
-                "#{trainee_type}_at_school_period": at_school_period,
-                school_partnership: frozen_school_partnership,
-                started_on: training_period.finished_on + 1.day
-              )
+              FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing,
+                                "#{trainee_type}_at_school_period": at_school_period,
+                                school_partnership: frozen_school_partnership,
+                                started_on: training_period.finished_on + 1.day)
             end
 
             before do
@@ -302,18 +310,11 @@ RSpec.describe API::Declarations::Create, type: :model do
           %w[no_payment eligible payable paid].each do |payment_status|
             context "with payment status `#{payment_status}`" do
               let!(:existing_duplicate_declaration) do
-                FactoryBot.create(:declaration,
-                                  :no_payment,
+                FactoryBot.create(:declaration, payment_status.to_sym,
                                   declaration_date:,
                                   declaration_type:,
                                   evidence_type:,
                                   training_period:)
-              end
-
-              let!(:another_existing_declaration) do
-                FactoryBot.create(:declaration,
-                                  payment_status.to_sym,
-                                  declaration_type:)
               end
 
               it { is_expected.to have_one_error_only }
@@ -327,28 +328,26 @@ RSpec.describe API::Declarations::Create, type: :model do
 
           context "when multiple training periods exist for the same lead provider" do
             let!(:training_period) do
-              FactoryBot.create(
-                :training_period,
-                :"for_#{trainee_type}",
-                :active,
-                "#{trainee_type}_at_school_period": at_school_period,
-                started_on: at_school_period.started_on,
-                finished_on: 2.months.ago
-              )
+              FactoryBot.create(:training_period, :"for_#{trainee_type}", :active,
+                                "#{trainee_type}_at_school_period": at_school_period,
+                                started_on: at_school_period.started_on,
+                                finished_on: 2.months.ago)
             end
 
             let!(:current_training_period) do
-              FactoryBot.create(
-                :training_period,
-                :"for_#{trainee_type}",
-                :ongoing,
-                "#{trainee_type}_at_school_period": at_school_period,
-                school_partnership: training_period.school_partnership,
-                started_on: 2.months.ago + 1.day
-              )
+              FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing,
+                                "#{trainee_type}_at_school_period": at_school_period,
+                                school_partnership: training_period.school_partnership,
+                                started_on: 2.months.ago + 1.day)
             end
 
-            let!(:current_milestone) { FactoryBot.create(:milestone, declaration_type:, schedule: current_training_period.schedule, start_date: Date.new(2024, 11, 1), milestone_date: Date.new(2024, 12, 1)) }
+            let!(:current_milestone) do
+              FactoryBot.create(:milestone,
+                                declaration_type:,
+                                schedule: current_training_period.schedule,
+                                start_date: Date.new(contract_period.year, 11, 1),
+                                milestone_date: Date.new(contract_period.year, 12, 1))
+            end
 
             it "selects the latest started training period, not the one closest to declaration_date" do
               expect(instance.training_period).to eq(current_training_period)
@@ -357,28 +356,26 @@ RSpec.describe API::Declarations::Create, type: :model do
 
           context "when a past finished training period and a future training period exist for the same lead provider" do
             let!(:training_period) do
-              FactoryBot.create(
-                :training_period,
-                :"for_#{trainee_type}",
-                :active,
-                "#{trainee_type}_at_school_period": at_school_period,
-                started_on: at_school_period.started_on,
-                finished_on: 2.weeks.ago
-              )
+              FactoryBot.create(:training_period, :"for_#{trainee_type}", :active,
+                                "#{trainee_type}_at_school_period": at_school_period,
+                                started_on: at_school_period.started_on,
+                                finished_on: 2.weeks.ago)
             end
 
             let!(:future_training_period) do
-              FactoryBot.create(
-                :training_period,
-                :"for_#{trainee_type}",
-                :ongoing,
-                "#{trainee_type}_at_school_period": at_school_period,
-                school_partnership: training_period.school_partnership,
-                started_on: 1.month.from_now
-              )
+              FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing,
+                                "#{trainee_type}_at_school_period": at_school_period,
+                                school_partnership: training_period.school_partnership,
+                                started_on: 1.month.from_now)
             end
 
-            let!(:future_milestone) { FactoryBot.create(:milestone, declaration_type:, schedule: future_training_period.schedule, start_date: Date.new(2024, 11, 1), milestone_date: Date.new(2024, 12, 1)) }
+            let!(:future_milestone) do
+              FactoryBot.create(:milestone,
+                                declaration_type:,
+                                schedule: future_training_period.schedule,
+                                start_date: Date.new(contract_period.year, 11, 1),
+                                milestone_date: Date.new(contract_period.year, 12, 1))
+            end
 
             it "selects the future training period" do
               expect(instance.training_period).to eq(future_training_period)
@@ -387,13 +384,9 @@ RSpec.describe API::Declarations::Create, type: :model do
 
           context "when only a future training period exists for the same lead provider" do
             let!(:training_period) do
-              FactoryBot.create(
-                :training_period,
-                :"for_#{trainee_type}",
-                :ongoing,
-                "#{trainee_type}_at_school_period": at_school_period,
-                started_on: 1.month.from_now
-              )
+              FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing,
+                                "#{trainee_type}_at_school_period": at_school_period,
+                                started_on: 1.month.from_now)
             end
 
             it "selects the future training period" do
@@ -409,41 +402,43 @@ RSpec.describe API::Declarations::Create, type: :model do
 
         context "validate declaration types are in sequence order" do
           let(:school_partnership) do
-            FactoryBot.create(
-              :school_partnership,
-              :for_year,
-              year: contract_period_year,
-              school: at_school_period.school
-            )
+            FactoryBot.create(:school_partnership, :for_year,
+                              year: contract_period_year,
+                              school: at_school_period.school)
           end
           let!(:training_period) do
-            FactoryBot.create(
-              :training_period,
-              :"for_#{trainee_type}",
-              :active,
-              "#{trainee_type}_at_school_period": at_school_period,
-              school_partnership:,
-              started_on: at_school_period.started_on,
-              finished_on: 1.week.from_now
-            )
+            FactoryBot.create(:training_period, :"for_#{trainee_type}", :active,
+                              "#{trainee_type}_at_school_period": at_school_period,
+                              school_partnership:,
+                              started_on: at_school_period.started_on,
+                              finished_on: 1.week.from_now)
           end
 
           context "when contract period is 2025" do
             let(:contract_period_year) { 2025 }
 
             context "when theres existing `started` declaration" do
-              let!(:milestone) { FactoryBot.create(:milestone, declaration_type: "completed", schedule:, start_date: Date.new(contract_period_year, 1, 1), milestone_date: Date.new(contract_period_year, 12, 1)) }
-              let!(:started_milestone) { FactoryBot.create(:milestone, declaration_type: "started", schedule:, start_date: Date.new(contract_period_year, 1, 1), milestone_date: Date.new(contract_period_year, 12, 1)) }
+              let!(:milestone) do
+                FactoryBot.create(:milestone,
+                                  declaration_type: "completed",
+                                  schedule:, start_date: Date.new(contract_period_year, 6, 1),
+                                  milestone_date: Date.new(contract_period_year, 12, 1))
+              end
+              let!(:started_milestone) do
+                FactoryBot.create(:milestone,
+                                  declaration_type: "started",
+                                  schedule:,
+                                  start_date: Date.new(contract_period_year, 6, 1),
+                                  milestone_date: Date.new(contract_period_year, 12, 1))
+              end
 
               # Existing `started` declaration
               let!(:started_declaration) do
-                FactoryBot.create(
-                  :declaration,
-                  declaration_type: :started,
-                  evidence_type: "training-event-attended",
-                  declaration_date: (started_milestone.start_date + 1.month).rfc3339,
-                  training_period:
-                )
+                FactoryBot.create(:declaration,
+                                  declaration_type: :started,
+                                  evidence_type: "training-event-attended",
+                                  declaration_date: (started_milestone.start_date + 1.month).rfc3339,
+                                  training_period:)
               end
 
               # New declaration
@@ -467,18 +462,16 @@ RSpec.describe API::Declarations::Create, type: :model do
             end
 
             context "when theres existing `completed` declaration" do
-              let!(:milestone) { FactoryBot.create(:milestone, declaration_type: "started", schedule:, start_date: Date.new(contract_period_year, 1, 1), milestone_date: Date.new(contract_period_year, 12, 1)) }
-              let!(:completed_milestone) { FactoryBot.create(:milestone, declaration_type: "completed", schedule:, start_date: Date.new(contract_period_year, 1, 1), milestone_date: Date.new(contract_period_year, 12, 1)) }
+              let!(:milestone) { FactoryBot.create(:milestone, declaration_type: "started", schedule:, start_date: Date.new(contract_period_year, 6, 1), milestone_date: Date.new(contract_period_year, 12, 1)) }
+              let!(:completed_milestone) { FactoryBot.create(:milestone, declaration_type: "completed", schedule:, start_date: Date.new(contract_period_year, 6, 1), milestone_date: Date.new(contract_period_year, 12, 1)) }
 
               # Existing `completed` declaration
               let!(:completed_declaration) do
-                FactoryBot.create(
-                  :declaration,
-                  declaration_type: :completed,
-                  evidence_type: "75-percent-engagement-met",
-                  declaration_date: (completed_milestone.start_date + 2.months).rfc3339,
-                  training_period:
-                )
+                FactoryBot.create(:declaration,
+                                  declaration_type: :completed,
+                                  evidence_type: "75-percent-engagement-met",
+                                  declaration_date: (completed_milestone.start_date + 2.months).rfc3339,
+                                  training_period:)
               end
 
               # New declaration
@@ -504,30 +497,26 @@ RSpec.describe API::Declarations::Create, type: :model do
             # Mentor has `started` and `completed` only, for ECT we do outside of existing declaration date test
             if trainee_type == :ect
               context "when theres existing `started` and `completed` declarations" do
-                let!(:milestone) { FactoryBot.create(:milestone, declaration_type: "retained-1", schedule:, start_date: Date.new(contract_period_year, 1, 1), milestone_date: Date.new(contract_period_year, 12, 1)) }
-                let!(:started_milestone) { FactoryBot.create(:milestone, declaration_type: "started", schedule:, start_date: Date.new(contract_period_year, 1, 1), milestone_date: Date.new(contract_period_year, 12, 1)) }
-                let!(:completed_milestone) { FactoryBot.create(:milestone, declaration_type: "completed", schedule:, start_date: Date.new(contract_period_year, 1, 1), milestone_date: Date.new(contract_period_year, 12, 1)) }
+                let!(:milestone) { FactoryBot.create(:milestone, declaration_type: "retained-1", schedule:, start_date: Date.new(contract_period_year, 6, 1), milestone_date: Date.new(contract_period_year, 12, 1)) }
+                let!(:started_milestone) { FactoryBot.create(:milestone, declaration_type: "started", schedule:, start_date: Date.new(contract_period_year, 6, 1), milestone_date: Date.new(contract_period_year, 12, 1)) }
+                let!(:completed_milestone) { FactoryBot.create(:milestone, declaration_type: "completed", schedule:, start_date: Date.new(contract_period_year, 6, 1), milestone_date: Date.new(contract_period_year, 12, 1)) }
 
                 # Existing `started` declaration
                 let!(:started_declaration) do
-                  FactoryBot.create(
-                    :declaration,
-                    declaration_type: :started,
-                    evidence_type: "training-event-attended",
-                    declaration_date: Date.new(contract_period_year, 2, 1).rfc3339,
-                    training_period:
-                  )
+                  FactoryBot.create(:declaration,
+                                    declaration_type: :started,
+                                    evidence_type: "training-event-attended",
+                                    declaration_date: Date.new(contract_period_year, 7, 1).rfc3339,
+                                    training_period:)
                 end
 
                 # Existing `completed` declaration
                 let!(:completed_declaration) do
-                  FactoryBot.create(
-                    :declaration,
-                    declaration_type: :completed,
-                    evidence_type: "75-percent-engagement-met",
-                    declaration_date: Date.new(contract_period_year, 6, 1).rfc3339,
-                    training_period:
-                  )
+                  FactoryBot.create(:declaration,
+                                    declaration_type: :completed,
+                                    evidence_type: "75-percent-engagement-met",
+                                    declaration_date: Date.new(contract_period_year, 9, 1).rfc3339,
+                                    training_period:)
                 end
 
                 let(:declaration_type) { "retained-1" }
@@ -560,7 +549,7 @@ RSpec.describe API::Declarations::Create, type: :model do
 
                 context "when `extended-1` is submitted after `completed` declaration dates" do
                   let(:declaration_type) { "extended-1" }
-                  let!(:milestone) { FactoryBot.create(:milestone, declaration_type:, schedule:, start_date: Date.new(contract_period_year, 1, 1), milestone_date: Date.new(contract_period_year, 12, 1)) }
+                  let!(:milestone) { FactoryBot.create(:milestone, declaration_type:, schedule:, start_date: Date.new(contract_period_year, 6, 1), milestone_date: Date.new(contract_period_year, 12, 1)) }
 
                   # New declaration with declaration date set 1 day after `completed`
                   let(:declaration_date) { (completed_declaration.declaration_date + 1.day).rfc3339 }
@@ -575,8 +564,8 @@ RSpec.describe API::Declarations::Create, type: :model do
             let(:contract_period_year) { 2024 }
 
             context "when `completed` is submitted before `started` declaration date" do
-              let!(:milestone) { FactoryBot.create(:milestone, declaration_type: "completed", schedule:, start_date: Date.new(contract_period_year, 1, 1), milestone_date: Date.new(contract_period_year, 12, 1)) }
-              let!(:started_milestone) { FactoryBot.create(:milestone, declaration_type: "started", schedule:, start_date: Date.new(contract_period_year, 1, 1), milestone_date: Date.new(contract_period_year, 12, 1)) }
+              let!(:milestone) { FactoryBot.create(:milestone, declaration_type: "completed", schedule:, start_date: Date.new(contract_period_year, 6, 1), milestone_date: Date.new(contract_period_year, 12, 1)) }
+              let!(:started_milestone) { FactoryBot.create(:milestone, declaration_type: "started", schedule:, start_date: Date.new(contract_period_year, 6, 1), milestone_date: Date.new(contract_period_year, 12, 1)) }
 
               # Existing `started` declaration
               let!(:started_declaration) do
@@ -584,7 +573,7 @@ RSpec.describe API::Declarations::Create, type: :model do
                   :declaration,
                   declaration_type: :started,
                   evidence_type: "training-event-attended",
-                  declaration_date: Date.new(contract_period_year, 6, 1).rfc3339,
+                  declaration_date: Date.new(contract_period_year, 8, 1).rfc3339,
                   training_period:
                 )
               end
@@ -598,8 +587,8 @@ RSpec.describe API::Declarations::Create, type: :model do
             end
 
             context "when `started` is submitted after `completed` declaration date" do
-              let!(:milestone) { FactoryBot.create(:milestone, declaration_type: "started", schedule:, start_date: Date.new(contract_period_year, 1, 1), milestone_date: Date.new(contract_period_year, 12, 1)) }
-              let!(:completed_milestone) { FactoryBot.create(:milestone, declaration_type: "completed", schedule:, start_date: Date.new(contract_period_year, 1, 1), milestone_date: Date.new(contract_period_year, 12, 1)) }
+              let!(:milestone) { FactoryBot.create(:milestone, declaration_type: "started", schedule:, start_date: Date.new(contract_period_year, 6, 1), milestone_date: Date.new(contract_period_year, 12, 1)) }
+              let!(:completed_milestone) { FactoryBot.create(:milestone, declaration_type: "completed", schedule:, start_date: Date.new(contract_period_year, 6, 1), milestone_date: Date.new(contract_period_year, 12, 1)) }
 
               # Existing `started` declaration
               let!(:completed_declaration) do
@@ -607,7 +596,7 @@ RSpec.describe API::Declarations::Create, type: :model do
                   :declaration,
                   declaration_type: :completed,
                   evidence_type: "75-percent-engagement-met",
-                  declaration_date: Date.new(contract_period_year, 3, 1).rfc3339,
+                  declaration_date: Date.new(contract_period_year, 8, 1).rfc3339,
                   training_period:
                 )
               end
@@ -634,7 +623,11 @@ RSpec.describe API::Declarations::Create, type: :model do
 
         context "when invalid" do
           let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :ongoing) }
-          let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
+          let!(:training_period) do
+            FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing,
+                              "#{trainee_type}_at_school_period": at_school_period,
+                              started_on: at_school_period.started_on)
+          end
           let(:teacher_api_id) { SecureRandom.uuid }
 
           it { expect(instance.create).to be(false) }
@@ -642,8 +635,19 @@ RSpec.describe API::Declarations::Create, type: :model do
         end
 
         context "when valid" do
-          let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", started_on: 6.months.ago, finished_on: 2.weeks.from_now) }
-          let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :active, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on, finished_on: at_school_period.finished_on) }
+          let(:at_school_period) do
+            FactoryBot.create(:"#{trainee_type}_at_school_period",
+                              started_on: 6.months.ago,
+                              finished_on: 2.weeks.from_now)
+          end
+          let!(:training_period) do
+            FactoryBot.create(:training_period, :"for_#{trainee_type}", :active,
+                              "#{trainee_type}_at_school_period": at_school_period,
+                              school_partnership:,
+                              started_on: at_school_period.started_on,
+                              finished_on: at_school_period.finished_on)
+          end
+
           let(:service) { instance_double(Declarations::Create) }
           let!(:payment_statement) { FactoryBot.create(:statement, :open, active_lead_provider:, deadline_date: 1.month.from_now) }
           let!(:mentorship_period) do

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Events::Record do
       lead_provider: FactoryBot.build(:lead_provider),
       delivery_partner: FactoryBot.build(:delivery_partner),
       user: FactoryBot.build(:user),
-      training_period: FactoryBot.build(:training_period),
+      training_period: FactoryBot.build(:training_period, :school_led), # NB: school_led prevents a stray contract_period
       mentorship_period: FactoryBot.build(:mentorship_period),
     }.each do |attribute, object|
       describe "when #{attribute} is missing" do

--- a/spec/services/milestones/create_spec.rb
+++ b/spec/services/milestones/create_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Milestones::Create do
   let(:params) do
     {
       declaration_type: "started",
-      start_date: Date.new(2026, 1, 1),
-      milestone_date: Date.new(2026, 6, 1),
+      start_date: Date.new(contract_period.year, 6, 1),
+      milestone_date: Date.new(contract_period.year, 9, 1),
     }
   end
 
@@ -70,8 +70,8 @@ RSpec.describe Milestones::Create do
       let(:params) do
         {
           declaration_type: "retained-1",
-          start_date: Date.new(2026, 6, 1),
-          milestone_date: Date.new(2026, 1, 1),
+          start_date: Date.new(contract_period.year, 6, 1),
+          milestone_date: Date.new(contract_period.year, 1, 1),
         }
       end
 

--- a/spec/services/teachers/change_schedule_spec.rb
+++ b/spec/services/teachers/change_schedule_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Teachers::ChangeSchedule do
         end
 
         context "when moving away from a frozen contract period" do
-          let(:contract_period) { training_period.contract_period }
+          let(:contract_period) { training_period.schedule.contract_period }
 
           before { contract_period.update!(payments_frozen_at: Time.zone.now) }
 

--- a/spec/validators/declaration_date_within_milestone_validator_spec.rb
+++ b/spec/validators/declaration_date_within_milestone_validator_spec.rb
@@ -15,14 +15,15 @@ RSpec.describe DeclarationDateWithinMilestoneValidator, type: :model do
     end
   end
 
-  let(:declaration_date) { Date.new(2022, 1, 30) }
-  let(:start_date) { Date.new(2022, 1, 29) }
-  let(:milestone_date) { Date.new(2022, 1, 31) }
-
-  let!(:milestone) { FactoryBot.create(:milestone, start_date:, milestone_date:) }
+  let(:declaration_date) { Date.new(contract_period.year, 7, 30) }
+  let(:start_date) { Date.new(contract_period.year, 7, 29) }
+  let(:milestone_date) { Date.new(contract_period.year, 7, 31) }
+  let(:contract_period) { FactoryBot.create(:contract_period, :current) }
+  let(:schedule) { FactoryBot.create(:schedule, contract_period:) }
+  let!(:milestone) { FactoryBot.create(:milestone, schedule:, start_date:, milestone_date:) }
 
   context "when before the milestone start" do
-    let(:declaration_date) { Date.new(2022, 1, 28) }
+    let(:declaration_date) { Date.new(contract_period.year, 7, 28) }
 
     it { is_expected.to have_error(:declaration_date, "Declaration date must be on or after the milestone start date for the same declaration type.") }
   end

--- a/spec/views/admin/finance/schedules/show.html.erb_spec.rb
+++ b/spec/views/admin/finance/schedules/show.html.erb_spec.rb
@@ -55,10 +55,12 @@ RSpec.describe "admin/finance/schedules/show.html.erb" do
     before do
       FactoryBot.create(:milestone,
                         schedule:,
+                        start_date: Date.new(contract_period.year, 9, 1),
                         declaration_type: "started")
 
       FactoryBot.create(:milestone,
                         schedule:,
+                        milestone_date: Date.new(contract_period.year, 10, 1),
                         declaration_type: "retained-1")
     end
 
@@ -78,8 +80,8 @@ RSpec.describe "admin/finance/schedules/show.html.erb" do
 
     it "formats dates" do
       render
-      expect(rendered).to have_text("1 September 2024")
-      expect(rendered).to have_text("1 October 2024")
+      expect(rendered).to have_text("1 September #{contract_period.year}")
+      expect(rendered).to have_text("1 October #{contract_period.year}")
     end
 
     it "disables the delete schedule button" do


### PR DESCRIPTION
### Context

Closes https://github.com/DFE-Digital/register-ects-project-board/issues/4026

At present there is no validation on a milestone's start date resulting in any date being accepted. What we need is for a milestone to not predate June 1st of the contract period year.

Whilst the validation rule is trivial the challenge with the change was getting the test suite to be reliable. 

1. Date fixtures in specs now reference the contract in question.
2. We factory contract periods in sequence which meant this change introduced errors in those specs.
3. The way factories were chained meant we could be left with an orphaned record that would cause specs to fail or be flaky.
4. Some factories persisted records during the build phase when they weren't meant to.

### Changes proposed in this pull request

Add milestone start date validation that ensures it is bounded by the contract period of the schedule.

- only initialise when building a factory so chained associations are not persisted
- pin the active lead provider factory to the current period where necessary
- update spec fixture dates to assert the contract period year not hard-coded values
- pin declaration create specs to 2024 otherwise they are flaky
- ensure no ghost contract periods remain if they were overwritten

### Guidance to review

<img width="2616" height="3232" alt="cpd-ec2-review-3065-web test teacherservices cloud_admin_finance_contract-periods_2027_schedules_323_milestones" src="https://github.com/user-attachments/assets/1a54beef-20da-48ea-b54e-9367f5fe2cce" />


