### PR TITLE
Handle existing declarations with invalid declaration_date for milestone

### DIFF
--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -69,7 +69,8 @@ class Declaration < ApplicationRecord
   validates :voided_by_user, presence: { message: "Voided by user must be set as well as the voided date" }, if: :voided_by_user_at
   validates :voided_by_user_at, presence: { message: "Voided by user at must be set as well as the voided by user" }, if: :voided_by_user
   validates :api_id, uniqueness: { case_sensitive: false, message: "API id already exists for another declaration" }
-  validates :declaration_date, presence: { message: "Declaration date must be specified" }, declaration_date_within_milestone: true
+  validates :declaration_date, presence: { message: "Declaration date must be specified" }
+  validates :declaration_date, declaration_date_within_milestone: true, if: :declaration_date_or_schedule_changed?
   validates :declaration_type, inclusion: { in: Declaration.declaration_types.keys, message: "Choose a valid declaration type" }
   validates :evidence_type, inclusion: { in: Declaration.evidence_types.keys, message: "Choose a valid evidence type" }, allow_nil: true
   validates :mentorship_period, absence: { message: "Mentor teacher can only be assigned to declarations for ECTs" }, if: :for_mentor?
@@ -175,6 +176,10 @@ class Declaration < ApplicationRecord
   end
 
 private
+
+  def declaration_date_or_schedule_changed?
+    declaration_date_changed? || training_period&.schedule_id_changed?
+  end
 
   def existing_declarations
     @existing_declarations ||= if training_period.for_ect?

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -132,10 +132,10 @@ describe Declaration do
     end
 
     describe "declaration date relative to milestone dates" do
-      subject(:declaration) { FactoryBot.build(:declaration, declaration_type: :started, declaration_date:, training_period:) }
+      subject(:declaration) { FactoryBot.build(:declaration, :started, declaration_date:, training_period:) }
 
       let(:schedule) { FactoryBot.create(:schedule, contract_period: school_partnership.contract_period) }
-      let(:milestone) { FactoryBot.create(:milestone, declaration_type: :started, schedule:) }
+      let(:milestone) { FactoryBot.create(:milestone, :started, schedule:) }
       let(:school_partnership) { FactoryBot.create(:school_partnership) }
       let(:training_period) { FactoryBot.create(:training_period, schedule:, school_partnership:) }
 
@@ -143,6 +143,44 @@ describe Declaration do
         let(:declaration_date) { Faker::Date.between(from: milestone.start_date, to: milestone.milestone_date) }
 
         it { is_expected.to be_valid }
+      end
+
+      context "when a declaration already exists with an invalid declaration_date" do
+        let(:declaration_date) { milestone.start_date.prev_day }
+
+        before { declaration.save!(validate: false) }
+
+        it "allows updates to the declaration" do
+          expect { declaration.update!(declaration_type: "retained-1") }.not_to raise_error
+        end
+
+        it "still validates the declaration date when it is changed" do
+          expect(declaration).to be_valid
+
+          declaration.declaration_date = milestone.milestone_date.next_day
+
+          expect(declaration).to be_invalid
+          expect(declaration.errors[:declaration_date]).to include("Declaration date must be on or before the milestone date for the same declaration type.")
+        end
+      end
+
+      context "when the declaration training period changes schedule and the declaration date is no longer valid" do
+        let(:declaration_date) { Faker::Date.between(from: milestone.start_date, to: milestone.milestone_date) }
+
+        before do
+          declaration.save!
+
+          different_contract_period = FactoryBot.create(:contract_period, year: school_partnership.contract_period.year - 1)
+          different_schedule = FactoryBot.create(:schedule, contract_period: different_contract_period)
+          FactoryBot.create(:milestone, :started, schedule: different_schedule)
+
+          declaration.training_period.schedule = different_schedule
+        end
+
+        it "is not valid" do
+          expect(declaration).to be_invalid
+          expect(declaration.errors[:declaration_date]).to include("Declaration date must be on or before the milestone date for the same declaration type.")
+        end
       end
 
       context "when the declaration date is before the milestone start_date" do

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -80,10 +80,7 @@ describe Declaration do
       context "when uplift_fee_enabled is false for the contract period" do
         let(:uplift_fees_enabled) { false }
 
-        it "is not valid" do
-          expect(declaration).not_to be_valid
-          expect(declaration.errors[:base]).to include("Uplifts are only applicable to started declarations in an uplift enabled contract period")
-        end
+        it { is_expected.to have_error(:base, "Uplifts are only applicable to started declarations in an uplift enabled contract period") }
 
         context "when uplifts are not present" do
           let(:sparsity_uplift) { nil }
@@ -96,10 +93,7 @@ describe Declaration do
       context "when declaration type is not started" do
         let(:declaration_type) { :completed }
 
-        it "is not valid" do
-          expect(declaration).not_to be_valid
-          expect(declaration.errors[:base]).to include("Uplifts are only applicable to started declarations in an uplift enabled contract period")
-        end
+        it { is_expected.to have_error(:base, "Uplifts are only applicable to started declarations in an uplift enabled contract period") }
       end
     end
 
