### PR TITLE
Add uplift target ratio to banded fee structures

### DIFF
--- a/app/components/admin/statements/provider_targets_component/banded_fee_component.rb
+++ b/app/components/admin/statements/provider_targets_component/banded_fee_component.rb
@@ -1,7 +1,6 @@
 module Admin::Statements
   class ProviderTargetsComponent::BandedFeeComponent < ApplicationComponent
     REVISED_RECRUITMENT_TARGET_MULTIPLIER = 1.5
-    UPLIFT_TARGET_PERCENTAGE = 33
 
     def initialize(contract:)
       @contract = contract
@@ -25,7 +24,7 @@ module Admin::Statements
           if display_uplifts?
             summary_list.with_row do |row|
               row.with_key(text: "Uplift target")
-              row.with_value(text: number_to_percentage(UPLIFT_TARGET_PERCENTAGE, precision: 0))
+              row.with_value(text: number_to_percentage(uplift_target_percentage, precision: 0))
             end
 
             summary_list.with_row do |row|
@@ -94,7 +93,9 @@ module Admin::Statements
       "(#{number_to_percentage(REVISED_RECRUITMENT_TARGET_MULTIPLIER * 100, precision: 0)})"
     end
 
-    def display_uplifts? = contract.ecf_contract_type?
+    def display_uplifts? = contract.ecf_contract_type? && uplift_target_ratio.present?
+    def uplift_target_ratio = banded_fee_structure.uplift_target_ratio
+    def uplift_target_percentage = uplift_target_ratio * 100
     def uplift_amount = banded_fee_structure.uplift_fee_per_declaration
 
     def band_term_label(band_term) = "Band #{band_term.letter}"

--- a/app/models/contract/banded_fee_structure.rb
+++ b/app/models/contract/banded_fee_structure.rb
@@ -26,6 +26,13 @@ class Contract::BandedFeeStructure < ApplicationRecord
               greater_than_or_equal_to: 0,
               message: "Uplift fee per declaration must be greater than or equal to zero"
             }
+  validates :uplift_target_ratio,
+            numericality: {
+              greater_than_or_equal_to: 0,
+              less_than_or_equal_to: 1,
+              message: "Uplift target ratio must be between 0 and 1",
+              allow_nil: true
+            }
   validates :monthly_service_fee,
             numericality: {
               greater_than_or_equal_to: 0,

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -318,6 +318,7 @@
   - id
   - recruitment_target
   - uplift_fee_per_declaration
+  - uplift_target_ratio
   - monthly_service_fee
   - setup_fee
   - created_at

--- a/db/migrate/20260614133538_add_uplift_target_ratio_to_contract_banded_fee_structures.rb
+++ b/db/migrate/20260614133538_add_uplift_target_ratio_to_contract_banded_fee_structures.rb
@@ -1,0 +1,9 @@
+class AddUpliftTargetRatioToContractBandedFeeStructures < ActiveRecord::Migration[8.0]
+  def change
+    add_column :contract_banded_fee_structures,
+               :uplift_target_ratio,
+               :decimal,
+               precision: 5,
+               scale: 4
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -179,6 +179,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_29_150700) do
     t.decimal "setup_fee", precision: 12, scale: 2, null: false
     t.datetime "updated_at", null: false
     t.decimal "uplift_fee_per_declaration", precision: 12, scale: 2, null: false
+    t.decimal "uplift_target_ratio", precision: 5, scale: 4
     t.index ["contract_id"], name: "index_banded_fee_structures_on_contract_id_unique_not_null", unique: true, where: "(contract_id IS NOT NULL)"
     t.index ["contract_id"], name: "index_contract_banded_fee_structures_on_contract_id"
   end

--- a/spec/components/admin/statements/provider_targets_component/banded_fee_component_spec.rb
+++ b/spec/components/admin/statements/provider_targets_component/banded_fee_component_spec.rb
@@ -1,12 +1,15 @@
 RSpec.describe Admin::Statements::ProviderTargetsComponent::BandedFeeComponent, type: :component do
   subject(:component) { described_class.new(contract:) }
 
