### PR TITLE
LeadProviderDeliveryPartnerships CRUD

### DIFF
--- a/app/controllers/admin/finance/active_lead_providers/lead_provider_delivery_partnerships_controller.rb
+++ b/app/controllers/admin/finance/active_lead_providers/lead_provider_delivery_partnerships_controller.rb
@@ -1,0 +1,92 @@
+module Admin::Finance::ActiveLeadProviders
+  class LeadProviderDeliveryPartnershipsController < Admin::Finance::BaseController
+    layout "full"
+
+    before_action :set_active_lead_provider
+    before_action :set_lead_provider_delivery_partnership, only: %i[delete destroy]
+    before_action :redirect_unless_editable, only: %i[new create delete destroy]
+
+    def index
+      contract_period = @active_lead_provider.contract_period
+
+      @breadcrumbs = {
+        "Finance" => admin_finance_path,
+        "Contract periods" => admin_contract_periods_path,
+        @active_lead_provider.contract_period_year.to_s => admin_contract_period_path(contract_period),
+        @active_lead_provider.lead_provider_name => admin_contract_period_active_lead_providers_path(contract_period),
+      }
+      @pagy, @lead_provider_delivery_partnerships = pagy(
+        @active_lead_provider.lead_provider_delivery_partnerships.includes(:delivery_partner).order("delivery_partners.name")
+      )
+    end
+
+    def new
+      @lead_provider_delivery_partnership = LeadProviderDeliveryPartnership.new
+      @available_delivery_partners = available_delivery_partners
+    end
+
+    def create
+      ::LeadProviderDeliveryPartnerships::Create.new(
+        author: current_user,
+        active_lead_provider: @active_lead_provider,
+        params: lead_provider_delivery_partnership_params
+      ).call
+
+      redirect_to index_path, notice: "Delivery partner added"
+    rescue ActiveRecord::RecordInvalid => e
+      @lead_provider_delivery_partnership = e.record
+      @available_delivery_partners = available_delivery_partners
+      render :new, status: :unprocessable_content
+    end
+
+    def delete
+      # This is our project specific pattern, so we need a comment to keep sonarcube happy.
+    end
+
+    def destroy
+      ::LeadProviderDeliveryPartnerships::Destroy.new(
+        author: current_user,
+        lead_provider_delivery_partnership: @lead_provider_delivery_partnership
+      ).call
+
+      redirect_to index_path, notice: "Delivery partner removed"
+    rescue ::LeadProviderDeliveryPartnerships::Destroy::DeletionError => e
+      redirect_to index_path, flash: { error: e.message }
+    end
+
+  private
+
+    def set_active_lead_provider
+      @active_lead_provider = ActiveLeadProvider
+        .includes(:contract_period, :lead_provider)
+        .find(params[:active_lead_provider_id])
+    end
+
+    def set_lead_provider_delivery_partnership
+      @lead_provider_delivery_partnership = @active_lead_provider.lead_provider_delivery_partnerships.find(params[:id])
+    end
+
+    def redirect_unless_editable
+      unless @active_lead_provider.editable?
+        redirect_to index_path,
+                    flash: {
+                      error: "Delivery partnerships cannot be changed once the contract period has started"
+                    }
+      end
+    end
+
+    def lead_provider_delivery_partnership_params
+      params.expect(lead_provider_delivery_partnership: [:delivery_partner_id])
+    end
+
+    def available_delivery_partners
+      DeliveryPartner.where.not(id: @active_lead_provider.delivery_partner_ids).order(:name)
+    end
+
+    def index_path
+      admin_contract_period_active_lead_provider_lead_provider_delivery_partnerships_path(
+        @active_lead_provider.contract_period, @active_lead_provider
+      )
+    end
+  end
+end

--- a/app/models/lead_provider_delivery_partnership.rb
+++ b/app/models/lead_provider_delivery_partnership.rb
@@ -4,9 +4,11 @@ class LeadProviderDeliveryPartnership < ApplicationRecord
   belongs_to :active_lead_provider
   belongs_to :delivery_partner
   has_many :school_partnerships
-  has_many :events
+  has_many :events, dependent: :nullify
   has_one :lead_provider, through: :active_lead_provider
   has_one :contract_period, through: :active_lead_provider
+
+  delegate :name, to: :delivery_partner, prefix: true
 
   touch -> { delivery_partner }, on_event: %i[create destroy], timestamp_attribute: :api_updated_at
 

--- a/app/services/delivery_partners/add_lead_provider_pairings.rb
+++ b/app/services/delivery_partners/add_lead_provider_pairings.rb
@@ -39,23 +39,12 @@ module DeliveryPartners
     def add_partnerships(ids_to_add)
       ids_to_add.each do |active_lead_provider_id|
         active_lead_provider = ActiveLeadProvider.find(active_lead_provider_id)
-        new_partnership = LeadProviderDeliveryPartnership.create!(
-          delivery_partner:,
-          active_lead_provider:
-        )
-
-        record_partnership_added_event(active_lead_provider, new_partnership)
+        LeadProviderDeliveryPartnerships::Create.new(
+          author:,
+          active_lead_provider:,
+          params: { delivery_partner_id: delivery_partner.id }
+        ).call
       end
