### PR TITLE
[3404] Apply current active contract period changes (Slice 3)

### DIFF
--- a/app/controllers/admin/teachers/training_periods/change_contract_period_wizard_controller.rb
+++ b/app/controllers/admin/teachers/training_periods/change_contract_period_wizard_controller.rb
@@ -20,16 +20,15 @@ module Admin
         end
 
         def create
-          if @wizard.valid_step?
-            @wizard.current_step.save!
+          unless @wizard.valid_step? && @wizard.current_step.save!
+            return render current_step, status: :unprocessable_content
+          end
 
-            if current_step == :check_answers
-              render current_step
-            else
-              redirect_to @wizard.next_step_path
-            end
+          if current_step == :check_answers
+            store.reset
+            redirect_to admin_teacher_training_path(@teacher), alert: "Contract period changed"
           else
-            render current_step, status: :unprocessable_content
+            redirect_to @wizard.next_step_path
           end
         end
 
@@ -46,7 +45,7 @@ module Admin
         end
 
         def ensure_changeable_training_period
-          unless ChangeContractPeriod::Eligibility.new(training_period: @training_period).eligible?
+          unless ChangeContractPeriod::Eligibility.new(training_period: @training_period).current_active_period_changeable?
             raise ActionController::BadRequest,
                   "Training period is not eligible for contract period change"
           end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -63,6 +63,7 @@ class Event < ApplicationRecord
     teacher_registration_undone
     teacher_withdraws_training_period
     teacher_changes_schedule_training_period
+    teacher_training_period_contract_period_changed
     teacher_declaration_voided
     teacher_declaration_awaiting_clawback
     teacher_declaration_created

--- a/app/services/admin/teachers/training_periods/change_contract_period/current_active_period.rb
+++ b/app/services/admin/teachers/training_periods/change_contract_period/current_active_period.rb
@@ -1,0 +1,135 @@
+module Admin
+  module Teachers
+    module TrainingPeriods
+      module ChangeContractPeriod
+        class CurrentActivePeriod
+          class UnsupportedTrainingPeriodError < StandardError; end
+          class ScheduleNotFoundError < StandardError; end
+
+          attr_reader :training_period, :contract_period, :school_partnership, :author
+
+          def initialize(training_period:, contract_period:, school_partnership:, author:)
+            @training_period = training_period
+            @contract_period = contract_period
+            @school_partnership = school_partnership
+            @author = author
+          end
+
+          def change_contract_period!
+            unless current_active_period?
+              raise UnsupportedTrainingPeriodError,
+                    "Contract period changes are only supported for the current active training period"
+            end
+
+            if equivalent_schedule.blank?
+              raise ScheduleNotFoundError,
+                    "No equivalent schedule found for #{training_period.schedule.identifier} in contract period #{contract_period.year}"
+            end
+
+            ActiveRecord::Base.transaction do
+              track_payments_frozen_year!
+              replacement_finished_on = training_period.finished_on
+              finish_training_period!
+              new_training_period = create_replacement_training_period!(finished_on: replacement_finished_on)
+              record_contract_period_changed_event!
+              new_training_period
+            end
+          end
+
+        private
+
+          def current_active_period?
+            relationships.current_active_period == training_period && training_period.started_on < Time.zone.today
+          end
+
+          def relationships
+            @relationships ||= ::TrainingPeriods::PeriodRelationships.new(training_period:)
+          end
+
+          def equivalent_schedule
+            @equivalent_schedule ||= Schedule.find_by(
+              identifier: training_period.schedule.identifier,
+              contract_period_year: contract_period.year
+            )
+          end
+
+          def finish_training_period!
+            if training_period.for_ect?
+              ::TrainingPeriods::Finish.ect_training(
+                author:,
+                training_period:,
+                ect_at_school_period: training_period.at_school_period,
+                finished_on: Date.yesterday
+              ).finish!
+            elsif training_period.for_mentor?
+              ::TrainingPeriods::Finish.mentor_training(
+                author:,
+                training_period:,
+                mentor_at_school_period: training_period.at_school_period,
+                finished_on: Date.yesterday
+              ).finish!
+            else
+              raise UnsupportedTrainingPeriodError, "Training period must be ECT or mentor"
+            end
+          end
+
+          def create_replacement_training_period!(finished_on:)
+            ::TrainingPeriods::Create.provider_led(
+              period: training_period.at_school_period,
+              started_on: Time.zone.today,
+              finished_on:,
+              school_partnership:,
+              expression_of_interest: nil,
+              schedule: equivalent_schedule,
+              author:
+            ).call
+          end
+
+          def record_contract_period_changed_event!
+            ::Events::Record.record_teacher_contract_period_changed_event!(
+              author:,
+              original_training_period: training_period,
+              teacher: training_period.teacher,
+              from_contract_period: current_contract_period,
+              to_contract_period: contract_period
+            )
+          end
+
+          def current_contract_period
+            @current_contract_period ||= training_period.contract_period
+          end
+
+          def track_payments_frozen_year!
+            return if current_contract_period == contract_period
+
+            if changing_from_payments_frozen_contract_period?
+              set_payments_frozen_year(year: current_contract_period.year)
+            elsif changing_to_payments_frozen_contract_period?
+              set_payments_frozen_year(year: nil)
+            end
+          end
+
+          def changing_from_payments_frozen_contract_period?
+            current_contract_period.payments_frozen?
+          end
+
+          def changing_to_payments_frozen_contract_period?
+            contract_period.payments_frozen?
+          end
+
+          def set_payments_frozen_year(year:)
+            attribute = if training_period.for_ect?
+                          :ect_payments_frozen_year
+                        elsif training_period.for_mentor?
+                          :mentor_payments_frozen_year
+                        else
+                          raise UnsupportedTrainingPeriodError, "Training period must be ECT or mentor"
+                        end
+
+            training_period.teacher.update!(attribute => year)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/admin/teachers/training_periods/change_contract_period/current_active_period.rb
+++ b/app/services/admin/teachers/training_periods/change_contract_period/current_active_period.rb
@@ -43,7 +43,7 @@ module Admin
           end
 
           def relationships
