### PR TITLE
Relax validation to enable schedule to be changed to reduced on completed ECTs

### DIFF
--- a/app/services/api/teachers/change_schedule.rb
+++ b/app/services/api/teachers/change_schedule.rb
@@ -158,7 +158,7 @@ module API::Teachers
       return if errors[:teacher_api_id].any?
       return unless training_period&.teacher_completed_training?
       # allow an ECT that has completed training to move to a reduced schedule
-      return if schedule&.reduced_schedule?
+      return if schedule&.reduced_schedule? && training_period&.for_ect?
 
       errors.add(:teacher_api_id, "You cannot change this participant's schedule as they have completed their training or induction.")
     end

--- a/app/services/api/teachers/change_schedule.rb
+++ b/app/services/api/teachers/change_schedule.rb
@@ -157,6 +157,8 @@ module API::Teachers
     def trainee_not_completed
       return if errors[:teacher_api_id].any?
       return unless training_period&.teacher_completed_training?
+      # allow an ECT that has completed training to move to a reduced schedule
+      return if schedule&.reduced_schedule?
 
       errors.add(:teacher_api_id, "You cannot change this participant's schedule as they have completed their training or induction.")
     end

--- a/app/services/teachers/change_schedule.rb
+++ b/app/services/teachers/change_schedule.rb
@@ -16,7 +16,7 @@ module Teachers
       ActiveRecord::Base.transaction do
         track_payments_frozen_year!
 
-        if training_period.started_on.past?
+        if new_training_period_required?
           create_new_training_period!
         else
           update_training_period_in_place!
@@ -27,6 +27,16 @@ module Teachers
     end
 
   private
+
+    def new_training_period_required?
+      return false if completed_ect_moving_to_reduced_schedule?
+
+      training_period.started_on.past?
+    end
+
+    def completed_ect_moving_to_reduced_schedule?
+      training_period.for_ect? && schedule.reduced_schedule? && training_period.teacher_completed_training?
+    end
 
     def update_training_period_in_place!
       training_period.update!(

--- a/spec/services/api/teachers/change_schedule_spec.rb
+++ b/spec/services/api/teachers/change_schedule_spec.rb
@@ -151,6 +151,16 @@ RSpec.describe API::Teachers::ChangeSchedule, type: :model do
               expect(subject).to have_one_error_per_attribute
               expect(subject).to have_error(:teacher_api_id, "You cannot change this participant's schedule as they have completed their training or induction.")
             end
+
+            context "when schedule is reduced" do
+              let(:schedule_identifier) { "ecf-reduced-april" }
+
+              if trainee_type == :ect
+                it { is_expected.to be_valid }
+              else
+                it { is_expected.to have_error(:schedule_identifier, "Mentors cannot be placed on a reduced schedule. Assign them to a different schedule.") }
+              end
+            end
           end
 
           context "guarded error messages" do

--- a/spec/services/api/teachers/change_schedule_spec.rb
+++ b/spec/services/api/teachers/change_schedule_spec.rb
@@ -158,6 +158,7 @@ RSpec.describe API::Teachers::ChangeSchedule, type: :model do
               if trainee_type == :ect
                 it { is_expected.to be_valid }
               else
+                it { is_expected.to have_error(:teacher_api_id, "You cannot change this participant's schedule as they have completed their training or induction.") }
                 it { is_expected.to have_error(:schedule_identifier, "Mentors cannot be placed on a reduced schedule. Assign them to a different schedule.") }
               end
             end

--- a/spec/services/teachers/change_schedule_spec.rb
+++ b/spec/services/teachers/change_schedule_spec.rb
@@ -116,10 +116,6 @@ RSpec.describe Teachers::ChangeSchedule do
               end
             end
 
-            # NOTE: this case is caught in the API::Teachers::ChangeSchedule but not in this service
-            #       If an ECT who has completed training should not change schedule to anything but
-            #       a reduced schedule - should this be handled here?
-            #
             context "when the new schedule is not a reduced schedule" do
               let(:new_schedule) { FactoryBot.create(:schedule, identifier: "ecf-extended-april", contract_period: new_contract_period) }
 

--- a/spec/services/teachers/change_schedule_spec.rb
+++ b/spec/services/teachers/change_schedule_spec.rb
@@ -89,6 +89,57 @@ RSpec.describe Teachers::ChangeSchedule do
           end
         end
 
+        if trainee_type == :ect
+          context "when the trainee has completed training" do
+            let(:training_period_finished_on) { 5.days.ago.to_date }
+            let!(:induction_period) { FactoryBot.create(:induction_period, :pass, teacher:) }
+
+            before do
+              teacher.update!(trs_induction_completed_date: 5.days.ago)
+            end
+
+            context "when the new schedule is a reduced schedule" do
+              let(:new_schedule) { FactoryBot.create(:schedule, identifier: "ecf-reduced-april", contract_period: new_contract_period) }
+
+              it "does not add a new training period" do
+                expect { service.change_schedule }.not_to change(TrainingPeriod, :count)
+              end
+
+              it "updates the existing training_period with the new schedule" do
+                service.change_schedule
+                expect(training_period.schedule).to eq new_schedule
+              end
+
+              it "doesn't alter the finished_on date of the training_period" do
+                service.change_schedule
+                expect(training_period.finished_on).to eq training_period_finished_on
+              end
+            end
+
+            # NOTE: this case is caught in the API::Teachers::ChangeSchedule but not in this service
+            #       If an ECT who has completed training should not change schedule to anything but
+            #       a reduced schedule - should this be handled here?
+            #
+            context "when the new schedule is not a reduced schedule" do
+              let(:new_schedule) { FactoryBot.create(:schedule, identifier: "ecf-extended-april", contract_period: new_contract_period) }
+
+              it "adds a new training period" do
+                expect { service.change_schedule }.to change(TrainingPeriod, :count).by(1)
+              end
+
+              it "updates the new training_period with the new schedule" do
+                service.change_schedule
+                expect(training_period.siblings.last.schedule).to eq new_schedule
+              end
+
+              it "doesn't alter the finished_on date of the original training_period" do
+                service.change_schedule
+                expect(training_period.finished_on).to eq training_period_finished_on
+              end
+            end
+          end
+        end
+
         context "event recording" do
           it "records a teacher changes schedule training period event" do
             freeze_time do


### PR DESCRIPTION
### Context

Currently, providers cannot change the schedule for an ECT once they have completed training. In some cases, ECTs on a reduced schedule complete before the provider is aware/able to move them to a reduced schedule.

This change modifies the validation to allow a provider to change the schedule for an ECT that has completed their training. This is restricted to only permitting a move to a reduced schedule.

In these instances we would also not want to add a new training period or reopen the last/completed training period, but only modify the last training period's schedule.

**NOTE**: I left a comment in the `Teachers::ChangeSchedule` regarding whether it should include any of the validation around the changing of the schedule for completed ECTs as wasn't sure if there should be something in there too regarding that or whether it was designed to as a one-size-fits-all kind of thing and those validations are left for the API (or UI) services.

### Changes proposed in this pull request

* modify the validation to allow providers to submit a change to a reduced schedule for a completed ECT
* change logic in the `Teachers::ChangeSchedule` service to update the existing rather than add a new training_period in these cases.

### Guidance to review

When checking for a completed ECT, they need to have a completed induction period (i.e. an induction period with an outcome).
