### PR TITLE
Fix mentorship period validation

### DIFF
--- a/app/models/concerns/interval.rb
+++ b/app/models/concerns/interval.rb
@@ -65,6 +65,8 @@ module Interval
       errors.add(:started_on, "Start date cannot overlap another #{name} period")
     elsif siblings.any? { |s| s.range.include?(finished_on) } || finished_on.nil?
       errors.add(:finished_on, "End date cannot overlap another #{name} period")
+    elsif siblings.any? { |s| (s.started_on..s.finished_on).overlap?(started_on..finished_on) }
+      errors.add(:base, "Period cannot overlap another #{name} period")
     end
   end
 

--- a/spec/models/mentorship_period_spec.rb
+++ b/spec/models/mentorship_period_spec.rb
@@ -39,6 +39,7 @@ describe MentorshipPeriod do
     describe "overlapping periods" do
       let(:started_on_message) { "Start date cannot overlap another Mentee period" }
       let(:finished_on_message) { "End date cannot overlap another Mentee period" }
+      let(:overlap_message) { "Period cannot overlap another Mentee period" }
 
       describe "#mentee_distinct_period" do
         PeriodHelpers::PeriodExamples.period_examples.each do |test|
@@ -85,6 +86,10 @@ describe MentorshipPeriod do
                 when "when the new period finishes after the existing one has started"
                   expect(messages).not_to have_key(:started_on)
                   expect(messages[:finished_on]).to include(finished_on_message)
+                when "when the new period envelops the existing one"
+                  expect(messages).not_to have_key(:started_on)
+                  expect(messages).not_to have_key(:finished_on)
+                  expect(messages[:base]).to include(overlap_message)
                 else
                   fail "test case didn't match an expectation"
                 end

--- a/spec/models/mentorship_period_spec.rb
+++ b/spec/models/mentorship_period_spec.rb
@@ -41,7 +41,7 @@ describe MentorshipPeriod do
       let(:finished_on_message) { "End date cannot overlap another Mentee period" }
 
       describe "#mentee_distinct_period" do
-        PeriodHelpers::PeriodExamples.period_examples.each_with_index do |test, index|
+        PeriodHelpers::PeriodExamples.period_examples.each do |test|
           context test.description do
             let(:school) { FactoryBot.create(:school) }
             let(:mentor) do
@@ -75,16 +75,18 @@ describe MentorshipPeriod do
                 expect(messages).not_to have_key(:started_on)
                 expect(messages).not_to have_key(:finished_on)
               else
-                case index
-                when 0
+                case test.description
+                when "when the existing period contains the new one"
                   expect(messages[:started_on]).to include(started_on_message)
                   expect(messages).not_to have_key(:finished_on)
-                when 1
+                when "when the new period starts before the existing one has finished"
                   expect(messages[:started_on]).to include(started_on_message)
                   expect(messages).not_to have_key(:finished_on)
-                when 2
+                when "when the new period finishes after the existing one has started"
                   expect(messages).not_to have_key(:started_on)
                   expect(messages[:finished_on]).to include(finished_on_message)
+                else
+                  fail "test case didn't match an expectation"
                 end
               end
             end

--- a/spec/support/period_helpers.rb
+++ b/spec/support/period_helpers.rb
@@ -31,6 +31,12 @@ module PeriodHelpers
           existing_period_range: 4.months.ago.to_date..2.months.ago.to_date,
           new_period_range: 1.month.ago.to_date..1.week.ago.to_date,
           expected_valid: true
+        ),
+        OpenStruct.new(
+          description: "when the new period envelops the existing one",
+          existing_period_range: 7.months.ago.to_date..2.weeks.ago.to_date,
+          new_period_range: 8.months.ago.to_date..1.week.ago.to_date,
+          expected_valid: false
         )
       ]
     end


### PR DESCRIPTION
### Context

There's a way to create overlapping mentorship periods because the validation misses cases where one period overlaps another on both sides.

## Background

We currently do two checks to make sure a new period doesn't overlap with its siblings.

First we check the new period's start date doesn't fall within a sibling:

```
  ┌─────────────────────┐
  │                     │
  │       Sibling       │
  │                     │
  └─────💥──────────────┴───────┐
        │                      │
        │      NewPeriod       │ ✅
        │                      │
        └──────────────────────┘
```

Then we check the new period's end date doesnt fall within a sibling:

```
            ┌─────────────────────┐
            │                     │
            │       Sibling       │
            │                     │
    ┌───────┴─────────────💥──────┘
    │                      │
✅  │      NewPeriod       │
    │                      │
    └──────────────────────┘
```

This leaves a third possibility. What if the clashing sibling contains neither the start date or finish date?

```
            ┌─────────────────────┐
            │                     │
            │       Sibling       │
            │                     │
    ┌───────┴─────────────────────┴────────┐
    │                                      │
✅  │              NewPeriod               │ ✅
    │                                      │
    └──────────────────────────────────────┘
```

The current checks don't work.

This PR adds a third check which looks for any overlap, and if there is one, adds a error to the object's base.

We encountered one invalid record in production because of this but it was added via a data migration script. I don't think it's possible to do it using the interface.

## Review guidance

The first commit just refactors the specs so they're less brittle. The second one is the important one.

Fixes DFE-Digital/register-ects-project-board#4098