-            @relationships ||= ::TrainingPeriods::PeriodRelationships.new(training_period:)
+            @relationships ||= ::TrainingPeriods::RelatedPeriods.new(training_period:)
           end
 
           def equivalent_schedule

--- a/app/services/admin/teachers/training_periods/change_contract_period/current_active_period.rb
+++ b/app/services/admin/teachers/training_periods/change_contract_period/current_active_period.rb
@@ -31,7 +31,7 @@ module Admin
               replacement_finished_on = training_period.finished_on
               finish_training_period!
               new_training_period = create_replacement_training_period!(finished_on: replacement_finished_on)
-              record_contract_period_changed_event!
+              record_contract_period_changed_event!(new_training_period:)
               new_training_period
             end
           end
@@ -85,10 +85,11 @@ module Admin
             ).call
           end
 
-          def record_contract_period_changed_event!
+          def record_contract_period_changed_event!(new_training_period:)
             ::Events::Record.record_teacher_contract_period_changed_event!(
               author:,
               original_training_period: training_period,
+              new_training_period:,
               teacher: training_period.teacher,
               from_contract_period: current_contract_period,
               to_contract_period: contract_period

--- a/app/services/admin/teachers/training_periods/change_contract_period/eligibility.rb
+++ b/app/services/admin/teachers/training_periods/change_contract_period/eligibility.rb
@@ -10,25 +10,23 @@ module Admin
           end
 
           def eligible?
-            return false unless training_period.provider_led_training_programme?
-            return false if training_period.school_partnership.blank?
+            return false unless provider_led_with_partnership?
             return false if finished_before_today?
-            return false if current_active_period.present? && !current_active_period_started_before_today?
+            return false if blocked_by_current_active_period?
 
-            return current_active_period == training_period if future_periods.empty?
-            return future_periods == [training_period] if current_active_period.blank?
+            return current_active_period? if no_future_periods?
+            return only_future_period? if no_current_active_period?
 
-            future_periods.include?(training_period) && same_lead_provider_delivery_partnership?(current_active_period, training_period)
+            future_period? && same_partnership_as_current_active_period?
           end
 
           def current_active_period_changeable?
-            return false unless training_period.provider_led_training_programme?
-            return false if training_period.school_partnership.blank?
+            return false unless provider_led_with_partnership?
             return false if finished_before_today?
-            return false unless current_active_period == training_period
+            return false unless current_active_period?
             return false unless current_active_period_started_before_today?
 
-            future_periods.empty?
+            no_future_periods?
           end
 
         private
@@ -45,9 +43,38 @@ module Admin
             @future_periods ||= relationships.future_periods.to_a
           end
 
-          def same_lead_provider_delivery_partnership?(period, other_period)
-            period.lead_provider_delivery_partnership.present? &&
-              period.lead_provider_delivery_partnership == other_period.lead_provider_delivery_partnership
+          def provider_led_with_partnership?
+            training_period.provider_led_training_programme? &&
+              training_period.school_partnership.present?
+          end
+
+          def blocked_by_current_active_period?
+            current_active_period.present? && !current_active_period_started_before_today?
+          end
+
+          def current_active_period?
+            current_active_period == training_period
+          end
+
+          def no_future_periods?
+            future_periods.empty?
+          end
+
+          def no_current_active_period?
+            current_active_period.blank?
+          end
+
+          def only_future_period?
+            future_periods == [training_period]
+          end
+
+          def future_period?
+            future_periods.include?(training_period)
+          end
+
+          def same_partnership_as_current_active_period?
+            current_active_period.lead_provider_delivery_partnership.present? &&
+              current_active_period.lead_provider_delivery_partnership == training_period.lead_provider_delivery_partnership
           end
 
           def current_active_period_started_before_today?

--- a/app/services/admin/teachers/training_periods/change_contract_period/eligibility.rb
+++ b/app/services/admin/teachers/training_periods/change_contract_period/eligibility.rb
@@ -11,7 +11,7 @@ module Admin
 
           def eligible?
             return false unless base_eligible?
-            return false if current_active_period.present? && !current_active_period_start_date_passed?
+            return false if current_active_period.present? && !current_active_period_started_before_today?
 
             return current_active_period == training_period if future_periods.empty?
             return future_periods == [training_period] if current_active_period.blank?
@@ -22,7 +22,7 @@ module Admin
           def current_active_period_changeable?
             return false unless base_eligible?
             return false unless current_active_period == training_period
-            return false unless current_active_period_start_date_passed?
+            return false unless current_active_period_started_before_today?
 
             future_periods.empty?
           end
@@ -53,7 +53,7 @@ module Admin
             !finished_before_today?
           end
 
-          def current_active_period_start_date_passed?
+          def current_active_period_started_before_today?
             current_active_period.started_on < Time.zone.today
           end
 

--- a/app/services/admin/teachers/training_periods/change_contract_period/eligibility.rb
+++ b/app/services/admin/teachers/training_periods/change_contract_period/eligibility.rb
@@ -10,14 +10,21 @@ module Admin
           end
 
           def eligible?
-            return false unless training_period.provider_led_training_programme?
-            return false if training_period.school_partnership.blank?
-            return false if finished_before_today?
+            return false unless base_eligible?
+            return false if current_active_period.present? && !current_active_period_start_date_passed?
 
             return current_active_period == training_period if future_periods.empty?
             return future_periods == [training_period] if current_active_period.blank?
 
             future_periods.include?(training_period) && same_lead_provider_delivery_partnership?(current_active_period, training_period)
+          end
+
+          def current_active_period_changeable?
+            return false unless base_eligible?
+            return false unless current_active_period == training_period
+            return false unless current_active_period_start_date_passed?
+
+            future_periods.empty?
           end
 
         private
@@ -37,6 +44,17 @@ module Admin
           def same_lead_provider_delivery_partnership?(period, other_period)
             period.lead_provider_delivery_partnership.present? &&
               period.lead_provider_delivery_partnership == other_period.lead_provider_delivery_partnership
+          end
+
+          def base_eligible?
+            return false unless training_period.provider_led_training_programme?
+            return false if training_period.school_partnership.blank?
+
+            !finished_before_today?
+          end
+
+          def current_active_period_start_date_passed?
+            current_active_period.started_on < Time.zone.today
           end
 
           def finished_before_today?

--- a/app/services/admin/teachers/training_periods/change_contract_period/eligibility.rb
+++ b/app/services/admin/teachers/training_periods/change_contract_period/eligibility.rb
@@ -10,7 +10,9 @@ module Admin
           end
 
           def eligible?
-            return false unless base_eligible?
+            return false unless training_period.provider_led_training_programme?
+            return false if training_period.school_partnership.blank?
+            return false if finished_before_today?
             return false if current_active_period.present? && !current_active_period_started_before_today?
 
             return current_active_period == training_period if future_periods.empty?
@@ -20,7 +22,9 @@ module Admin
           end
 
           def current_active_period_changeable?
-            return false unless base_eligible?
+            return false unless training_period.provider_led_training_programme?
+            return false if training_period.school_partnership.blank?
+            return false if finished_before_today?
             return false unless current_active_period == training_period
             return false unless current_active_period_started_before_today?
 
@@ -44,13 +48,6 @@ module Admin
           def same_lead_provider_delivery_partnership?(period, other_period)
             period.lead_provider_delivery_partnership.present? &&
               period.lead_provider_delivery_partnership == other_period.lead_provider_delivery_partnership
-          end
-
-          def base_eligible?
-            return false unless training_period.provider_led_training_programme?
-            return false if training_period.school_partnership.blank?
-
-            !finished_before_today?
           end
 
           def current_active_period_started_before_today?

--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -513,13 +513,34 @@ module Events
       new(event_type:, author:, heading:, training_period: original_training_period, schedule: original_schedule, teacher:, lead_provider:, metadata:, happened_at:).record_event!
     end
 
-    def self.record_teacher_contract_period_changed_event!(author:, original_training_period:, teacher:, from_contract_period:, to_contract_period:, happened_at: Time.zone.now)
+    def self.record_teacher_contract_period_changed_event!(
+      author:,
+      original_training_period:,
+      new_training_period:,
+      teacher:,
+      from_contract_period:,
+      to_contract_period:,
+      happened_at: Time.zone.now
+    )
       event_type = :teacher_training_period_contract_period_changed
       teacher_name = Teachers::Name.new(teacher).full_name
       training_type = (original_training_period.for_ect?) ? "ECT" : "mentor"
       heading = "#{teacher_name}’s #{training_type} training contract period changed from #{from_contract_period.year} to #{to_contract_period.year}"
+      metadata = {
+        new_training_period_id: new_training_period.id,
+        to_contract_period_id: to_contract_period.id,
+      }
 
-      new(event_type:, author:, heading:, training_period: original_training_period, contract_period: from_contract_period, teacher:, happened_at:).record_event!
+      new(
+        event_type:,
+        author:,
+        heading:,
+        training_period: original_training_period,
+        contract_period: from_contract_period,
+        teacher:,
+        metadata:,
+        happened_at:
+      ).record_event!
     end
 
     def self.record_teacher_schedule_assigned_to_training_period!(author:, training_period:, teacher:, schedule:, happened_at: Time.zone.now)

--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -513,6 +513,15 @@ module Events
       new(event_type:, author:, heading:, training_period: original_training_period, schedule: original_schedule, teacher:, lead_provider:, metadata:, happened_at:).record_event!
     end
 
+    def self.record_teacher_contract_period_changed_event!(author:, original_training_period:, teacher:, from_contract_period:, to_contract_period:, happened_at: Time.zone.now)
+      event_type = :teacher_training_period_contract_period_changed
+      teacher_name = Teachers::Name.new(teacher).full_name
+      training_type = (original_training_period.for_ect?) ? "ECT" : "mentor"
+      heading = "#{teacher_name}’s #{training_type} training contract period changed from #{from_contract_period.year} to #{to_contract_period.year}"
+
+      new(event_type:, author:, heading:, training_period: original_training_period, contract_period: from_contract_period, teacher:, happened_at:).record_event!
+    end
+
     def self.record_teacher_schedule_assigned_to_training_period!(author:, training_period:, teacher:, schedule:, happened_at: Time.zone.now)
       event_type = :teacher_schedule_assigned_to_training_period
       teacher_name = Teachers::Name.new(teacher).full_name

--- a/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/check_answers_step.rb
+++ b/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/check_answers_step.rb
@@ -3,11 +3,33 @@ module Admin
     module TrainingPeriods
       module ChangeContractPeriodWizard
         class CheckAnswersStep < Step
+          CurrentActivePeriodChange = ::Admin::Teachers::TrainingPeriods::ChangeContractPeriod::CurrentActivePeriod
+
           self.expected_store_keys = %i[contract_period_year school_partnership_id]
 
           def previous_step = :select_partnership
 
-          def save! = true
+          def save!
+            service.change_contract_period!
+            true
+          rescue CurrentActivePeriodChange::UnsupportedTrainingPeriodError
+            errors.add(:base, "Training period is not eligible for contract period change")
+            false
+          rescue CurrentActivePeriodChange::ScheduleNotFoundError
+            errors.add(:base, "A matching schedule could not be found for the selected contract period")
+            false
+          end
+
+        private
+
+          def service
+            CurrentActivePeriodChange.new(
+              training_period: wizard.training_period,
+              contract_period: wizard.selected_contract_period,
+              school_partnership: wizard.selected_school_partnership,
+              author: wizard.author
+            )
+          end
         end
       end
     end

--- a/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/step.rb
+++ b/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/step.rb
@@ -6,7 +6,10 @@ module Admin
           def self.permitted_params = []
 
           def save!
-            persist if wizard.valid_step?
+            return false unless wizard.valid_step?
+
+            persist
+            true
           end
 
         private

--- a/spec/requests/admin/teachers/training_periods/change_contract_period_wizard_spec.rb
+++ b/spec/requests/admin/teachers/training_periods/change_contract_period_wizard_spec.rb
@@ -186,6 +186,7 @@ RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardCont
       expect(response).to redirect_to(admin_teacher_training_path(teacher))
       expect(training_period.reload.finished_on).to eq(today.yesterday)
       expect(replacement_training_period.contract_period).to eq(target_contract_period)
+      expect(replacement_training_period.school_partnership).to eq(target_school_partnership)
       expect(replacement_training_period.schedule).to eq(target_schedule)
 
       follow_redirect!

--- a/spec/requests/admin/teachers/training_periods/change_contract_period_wizard_spec.rb
+++ b/spec/requests/admin/teachers/training_periods/change_contract_period_wizard_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardCont
   end
   let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:) }
   let(:schedule) { FactoryBot.create(:schedule, contract_period: current_contract_period) }
