### PR TITLE
Update DfE Sign-in access denied pages

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,14 +1,21 @@
 class PagesController < ApplicationController
   after_action :allow_search_engine_indexing, only: :home
 
+  DFE_SIGN_IN_REQUEST_ORGANISATION_URL =
+    "https://services.signin.education.gov.uk/request-organisation/search"
+
+  DFE_SIGN_IN_MY_SERVICES_URL =
+    "https://services.signin.education.gov.uk/my-services"
+
   def home
     redirect_to(post_login_redirect_path) and return if authenticated?
   end
 
   # Unrecognised DfE Sign In user (org/role)
   def access_denied
-    @dfe_sign_in_profile_url = Rails.application.config.dfe_sign_in_profile
     @organisation_name = session[:invalid_user_organisation_name]
+    @dfe_sign_in_request_organisation_url = DFE_SIGN_IN_REQUEST_ORGANISATION_URL
+    @dfe_sign_in_my_services_url = DFE_SIGN_IN_MY_SERVICES_URL
   end
 
   def support

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,12 +1,6 @@
 class PagesController < ApplicationController
   after_action :allow_search_engine_indexing, only: :home
 
-  DFE_SIGN_IN_REQUEST_ORGANISATION_URL =
-    "https://services.signin.education.gov.uk/request-organisation/search"
-
-  DFE_SIGN_IN_MY_SERVICES_URL =
-    "https://services.signin.education.gov.uk/my-services"
-
   def home
     redirect_to(post_login_redirect_path) and return if authenticated?
   end
@@ -14,8 +8,10 @@ class PagesController < ApplicationController
   # Unrecognised DfE Sign In user (org/role)
   def access_denied
     @organisation_name = session[:invalid_user_organisation_name]
-    @dfe_sign_in_request_organisation_url = DFE_SIGN_IN_REQUEST_ORGANISATION_URL
-    @dfe_sign_in_my_services_url = DFE_SIGN_IN_MY_SERVICES_URL
+    @dfe_sign_in_request_organisation_url =
+      Rails.application.config.dfe_sign_in_request_organisation_url
+    @dfe_sign_in_my_services_url =
+      Rails.application.config.dfe_sign_in_my_services_url
   end
 
   def support

--- a/app/views/pages/access_denied.html.erb
+++ b/app/views/pages/access_denied.html.erb
@@ -1,15 +1,9 @@
 <%
-  page_data(title: @organisation_name.present? ? "You do not have approved access to this service" : "You do not have access to this service")
+  page_data(
+    title: @organisation_name.present? ?
+      "You do not have approved access to this service from your school or organisation" :
+      "You cannot use this service until you have DfE Sign-in account access to a school or organisation"
+  )
 %>
 
 <%= render @organisation_name.present? ? '/pages/access_denied/with_organisation' : '/pages/access_denied/without_organisation' %>
-
-<p class="govuk-body">
-  <%=
-    govuk_link_to('Go to DfE Sign-In profile',
-        no_visited_state: true,
-        new_tab: true,
-        href: @dfe_sign_in_profile_url
-    )
-  %>
-</p>

--- a/app/views/pages/access_denied/_with_organisation.md.erb
+++ b/app/views/pages/access_denied/_with_organisation.md.erb
@@ -6,9 +6,9 @@ You do not have approved access to the service from <%= @organisation_name %>.
 
 ### If you selected the wrong school or organisation when you signed in
 
-Sign out of DfE Sign-in.
+1. Sign out of DfE Sign-in.
 
-Sign in again and select the school or organisation for where you want to use the service.
+2. Sign in again and select the school or organisation for where you want to use the service.
 
 ### If you’ve signed in with the correct school or organisation
 

--- a/app/views/pages/access_denied/_with_organisation.md.erb
+++ b/app/views/pages/access_denied/_with_organisation.md.erb
@@ -7,7 +7,6 @@ You do not have approved access to the service from <%= @organisation_name %>.
 ### If you selected the wrong school or organisation when you signed in
 
 1. Sign out of DfE Sign-in.
-
 2. Sign in again and select the school or organisation for where you want to use the service.
 
 ### If you’ve signed in with the correct school or organisation
