### PR TITLE
[3404] Add check answers step to contract period change wizard (Slice 2)

### DIFF
--- a/app/controllers/admin/teachers/training_periods/change_contract_period_wizard_controller.rb
+++ b/app/controllers/admin/teachers/training_periods/change_contract_period_wizard_controller.rb
@@ -23,7 +23,7 @@ module Admin
           if @wizard.valid_step?
             @wizard.current_step.save!
 
-            if current_step == :select_partnership
+            if current_step == :check_answers
               render current_step
             else
               redirect_to @wizard.next_step_path

--- a/app/views/admin/teachers/training_periods/change_contract_period_wizard/check_answers.html.erb
+++ b/app/views/admin/teachers/training_periods/change_contract_period_wizard/check_answers.html.erb
@@ -1,0 +1,40 @@
+<% page_data(
+  title: "Confirm contract period change for #{@wizard.teacher_name}",
+  error: @wizard.current_step.errors.present?,
+  backlink_href: @wizard.previous_step_path
+) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
+      <%= content_for(:error_summary) { f.govuk_error_summary } %>
+
+      <%= govuk_summary_list do |list| %>
+        <%= list.with_row do |row| %>
+          <%= row.with_key { "Existing contract period" } %>
+          <%= row.with_value { @wizard.existing_contract_period.year.to_s } %>
+        <% end %>
+
+        <%= list.with_row do |row| %>
+          <%= row.with_key { "New contract period" } %>
+          <%= row.with_value { @wizard.selected_contract_period.year.to_s } %>
+        <% end %>
+
+        <%= list.with_row do |row| %>
+          <%= row.with_key { "Partnership" } %>
+          <%= row.with_value { @wizard.selected_partnership_name } %>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_submit "Confirm" %>
+    <% end %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to(
+            "Cancel and go back to #{@wizard.teacher_name}",
+            admin_teacher_path(@teacher),
+            no_visited_state: true
+          ) %>
+    </p>
+  </div>
+</div>

--- a/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/check_answers_step.rb
+++ b/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/check_answers_step.rb
@@ -1,0 +1,15 @@
+module Admin
+  module Teachers
+    module TrainingPeriods
+      module ChangeContractPeriodWizard
+        class CheckAnswersStep < Step
+          self.expected_store_keys = %i[contract_period_year school_partnership_id]
+
+          def previous_step = :select_partnership
+
+          def save! = true
+        end
+      end
+    end
+  end
+end

--- a/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/select_partnership_step.rb
+++ b/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/select_partnership_step.rb
@@ -11,6 +11,7 @@ module Admin
           def self.permitted_params = %i[school_partnership_id]
 
           def previous_step = :select_contract_period
+          def next_step = :check_answers
 
         private
 

--- a/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard.rb
+++ b/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard.rb
@@ -12,7 +12,8 @@ module Admin
           steps do
             [{
               select_contract_period: SelectContractPeriodStep,
-              select_partnership: SelectPartnershipStep
+              select_partnership: SelectPartnershipStep,
+              check_answers: CheckAnswersStep
             }]
           end
 
@@ -23,6 +24,9 @@ module Admin
             return steps unless selected_contract_period_allowed?
 
             steps << :select_partnership
+            return steps unless selected_school_partnership_allowed?
+
+            steps << :check_answers
           end
 
           def allowed_step_path
@@ -60,6 +64,12 @@ module Admin
             @selected_contract_period ||= contract_periods.find_by(year: store.contract_period_year)
           end
 
+          def selected_school_partnership
+            return if store.school_partnership_id.blank?
+
+            @selected_school_partnership ||= school_partnerships.find_by(id: store.school_partnership_id)
+          end
+
           def school_partnerships
             return SchoolPartnership.none unless selected_contract_period
 
@@ -89,6 +99,16 @@ module Admin
             step_path(current_step.previous_step)
           end
 
+          def existing_contract_period
+            training_period.contract_period
+          end
+
+          def selected_partnership_name
+            return unless selected_school_partnership
+
+            "#{selected_school_partnership.lead_provider.name} & #{selected_school_partnership.delivery_partner.name}"
+          end
+
         private
 
           def current_contract_period
@@ -108,6 +128,11 @@ module Admin
           def selected_contract_period_allowed?
             store.contract_period_year.present? &&
               contract_periods.where(year: store.contract_period_year).exists?
+          end
+
+          def selected_school_partnership_allowed?
+            store.school_partnership_id.present? &&
+              school_partnerships.where(id: store.school_partnership_id).exists?
           end
 
           def step_path(step_name)

--- a/spec/requests/admin/teachers/training_periods/change_contract_period_wizard_spec.rb
+++ b/spec/requests/admin/teachers/training_periods/change_contract_period_wizard_spec.rb
@@ -109,17 +109,69 @@ RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardCont
 
     it "renders the partnership selection page after a contract period has been selected" do
       target_school_partnership
+      partnership_name =
+        "#{target_school_partnership.lead_provider.name} & #{target_school_partnership.delivery_partner.name}"
 
       post(
         path_for_step("select-contract-period"),
         params: { select_contract_period: { contract_period_year: target_contract_period.year } }
       )
       follow_redirect!