+  let(:target_schedule) { FactoryBot.create(:schedule, contract_period: target_contract_period, identifier: schedule.identifier) }
   let(:training_period) do
     FactoryBot.create(
       :training_period,
@@ -34,6 +35,8 @@ RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardCont
       started_on: today.prev_month
     )
   end
+  let(:replacement_training_periods) { TrainingPeriod.where(ect_at_school_period:).where.not(id: training_period.id) }
+  let(:replacement_training_period) { replacement_training_periods.sole }
   let(:teacher_name) { Teachers::Name.new(teacher).full_name }
 
   around do |example|
@@ -60,6 +63,14 @@ RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardCont
 
     it "returns bad request when the training period is not eligible" do
       training_period.update!(finished_on: today.yesterday)
+
+      get path_for_step("select-contract-period")
+
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it "returns bad request when the training period starts in the future" do
+      training_period.update!(started_on: today.next_month, finished_on: nil)
 
       get path_for_step("select-contract-period")
 
@@ -163,15 +174,35 @@ RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardCont
   end
 
   describe "POST check-answers" do
-    it "does not apply the contract period change in this slice" do
+    it "applies the contract period change and redirects to the training tab" do
+      target_school_partnership
+      target_schedule
+      select_contract_period_and_partnership
+
+      expect {
+        post path_for_step("check-answers"), params: { check_answers: {} }
+      }.to change { TrainingPeriod.where(ect_at_school_period:).count }.by(1)
+
+      expect(response).to redirect_to(admin_teacher_training_path(teacher))
+      expect(training_period.reload.finished_on).to eq(today.yesterday)
+      expect(replacement_training_period.contract_period).to eq(target_contract_period)
+      expect(replacement_training_period.schedule).to eq(target_schedule)
+
+      follow_redirect!
+
+      expect(response.body).to include("Contract period changed")
+    end
+
+    it "shows an error when the selected contract period has no matching schedule" do
+      target_school_partnership
       select_contract_period_and_partnership
 
       expect {
         post path_for_step("check-answers"), params: { check_answers: {} }
       }.not_to change(TrainingPeriod, :count)
 
