### PR TITLE
Use `.includes` rather than `.joins` on schools index page

### DIFF
--- a/app/services/schools/search.rb
+++ b/app/services/schools/search.rb
@@ -11,7 +11,7 @@ module Schools
   private
 
     def all_schools
-      School.joins(:gias_school)
+      School.includes(:gias_school)
     end
 
     def query


### PR DESCRIPTION
This makes Rails load the associated objects and prevents the n+1 on the admin schools index page