-    end
-
-    def record_partnership_added_event(active_lead_provider, new_partnership)
-      Events::Record.record_lead_provider_delivery_partnership_added_event!(
-        delivery_partner:,
-        lead_provider: active_lead_provider.lead_provider,
-        contract_period:,
-        author:,
-        lead_provider_delivery_partnership: new_partnership
-      )
     end
   end
 end

--- a/app/services/delivery_partners/update_lead_provider_pairings.rb
+++ b/app/services/delivery_partners/update_lead_provider_pairings.rb
@@ -46,12 +46,11 @@ module DeliveryPartners
     def add_partnerships(ids_to_add)
       ids_to_add.each do |active_lead_provider_id|
         active_lead_provider = ActiveLeadProvider.find(active_lead_provider_id)
-        new_partnership = LeadProviderDeliveryPartnership.create!(
-          delivery_partner:,
-          active_lead_provider:
-        )
-
-        record_partnership_added_event(active_lead_provider, new_partnership)
+        LeadProviderDeliveryPartnerships::Create.new(
+          author:,
+          active_lead_provider:,
+          params: { delivery_partner_id: delivery_partner.id }
+        ).call
       end
     end
 
@@ -65,16 +64,6 @@ module DeliveryPartners
         record_partnership_removed_event(active_lead_provider, partnership)
         partnership.destroy!
       end
-    end
-
-    def record_partnership_added_event(active_lead_provider, new_partnership)
-      Events::Record.record_lead_provider_delivery_partnership_added_event!(
-        delivery_partner:,
-        lead_provider: active_lead_provider.lead_provider,
-        contract_period:,
-        author:,
-        lead_provider_delivery_partnership: new_partnership
-      )
     end
 
     def record_partnership_removed_event(active_lead_provider, removed_partnership)

--- a/app/services/lead_provider_delivery_partnerships/create.rb
+++ b/app/services/lead_provider_delivery_partnerships/create.rb
@@ -1,0 +1,27 @@
+module LeadProviderDeliveryPartnerships
+  class Create
+    attr_reader :lead_provider_delivery_partnership, :author
+
+    def initialize(author:, active_lead_provider:, params:)
+      @author = author
+      @lead_provider_delivery_partnership = LeadProviderDeliveryPartnership.new(
+        params.merge(active_lead_provider:)
+      )
+    end
+
+    def call
+      ActiveRecord::Base.transaction do
+        lead_provider_delivery_partnership.save!
+        Events::Record.record_lead_provider_delivery_partnership_added_event!(
+          author:,
+          delivery_partner: lead_provider_delivery_partnership.delivery_partner,
+          lead_provider: lead_provider_delivery_partnership.lead_provider,
+          contract_period: lead_provider_delivery_partnership.contract_period,
+          lead_provider_delivery_partnership:
+        )
+      end
+
+      lead_provider_delivery_partnership
+    end
+  end
+end

--- a/app/services/lead_provider_delivery_partnerships/destroy.rb
+++ b/app/services/lead_provider_delivery_partnerships/destroy.rb
@@ -1,0 +1,33 @@
+module LeadProviderDeliveryPartnerships
+  class Destroy
+    class DeletionError < StandardError; end
+
+    attr_reader :lead_provider_delivery_partnership, :author
+
+    def initialize(author:, lead_provider_delivery_partnership:)
+      @author = author
+      @lead_provider_delivery_partnership = lead_provider_delivery_partnership
+    end
+
+    def call
+      raise DeletionError, "Cannot remove a delivery partner with school partnerships" if lead_provider_delivery_partnership.school_partnerships.any?
+
+      delivery_partner = lead_provider_delivery_partnership.delivery_partner
+      lead_provider = lead_provider_delivery_partnership.lead_provider
+      contract_period = lead_provider_delivery_partnership.contract_period
+
+      ActiveRecord::Base.transaction do
+        Events::Record.record_lead_provider_delivery_partnership_removed_event!(
+          author:,
+          delivery_partner:,
+          lead_provider:,
+          contract_period:,
+          lead_provider_delivery_partnership:
+        )
+        lead_provider_delivery_partnership.destroy!
+      end
+
+      true
+    end
+  end
+end

--- a/app/views/admin/finance/active_lead_providers/index.html.erb
+++ b/app/views/admin/finance/active_lead_providers/index.html.erb
@@ -33,7 +33,7 @@
             <%= govuk_link_to(pluralize(alp.statements.size, "statement"), admin_contract_period_active_lead_provider_statements_path(@contract_period, alp), visually_hidden_suffix: "for #{alp.lead_provider.name}") %>
           <% end %>
           <% row.with_cell do %>
-            <%= govuk_link_to(pluralize(alp.delivery_partners.size, "delivery partner"), admin_delivery_partners_path, visually_hidden_suffix: "for #{alp.lead_provider.name}") %>
+            <%= govuk_link_to(pluralize(alp.delivery_partners.size, "delivery partner"), admin_contract_period_active_lead_provider_lead_provider_delivery_partnerships_path(@contract_period, alp), visually_hidden_suffix: "for #{alp.lead_provider.name}") %>
           <% end %>
           <% if @editable %>
             <% row.with_cell do %>