-      expect(response).to have_http_status(:ok)
-      expect(response.body).to include("Confirm contract period change for #{teacher_name}")
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include("A matching schedule could not be found for the selected contract period")
     end
   end
 

--- a/spec/services/admin/teachers/training_periods/change_contract_period/current_active_period_spec.rb
+++ b/spec/services/admin/teachers/training_periods/change_contract_period/current_active_period_spec.rb
@@ -1,0 +1,188 @@
+RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriod::CurrentActivePeriod do
+  include ActiveJob::TestHelper
+
+  subject(:service_call) do
+    described_class.new(
+      training_period:,
+      contract_period: target_contract_period,
+      school_partnership: target_school_partnership,
+      author:
+    ).change_contract_period!
+  end
+
+  let(:today) { Date.new(2026, 2, 1) }
+  let(:author) { Events::SystemAuthor.new }
+  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:school) { FactoryBot.create(:school) }
+  let(:current_contract_period) { FactoryBot.create(:contract_period, year: 2025) }
+  let(:target_contract_period) { FactoryBot.create(:contract_period, year: 2026) }
+  let(:school_partnership) { FactoryBot.create(:school_partnership, :for_year, year: current_contract_period.year, school:) }
+  let(:target_school_partnership) { FactoryBot.create(:school_partnership, :for_year, year: target_contract_period.year, school:) }
+  let(:schedule) { FactoryBot.create(:schedule, contract_period: current_contract_period) }
+  let!(:target_schedule) { FactoryBot.create(:schedule, contract_period: target_contract_period, identifier: schedule.identifier) }
+  let(:started_on) { today.prev_month }
+  let(:finished_on) { nil }
+  let(:ect_at_school_period) do
+    FactoryBot.create(
+      :ect_at_school_period,
+      :ongoing,
+      teacher:,
+      school:,
+      started_on: today.prev_year,
+      finished_on: nil
+    )
+  end
+  let!(:training_period) do
+    FactoryBot.create(
+      :training_period,
+      :ongoing,
+      ect_at_school_period:,
+      school_partnership:,
+      schedule:,
+      started_on:,
+      finished_on:
+    )
+  end
+
+  around do |example|
+    travel_to(today) { perform_enqueued_jobs { example.run } }
+  end
+
+  it "ends the current training period and creates a replacement in the selected contract period" do
+    replacement_training_period = nil
+
+    expect {
+      replacement_training_period = service_call
+    }
+      .to change(TrainingPeriod, :count).by(1)
+      .and change { Event.where(event_type: "teacher_training_period_contract_period_changed").count }.by(1)
+
+    expect(training_period.reload.finished_on).to eq(today.yesterday)
+    expect(replacement_training_period.started_on).to eq(today)
+    expect(replacement_training_period.finished_on).to be_nil
+    expect(replacement_training_period.school_partnership).to eq(target_school_partnership)
+    expect(replacement_training_period.contract_period).to eq(target_contract_period)
+    expect(replacement_training_period.schedule).to eq(target_schedule)
+    expect(replacement_training_period.expression_of_interest).to be_nil
+  end
+
+  it "does not record a teacher schedule change event" do
+    expect {
+      service_call
+    }.not_to(change { Event.where(event_type: "teacher_changes_schedule_training_period").count })
+  end
+
+  context "when the current training period has a future end date" do
+    let(:finished_on) { today.next_month }
+
+    it "carries the future end date onto the replacement period" do
+      replacement_training_period = service_call
+
+      expect(replacement_training_period.finished_on).to eq(finished_on)
+    end
+  end
+
+  context "when the training period is not the current active period" do
+    let(:started_on) { today.next_month }
+
+    it "raises an unsupported training period error" do
+      expect {
+        service_call
+      }.to raise_error(
+        described_class::UnsupportedTrainingPeriodError,
+        "Contract period changes are only supported for the current active training period"
+      )
+    end
+  end
+
+  context "when there is no equivalent schedule in the selected contract period" do
+    let!(:target_schedule) { nil }
+
+    it "raises a schedule not found error" do
+      expect {
+        service_call
+      }.to raise_error(
+        described_class::ScheduleNotFoundError,
+        "No equivalent schedule found for #{schedule.identifier} in contract period #{target_contract_period.year}"
+      )
+    end
+  end
+
+  context "for ECT training" do
+    context "when moving away from a frozen contract period" do
+      let(:current_contract_period) { FactoryBot.create(:contract_period, :with_payments_frozen, year: 2022) }
+
+      it "tracks the frozen year on the teacher" do
+        service_call
+
+        expect(teacher.reload.ect_payments_frozen_year).to eq(current_contract_period.year)
+      end
+    end
+
+    context "when moving back to a frozen contract period" do
+      let(:current_contract_period) { FactoryBot.create(:contract_period, year: 2025, payments_frozen_at: nil) }
+      let(:target_contract_period) { FactoryBot.create(:contract_period, :with_payments_frozen, year: 2022) }
+      let(:teacher) { FactoryBot.create(:teacher, ect_payments_frozen_year: target_contract_period.year) }
+
+      it "clears the frozen year on the teacher" do
+        service_call
+
+        expect(teacher.reload.ect_payments_frozen_year).to be_nil
+        expect(teacher.reload.mentor_payments_frozen_year).to be_nil
+      end
+    end
+  end
+
+  context "for mentor training" do
+    let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:, school:, started_on: today.prev_year) }
+    let!(:training_period) do
+      FactoryBot.create(
+        :training_period,
+        :for_mentor,
+        :ongoing,
+        mentor_at_school_period:,
+        school_partnership:,
+        schedule:,
+        started_on:,
+        finished_on:
+      )
+    end
+
+    it "creates a replacement mentor training period" do
+      replacement_training_period = nil
+
+      expect {
+        replacement_training_period = service_call
+      }.to change(TrainingPeriod, :count).by(1)
+
+      expect(training_period.reload.finished_on).to eq(today.yesterday)
+      expect(replacement_training_period.started_on).to eq(today)
+      expect(replacement_training_period.school_partnership).to eq(target_school_partnership)
+      expect(replacement_training_period.schedule).to eq(target_schedule)
+    end
+
+    context "when moving away from a frozen contract period" do
+      let(:current_contract_period) { FactoryBot.create(:contract_period, :with_payments_frozen, year: 2022) }
+
+      it "tracks the frozen year on the mentor field" do
+        service_call
+
+        expect(teacher.reload.mentor_payments_frozen_year).to eq(current_contract_period.year)
+        expect(teacher.ect_payments_frozen_year).to be_nil
+      end
+    end
+
+    context "when moving back to a frozen contract period" do
+      let(:current_contract_period) { FactoryBot.create(:contract_period, year: 2025, payments_frozen_at: nil) }
+      let(:target_contract_period) { FactoryBot.create(:contract_period, :with_payments_frozen, year: 2022) }
+      let(:teacher) { FactoryBot.create(:teacher, mentor_payments_frozen_year: target_contract_period.year) }
+
+      it "clears the frozen year on the mentor field" do
+        service_call
+
+        expect(teacher.reload.mentor_payments_frozen_year).to be_nil
+        expect(teacher.reload.ect_payments_frozen_year).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/admin/teachers/training_periods/change_contract_period/eligibility_spec.rb
+++ b/spec/services/admin/teachers/training_periods/change_contract_period/eligibility_spec.rb
@@ -130,6 +130,14 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriod::Eligibili
     end
   end
 
