### PR TITLE
4064-rel-note-update-change-schedule

### DIFF
--- a/app/views/api/release_notes/release_notes.yml
+++ b/app/views/api/release_notes/release_notes.yml
@@ -33,11 +33,9 @@
 
     We’ve changed validation rules to allow lead providers to submit a reduced schedule for ECTs who’ve completed training.
 
-    Previously, lead providers could not change schedules after training was complete.
-
     ## Why we’ve made this change
 
-    In some cases, ECTs on a reduced schedule complete training before the lead provider was aware. Previously, this meant lead providers were unable to change the schedule.
+    In some cases, lead providers were not aware that ECTs were on a reduced schedule before they completed training. Previously, lead providers were unable to change the ECT's schedule after training completion.
 
     Lead providers need to be able to change an ECT’s schedule to reduced even after training has been completed. 
 

--- a/app/views/api/release_notes/release_notes.yml
+++ b/app/views/api/release_notes/release_notes.yml
@@ -35,7 +35,7 @@
 
     ## Why we’ve made this change
 
-    In some cases, lead providers were not aware that ECTs were on a reduced schedule before they completed training. Previously, lead providers were unable to change the ECT's schedule after training completion.
+    In some cases, lead providers were not aware that ECTs were on a reduced schedule before they completed training. Previously, lead providers were unable to change an ECT’s schedule after training had been completed.
 
     Lead providers need to be able to change an ECT’s schedule to reduced even after training has been completed. 
 

--- a/app/views/api/release_notes/release_notes.yml
+++ b/app/views/api/release_notes/release_notes.yml
@@ -21,6 +21,27 @@
 #
 #     **bold** and _italic_ text
 
+- title: ECT schedules can be changed to reduced after they’ve completed training 
+  date: 2026-06-17
+  tags:
+    - new-feature
+    - production-release
+  body: |
+    Lead providers can now move ECTs who’ve completed training to a reduced schedule where appropriate.
+
+    ## What’s changed
+
+    We’ve changed validation rules to allow lead providers to submit a reduced schedule for ECTs who’ve completed training.
+
+    Previously, lead providers could not change schedules after training was complete.
+
+    ## Why we’ve made this change
+
+    In some cases, ECTs on a reduced schedule have completed training before the lead provider was aware. This meant lead providers were unable to change the schedule.
+
+    Lead providers need to be able to change an ECT’s schedule to reduced even after training has been completed. 
+
+
 - title: Update to the updated_at attribute on GET partnerships when participant counts change in partnerships
   date: 2026-06-16
   tags:

--- a/app/views/api/release_notes/release_notes.yml
+++ b/app/views/api/release_notes/release_notes.yml
@@ -21,23 +21,27 @@
 #
 #     **bold** and _italic_ text
 
-- title: Schedules can be changed to reduced after ECTs have completed training 
+- title: Schedules can be changed to reduced after ECTs have completed induction 
   date: 2026-06-17
   tags:
     - new-feature
     - production-release
   body: |
-    Lead providers can now move ECTs who’ve completed training to a reduced schedule where appropriate.
+    Lead providers can now move ECTs who’ve completed induction to a reduced schedule where appropriate.
 
     ## What’s changed
 
-    We’ve changed validation rules to allow lead providers to submit a reduced schedule for ECTs who’ve completed training.
+    We’ve changed validation rules to allow lead providers to submit a reduced schedule for ECTs who’ve completed their induction.
 
     ## Why we’ve made this change
 
-    In some cases, lead providers were not aware that ECTs were on a reduced schedule before they completed training. Previously, lead providers were unable to change an ECT’s schedule after training had been completed.
+    In some cases, lead providers were not aware that ECTs were on a reduced schedule before they completed induction. Previously, lead providers were unable to change an ECT’s schedule after induction had been completed.
 
-    Lead providers need to be able to change an ECT’s schedule to reduced even after training has been completed. 
+    Lead providers need to be able to change an ECT’s schedule to reduced even after induction has been completed. 
+
+    ## What you need to do
+    
+    No action is needed. However, lead providers can use this change in validation to any existing cases where a reduced induction was completed before they could assign the ECT to a reduced schedule.
 
 
 - title: Update to the updated_at attribute on GET partnerships when participant counts change in partnerships
@@ -62,7 +66,7 @@
 
     ## What you need to do
 
-    No action is needed. However, you should:
+    No action is needed. However, lead providers should:
 
     - note that `updated_at` will be updated nightly when reflecting changes in the number of participants currently training
     - expect `updated_at` to change more frequently where participant activity changes

--- a/app/views/api/release_notes/release_notes.yml
+++ b/app/views/api/release_notes/release_notes.yml
@@ -21,7 +21,7 @@
 #
 #     **bold** and _italic_ text
 
-- title: ECT schedules can be changed to reduced after they’ve completed training 
+- title: Schedules can be changed to reduced after ECTs have completed training 
   date: 2026-06-17
   tags:
     - new-feature
@@ -37,7 +37,7 @@
 
     ## Why we’ve made this change
 
-    In some cases, ECTs on a reduced schedule have completed training before the lead provider was aware. This meant lead providers were unable to change the schedule.
+    In some cases, ECTs on a reduced schedule complete training before the lead provider was aware. Previously, this meant lead providers were unable to change the schedule.
 
     Lead providers need to be able to change an ECT’s schedule to reduced even after training has been completed. 
 

--- a/app/views/api/release_notes/release_notes.yml
+++ b/app/views/api/release_notes/release_notes.yml
@@ -42,7 +42,7 @@
 
     ## What you need to do
     
-    No action is needed. However, lead providers can use this change in validation to any existing cases where a reduced induction was completed before they could assign the ECT to a reduced schedule.
+    No action is needed. However, lead providers can use this change in validation for any existing cases where a reduced induction was completed before they could assign the ECT to a reduced schedule.
 
 
 - title: Update to the updated_at attribute on GET partnerships when participant counts change in partnerships

--- a/app/views/api/release_notes/release_notes.yml
+++ b/app/views/api/release_notes/release_notes.yml
@@ -26,6 +26,7 @@
   tags:
     - new-feature
     - production-release
+    - sandbox-release
   body: |
     Lead providers can now move ECTs who’ve completed induction to a reduced schedule where appropriate.
 


### PR DESCRIPTION
Release note entry for validation changes for changing schedules after training completed.

### Context
Add release note entry for the changes to the validation rule for changing a schedule to reduced after an ECT has completed training.

### Changes proposed in this pull request
New note added to release_notes.yml
### Guidance to review
Fact and sanity check in review app.
