### PR TITLE
Add new attribute `most_recent_induction_period_end_date` to `API::TeacherSerializer`

### DIFF
--- a/app/serializers/api/teacher_serializer.rb
+++ b/app/serializers/api/teacher_serializer.rb
@@ -125,6 +125,11 @@ class API::TeacherSerializer < Blueprinter::Base
     field(:full_name) { |teacher| Teachers::Name.new(teacher).full_name }
     field(:trn, name: :teacher_reference_number)
     field(:api_updated_at, name: :updated_at)
+    field(:most_recent_induction_period_end_date) do |teacher|
+      if teacher.ect_at_school_periods.any?
+        teacher.induction_periods.started_on_or_before(Time.zone.today).latest_first.first&.finished_on
+      end
+    end
 
     association :ecf_enrolments, blueprint: TrainingPeriodSerializer do |teacher, options|
       metadata = ::API::TeacherSerializer.lead_provider_metadata(teacher:, options:)

--- a/app/serializers/api/teacher_serializer.rb
+++ b/app/serializers/api/teacher_serializer.rb
@@ -80,6 +80,11 @@ class API::TeacherSerializer < Blueprinter::Base
           API::Teachers::InductionStatus.new(teacher:).induction_end_date
         end
       end
+      field(:most_recent_induction_period_end_date) do |(training_period, teacher, _)|
+        if training_period.for_ect?
+          API::Teachers::InductionStatus.new(teacher:).most_recent_induction_period_end_date
+        end
+      end
       field(:overall_induction_start_date) do |(training_period, teacher, _)|
         if training_period.for_ect?
           API::Teachers::InductionStatus.new(teacher:).induction_start_date
@@ -125,11 +130,6 @@ class API::TeacherSerializer < Blueprinter::Base
     field(:full_name) { |teacher| Teachers::Name.new(teacher).full_name }
     field(:trn, name: :teacher_reference_number)
     field(:api_updated_at, name: :updated_at)
-    field(:most_recent_induction_period_end_date) do |teacher|
-      if teacher.ect_at_school_periods.any?
-        teacher.induction_periods.started_on_or_before(Time.zone.today).latest_first.first&.finished_on
-      end
-    end
 
     association :ecf_enrolments, blueprint: TrainingPeriodSerializer do |teacher, options|
       metadata = ::API::TeacherSerializer.lead_provider_metadata(teacher:, options:)

--- a/app/services/api/teachers/induction_status.rb
+++ b/app/services/api/teachers/induction_status.rb
@@ -19,7 +19,7 @@ module API::Teachers
     end
 
     def most_recent_induction_period_end_date
-      teacher.induction_periods.started_on_or_before(Time.zone.today).latest_first.first&.finished_on
+      teacher.induction_periods.latest_first.first&.finished_on
     end
   end
 end

--- a/app/services/api/teachers/induction_status.rb
+++ b/app/services/api/teachers/induction_status.rb
@@ -17,5 +17,9 @@ module API::Teachers
     def completed_induction?
       induction_end_date.present?
     end
+
+    def most_recent_induction_period_end_date
+      teacher.induction_periods.started_on_or_before(Time.zone.today).latest_first.first&.finished_on
+    end
   end
 end

--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -258,6 +258,7 @@ paths:
                       attributes:
                         full_name: John Doe
                         teacher_reference_number: '1234567'
+                        most_recent_induction_period_end_date: '2025-05-31'
                         ecf_enrolments:
                         - training_record_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
                           email: jane.smith@example.com
@@ -321,6 +322,7 @@ paths:
                       attributes:
                         full_name: John Doe
                         teacher_reference_number: '1234567'
+                        most_recent_induction_period_end_date: '2025-05-31'
                         ecf_enrolments:
                         - training_record_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
                           email: jane.smith@example.com
@@ -390,6 +392,7 @@ paths:
                       attributes:
                         full_name: John Doe
                         teacher_reference_number: '1234567'
+                        most_recent_induction_period_end_date: '2025-05-31'
                         ecf_enrolments:
                         - training_record_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
                           email: jane.smith@example.com