@@ -17,8 +16,8 @@ You’ll need to request access to the 'Register early career teachers' service 
 The school or organisation need to approve your request before you can use the service.
 
 <%= govuk_link_to(
-  "Request access to the service using your DfE Sign-in account.",
-  @dfe_sign_in_profile_url,
+  "Request access to the service using your DfE Sign-in account",
+  @dfe_sign_in_my_services_url,
   no_visited_state: true,
   new_tab: true
 ) %>

--- a/app/views/pages/access_denied/_with_organisation.md.erb
+++ b/app/views/pages/access_denied/_with_organisation.md.erb
@@ -1,8 +1,24 @@
-You tried to sign in with <%= @organisation_name %> as your organisation.
-You do not have approved access to this service with that organisation.
+You’ve tried to access the 'Register early career teachers' service with <%= @organisation_name %> as your school or organisation.
 
-**If you selected the incorrect organisation**, you need to sign out of DfE Sign-in,
-before signing in again and select a different organisation.
+You do not have approved access to the service from <%= @organisation_name %>.
 
-If you think you should have access to <%= @organisation_name %>, you need to request access from your approver.
-You can request access directly from DfE Sign-in.
+## What you need to do
+
+### If you selected the wrong school or organisation when you signed in
+
+Sign out of DfE Sign-in.
+
+Sign in again and select the school or organisation for where you want to use the service.
+
+### If you’ve signed in with the correct school or organisation
+
+You’ll need to request access to the 'Register early career teachers' service from the school or organisation.
+
+The school or organisation need to approve your request before you can use the service.
+
+<%= govuk_link_to(
+  "Request access to the service using your DfE Sign-in account.",
+  @dfe_sign_in_profile_url,
+  no_visited_state: true,
+  new_tab: true
+) %>

--- a/app/views/pages/access_denied/_without_organisation.md.erb
+++ b/app/views/pages/access_denied/_without_organisation.md.erb
@@ -1,4 +1,18 @@
-You must be an approved user to access this service.
+Your DfE Sign-in account does not have access to a school or organisation.
 
-If you think you should have access, you can request it from your organisation's approver.
-You request access directly from DfE Sign-in.
+You cannot use this service until you have access.
+
+## What you need to do
+
+In your DfE Sign-in account, request access to the school or organisation.
+
+Request access to the 'Register early career teachers'.
+
+The school or organisation need to approve your requests before you can use the service.
+
+<%= govuk_link_to(
+  "Request access to a school or organisation using your DfE Sign-in account.",
+  @dfe_sign_in_profile_url,
+  no_visited_state: true,
+  new_tab: true
+) %>

--- a/app/views/pages/access_denied/_without_organisation.md.erb
+++ b/app/views/pages/access_denied/_without_organisation.md.erb
@@ -5,14 +5,13 @@ You cannot use this service until you have access.
 ## What you need to do
 
 1. In your DfE Sign-in account, request access to the school or organisation.
-
 2. Request access to the 'Register early career teachers' service.
 
 The school or organisation need to approve your requests before you can use the service.
 
 <%= govuk_link_to(
-  "Request access to a school or organisation using your DfE Sign-in account.",
-  @dfe_sign_in_profile_url,
+  "Request access to a school or organisation using your DfE Sign-in account",
+  @dfe_sign_in_request_organisation_url,
   no_visited_state: true,
   new_tab: true
 ) %>

--- a/app/views/pages/access_denied/_without_organisation.md.erb
+++ b/app/views/pages/access_denied/_without_organisation.md.erb
@@ -6,7 +6,7 @@ You cannot use this service until you have access.
 
 1. In your DfE Sign-in account, request access to the school or organisation.
 
-2. Request access to the 'Register early career teachers'.
+2. Request access to the 'Register early career teachers' service.
 
 The school or organisation need to approve your requests before you can use the service.
 

--- a/app/views/pages/access_denied/_without_organisation.md.erb
+++ b/app/views/pages/access_denied/_without_organisation.md.erb
@@ -4,9 +4,9 @@ You cannot use this service until you have access.
 
 ## What you need to do
 
-In your DfE Sign-in account, request access to the school or organisation.
+1. In your DfE Sign-in account, request access to the school or organisation.
 