+      page = Capybara.string(response.body)
 
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("Select #{target_contract_period.year} partnership for #{teacher_name}")
-      expect(response.body).to include("#{target_school_partnership.lead_provider.name} &amp; #{target_school_partnership.delivery_partner.name}")
+      expect(page).to have_text(partnership_name)
       expect(response.body).to include(admin_school_partnerships_path(school.urn))
+    end
+  end
+
+  describe "POST select-partnership" do
+    it "redirects to check answers when the selection is valid" do
+      select_contract_period_and_partnership
+
+      expect(response).to redirect_to(path_for_step("check-answers"))
+    end
+  end
+
+  describe "GET check-answers" do
+    it "redirects to select partnership when no partnership has been selected" do
+      post(
+        path_for_step("select-contract-period"),
+        params: { select_contract_period: { contract_period_year: target_contract_period.year } }
+      )
+
+      get path_for_step("check-answers")
+
+      expect(response).to redirect_to(path_for_step("select-partnership"))
+    end
+
+    it "renders the CYA page after the contract period and partnership have been selected" do
+      select_contract_period_and_partnership
+
+      get path_for_step("check-answers")
+      page = Capybara.string(response.body)
+      partnership_name =
+        "#{target_school_partnership.lead_provider.name} & #{target_school_partnership.delivery_partner.name}"
+
+      expect(response).to have_http_status(:ok)
+      expect(page).to have_text("Confirm contract period change for #{teacher_name}")
+      expect(page).to have_text(current_contract_period.year.to_s)
+      expect(page).to have_text(target_contract_period.year.to_s)
+      expect(page).to have_text(partnership_name)
+    end
+  end
+
+  describe "POST check-answers" do
+    it "does not apply the contract period change in this slice" do
+      select_contract_period_and_partnership
+
+      expect {
+        post path_for_step("check-answers"), params: { check_answers: {} }
+      }.not_to change(TrainingPeriod, :count)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Confirm contract period change for #{teacher_name}")
     end
   end
 
@@ -127,5 +179,17 @@ private
 
   def path_for_step(step, teacher: self.teacher, training_period: self.training_period)
     "/admin/teachers/#{teacher.id}/training-periods/#{training_period.id}/contract-period/change/#{step}"
+  end
+
+  def select_contract_period_and_partnership
+    post(
+      path_for_step("select-contract-period"),
+      params: { select_contract_period: { contract_period_year: target_contract_period.year } }
+    )
+
+    post(
+      path_for_step("select-partnership"),
+      params: { select_partnership: { school_partnership_id: target_school_partnership.id } }
+    )
   end
 end

--- a/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/check_answers_step_spec.rb
+++ b/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/check_answers_step_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::CheckAnswersStep do
+  subject(:step) { described_class.new(wizard:) }
+
+  let(:wizard) do
+    instance_double(
+      Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Wizard,
+      store:
+    )
+  end
+  let(:store) { FactoryBot.build(:session_repository) }
+
+  describe "#previous_step" do
+    it "returns select partnership" do
+      expect(step.previous_step).to eq(:select_partnership)
+    end
+  end
+end

--- a/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard_spec.rb
+++ b/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard_spec.rb
@@ -13,6 +13,14 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Wiz
       school:
     )
   end
+  let(:target_school_partnership) do
+    FactoryBot.create(
+      :school_partnership,
+      :for_year,
+      year: target_contract_period.year,
+      school:
+    )
+  end
   let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:) }
   let(:schedule) { FactoryBot.create(:schedule, contract_period: current_contract_period) }
   let(:training_period) do
@@ -47,10 +55,28 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Wiz
       it { is_expected.to eq(%i[select_contract_period select_partnership]) }
     end
 
+    context "when an available contract period and partnership have been selected" do
+      before do
+        store.contract_period_year = target_contract_period.year
+        store.school_partnership_id = target_school_partnership.id
+      end
+
+      it { is_expected.to eq(%i[select_contract_period select_partnership check_answers]) }
+    end
+
     context "when an unavailable contract period has been selected" do
       before { store.contract_period_year = current_contract_period.year }
 
       it { is_expected.to eq([:select_contract_period]) }
+    end
+
+    context "when an unavailable partnership has been selected" do
+      before do
+        store.contract_period_year = target_contract_period.year
+        store.school_partnership_id = school_partnership.id
+      end
+
+      it { is_expected.to eq(%i[select_contract_period select_partnership]) }
     end
   end
 


### PR DESCRIPTION
### What

Following on from #3058, this is the second slice of the contract period change journey for admins.

Add the check answers step to the contract period change wizard.

This introduces:

- check answers
- summary rows and helper logic for:
  - existing contract period
  - new contract period
  - selected partnership
- back and cancel links
- a Confirm button
- guards so the check answers step is only available after a valid contract period and partnership have been selected

## Screenshot

| `/check-answers` |
|-------------------|
|<img width="1089" height="825" alt="image" src="https://github.com/user-attachments/assets/fbb5ceae-45fd-496a-98d3-2e1b3b7ba0a2" />|

### Not included

This PR does not:

- display the Change link on the Training tab
- apply the contract period change
- create or update training periods
- record events
- add success messaging