@@ -478,6 +481,7 @@ paths:
                       attributes:
                         full_name: John Doe
                         teacher_reference_number: '1234567'
+                        most_recent_induction_period_end_date: '2025-05-31'
                         ecf_enrolments:
                         - training_record_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
                           email: jane.smith@example.com
@@ -566,6 +570,7 @@ paths:
                       attributes:
                         full_name: John Doe
                         teacher_reference_number: '1234567'
+                        most_recent_induction_period_end_date: '2025-05-31'
                         ecf_enrolments:
                         - training_record_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
                           email: jane.smith@example.com
@@ -652,6 +657,7 @@ paths:
                       attributes:
                         full_name: John Doe
                         teacher_reference_number: '1234567'
+                        most_recent_induction_period_end_date: '2025-05-31'
                         ecf_enrolments:
                         - training_record_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
                           email: jane.smith@example.com
@@ -2577,6 +2583,13 @@ components:
               type: string
               nullable: true
               example: '1234567'
+            most_recent_induction_period_end_date:
+              description: The end date of the most recent induction period for this
+                participant
+              type: string
+              nullable: true
+              format: date
+              example: '2025-05-31'
             ecf_enrolments:
               type: array
               nullable: false

--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -258,7 +258,6 @@ paths:
                       attributes:
                         full_name: John Doe
                         teacher_reference_number: '1234567'
-                        most_recent_induction_period_end_date: '2025-05-31'
                         ecf_enrolments:
                         - training_record_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
                           email: jane.smith@example.com
@@ -278,6 +277,7 @@ paths:
                           deferral:
                           created_at: '2023-01-01T00:00:00Z'
                           induction_end_date: '2023-01-01'
+                          most_recent_induction_period_end_date: '2025-05-31'
                           overall_induction_start_date: '2023-01-01'
                           mentor_funding_end_date: '2023-01-01'
                           cohort_changed_after_payments_frozen: true
@@ -322,7 +322,6 @@ paths:
                       attributes:
                         full_name: John Doe
                         teacher_reference_number: '1234567'
-                        most_recent_induction_period_end_date: '2025-05-31'
                         ecf_enrolments:
                         - training_record_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
                           email: jane.smith@example.com
@@ -342,6 +341,7 @@ paths:
                           deferral:
                           created_at: '2023-01-01T00:00:00Z'
                           induction_end_date: '2023-01-01'
+                          most_recent_induction_period_end_date: '2025-05-31'
                           overall_induction_start_date: '2023-01-01'
                           mentor_funding_end_date: '2023-01-01'
                           cohort_changed_after_payments_frozen: true
@@ -392,7 +392,6 @@ paths:
                       attributes:
                         full_name: John Doe
                         teacher_reference_number: '1234567'
-                        most_recent_induction_period_end_date: '2025-05-31'
                         ecf_enrolments:
                         - training_record_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
                           email: jane.smith@example.com
@@ -414,6 +413,7 @@ paths:
                           deferral:
                           created_at: '2023-01-01T00:00:00Z'
                           induction_end_date: '2023-01-01'
+                          most_recent_induction_period_end_date: '2025-05-31'
                           overall_induction_start_date: '2023-01-01'
                           mentor_funding_end_date: '2023-01-01'
                           cohort_changed_after_payments_frozen: true
@@ -481,7 +481,6 @@ paths:
                       attributes:
                         full_name: John Doe
                         teacher_reference_number: '1234567'
-                        most_recent_induction_period_end_date: '2025-05-31'
                         ecf_enrolments:
                         - training_record_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
                           email: jane.smith@example.com
@@ -503,6 +502,7 @@ paths:
                             date: '2021-05-31T02:22:32.000Z'
                           created_at: '2023-01-01T00:00:00Z'
                           induction_end_date: '2023-01-01'
+                          most_recent_induction_period_end_date: '2025-05-31'
                           overall_induction_start_date: '2023-01-01'
                           mentor_funding_end_date: '2023-01-01'
                           cohort_changed_after_payments_frozen: true