-Request access to the 'Register early career teachers'.
+2. Request access to the 'Register early career teachers'.
 
 The school or organisation need to approve your requests before you can use the service.
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -79,11 +79,11 @@ module RegisterEarlyCareerTeachers
     config.dfe_sign_in_profile = ENV.fetch("DFE_SIGN_IN_PROFILE", "https://test-profile.signin.education.gov.uk")
     config.dfe_sign_in_request_organisation_url = ENV.fetch(
       "DFE_SIGN_IN_REQUEST_ORGANISATION_URL",
-      "https://services.signin.education.gov.uk/request-organisation/search"
+      "https://test-services.signin.education.gov.uk/request-organisation/search"
     )
     config.dfe_sign_in_my_services_url = ENV.fetch(
       "DFE_SIGN_IN_MY_SERVICES_URL",
-      "https://services.signin.education.gov.uk/my-services"
+      "https://test-services.signin.education.gov.uk/my-services"
     )
     config.dfe_sign_in_issuer = ENV.fetch("DFE_SIGN_IN_ISSUER", "https://test-oidc.signin.education.gov.uk")
     config.dfe_sign_in_client_id = ENV["DFE_SIGN_IN_CLIENT_ID"]

--- a/config/application.rb
+++ b/config/application.rb
@@ -77,6 +77,14 @@ module RegisterEarlyCareerTeachers
     config.max_session_idle_time = requested_timeout.seconds
 
     config.dfe_sign_in_profile = ENV.fetch("DFE_SIGN_IN_PROFILE", "https://test-profile.signin.education.gov.uk")
+    config.dfe_sign_in_request_organisation_url = ENV.fetch(
+      "DFE_SIGN_IN_REQUEST_ORGANISATION_URL",
+      "https://services.signin.education.gov.uk/request-organisation/search"
+    )
+    config.dfe_sign_in_my_services_url = ENV.fetch(
+      "DFE_SIGN_IN_MY_SERVICES_URL",
+      "https://services.signin.education.gov.uk/my-services"
+    )
     config.dfe_sign_in_issuer = ENV.fetch("DFE_SIGN_IN_ISSUER", "https://test-oidc.signin.education.gov.uk")
     config.dfe_sign_in_client_id = ENV["DFE_SIGN_IN_CLIENT_ID"]
     config.dfe_sign_in_secret = ENV["DFE_SIGN_IN_SECRET"]

--- a/config/terraform/application/config/production.yml
+++ b/config/terraform/application/config/production.yml
@@ -17,6 +17,8 @@ DFE_SIGN_IN_CLIENT_ID: RegisterECTs
 DFE_SIGN_IN_ISSUER: "https://oidc.signin.education.gov.uk"
 DFE_SIGN_IN_REDIRECT_URI: "https://www.register-early-career-teachers.education.gov.uk/auth/dfe/callback"
 DFE_SIGN_IN_SIGN_OUT_REDIRECT_URI: "https://www.register-early-career-teachers.education.gov.uk/sign-out"
+DFE_SIGN_IN_REQUEST_ORGANISATION_URL: "https://services.signin.education.gov.uk/request-organisation/search"
+DFE_SIGN_IN_MY_SERVICES_URL: "https://services.signin.education.gov.uk/my-services"
 SERVICE_URL: "https://www.register-early-career-teachers.education.gov.uk"
 DFE_ANALYTICS_ENABLED: true
 TRS_API_BASE_URL: "https://teacher-qualifications-api.education.gov.uk"

--- a/config/terraform/application/config/sandbox.yml
+++ b/config/terraform/application/config/sandbox.yml
@@ -20,6 +20,8 @@ DFE_SIGN_IN_CLIENT_ID: RegisterECTs
 DFE_SIGN_IN_ISSUER: "https://pp-oidc.signin.education.gov.uk"
 DFE_SIGN_IN_REDIRECT_URI: "https://sandbox.register-early-career-teachers.education.gov.uk/auth/dfe/callback"
 DFE_SIGN_IN_SIGN_OUT_REDIRECT_URI: "https://sandbox.register-early-career-teachers.education.gov.uk/sign-out"