+  context "when the current active training period starts today" do
+    let(:started_on) { today }
+
+    it "is not eligible" do
+      expect(eligibility).not_to be_eligible
+    end
+  end
+
   context "when there is only one future period and no current active period" do
     let(:started_on) { today.next_month }
 
@@ -229,6 +237,53 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriod::Eligibili
 
     it "is not eligible" do
       expect(eligibility).not_to be_eligible
+    end
+  end
+
+  describe "#current_active_period_changeable?" do
+    it "is changeable for a provider-led active current period with no future periods" do
+      expect(eligibility).to be_current_active_period_changeable
+    end
+
+    context "when the training period starts today" do
+      let(:started_on) { today }
+
+      it "is not changeable" do
+        expect(eligibility).not_to be_current_active_period_changeable
+      end
+    end
+
+    context "when the training period starts in the future" do
+      let(:started_on) { today.next_month }
+
+      it "is not changeable" do
+        expect(eligibility).not_to be_current_active_period_changeable
+      end
+    end
+
+    context "when there is a future period" do
+      let(:future_started_on) { today.next_month }
+      let(:finished_on) { future_started_on.yesterday }
+
+      before do
+        FactoryBot.create(
+          :training_period,
+          ect_at_school_period: FactoryBot.create(
+            :ect_at_school_period,
+            teacher:,
+            school:,
+            started_on: future_started_on,
+            finished_on: nil
+          ),
+          school_partnership:,
+          started_on: future_started_on,
+          finished_on: nil
+        )
+      end
+
+      it "is not changeable" do
+        expect(eligibility).not_to be_current_active_period_changeable
+      end
     end
   end
 end

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -1461,7 +1461,14 @@ RSpec.describe Events::Record do
     let(:from_schedule) { FactoryBot.create(:schedule, contract_period: from_contract_period) }
 
     context "when ECT training" do
