### PR TITLE
Better trace errors through the logs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,7 +24,7 @@ class ApplicationController < ActionController::Base
     Sentry.set_user(
       email: current_user&.email,
       id: current_user.try(:id),
-      dfe_sign_in_user_id: current_user.try(:dfe_sign_in_user_id)
+      dfe_sign_in_user_fingerprint: current_user_dfe_sign_in_user_fingerprint
     )
   end
 
@@ -41,6 +41,19 @@ private
     super
     payload[:current_user_class] = current_user&.class&.name
     payload[:current_user_id] = current_user.try(:id)
-    payload[:current_user_dfe_sign_in_user_id] = current_user.try(:dfe_sign_in_user_id)
+    payload[:current_user_dfe_sign_in_user_fingerprint] =
+      current_user_dfe_sign_in_user_fingerprint
+  end
+
+  def current_user_dfe_sign_in_user_fingerprint
+    dfe_sign_in_user_id = current_user.try(:dfe_sign_in_user_id)
+
+    return if dfe_sign_in_user_id.blank?
+
+    OpenSSL::HMAC.hexdigest(
+      "SHA256",
+      Rails.application.secret_key_base,
+      dfe_sign_in_user_id
+    )
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,7 +21,11 @@ class ApplicationController < ActionController::Base
   end
 
   def set_sentry_user
-    Sentry.set_user(email: current_user&.email)
+    Sentry.set_user(
+      email: current_user&.email,
+      id: current_user.try(:id),
+      dfe_sign_in_user_id: current_user.try(:dfe_sign_in_user_id)
+    )
   end
 
 private
@@ -37,5 +41,6 @@ private
     super
     payload[:current_user_class] = current_user&.class&.name
     payload[:current_user_id] = current_user.try(:id)
+    payload[:current_user_dfe_sign_in_user_id] = current_user.try(:dfe_sign_in_user_id)
   end
 end

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -15,6 +15,7 @@ unless Rails.application.config.bypass_filter_parameter_logging
     corrected_name
     crypt
     date_of_birth
+    dfe_sign_in_user_id
     email
     emails
     email_address

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,55 @@
+RSpec.describe ApplicationController, type: :controller do
+  controller do
+    def index
+      head :ok
+    end
+  end
+
+  before do
+    routes.draw { get "index" => "anonymous#index" }
+    allow(controller).to receive(:current_user).and_return(current_user)
+  end
+
+  let(:email) { "user@example.com" }
+  let(:dfe_sign_in_user_id) { SecureRandom.uuid }
+  let(:current_user) do
+    FactoryBot.build(
+      :school_user,
+      :at_random_school,
+      email:,
+      dfe_sign_in_user_id:
+    )
+  end
+  let(:dfe_sign_in_user_fingerprint) do
+    OpenSSL::HMAC.hexdigest(
+      "SHA256",
+      Rails.application.secret_key_base,
+      dfe_sign_in_user_id
+    )
+  end
+
+  it "sets Sentry user context with a DfE Sign in user fingerprint" do
+    allow(Sentry).to receive(:set_user)
+
+    get :index
+
+    expect(Sentry).to have_received(:set_user).with(
+      email:,
+      id: nil,
+      dfe_sign_in_user_fingerprint:
+    )
+  end
+
+  it "adds a fingerprinted DfE Sign in user ID to the log payload" do
+    payload = {}
+
+    controller.send(:append_info_to_payload, payload)
+
+    expect(payload).to include(
+      current_user_class: "Sessions::Users::SchoolUser",
+      current_user_id: nil,
+      current_user_dfe_sign_in_user_fingerprint: dfe_sign_in_user_fingerprint
+    )
+    expect(payload).not_to have_key(:current_user_dfe_sign_in_user_id)
+  end
+end


### PR DESCRIPTION
Before, it was difficult to investigate errors via the logs. You'd need to find the error in Sentry, and try and guesstimate which logs corresponded to that error.

We already add the `current_user_id` to the logs payload, but this only applies for users with a `User` record in the database (i.e internal users).

In order to better trace a user's journey through the logs, this adds their `dfe_sign_in_user_id` to the log payload, and adds it to the user's context in Sentry.

Now, you can look at an error in Sentry and use the user ID to trace the error back through the logs.

This will help us better piece together the journey a user went on before running into issues.

This is the first in a series of incremental changes to our setup that hope to make it easier to resolve support queries and fix bugs.