--- a/app/views/admin/finance/active_lead_providers/lead_provider_delivery_partnerships/delete.html.erb
+++ b/app/views/admin/finance/active_lead_providers/lead_provider_delivery_partnerships/delete.html.erb
@@ -1,0 +1,24 @@
+<% page_data(
+  title: "Remove #{@lead_provider_delivery_partnership.delivery_partner_name} from #{@active_lead_provider.contract_period_year}",
+  caption: @active_lead_provider.lead_provider_name,
+  backlink_href: admin_contract_period_active_lead_provider_lead_provider_delivery_partnerships_path(@active_lead_provider.contract_period, @active_lead_provider)
+) %>
+
+<% if @lead_provider_delivery_partnership.school_partnerships.any? %>
+  <%= govuk_warning_text do %>
+    This delivery partner has school partnerships and cannot be removed.
+  <% end %>
+
+  <%= govuk_button_link_to "Return to delivery partnerships", admin_contract_period_active_lead_provider_lead_provider_delivery_partnerships_path(@active_lead_provider.contract_period, @active_lead_provider), secondary: true %>
+<% else %>
+  <%= govuk_warning_text do %>
+    Are you sure you want to remove <%= @lead_provider_delivery_partnership.delivery_partner_name %>?<br>
+    This action cannot be undone.
+  <% end %>
+
+  <div class="govuk-button-group">
+    <%= govuk_button_to "Remove delivery partner", admin_contract_period_active_lead_provider_lead_provider_delivery_partnership_path(@active_lead_provider.contract_period, @active_lead_provider, @lead_provider_delivery_partnership), method: :delete, warning: true %>
+
+    <%= govuk_button_link_to "Cancel", admin_contract_period_active_lead_provider_lead_provider_delivery_partnerships_path(@active_lead_provider.contract_period, @active_lead_provider), secondary: true %>
+  </div>
+<% end %>

--- a/app/views/admin/finance/active_lead_providers/lead_provider_delivery_partnerships/index.html.erb
+++ b/app/views/admin/finance/active_lead_providers/lead_provider_delivery_partnerships/index.html.erb
@@ -1,0 +1,21 @@
+<% page_data(title: "#{@active_lead_provider.lead_provider_name} delivery partnerships for #{@active_lead_provider.contract_period_year}", breadcrumbs: @breadcrumbs) %>
+
+<% if @lead_provider_delivery_partnerships.none? %>
+  <p class="govuk-body">No delivery partners found</p>
+<% else %>
+  <%=
+    govuk_table(
+      head: ["Delivery partner", ""],
+      rows: @lead_provider_delivery_partnerships.map { |lpdp|
+        [
+          govuk_link_to(lpdp.delivery_partner_name, admin_delivery_partner_path(lpdp.delivery_partner)),
+          @active_lead_provider.editable? ? govuk_button_link_to("Remove", delete_admin_contract_period_active_lead_provider_lead_provider_delivery_partnership_path(@active_lead_provider.contract_period, @active_lead_provider, lpdp), secondary: true, visually_hidden_suffix: lpdp.delivery_partner_name, class: "govuk-!-margin-bottom-0") : "",
+        ]
+      }
+    )
+  %>
+<% end %>
+
+<%= render Shared::PaginationSummaryComponent.new(pagy: @pagy, record_name: "delivery partners") %>
+
+<%= govuk_button_link_to("Add delivery partner", new_admin_contract_period_active_lead_provider_lead_provider_delivery_partnership_path(@active_lead_provider.contract_period, @active_lead_provider), disabled: !@active_lead_provider.editable?) %>

--- a/app/views/admin/finance/active_lead_providers/lead_provider_delivery_partnerships/new.html.erb
+++ b/app/views/admin/finance/active_lead_providers/lead_provider_delivery_partnerships/new.html.erb
@@ -1,0 +1,25 @@
+<%
+  page_data(
+    title: "Add delivery partner to #{@active_lead_provider.lead_provider_name} for #{@active_lead_provider.contract_period_year}",
+    error: @lead_provider_delivery_partnership.errors.present?,
+    backlink_href: admin_contract_period_active_lead_provider_lead_provider_delivery_partnerships_path(@active_lead_provider.contract_period, @active_lead_provider)
+  )
+%>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @lead_provider_delivery_partnership,
+                   url: admin_contract_period_active_lead_provider_lead_provider_delivery_partnerships_path(@active_lead_provider.contract_period, @active_lead_provider),
+                   method: :post do |f| %>
+      <%= content_for(:error_summary) { f.govuk_error_summary } %>
+      <%= f.govuk_collection_select :delivery_partner_id,
+                                    @available_delivery_partners,
+                                    :id,
+                                    :name,
+                                    label: { text: "Delivery partner" },
+                                    options: { include_blank: true },
+                                    class: "autocomplete" %>
+      <%= f.govuk_submit "Save" %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -118,6 +118,9 @@ namespace :admin do
                 member { get :delete }
               end
               resources :contracts, only: %i[index], controller: "active_lead_providers/contracts"