-      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher:) }
+      let(:ect_at_school_period) do
+        FactoryBot.create(
+          :ect_at_school_period,
+          teacher:,
+          started_on: 2.months.ago.to_date,
+          finished_on: nil
+        )
+      end
       let(:school_partnership) do
         FactoryBot.create(
           :school_partnership,
@@ -1476,7 +1483,25 @@ RSpec.describe Events::Record do
           :for_ect,
           ect_at_school_period:,
           school_partnership:,
-          schedule: from_schedule
+          schedule: from_schedule,
+          started_on: 1.month.ago.to_date,
+          finished_on: Date.yesterday
+        )
+      end
+      let(:to_schedule) { FactoryBot.create(:schedule, contract_period: to_contract_period) }
+      let(:new_training_period) do
+        FactoryBot.create(
+          :training_period,
+          :for_ect,
+          ect_at_school_period:,
+          school_partnership: FactoryBot.create(
+            :school_partnership,
+            :for_year,
+            year: to_contract_period.year,
+            school: ect_at_school_period.school
+          ),
+          schedule: to_schedule,
+          started_on: Time.zone.today
         )
       end
 
@@ -1485,6 +1510,7 @@ RSpec.describe Events::Record do
           Events::Record.record_teacher_contract_period_changed_event!(
             author:,
             original_training_period:,
+            new_training_period:,
             teacher:,
             from_contract_period:,
             to_contract_period:
@@ -1496,6 +1522,10 @@ RSpec.describe Events::Record do
             teacher:,
             heading: "#{teacher_name}’s ECT training contract period changed from #{from_contract_period.year} to #{to_contract_period.year}",
             event_type: :teacher_training_period_contract_period_changed,
+            metadata: {
+              new_training_period_id: new_training_period.id,
+              to_contract_period_id: to_contract_period.id,
+            },
             happened_at: Time.zone.now,
             **author_params
           )

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -1454,6 +1454,56 @@ RSpec.describe Events::Record do
     end
   end
 
