### PR TITLE
Drop legacy school_urn from school_funding_eligibilities

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -144,7 +144,6 @@ shared:
     - opted_out_of_reminder_emails_until
   :school_funding_eligibilities:
     - id
-    - school_urn
     - gias_school_urn
     - contract_period_year
     - pupil_premium_uplift

--- a/db/migrate/20260615120000_remove_school_urn_from_school_funding_eligibilities.rb
+++ b/db/migrate/20260615120000_remove_school_urn_from_school_funding_eligibilities.rb
@@ -8,17 +8,6 @@ class RemoveSchoolURNFromSchoolFundingEligibilities < ActiveRecord::Migration[8.
   end
 
   def down
-    add_column :school_funding_eligibilities, :school_urn, :bigint
-    add_index :school_funding_eligibilities, :school_urn
-
-    execute(<<~SQL)
-      UPDATE school_funding_eligibilities
-      SET school_urn = gias_school_urn
-      WHERE school_urn IS NULL
-    SQL
-
-    add_foreign_key :school_funding_eligibilities, :schools,
-                    column: :school_urn,
-                    primary_key: :urn
+    raise ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/migrate/20260615120000_remove_school_urn_from_school_funding_eligibilities.rb
+++ b/db/migrate/20260615120000_remove_school_urn_from_school_funding_eligibilities.rb
@@ -1,0 +1,24 @@
+class RemoveSchoolURNFromSchoolFundingEligibilities < ActiveRecord::Migration[8.0]
+  def up
+    remove_foreign_key :school_funding_eligibilities, :schools,
+                       column: :school_urn,
+                       primary_key: :urn
+
+    remove_column :school_funding_eligibilities, :school_urn
+  end
+
+  def down
+    add_column :school_funding_eligibilities, :school_urn, :bigint
+    add_index :school_funding_eligibilities, :school_urn
+
+    execute(<<~SQL)
+      UPDATE school_funding_eligibilities
+      SET school_urn = gias_school_urn
+      WHERE school_urn IS NULL
+    SQL
+
+    add_foreign_key :school_funding_eligibilities, :schools,
+                    column: :school_urn,
+                    primary_key: :urn
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_12_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_15_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -626,12 +626,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_12_120000) do
     t.datetime "created_at", null: false
     t.bigint "gias_school_urn", null: false
     t.boolean "pupil_premium_uplift", default: false, null: false
-    t.bigint "school_urn"
     t.boolean "sparsity_uplift", default: false, null: false
     t.datetime "updated_at", null: false
     t.index ["contract_period_year"], name: "index_school_funding_eligibilities_on_contract_period_year"
     t.index ["gias_school_urn"], name: "index_school_funding_eligibilities_on_gias_school_urn"
-    t.index ["school_urn"], name: "index_school_funding_eligibilities_on_school_urn"
   end
 
   create_table "school_partnerships", force: :cascade do |t|
@@ -998,7 +996,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_12_120000) do
   add_foreign_key "schedules", "contract_periods", column: "contract_period_year", primary_key: "year"
   add_foreign_key "school_funding_eligibilities", "contract_periods", column: "contract_period_year", primary_key: "year"
   add_foreign_key "school_funding_eligibilities", "gias_schools", column: "gias_school_urn", primary_key: "urn"
-  add_foreign_key "school_funding_eligibilities", "schools", column: "school_urn", primary_key: "urn"
   add_foreign_key "school_partnerships", "schools"
   add_foreign_key "schools", "appropriate_body_periods", column: "last_chosen_appropriate_body_id"
   add_foreign_key "schools", "contract_periods", column: "induction_tutor_last_nominated_in", primary_key: "year"

--- a/documentation/domain-model.md
+++ b/documentation/domain-model.md
@@ -110,12 +110,11 @@ erDiagram
     integer id
     integer contract_period_year
     datetime created_at
+    integer gias_school_urn
     boolean pupil_premium_uplift
-    integer school_urn
     boolean sparsity_uplift
     datetime updated_at
   }
-  SchoolFundingEligibility }o--|| School : belongs_to
   SchoolFundingEligibility }o--|| ContractPeriod : belongs_to
   School {
     integer id


### PR DESCRIPTION
Part 2 following #3068: contract stage of pointing school_funding_eligibilities at gias_schools. Deploy after the expand migration is fully deployed.