+              resources :lead_provider_delivery_partnerships, only: %i[index new create destroy], controller: "active_lead_providers/lead_provider_delivery_partnerships" do
+                member { get :delete }
+              end
             end
           end
         end

--- a/spec/models/lead_provider_delivery_partnership_spec.rb
+++ b/spec/models/lead_provider_delivery_partnership_spec.rb
@@ -3,7 +3,7 @@ describe LeadProviderDeliveryPartnership do
     it { is_expected.to belong_to(:active_lead_provider) }
     it { is_expected.to belong_to(:delivery_partner) }
     it { is_expected.to have_many(:school_partnerships) }
-    it { is_expected.to have_many(:events) }
+    it { is_expected.to have_many(:events).dependent(:nullify) }
     it { is_expected.to have_one(:lead_provider).through(:active_lead_provider) }
     it { is_expected.to have_one(:contract_period).through(:active_lead_provider) }
   end

--- a/spec/requests/admin/finance/active_lead_providers/lead_provider_delivery_partnerships_spec.rb
+++ b/spec/requests/admin/finance/active_lead_providers/lead_provider_delivery_partnerships_spec.rb
@@ -1,0 +1,209 @@
+RSpec.describe "Admin finance active lead provider lead provider delivery partnerships", :enable_finance_contract_periods, type: :request do
+  let(:contract_period) { FactoryBot.create(:contract_period, :next) }
+  let(:lead_provider) { FactoryBot.create(:lead_provider) }
+  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, contract_period:, lead_provider:) }
+  let(:delivery_partner) { FactoryBot.create(:delivery_partner) }
+  let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner:) }
+
+  let(:index_path) { admin_contract_period_active_lead_provider_lead_provider_delivery_partnerships_path(contract_period, active_lead_provider) }
+  let(:new_path) { new_admin_contract_period_active_lead_provider_lead_provider_delivery_partnership_path(contract_period, active_lead_provider) }
+  let(:delete_path) { delete_admin_contract_period_active_lead_provider_lead_provider_delivery_partnership_path(contract_period, active_lead_provider, lead_provider_delivery_partnership) }
+  let(:destroy_path) { admin_contract_period_active_lead_provider_lead_provider_delivery_partnership_path(contract_period, active_lead_provider, lead_provider_delivery_partnership) }
+
+  describe "GET .../lead_provider_delivery_partnerships" do
+    let!(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner:) }
+
+    it "redirects to sign in path when not signed in" do
+      get index_path
+      expect(response).to redirect_to(sign_in_path)
+    end
+
+    context "with an authenticated non-DfE user" do
+      include_context "sign in as non-DfE user"
+
+      it "requires authorisation" do
+        get index_path
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context "when signed in as a finance DfE user" do
+      include_context "sign in as finance DfE user"
+
+      it "renders the delivery partnerships index page" do
+        get index_path
+        expect(response).to have_http_status(:ok)
+      end
+
+      context "when the contract period has started" do
+        let(:contract_period) { FactoryBot.create(:contract_period, :current) }
+
+        it "renders the delivery partnerships index page" do
+          get index_path
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+  end
+
+  describe "GET .../lead_provider_delivery_partnerships/new" do
+    it "redirects to sign in path when not signed in" do
+      get new_path
+      expect(response).to redirect_to(sign_in_path)
+    end
+
+    context "when signed in as a finance DfE user" do
+      include_context "sign in as finance DfE user"
+
+      it "renders the new form" do
+        get new_path
+        expect(response).to have_http_status(:ok)
+      end
+
+      context "when the contract period has started" do
+        let(:contract_period) { FactoryBot.create(:contract_period, :current) }
+
+        it "blocks the new form, redirecting to the index" do
+          get new_path
+          expect(response).to redirect_to(index_path)
+        end
+      end
+    end
+
+    context "when signed in as a non-finance DfE user" do
+      include_context "sign in as DfE user"
+
+      it "requires authorisation" do
+        get new_path
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "POST .../lead_provider_delivery_partnerships" do
+    context "when signed in as a finance DfE user" do
+      include_context "sign in as finance DfE user"
+
+      it "creates a delivery partnership and redirects to the index" do
+        expect {
+          post index_path, params: { lead_provider_delivery_partnership: { delivery_partner_id: delivery_partner.id } }
+        }.to change(LeadProviderDeliveryPartnership, :count).by(1)
+
+        expect(response).to redirect_to(index_path)
+      end
+
+      context "when the params are invalid" do
+        it "re-renders with an error status" do
+          post index_path, params: { lead_provider_delivery_partnership: { delivery_partner_id: nil } }
+
+          expect(response).to have_http_status(:unprocessable_content)
+        end
+      end
+
+      context "when the contract period has started" do
+        let(:contract_period) { FactoryBot.create(:contract_period, :current) }
+
+        it "blocks the create, redirecting to the index" do
+          expect {
+            post index_path, params: { lead_provider_delivery_partnership: { delivery_partner_id: delivery_partner.id } }
+          }.not_to change(LeadProviderDeliveryPartnership, :count)
+          expect(response).to redirect_to(index_path)
+        end
+      end
+    end
+
+    context "when signed in as a non-finance DfE user" do
+      include_context "sign in as DfE user"
+
+      it "requires authorisation" do
+        post index_path, params: { lead_provider_delivery_partnership: { delivery_partner_id: delivery_partner.id } }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "GET .../lead_provider_delivery_partnerships/:id/delete" do
+    context "when signed in as a finance DfE user" do
+      include_context "sign in as finance DfE user"
+
+      it "renders the confirmation page" do
+        get delete_path
+        expect(response).to have_http_status(:ok)
+      end
+
+      context "when the delivery partner has school partnerships" do
+        before do
+          school = FactoryBot.create(:school)
+          FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:, school:)
+        end
+
+        it "renders the confirmation page" do
+          get delete_path
+          expect(response).to have_http_status(:ok)
+        end
+      end
+
+      context "when the contract period has started" do
+        let(:contract_period) { FactoryBot.create(:contract_period, :current) }
+
+        it "blocks the delete page, redirecting to the index" do
+          get delete_path
+          expect(response).to redirect_to(index_path)
+        end
+      end
+    end
+  end
+
+  describe "DELETE .../lead_provider_delivery_partnerships/:id" do
+    context "when signed in as a finance DfE user" do
+      include_context "sign in as finance DfE user"
+
+      it "destroys the delivery partnership and redirects to the index" do
+        lead_provider_delivery_partnership
+
+        expect {
+          delete destroy_path
+        }.to change(LeadProviderDeliveryPartnership, :count).by(-1)
+
+        expect(response).to redirect_to(index_path)
+      end
+
+      context "when the delivery partner has school partnerships" do
+        before do
+          school = FactoryBot.create(:school)
+          FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:, school:)
+        end
+
+        it "does not destroy and redirects with an error" do
+          expect {
+            delete destroy_path
+          }.not_to change(LeadProviderDeliveryPartnership, :count)
+
+          expect(response).to redirect_to(index_path)
+        end
+      end
+
+      context "when the contract period has started" do
+        let(:contract_period) { FactoryBot.create(:contract_period, :current) }
+
+        it "blocks the destroy, redirecting to the index" do
+          lead_provider_delivery_partnership
+
+          expect {
+            delete destroy_path
+          }.not_to change(LeadProviderDeliveryPartnership, :count)
+          expect(response).to redirect_to(index_path)
+        end
+      end
+    end
+
+    context "when signed in as a non-finance DfE user" do
+      include_context "sign in as DfE user"
+
+      it "requires authorisation" do
+        delete destroy_path
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/services/delivery_partners/add_lead_provider_pairings_spec.rb
+++ b/spec/services/delivery_partners/add_lead_provider_pairings_spec.rb
@@ -94,7 +94,9 @@ RSpec.describe DeliveryPartners::AddLeadProviderPairings do
       let(:new_active_lead_provider_ids) { [active_lead_provider_1.id] }
 
       it "returns false and logs error when ActiveRecord::RecordInvalid is raised" do