+  describe ".record_teacher_contract_period_changed_event!" do
+    let(:teacher_name) { Teachers::Name.new(teacher).full_name }
+    let(:from_contract_period) { FactoryBot.create(:contract_period, year: 2025) }
+    let(:to_contract_period) { FactoryBot.create(:contract_period, year: 2026) }
+    let(:from_schedule) { FactoryBot.create(:schedule, contract_period: from_contract_period) }
+
+    context "when ECT training" do
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher:) }
+      let(:school_partnership) do
+        FactoryBot.create(
+          :school_partnership,
+          :for_year,
+          year: from_contract_period.year,
+          school: ect_at_school_period.school
+        )
+      end
+      let(:original_training_period) do
+        FactoryBot.create(
+          :training_period,
+          :for_ect,
+          ect_at_school_period:,
+          school_partnership:,
+          schedule: from_schedule
+        )
+      end
+
+      it "queues a RecordEventJob with the correct values" do
+        freeze_time do
+          Events::Record.record_teacher_contract_period_changed_event!(
+            author:,
+            original_training_period:,
+            teacher:,
+            from_contract_period:,
+            to_contract_period:
+          )
+
+          expect(RecordEventJob).to have_received(:perform_later).with(
+            training_period: original_training_period,
+            contract_period: from_contract_period,
+            teacher:,
+            heading: "#{teacher_name}’s ECT training contract period changed from #{from_contract_period.year} to #{to_contract_period.year}",
+            event_type: :teacher_training_period_contract_period_changed,
+            happened_at: Time.zone.now,
+            **author_params
+          )
+        end
+      end
+    end
+  end
+
   describe ".record_bulk_upload_started_event!" do
     let(:batch) { FactoryBot.create(:pending_induction_submission_batch, :action, appropriate_body_period:) }
 


### PR DESCRIPTION
## What

Following on from #3083, this is the third slice of the contract period change journey for admins.

This PR adds the current active period mutation slice of the contract period change journey.

This introduces:

- a service for applying contract period changes to current active training periods
- creation of a replacement training period using the selected partnership and contract period
- equivalent schedule lookup in the selected contract period
- ending the previous training period
- frozen year tracking for ECT and mentors
- contract period change event recording
- CYA submission
- redirect back to the training tab with the success message

## Not included

This PR does not:

- display the Change link on the training tab
- support future starting training period mutation
- handle same/different LP/DP future transfer behaviour
- change contract period eligibility for EOI only participants
- add the no partnership dead end page