+  let(:uplift_target_ratio) { 0.33 }
+
   let(:banded_fee_structure) do
     FactoryBot.build_stubbed(
       :contract_banded_fee_structure,
       :with_band_terms,
       recruitment_target: 2500,
       uplift_fee_per_declaration: 50,
+      uplift_target_ratio:,
       setup_fee: 5000,
       declaration_boundaries: [
         { min: 1, max: 50 },
@@ -43,6 +46,18 @@ RSpec.describe Admin::Statements::ProviderTargetsComponent::BandedFeeComponent, 
       expect(page).to have_summary_list_row("Uplift target", value: "33%")
     end
 
+    context "when the uplift target ratio is missing" do
+      let(:uplift_target_ratio) { nil }
+
+      it "does not render the uplift target" do
+        expect(page).not_to have_summary_list_row("Uplift target")
+      end
+
+      it "does not render the uplift amount" do
+        expect(page).not_to have_summary_list_row("Uplift amount")
+      end
+    end
+
     it "renders the uplift amount" do
       expect(page).to have_summary_list_row("Uplift amount", value: "£50.00")
     end
@@ -61,6 +76,15 @@ RSpec.describe Admin::Statements::ProviderTargetsComponent::BandedFeeComponent, 
           ["Band C", 101, 150, /£\d+\.\d{2}/]
         ]
       )
+    end
+
+    context "when the uplift target ratio is not the default" do
+      let(:uplift_target_ratio) { 0.4 }
+
+      it "renders the uplift target from the banded fee structure" do
+        expect(page).to have_summary_list_row("Uplift target", value: "40%")
+        expect(page).not_to have_summary_list_row("Uplift target", value: "33%")
+      end
     end
   end
 

--- a/spec/factories/contract/banded_fee_structure_factory.rb
+++ b/spec/factories/contract/banded_fee_structure_factory.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :contract_banded_fee_structure, class: "Contract::BandedFeeStructure" do
     recruitment_target { Faker::Number.between(from: 1_000, to: 10_000) }
     uplift_fee_per_declaration { Faker::Number.between(from: 50, to: 100) }
+    uplift_target_ratio { 0.33 }
     monthly_service_fee { Faker::Number.between(from: 0, to: 20_000) }
     setup_fee { Faker::Number.between(from: 1_000, to: 50_000) }
 

--- a/spec/models/contract/banded_fee_structure_spec.rb
+++ b/spec/models/contract/banded_fee_structure_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Contract::BandedFeeStructure, type: :model do
     it { is_expected.to validate_presence_of(:uplift_fee_per_declaration).with_message("Uplift fee per declaration is required") }
     it { is_expected.to validate_numericality_of(:uplift_fee_per_declaration).is_greater_than_or_equal_to(0).with_message("Uplift fee per declaration must be greater than or equal to zero") }
 
+    it { is_expected.to validate_numericality_of(:uplift_target_ratio).is_greater_than_or_equal_to(0).is_less_than_or_equal_to(1).with_message("Uplift target ratio must be between 0 and 1").allow_nil }
     it { is_expected.to validate_numericality_of(:monthly_service_fee).is_greater_than_or_equal_to(0).with_message("Monthly service fee must be greater than or equal to zero").allow_nil }
 
     it { is_expected.to validate_presence_of(:setup_fee).with_message("Setup fee is required") }

--- a/spec/services/active_lead_providers/seed_from_previous_spec.rb
+++ b/spec/services/active_lead_providers/seed_from_previous_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe ActiveLeadProviders::SeedFromPrevious do
 
       describe "contract fee structures" do
         it "builds a new banded_fee_structure for the new contract, based on the previous" do
-          fee_attributes = %i[recruitment_target setup_fee uplift_fee_per_declaration monthly_service_fee]
+          fee_attributes = %i[recruitment_target setup_fee uplift_fee_per_declaration uplift_target_ratio monthly_service_fee]
           expect(new_contract.banded_fee_structure.slice(*fee_attributes))
             .to eq(previous_contract.banded_fee_structure.slice(*fee_attributes))
           expect(new_contract.banded_fee_structure).not_to eq(previous_contract.banded_fee_structure)


### PR DESCRIPTION
### Context
The provider targets component currently renders the uplift target as a hardcoded 33%.

ECF stores the source contract value as uplift_target on CallOffContract, for example 0.33 or 0.4. Some historic/source contract values may not be 33%, so RECT should not hardcode this value in the component.

### Changes proposed in this pull request
- Adds uplift_target_ratio to contract_banded_fee_structures
- Adds model validation allowing nil, but ensuring any populated value is between 0 and 1
- Updates ::BandedFeeComponent to render the uplift target from `banded_fee_structure.uplift_target_ratio` instead of a hardcoded 33%
- Converts the ratio to a percentage only at display time, so 0.4 renders as 40%

### Guidance to review

N.B.
The ECF data backfill is not included in this PR. That will be done separately.