-        allow(LeadProviderDeliveryPartnership).to receive(:create!).and_raise(ActiveRecord::RecordInvalid.new(LeadProviderDeliveryPartnership.new))
+        create_service = instance_double(LeadProviderDeliveryPartnerships::Create)
+        allow(LeadProviderDeliveryPartnerships::Create).to receive(:new).and_return(create_service)
+        allow(create_service).to receive(:call).and_raise(ActiveRecord::RecordInvalid.new(LeadProviderDeliveryPartnership.new))
         expect(Rails.logger).to receive(:error).with(/Failed to add lead provider pairings/)
 
         result = service.add!

--- a/spec/services/delivery_partners/update_lead_provider_pairings_spec.rb
+++ b/spec/services/delivery_partners/update_lead_provider_pairings_spec.rb
@@ -192,7 +192,9 @@ RSpec.describe DeliveryPartners::UpdateLeadProviderPairings do
       let(:new_active_lead_provider_ids) { [active_lead_provider_1.id] }
 
       before do
-        allow(LeadProviderDeliveryPartnership).to receive(:create!).and_raise(ActiveRecord::RecordInvalid.new(LeadProviderDeliveryPartnership.new))
+        create_service = instance_double(LeadProviderDeliveryPartnerships::Create)
+        allow(LeadProviderDeliveryPartnerships::Create).to receive(:new).and_return(create_service)
+        allow(create_service).to receive(:call).and_raise(ActiveRecord::RecordInvalid.new(LeadProviderDeliveryPartnership.new))
       end
 
       it "returns false on error" do