@@ -570,7 +570,6 @@ paths:
                       attributes:
                         full_name: John Doe
                         teacher_reference_number: '1234567'
-                        most_recent_induction_period_end_date: '2025-05-31'
                         ecf_enrolments:
                         - training_record_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
                           email: jane.smith@example.com
@@ -590,6 +589,7 @@ paths:
                           deferral:
                           created_at: '2023-01-01T00:00:00Z'
                           induction_end_date: '2023-01-01'
+                          most_recent_induction_period_end_date: '2025-05-31'
                           overall_induction_start_date: '2023-01-01'
                           mentor_funding_end_date: '2023-01-01'
                           cohort_changed_after_payments_frozen: true
@@ -657,7 +657,6 @@ paths:
                       attributes:
                         full_name: John Doe
                         teacher_reference_number: '1234567'
-                        most_recent_induction_period_end_date: '2025-05-31'
                         ecf_enrolments:
                         - training_record_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
                           email: jane.smith@example.com
@@ -681,6 +680,7 @@ paths:
                             date: '2021-05-31T02:22:32.000Z'
                           created_at: '2023-01-01T00:00:00Z'
                           induction_end_date: '2023-01-01'
+                          most_recent_induction_period_end_date: '2025-05-31'
                           overall_induction_start_date: '2023-01-01'
                           mentor_funding_end_date: '2023-01-01'
                           cohort_changed_after_payments_frozen: true
@@ -2583,13 +2583,6 @@ components:
               type: string
               nullable: true
               example: '1234567'
-            most_recent_induction_period_end_date:
-              description: The end date of the most recent induction period for this
-                participant
-              type: string
-              nullable: true
-              format: date
-              example: '2025-05-31'
             ecf_enrolments:
               type: array
               nullable: false
@@ -3010,6 +3003,12 @@ components:
           format: date
           example: '2023-01-01'
           nullable: true
+        most_recent_induction_period_end_date:
+          description: The end date of the most recent induction period for this participant
+          type: string
+          nullable: true
+          format: date
+          example: '2025-05-31'
         overall_induction_start_date:
           description: The date the participant started their induction, reported
             by their appropriate body.

--- a/spec/serializers/api/teacher_serializer_spec.rb
+++ b/spec/serializers/api/teacher_serializer_spec.rb
@@ -37,6 +37,29 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
       expect(attributes["teacher_reference_number"]).to eq(teacher.trn)
     end
 
+    describe "`most_recent_induction_period_end_date`" do
+      subject(:most_recent_induction_period_end_date) { attributes["most_recent_induction_period_end_date"] }
+
+      context "when the teacher is not an ECT" do
+        it { is_expected.to be_nil }
+      end
+
+      context "when the teacher is an ECT" do
+        let(:teacher) { FactoryBot.create(:teacher, :induction_in_progress) }
+        let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:) }
+        let!(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:) }
+
+        it { is_expected.to be_nil }
+
+        context "when the latest induction period is closed" do
+          let(:teacher) { FactoryBot.create(:teacher, :induction_completed) }
+          let!(:induction_period) { FactoryBot.create(:induction_period, :pass, teacher:) }
+
+          it { is_expected.to eq induction_period.finished_on.to_fs(:api) }
+        end
+      end
+    end
+
     describe "`full_name`" do
       subject(:full_name) { attributes["full_name"] }
 

--- a/spec/serializers/api/teacher_serializer_spec.rb
+++ b/spec/serializers/api/teacher_serializer_spec.rb
@@ -427,6 +427,8 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
 
             expect(mentor_enrolment["induction_end_date"]).to be_nil
 
+            expect(mentor_enrolment["most_recent_induction_period_end_date"]).to be_nil
+
             expect(mentor_enrolment["overall_induction_start_date"]).to be_nil
 
             expect(mentor_enrolment["mentor_funding_end_date"]).to eq(teacher.mentor_became_ineligible_for_funding_on.to_fs(:api))