@@ -159,8 +153,7 @@ describe Declaration do
 
           declaration.declaration_date = milestone.milestone_date.next_day
 
-          expect(declaration).to be_invalid
-          expect(declaration.errors[:declaration_date]).to include("Declaration date must be on or before the milestone date for the same declaration type.")
+          expect(declaration).to have_error(:declaration_date, "Declaration date must be on or before the milestone date for the same declaration type.")
         end
       end
 
@@ -177,28 +170,19 @@ describe Declaration do
           declaration.training_period.schedule = different_schedule
         end
 
-        it "is not valid" do
-          expect(declaration).to be_invalid
-          expect(declaration.errors[:declaration_date]).to include("Declaration date must be on or before the milestone date for the same declaration type.")
-        end
+        it { is_expected.to have_error(:declaration_date, "Declaration date must be on or before the milestone date for the same declaration type.") }
       end
 
       context "when the declaration date is before the milestone start_date" do
         let(:declaration_date) { milestone.start_date - 1.day }
 
-        it "is not valid" do
-          expect(declaration).not_to be_valid
-          expect(declaration.errors[:declaration_date]).to include("Declaration date must be on or after the milestone start date for the same declaration type.")
-        end
+        it { is_expected.to have_error(:declaration_date, "Declaration date must be on or after the milestone start date for the same declaration type.") }
       end
 
       context "when the declaration date is after the milestone_date" do
         let(:declaration_date) { milestone.milestone_date + 1.day }
 
-        it "is not valid" do
-          expect(declaration).not_to be_valid
-          expect(declaration.errors[:declaration_date]).to include("Declaration date must be on or before the milestone date for the same declaration type.")
-        end
+        it { is_expected.to have_error(:declaration_date, "Declaration date must be on or before the milestone date for the same declaration type.") }
       end
 
       describe "contract period consistent across associations" do
@@ -221,10 +205,7 @@ describe Declaration do
           context "when contract periods do not match" do
             subject { FactoryBot.build(:declaration, training_period:, payment_statement: mismatch_statement) }
 
-            it "adds an error to schedule" do
-              expect(subject).to be_invalid
-              expect(subject.errors[:training_period]).to include("Contract period mismatch: training period, payment_statement and clawback_statement must have the same contract period.")
-            end
+            it { is_expected.to have_error(:training_period, "Contract period mismatch: training period, payment_statement and clawback_statement must have the same contract period.") }
           end
         end
 
@@ -238,10 +219,7 @@ describe Declaration do
           context "when contract periods do not match" do
             subject { FactoryBot.build(:declaration, training_period:, clawback_statement: mismatch_statement) }
 
-            it "adds an error to schedule" do
-              expect(subject).to be_invalid
-              expect(subject.errors[:training_period]).to include("Contract period mismatch: training period, payment_statement and clawback_statement must have the same contract period.")
-            end
+            it { is_expected.to have_error(:training_period, "Contract period mismatch: training period, payment_statement and clawback_statement must have the same contract period.") }
           end
         end
       end
@@ -260,10 +238,7 @@ describe Declaration do
         let(:mentee) { FactoryBot.create(:ect_at_school_period, school:, started_on:, finished_on: nil) }
         let(:mentorship_period) { FactoryBot.create(:mentorship_period, mentor:, mentee:, started_on:, finished_on: nil) }
 
-        it "is not valid" do
-          expect(declaration).not_to be_valid
-          expect(declaration.errors[:mentorship_period]).to include("Mentorship period must belong to the trainee")
-        end
+        it { is_expected.to have_error(:mentorship_period, "Mentorship period must belong to the trainee") }
       end
 
       context "when the mentorship_period does belong to the trainee" do
@@ -291,10 +266,7 @@ describe Declaration do
           context "when the declaration_type is #{disallowed_type}" do
             subject { FactoryBot.build(:declaration, training_period:, declaration_type: disallowed_type) }
 
-            it "is not valid" do
-              expect(subject).not_to be_valid
-              expect(subject.errors[:declaration_type]).to include("Only 'started' or 'completed' declaration types are allowed for mentor funding enabled contract periods.")
-            end
+            it { is_expected.to have_error(:declaration_type, "Only 'started' or 'completed' declaration types are allowed for mentor funding enabled contract periods.") }
 
             context "when the training period is for an ECT" do
               let(:training_period) { FactoryBot.create(:training_period, :for_ect) }


### PR DESCRIPTION
## Context

We migrated ~4k declarations from ECF to training periods such that the schedule milestone no longer matches the declaration date.

During migration we skipped validation for this, but the validation on the model is now causing errors to throw when lead providers attempt to void these declarations.

## Changes proposed

Only apply declaration date validation if it has been changed (in doing so we can update declarations with an already-persisted, invalid declaration date).

We also want to re-validate the `declaration_date` if the training period's schedule changes, causing it to become outside the new milestone bounds.