--- a/spec/services/lead_provider_delivery_partnerships/create_spec.rb
+++ b/spec/services/lead_provider_delivery_partnerships/create_spec.rb
@@ -1,0 +1,39 @@
+describe LeadProviderDeliveryPartnerships::Create do
+  subject(:service) { described_class.new(author:, active_lead_provider:, params:) }
+
+  let(:user) { FactoryBot.create(:user, :admin) }
+  let(:author) { Sessions::Users::DfEPersona.new(email: user.email) }
+  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
+  let(:delivery_partner) { FactoryBot.create(:delivery_partner) }
+  let(:params) { { delivery_partner_id: delivery_partner.id } }
+
+  before do
+    allow(Events::Record).to receive(:record_lead_provider_delivery_partnership_added_event!)
+  end
+
+  context "with valid params" do
+    it "creates the lead provider delivery partnership and records an added event" do
+      result = nil
+      expect { result = service.call }.to change(LeadProviderDeliveryPartnership, :count).by(1)
+
+      expect(result).to be_persisted
+      expect(result).to have_attributes(active_lead_provider:, delivery_partner:)
+      expect(Events::Record).to have_received(:record_lead_provider_delivery_partnership_added_event!).with(
+        author:,
+        delivery_partner:,
+        lead_provider: active_lead_provider.lead_provider,
+        contract_period: active_lead_provider.contract_period,
+        lead_provider_delivery_partnership: result
+      )
+    end
+  end
+
+  context "with invalid params" do
+    let(:params) { { delivery_partner_id: nil } }
+
+    it "raises ActiveRecord::RecordInvalid and does not record an event" do
+      expect { service.call }.to raise_error(ActiveRecord::RecordInvalid)
+      expect(Events::Record).not_to have_received(:record_lead_provider_delivery_partnership_added_event!)
+    end
+  end
+end

--- a/spec/services/lead_provider_delivery_partnerships/destroy_spec.rb
+++ b/spec/services/lead_provider_delivery_partnerships/destroy_spec.rb
@@ -1,0 +1,41 @@
+describe LeadProviderDeliveryPartnerships::Destroy do
+  subject(:service) { described_class.new(author:, lead_provider_delivery_partnership:) }
+
+  let(:user) { FactoryBot.create(:user, :admin) }
+  let(:author) { Sessions::Users::DfEPersona.new(email: user.email) }
+  let!(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership) }
+
+  before do
+    allow(Events::Record).to receive(:record_lead_provider_delivery_partnership_removed_event!)
+  end
+
+  context "when the partnership has no school partnerships" do
+    it "destroys the partnership and records a removed event" do
+      result = nil
+      expect { result = service.call }.to change(LeadProviderDeliveryPartnership, :count).by(-1)
+
+      expect(result).to be(true)
+      expect(Events::Record).to have_received(:record_lead_provider_delivery_partnership_removed_event!).with(
+        author:,
+        delivery_partner: lead_provider_delivery_partnership.delivery_partner,
+        lead_provider: lead_provider_delivery_partnership.lead_provider,
+        contract_period: lead_provider_delivery_partnership.contract_period,
+        lead_provider_delivery_partnership:
+      )
+    end
+  end
+
+  context "when the partnership has school partnerships" do
+    before { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:) }
+
+    it "raises DeletionError and does not destroy the partnership or record an event" do
+      expect { service.call }.to raise_error(
+        LeadProviderDeliveryPartnerships::Destroy::DeletionError,
+        "Cannot remove a delivery partner with school partnerships"
+      )
+
+      expect(LeadProviderDeliveryPartnership.exists?(lead_provider_delivery_partnership.id)).to be(true)
+      expect(Events::Record).not_to have_received(:record_lead_provider_delivery_partnership_removed_event!)
+    end
+  end
+end

--- a/spec/views/admin/finance/active_lead_providers/index.html.erb_spec.rb
+++ b/spec/views/admin/finance/active_lead_providers/index.html.erb_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "admin/finance/active_lead_providers/index.html.erb" do
       expect(rendered).to have_css("tr", text: alp.lead_provider.name)
       expect(rendered).to have_link("0 contracts", href: admin_contract_period_active_lead_provider_contracts_path(contract_period, alp))
       expect(rendered).to have_link("0 statements", href: admin_contract_period_active_lead_provider_statements_path(contract_period, alp))
-      expect(rendered).to have_link("0 delivery partners", href: admin_delivery_partners_path)
+      expect(rendered).to have_link("0 delivery partners", href: admin_contract_period_active_lead_provider_lead_provider_delivery_partnerships_path(contract_period, alp))
     end
 
     expect(rendered).to have_css(".govuk-button--secondary", count: 3, text: "Remove")
@@ -67,7 +67,7 @@ RSpec.describe "admin/finance/active_lead_providers/index.html.erb" do
         name = alp.lead_provider.name
         expect(rendered).to have_link("0 contracts for #{name}", href: admin_contract_period_active_lead_provider_contracts_path(contract_period, alp))
         expect(rendered).to have_link("0 statements for #{name}", href: admin_contract_period_active_lead_provider_statements_path(contract_period, alp))
-        expect(rendered).to have_link("0 delivery partners for #{name}", href: admin_delivery_partners_path)
+        expect(rendered).to have_link("0 delivery partners for #{name}", href: admin_contract_period_active_lead_provider_lead_provider_delivery_partnerships_path(contract_period, alp))
       end
     end
   end