+DFE_SIGN_IN_REQUEST_ORGANISATION_URL: "https://pp-services.signin.education.gov.uk/request-organisation/search"
+DFE_SIGN_IN_MY_SERVICES_URL: "https://pp-services.signin.education.gov.uk/my-services"
 SERVICE_URL: "https://sandbox.register-early-career-teachers.education.gov.uk"
 DFE_ANALYTICS_ENABLED: true
 TRS_API_BASE_URL: "https://preprod.teacher-qualifications-api.education.gov.uk"

--- a/config/terraform/application/config/staging.yml
+++ b/config/terraform/application/config/staging.yml
@@ -21,6 +21,8 @@ DFE_SIGN_IN_CLIENT_ID: RegisterECTs
 DFE_SIGN_IN_ISSUER: "https://pp-oidc.signin.education.gov.uk"
 DFE_SIGN_IN_REDIRECT_URI: "https://staging.register-early-career-teachers.education.gov.uk/auth/dfe/callback"
 DFE_SIGN_IN_SIGN_OUT_REDIRECT_URI: "https://staging.register-early-career-teachers.education.gov.uk/sign-out"
+DFE_SIGN_IN_REQUEST_ORGANISATION_URL: "https://pp-services.signin.education.gov.uk/request-organisation/search"
+DFE_SIGN_IN_MY_SERVICES_URL: "https://pp-services.signin.education.gov.uk/my-services"
 SERVICE_URL: "https://staging.register-early-career-teachers.education.gov.uk"
 DFE_ANALYTICS_ENABLED: true
 TRS_API_BASE_URL: "https://preprod.teacher-qualifications-api.education.gov.uk"

--- a/spec/features/access_denial_spec.rb
+++ b/spec/features/access_denial_spec.rb
@@ -94,11 +94,11 @@ private
 
   def and_i_see_a_link_to_request_access_to_a_school_or_organisation
     expect(page.content).to include(
-      "Request access to a school or organisation using your DfE Sign-in account."
+      "Request access to a school or organisation using your DfE Sign-in account"
     )
 
     expect(page.content).to include(
-      "https://test-profile.signin.education.gov.uk"
+      "https://services.signin.education.gov.uk/request-organisation/search"
     )
   end
 
@@ -114,11 +114,11 @@ private
 
   def and_i_see_a_link_to_request_access_to_the_service
     expect(page.content).to include(
-      "Request access to the service using your DfE Sign-in account."
+      "Request access to the service using your DfE Sign-in account"
     )
 
     expect(page.content).to include(
-      "https://test-profile.signin.education.gov.uk"
+      "https://services.signin.education.gov.uk/my-services"
     )
   end
 end

--- a/spec/features/access_denial_spec.rb
+++ b/spec/features/access_denial_spec.rb
@@ -98,7 +98,7 @@ private
     )
 
     expect(page.content).to include(
-      "https://services.signin.education.gov.uk/request-organisation/search"
+      Rails.application.config.dfe_sign_in_request_organisation_url
     )
   end
 
@@ -118,7 +118,7 @@ private
     )
 
     expect(page.content).to include(
-      "https://services.signin.education.gov.uk/my-services"
+      Rails.application.config.dfe_sign_in_my_services_url
     )
   end
 end

--- a/spec/features/access_denial_spec.rb
+++ b/spec/features/access_denial_spec.rb
@@ -7,10 +7,22 @@ RSpec.describe "Access denial" do
 
     scenario "they see the access denied page" do
       then_i_see_the_access_denied_page
-      and_i_see_the_title("You do not have access to this service")
-      expect(page.content).to include("You must be an approved user to access this service.")
+
+      and_i_see_the_title(
+        "You cannot use this service until you have DfE Sign-in account access to a school or organisation"
+      )
+
+      expect(page.content).to include(
+        "Your DfE Sign-in account does not have access to a school or organisation."
+      )
+
+      expect(page.content).to include(
+        "You cannot use this service until you have access."
+      )
+
       expect(page.content).not_to include("Invalid Organisation")
-      and_i_see_a_link_to_my_dfe_sign_in_profile
+
+      and_i_see_a_link_to_request_access_to_a_school_or_organisation
     end
   end
 