@@ -493,6 +495,25 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
             it "serializes the deferral" do
               expect(mentor_enrolment["training_status"]).to eq("deferred")
               expect(mentor_enrolment["deferral"]).to eq({ "date" => mentor_training_period.deferred_at.utc.rfc3339, "reason" => "bereavement" })
+            end
+          end
+
+          context "when there is an induction period" do
+            context "when the latest induction period is ongoing" do
+              let!(:first_induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:) }
+
+              it "serializes `most_recent_induction_period_end_date` as nil" do
+                expect(mentor_enrolment["most_recent_induction_period_end_date"]).to be_nil
+              end
+            end
+
+            context "when the latest induction period is closed" do
+              let!(:first_induction_period) { FactoryBot.create(:induction_period, teacher:) }
+              let!(:latest_induction_period) { FactoryBot.create(:induction_period, :pass, teacher:, started_on: 1.week.ago, finished_on: 2.days.ago) }
+
+              it "serializes `most_recent_induction_period_end_date` as nil" do
+                expect(mentor_enrolment["most_recent_induction_period_end_date"]).to be_nil
+              end
             end
           end
         end

--- a/spec/serializers/api/teacher_serializer_spec.rb
+++ b/spec/serializers/api/teacher_serializer_spec.rb
@@ -37,29 +37,6 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
       expect(attributes["teacher_reference_number"]).to eq(teacher.trn)
     end
 
-    describe "`most_recent_induction_period_end_date`" do
-      subject(:most_recent_induction_period_end_date) { attributes["most_recent_induction_period_end_date"] }
-
-      context "when the teacher is not an ECT" do
-        it { is_expected.to be_nil }
-      end
-
-      context "when the teacher is an ECT" do
-        let(:teacher) { FactoryBot.create(:teacher, :induction_in_progress) }
-        let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:) }
-        let!(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:) }
-
-        it { is_expected.to be_nil }
-
-        context "when the latest induction period is closed" do
-          let(:teacher) { FactoryBot.create(:teacher, :induction_completed) }
-          let!(:induction_period) { FactoryBot.create(:induction_period, :pass, teacher:) }
-
-          it { is_expected.to eq induction_period.finished_on.to_fs(:api) }
-        end
-      end
-    end
-
     describe "`full_name`" do
       subject(:full_name) { attributes["full_name"] }
 
@@ -199,6 +176,8 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
 
             expect(ect_enrolment["induction_end_date"]).to be_nil
 
+            expect(ect_enrolment["most_recent_induction_period_end_date"]).to be_nil
+
             expect(ect_enrolment["overall_induction_start_date"]).to be_nil
 
             expect(ect_enrolment["mentor_funding_end_date"]).to be_nil
@@ -281,6 +260,32 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
 
               it "serializes `induction_end_date` from TRS induction completed date" do
                 expect(ect_enrolment["induction_end_date"]).to eq(teacher.trs_induction_completed_date.to_fs(:api))
+              end
+            end
+          end
+
+          describe "`most_recent_induction_period_end_date`" do
+            context "when the latest induction_period is ongoing" do
+              let!(:first_induction_period) { FactoryBot.create(:induction_period, teacher:) }
+              let!(:latest_induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, started_on: 1.day.ago) }
+
+              it "serializes `most_recent_induction_period_end_date` as nil" do
+                expect(ect_enrolment["most_recent_induction_period_end_date"]).to be_nil
+              end
+            end
+
+            context "when the latest induction period is closed" do
+              let!(:first_induction_period) { FactoryBot.create(:induction_period, teacher:) }
+              let!(:latest_induction_period) { FactoryBot.create(:induction_period, :pass, teacher:, started_on: 1.week.ago, finished_on: 2.days.ago) }
+
+              it "serializes `most_recent_induction_period_end_date` as the latest induction period `finished_on`" do
+                expect(ect_enrolment["most_recent_induction_period_end_date"]).to eq(latest_induction_period.finished_on.to_fs(:api))
+              end
+            end
+
+            context "when there is no induction period" do
+              it "serializes `most_recent_induction_period_end_date` as nil" do
+                expect(ect_enrolment["most_recent_induction_period_end_date"]).to be_nil
               end
             end
           end