--- a/spec/views/admin/finance/active_lead_providers/lead_provider_delivery_partnerships/delete.html.erb_spec.rb
+++ b/spec/views/admin/finance/active_lead_providers/lead_provider_delivery_partnerships/delete.html.erb_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe "admin/finance/active_lead_providers/lead_provider_delivery_partnerships/delete.html.erb" do
+  let(:contract_period) do
+    FactoryBot.create(:contract_period, year: 2099, started_on: Date.new(2099, 6, 1), finished_on: Date.new(2100, 5, 31))
+  end
+  let(:lead_provider) { FactoryBot.create(:lead_provider) }
+  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, contract_period:, lead_provider:) }
+  let(:delivery_partner) { FactoryBot.create(:delivery_partner) }
+  let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner:) }
+
+  let(:index_path) { admin_contract_period_active_lead_provider_lead_provider_delivery_partnerships_path(contract_period, active_lead_provider) }
+  let(:destroy_path) { admin_contract_period_active_lead_provider_lead_provider_delivery_partnership_path(contract_period, active_lead_provider, lead_provider_delivery_partnership) }
+
+  before do
+    assign(:active_lead_provider, active_lead_provider)
+    assign(:lead_provider_delivery_partnership, lead_provider_delivery_partnership)
+  end
+
+  it "renders the delete confirmation with a back link, warning and remove button" do
+    render
+
+    expect(view.content_for(:page_title)).to eq("Remove #{delivery_partner.name} from 2099")
+    expect(view.content_for(:backlink_or_breadcrumb)).to have_link("Back", href: index_path)
+
+    expect(rendered).to have_content("Are you sure you want to remove #{delivery_partner.name}?")
+    expect(rendered).to have_selector("form[action='#{destroy_path}']")
+    expect(rendered).to have_selector("input[name='_method'][value='delete']", visible: :all)
+    expect(rendered).to have_button("Remove delivery partner")
+    expect(rendered).to have_link("Cancel", href: index_path)
+  end
+
+  context "when the delivery partner has school partnerships" do
+    before { allow(lead_provider_delivery_partnership).to receive(:school_partnerships).and_return(double(any?: true)) }
+
+    it "explains it cannot be removed and hides the remove button" do
+      render
+
+      expect(rendered).to have_content("school partnerships and cannot be removed")
+      expect(rendered).not_to have_button("Remove delivery partner")
+      expect(rendered).to have_link("Return to delivery partnerships", href: index_path)
+    end
+  end
+end

--- a/spec/views/admin/finance/active_lead_providers/lead_provider_delivery_partnerships/index.html.erb_spec.rb
+++ b/spec/views/admin/finance/active_lead_providers/lead_provider_delivery_partnerships/index.html.erb_spec.rb
@@ -1,0 +1,62 @@
+RSpec.describe "admin/finance/active_lead_providers/lead_provider_delivery_partnerships/index.html.erb" do
+  let(:contract_period) do
+    FactoryBot.create(:contract_period, year: 2099, started_on: Date.new(2099, 6, 1), finished_on: Date.new(2100, 5, 31))
+  end
+  let(:lead_provider) { FactoryBot.create(:lead_provider) }
+  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, contract_period:, lead_provider:) }
+  let(:delivery_partner) { FactoryBot.create(:delivery_partner) }
+  let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner:) }
+  let(:partnerships) { [lead_provider_delivery_partnership] }
+  let(:pagy) { Pagy.new(count: partnerships.count, limit: 10, page: 1) }
+
+  before do
+    assign(:active_lead_provider, active_lead_provider)
+    assign(:lead_provider_delivery_partnerships, partnerships)
+    assign(:pagy, pagy)
+    assign(:breadcrumbs, {
+      "Finance" => admin_finance_path,
+      "Contract periods" => admin_contract_periods_path,
+      contract_period.year.to_s => admin_contract_period_path(contract_period),
+      lead_provider.name => admin_contract_period_active_lead_providers_path(contract_period),
+    })
+  end
+
+  it "renders the title, breadcrumbs, delivery partners table, remove buttons, and add button" do
+    render
+
+    expect(view.content_for(:page_title)).to eq("#{lead_provider.name} delivery partnerships for 2099")
+    expect(view.content_for(:backlink_or_breadcrumb)).to have_link("Finance", href: admin_finance_path)
+    expect(view.content_for(:backlink_or_breadcrumb)).to have_link("Contract periods", href: admin_contract_periods_path)
+    expect(view.content_for(:backlink_or_breadcrumb)).to have_link(contract_period.year.to_s, href: admin_contract_period_path(contract_period))
+    expect(view.content_for(:backlink_or_breadcrumb)).to have_link(lead_provider.name, href: admin_contract_period_active_lead_providers_path(contract_period))
+
+    expect(rendered).to have_link(delivery_partner.name, href: admin_delivery_partner_path(delivery_partner))
+    expect(rendered).to have_link("Remove", href: delete_admin_contract_period_active_lead_provider_lead_provider_delivery_partnership_path(contract_period, active_lead_provider, lead_provider_delivery_partnership))
+    expect(rendered).to have_link("Add delivery partner", href: new_admin_contract_period_active_lead_provider_lead_provider_delivery_partnership_path(contract_period, active_lead_provider))
+    expect(rendered).not_to have_selector("a[aria-disabled='true']", text: "Add delivery partner")
+  end
+
+  context "when the contract period has already started" do
+    let(:contract_period) do
+      FactoryBot.create(:contract_period, year: 2020, started_on: Date.new(2020, 6, 1), finished_on: Date.new(2021, 5, 31))
+    end
+
+    it "hides remove buttons and renders the add button in a disabled state" do
+      render
+
+      expect(rendered).not_to have_link("Remove")
+      expect(rendered).to have_selector("a[disabled], a[aria-disabled='true']", text: "Add delivery partner")
+    end
+  end
+
+  context "when there are no delivery partners" do
+    let(:partnerships) { [] }
+
+    it "displays a message informing me there are no delivery partners" do
+      render
+
+      expect(rendered).to have_content("No delivery partners found")
+      expect(rendered).not_to have_css(".govuk-table")
+    end
+  end
+end

