### PR TITLE
Prevent resuming participants that were deferred/withdrawn today

### DIFF
--- a/app/services/api/teachers/resume.rb
+++ b/app/services/api/teachers/resume.rb
@@ -4,6 +4,7 @@ module API::Teachers
 
     validate :not_already_active
     validate :no_ongoing_today_training_period
+    validate :training_period_not_finished_today
     validate :school_period_ongoing_today
 
     def resume
@@ -18,6 +19,17 @@ module API::Teachers
     end
 
   private
+
+    def training_period_not_finished_today
+      return if errors[:teacher_api_id].any?
+      return unless training_period_finished_today?
+
+      errors.add(:teacher_api_id, "You cannot resume a participant on the same day they were withdrawn or deferred. Resume them tomorrow or later.")
+    end
+
+    def training_period_finished_today?
+      training_period&.finished_on&.today?
+    end
 
     def not_already_active
       return if errors[:teacher_api_id].any?

--- a/spec/services/api/teachers/resume_spec.rb
+++ b/spec/services/api/teachers/resume_spec.rb
@@ -17,6 +17,14 @@ RSpec.describe API::Teachers::Resume, type: :model do
 
           it { is_expected.to be_valid }
 
+          context "when training period has finished today" do
+            let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :ongoing, started_on: 2.months.ago, finished_on: Date.current) }
+            let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :deferred, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on, finished_on: at_school_period.finished_on) }
+
+            it { is_expected.to have_one_error_per_attribute }
+            it { is_expected.to have_error(:teacher_api_id, "You cannot resume a participant on the same day they were withdrawn or deferred. Resume them tomorrow or later.") }
+          end
+
           context "when teacher training period is active/ongoing" do
             let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :ongoing, started_on: 2.months.ago) }
             let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
@@ -56,7 +64,8 @@ RSpec.describe API::Teachers::Resume, type: :model do
             it { is_expected.to have_error(:teacher_api_id, "The participant is no longer at the school. Please contact the induction tutor to resolve.") }
           end
 
-          context "when the school period finishes today" do
+          context "when the school period finishes today, but the training period finished before today" do
+            let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :deferred, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on, finished_on: 2.days.ago) }
             let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :ongoing, started_on: 2.months.ago, finished_on: Date.current) }
 
             it { is_expected.to have_one_error_per_attribute }


### PR DESCRIPTION
### Context

Currently, if a lead provider withdraws/defers a participant we close their `TrainingPeriod` by setting the `finished_on` to today.

If this happened by mistake, the lead provider will immediately try and resume the participant; this attempts to create a new `TrainingPeriod` that starts today, which results in an error (as training periods can't finish/start on the same day).

### Changes proposed in this pull request

- Prevent resuming participants that were deferred/withdrawn today

We are going to look at fixing this in a more convenient way for lead providers (perhaps by undoing the withdrawal/deferral rather than creating a new training period), but for now to avoid an internal server error we are going to return an error message to ask them to try again tomorrow.

### Guidance to review

Defer/withdraw a participant (that has an ongoing school period) and then immediately try to resume their training.