--- a/spec/services/api/teachers/induction_status_spec.rb
+++ b/spec/services/api/teachers/induction_status_spec.rb
@@ -86,4 +86,35 @@ RSpec.describe API::Teachers::InductionStatus, type: :model do
       it { is_expected.not_to be_completed_induction }
     end
   end
+
+  describe "#most_recent_induction_period_end_date" do
+    subject(:end_date) { instance.most_recent_induction_period_end_date }
+
+    context "when a teacher has completed induction" do
+      let(:teacher) { completed_period.teacher }
+      let(:completed_period) { FactoryBot.create(:induction_period, :pass) }
+
+      it { is_expected.to eq completed_period.finished_on }
+    end
+
+    context "when the teacher has an ongoing induction_period" do
+      let(:teacher) { FactoryBot.create(:induction_period, :ongoing).teacher }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when the teacher has multiple induction periods" do
+      let(:teacher) { closed_period.teacher }
+      let(:closed_period) { FactoryBot.create(:induction_period, finished_on: 10.days.ago) }
+      let!(:latest_period) { FactoryBot.create(:induction_period, :ongoing, started_on: 9.days.ago, teacher:) }
+
+      it { is_expected.to eq latest_period.finished_on }
+    end
+
+    context "when the teacher does not have any induction periods" do
+      let(:teacher) { FactoryBot.create(:teacher) }
+
+      it { is_expected.to be_nil }
+    end
+  end
 end

--- a/spec/swagger_schemas/models/participant.rb
+++ b/spec/swagger_schemas/models/participant.rb
@@ -28,13 +28,6 @@ PARTICIPANT = {
           nullable: true,
           example: "1234567",
         },
-        most_recent_induction_period_end_date: {
-          description: "The end date of the most recent induction period for this participant",
-          type: :string,
-          nullable: true,
-          format: :date,
-          example: "2025-05-31",
-        },
         ecf_enrolments: {
           type: :array,
           nullable: false,

--- a/spec/swagger_schemas/models/participant.rb
+++ b/spec/swagger_schemas/models/participant.rb
@@ -28,6 +28,13 @@ PARTICIPANT = {
           nullable: true,
           example: "1234567",
         },
+        most_recent_induction_period_end_date: {
+          description: "The end date of the most recent induction period for this participant",
+          type: :string,
+          nullable: true,
+          format: :date,
+          example: "2025-05-31",
+        },
         ecf_enrolments: {
           type: :array,
           nullable: false,

--- a/spec/swagger_schemas/models/participants/ecf_enrolment.rb
+++ b/spec/swagger_schemas/models/participants/ecf_enrolment.rb
@@ -152,6 +152,13 @@ PARTICIPANT_ECF_ENROLMENT = {
       example: "2023-01-01",
       nullable: true
     },
+    most_recent_induction_period_end_date: {
+      description: "The end date of the most recent induction period for this participant",
+      type: :string,
+      nullable: true,
+      format: :date,
+      example: "2025-05-31",
+    },
     overall_induction_start_date: {
       description: "The date the participant started their induction, reported by their appropriate body.",
       type: :string,


### PR DESCRIPTION
### Context

To help providers understand where an ECT is with their induction we can add a new field to the serializer to surface the `finished_on` date of the teacher's most recent `InductionPeriod`.

### Changes proposed in this pull request

* Adds `most_recent_induction_period_end_date` attribute to the `API::TeacherSerializer`
* surface the `most_recent_induction_period_end_date` in the `ecf_enrolment` section
* Add `most_recent_induction_period_end_date` method to `API::Teachers::InductionStatus`
* Updates specs
* Updates swagger docs

### Guidance to review

Access the participant API end point.

* for a mentor teacher, the `most_recent_induction_period_end_date` should be `null`
* for an ECT with an ongoing `InductionPeriod`, the `most_recent_induction_period_end_date` should be `null`
* for an ECT whose latest `InductionPeriod` is closed, the `most_recent_induction_period_end_date` should match the `finished_on` date of the latest `InductionPeriod`