@@ -22,13 +34,17 @@ RSpec.describe "Access denial" do
 
     scenario "they see the access denied page" do
       then_i_see_the_access_denied_page
-      and_i_see_the_title("You do not have approved access to this service")
+
+      and_i_see_the_title(
+        "You do not have approved access to this service from your school or organisation"
+      )
+
       and_i_see_my_organisation_name
-      and_i_see_a_link_to_my_dfe_sign_in_profile
+      and_i_see_a_link_to_request_access_to_the_service
     end
   end
 
-  context "when the user is from a unrecognised school" do
+  context "when the user is from an unrecognised school" do
     # DSI response includes both unrecognised UUID and URN
     before do
       sign_in_as_unrecognised_user
@@ -36,9 +52,13 @@ RSpec.describe "Access denial" do
 
     scenario "they see the access denied page" do
       then_i_see_the_access_denied_page
-      and_i_see_the_title("You do not have approved access to this service")
+
+      and_i_see_the_title(
+        "You do not have approved access to this service from your school or organisation"
+      )
+
       and_i_see_my_organisation_name
-      and_i_see_a_link_to_my_dfe_sign_in_profile
+      and_i_see_a_link_to_request_access_to_the_service
     end
   end
 
@@ -52,9 +72,13 @@ RSpec.describe "Access denial" do
 
     scenario "they see the access denied page" do
       then_i_see_the_access_denied_page
-      and_i_see_the_title("You do not have approved access to this service")
+
+      and_i_see_the_title(
+        "You do not have approved access to this service from your school or organisation"
+      )
+
       and_i_see_my_organisation_name
-      and_i_see_a_link_to_my_dfe_sign_in_profile
+      and_i_see_a_link_to_request_access_to_the_service
     end
   end
 
@@ -68,12 +92,33 @@ private
     expect(page.title).to start_with(title)
   end
 
-  def and_i_see_a_link_to_my_dfe_sign_in_profile
-    expect(page.content).to have_link("Go to DfE Sign-In profile (opens in new tab)", href: "https://test-profile.signin.education.gov.uk")
+  def and_i_see_a_link_to_request_access_to_a_school_or_organisation
+    expect(page.content).to include(
+      "Request access to a school or organisation using your DfE Sign-in account."
+    )
+
+    expect(page.content).to include(
+      "https://test-profile.signin.education.gov.uk"
+    )
   end
 
   def and_i_see_my_organisation_name
-    expect(page.content).to include("You tried to sign in with Invalid Organisation as your organisation.")
-    expect(page.content).to include("If you think you should have access to Invalid Organisation, you need to request access from your approver.")
+    expect(page.content).to include(
+      "You’ve tried to access the ‘Register early career teachers’ service with Invalid Organisation as your school or organisation."
+    )
+
+    expect(page.content).to include(
+      "You do not have approved access to the service from Invalid Organisation."
+    )
+  end
+
+  def and_i_see_a_link_to_request_access_to_the_service
+    expect(page.content).to include(
+      "Request access to the service using your DfE Sign-in account."
+    )
+
+    expect(page.content).to include(
+      "https://test-profile.signin.education.gov.uk"
+    )
   end
 end


### PR DESCRIPTION
Ticket:[here](https://github.com/DFE-Digital/register-ects-project-board/issues/4076)

**Context**

This updates the two DfE Sign-in access denied pages shown when a user cannot access the service.

There are two separate states:

1. the user does not have a school or organisation attached to their DfE Sign-in account
2. the user has selected a school or organisation, but does not have approved access to the Register early career teachers service for that organisation

**Changes proposed in this pull request**

- Updated the access denied page titles/headings for both DfE Sign-in access states.
- Replaced the old generic access denied content with the new ticket/prototype copy.
- Moved the DfE Sign-in link from the shared wrapper into the relevant page partials so each state has the correct request-access CTA:
   - request access to a school or organisation
   - request access to the service
- Updated the access denial feature spec to cover the new content for both page variants

**Guidance to review**
- Check the copy matches the ticket/prototype for both access denied states.
- Check the correct partial is shown depending on whether an organisation name is present.
- Check the DfE Sign-in request-access link text is correct for each state.