### PR TITLE
Schools can only choose current appropriate bodies

### DIFF
--- a/app/helpers/appropriate_body_helper.rb
+++ b/app/helpers/appropriate_body_helper.rb
@@ -3,7 +3,10 @@ module AppropriateBodyHelper
 
   # TODO: appropriate_bodies_options_for_collection shows inaccurate and inactive TSHs
   def appropriate_bodies_options_for_collection
-    AppropriateBodyPeriod.teaching_school_hub.select(:id, :name).all
+    AppropriateBodyPeriod
+      .teaching_school_hub
+      .where.not(dfe_sign_in_organisation_id: nil)
+      .select(:id, :name)
   end
 
   # @return [Array<FormChoice>]

--- a/spec/helpers/appropriate_body_helper_spec.rb
+++ b/spec/helpers/appropriate_body_helper_spec.rb
@@ -3,6 +3,29 @@ RSpec.describe AppropriateBodyHelper, type: :helper do
   include GovukLinkHelper
   include GovukVisuallyHiddenHelper
 
+  describe "#appropriate_bodies_options_for_collection" do
+    subject { appropriate_bodies_options_for_collection }
+
+    let!(:national_appropriate_body_period) do
+      FactoryBot.create(:appropriate_body_period, :national)
+    end
+    let!(:local_authority_appropriate_body_period) do
+      FactoryBot.create(:appropriate_body_period, :local_authority)
+    end
+    let!(:teaching_school_hub_appropriate_body_period) do
+      FactoryBot.create(:appropriate_body_period, :teaching_school_hub)
+    end
+    let!(:missing_dfe_sign_in_organisation_id_appropriate_body_period) do
+      FactoryBot.create(
+        :appropriate_body_period,
+        :teaching_school_hub,
+        dfe_sign_in_organisation_id: nil
+      )
+    end
+
+    it { is_expected.to contain_exactly(teaching_school_hub_appropriate_body_period) }
+  end
+
   describe "#induction_programme_choices" do
     it "returns an array of FormChoice" do
       expect(induction_programme_choices).to be_an(Array)


### PR DESCRIPTION
### Context

[Teams discussion](https://teams.microsoft.com/l/message/19:wrVA9ZipsSjXLCrfIhG_aeXg61D4MjtXfyz2AR2lDjw1@thread.tacv2/1781693340992?tenantId=fad277c9-c60a-4da1-b5f3-b3b8b34a82f9&groupId=5e035efe-5b2b-491b-9e3e-d832445e4ad1&parentMessageId=1781693340992&teamName=Schools%20Digital&channelName=CPD%20Register%20ECTs&createdTime=1781693340992&ngc=true&allowXTenantAccess=true)

### Changes proposed in this pull request

Before, we allowed schools to choose any appropriate body that was a teaching school hub.

In production this included a bunch of appropriate bodies that were not relevant, though.

This filters the appropriate body periods that are available to select to those that have a `dfe_sign_in_organisation_id`.

### Guidance to review
