### PR TITLE
Reset add partnership wizard store before initialization

### DIFF
--- a/app/controllers/admin/schools/add_partnership_wizard_controller.rb
+++ b/app/controllers/admin/schools/add_partnership_wizard_controller.rb
@@ -8,9 +8,9 @@ module Admin
       include WizardStoreRescuable
 
       before_action :set_school
+      before_action :reset_store_on_entry
       before_action :initialize_wizard
       before_action :check_allowed_step
-      before_action :reset_store_on_entry
 
       def new
         render current_step


### PR DESCRIPTION
### Summary

@ericaporter identified in a recent [PR review](https://github.com/DFE-Digital/register-early-career-teachers-public/pull/3058#discussion_r3421204571) that we should reset the wizard store before building the wizard.

This is safer because it ensures any later wizard initialization or step checks use the cleared store rather than stale session data.

This PR brings the `AddPartnershipWizard` in line with that ordering.