### PR TITLE
Fix flaky test

### DIFF
--- a/spec/requests/api/release_notes_spec.rb
+++ b/spec/requests/api/release_notes_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe "Release Notes" do
+  include ActionView::Helpers::SanitizeHelper
+
   describe "GET /api/guidance/release-notes" do
     it "renders valid notes" do
       expect { get(api_guidance_release_notes_path) }.not_to raise_error
@@ -23,7 +25,7 @@ RSpec.describe "Release Notes" do
         get(api_guidance_release_note_path(note.slug))
 
         expect(response).to be_successful
-        expect(response.body).to include(note.title)
+        expect(sanitize(response.body)).to include(note.title)
         expect(response.body).to include(note.body)
         expect(response.body).to include(note.date)
         expect(response.body).to include(note.tags.sample.titleize.humanize)


### PR DESCRIPTION
Before, this test would fail if the sampled release note title contained any punctuation.

This sanitizes the response body before we assert against it, so we don't run into [failures] comparing things like

```
Added new withdrawal reason &#39;changed_lead_provider&#39;
```

with things like

```
Added new withdrawal reason 'changed_lead_provider'
```

Now, this test should pass every time.

[failures]: https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/27689556289/job/81896706520?pr=3099