--- a/spec/views/admin/finance/active_lead_providers/lead_provider_delivery_partnerships/new.html.erb_spec.rb
+++ b/spec/views/admin/finance/active_lead_providers/lead_provider_delivery_partnerships/new.html.erb_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe "admin/finance/active_lead_providers/lead_provider_delivery_partnerships/new.html.erb" do
+  let(:contract_period) do
+    FactoryBot.create(:contract_period, year: 2099, started_on: Date.new(2099, 6, 1), finished_on: Date.new(2100, 5, 31))
+  end
+  let(:lead_provider) { FactoryBot.create(:lead_provider) }
+  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, contract_period:, lead_provider:) }
+  let(:delivery_partner) { FactoryBot.create(:delivery_partner) }
+  let(:lead_provider_delivery_partnership) { LeadProviderDeliveryPartnership.new }
+
+  let(:index_path) { admin_contract_period_active_lead_provider_lead_provider_delivery_partnerships_path(contract_period, active_lead_provider) }
+
+  before do
+    assign(:active_lead_provider, active_lead_provider)
+    assign(:lead_provider_delivery_partnership, lead_provider_delivery_partnership)
+    assign(:available_delivery_partners, [delivery_partner])
+  end
+
+  it "renders the new form with a delivery partner select and a back link" do
+    render
+
+    expect(view.content_for(:page_title)).to eq("Add delivery partner to #{lead_provider.name} for 2099")
+    expect(view.content_for(:backlink_or_breadcrumb)).to have_link("Back", href: index_path)
+
+    expect(rendered).to have_selector("form[action='#{index_path}']")
+    expect(rendered).to have_css("select[name='lead_provider_delivery_partnership[delivery_partner_id]'] option[value='#{delivery_partner.id}']", text: delivery_partner.name)
+    expect(rendered).to have_button("Save")
+  end
+
+  context "when the form is invalid" do
+    let(:lead_provider_delivery_partnership) { LeadProviderDeliveryPartnership.new.tap(&:valid?) }
+
+    it "prefixes the page title with 'Error:' and renders an error summary" do
+      render
+
+      expect(view.content_for(:page_title)).to start_with("Error:")
+      expect(view.content_for(:error_summary)).to have_css(".govuk-error-summary")
+    end
+  end
+end


### PR DESCRIPTION
### Context

Resolves https://github.com.mcas.ms/DFE-Digital/register-ects-project-board/issues/4045

### Changes proposed in this pull request

CRUD screens for an AcitveLeadProvider's LeadDeliveryPartnership:

#### From the existing ActiveLeadProviders screen, we can now link to LeadProviderDeliveryPartnerships...

<img width="1064" height="825" alt="Screenshot 2026-06-16 at 11 49 24" src="https://github.com/user-attachments/assets/b83d4003-3fee-4e25-9a8f-077e89e0415f" />

#### Where we see them (enabled if the ContractPeriod has not year started)...

<img width="1075" height="901" alt="Screenshot 2026-06-16 at 11 49 32" src="https://github.com/user-attachments/assets/4fa52592-b73e-4fb9-b0f6-6f4e5fe85a26" />

#### ..and disabled if it has

<img width="1042" height="822" alt="Screenshot 2026-06-16 at 11 53 37" src="https://github.com/user-attachments/assets/b552eb5e-c64d-4136-8793-efa7e19fdb43" />

#### When we want to add a DeliveryPartner we see the add form...

<img width="1111" height="745" alt="Screenshot 2026-06-16 at 11 50 11" src="https://github.com/user-attachments/assets/5ff6c99f-90ae-4c51-8169-6547fc8dff68" />


#### With a typeahead...
<img width="1205" height="964" alt="Screenshot 2026-06-16 at 11 50 19" src="https://github.com/user-attachments/assets/deddd2b9-be54-42dd-a914-a449073ca180" />


#### When we want to remove a delivery partner we see the confirmation screen...
<img width="1086" height="688" alt="Screenshot 2026-06-16 at 11 49 43" src="https://github.com/user-attachments/assets/e9ef7e14-689c-4f69-af5f-e289013b4d5e" />

#### And can click through to see the DeliveryPartner itself (the existing screen...)
<img width="1232" height="1043" alt="Screenshot 2026-06-16 at 11 50 34" src="https://github.com/user-attachments/assets/9da65893-fa0e-4d83-8182-33b293a247db" />


### Guidance to review

* Standard pattern for our Rails controller. 
* No Edit/Update required. The LeadProviderDeliveryPartnership table is just a many-to-many mapping table from an ActiveLeadProvider to a DeliveryPartner.