### PR TITLE
Make API errors easier to read

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -2,18 +2,30 @@ class ErrorsController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def not_found
-    render "not_found", formats: :html, status: :not_found
+    respond_to do |format|
+      format.json { render json: { error: "Resource not found" }, status: :not_found }
+      format.any { render "not_found", formats: :html, status: :not_found }
+    end
   end
 
   def unprocessable_content
-    render "unprocessable_content", formats: :html, status: :unprocessable_content
+    respond_to do |format|
+      format.json { render json: { error: "Unprocessable content" }, status: :unprocessable_content }
+      format.any { render "unprocessable_content", formats: :html, status: :unprocessable_content }
+    end
   end
 
   def too_many_requests
-    render "too_many_requests", formats: :html, status: :too_many_requests
+    respond_to do |format|
+      format.json { render json: { error: "Too many requests" }, status: :too_many_requests }
+      format.any { render "too_many_requests", formats: :html, status: :too_many_requests }
+    end
   end
 
   def internal_server_error
-    render "internal_server_error", formats: :html, status: :internal_server_error
+    respond_to do |format|
+      format.json { render json: { error: "Internal server error" }, status: :internal_server_error }
+      format.any { render "internal_server_error", formats: :html, status: :internal_server_error }
+    end
   end
 end

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -55,7 +55,33 @@ RSpec.describe "Errors", type: :request do
     end
   end
 
-  context "when the request format is not HTML" do
+  context "when the request format is JSON" do
+    it "renders a json 404 error for /404.json" do
+      get "/404.json"
+
+      expect(response).to have_http_status(:not_found)
+      payload = JSON.parse(response.body)
+      expect(payload["error"]).to eq("Resource not found")
+    end
+
+    it "renders a json 422 error /422.json" do
+      get "/422.json"
+
+      expect(response).to have_http_status(:unprocessable_content)
+      payload = JSON.parse(response.body)
+      expect(payload["error"]).to eq("Unprocessable content")
+    end
+
+    it "renders a json 500 error for /500.json" do
+      get "/500.json"
+
+      expect(response).to have_http_status(:internal_server_error)
+      payload = JSON.parse(response.body)
+      expect(payload["error"]).to eq("Internal server error")
+    end
+  end
+
+  context "when the request format is not HTML or JSON" do
     it "renders the 404 HTML page for /404.pdf" do
       get "/404.pdf"
 


### PR DESCRIPTION
### Context

Default unhandled errors are being rendered in HTML for API clients.  These should return a JSON response so that they can be easily consumed.

### Changes proposed in this pull request

Add simple JSON responses for the unhandled errors.

### Guidance to review
