### PR TITLE
Allow statements to be added after a contract period has been started if not frozen

### DIFF
--- a/app/controllers/admin/finance/active_lead_providers/statements_controller.rb
+++ b/app/controllers/admin/finance/active_lead_providers/statements_controller.rb
@@ -4,7 +4,8 @@ module Admin::Finance::ActiveLeadProviders
 
     before_action :set_active_lead_provider
     before_action :set_statement, only: %i[show edit update delete destroy]
-    before_action :redirect_unless_editable, only: %i[new create edit update delete destroy]
+    before_action :redirect_unless_addable, only: %i[new create]
+    before_action :redirect_unless_editable, only: %i[edit update delete destroy]
 
     def index
       contract_period = @active_lead_provider.contract_period
@@ -73,6 +74,13 @@ module Admin::Finance::ActiveLeadProviders
 
     def set_statement
       @statement = @active_lead_provider.statements.find(params[:id])
+    end
+
+    def redirect_unless_addable
+      if @active_lead_provider.contract_period.payments_frozen?
+        redirect_to statements_path,
+                    flash: { error: "Statements cannot be added once the contract period is frozen" }
+      end
     end
 
     def redirect_unless_editable

--- a/app/views/admin/finance/active_lead_providers/statements/index.html.erb
+++ b/app/views/admin/finance/active_lead_providers/statements/index.html.erb
@@ -32,4 +32,4 @@
 
 <%= render Shared::PaginationSummaryComponent.new(pagy: @pagy, record_name: "statements") %>
 
-<%= govuk_button_link_to("Add statement", new_admin_contract_period_active_lead_provider_statement_path(@active_lead_provider.contract_period, @active_lead_provider), disabled: @active_lead_provider.contract_period.started_on_or_before_today?) %>
+<%= govuk_button_link_to("Add statement", new_admin_contract_period_active_lead_provider_statement_path(@active_lead_provider.contract_period, @active_lead_provider), disabled: @active_lead_provider.contract_period.payments_frozen?) %>

--- a/spec/requests/admin/finance/active_lead_providers/statements_spec.rb
+++ b/spec/requests/admin/finance/active_lead_providers/statements_spec.rb
@@ -51,8 +51,17 @@ RSpec.describe "Admin finance active lead provider statements", :enable_finance_
         expect(response).to have_http_status(:ok)
       end
 
-      context "when the contract period has started" do
+      context "when the contract period has started but is not frozen" do
         let(:contract_period) { FactoryBot.create(:contract_period, :current) }
+
+        it "allows the new form" do
+          get new_path
+          expect(response).to have_http_status(:ok)
+        end
+      end
+
+      context "when the contract period is frozen" do
+        let(:contract_period) { FactoryBot.create(:contract_period, :current, :with_payments_frozen) }
 
         it "blocks the new form, redirecting to the index" do
           get new_path
@@ -121,8 +130,18 @@ RSpec.describe "Admin finance active lead provider statements", :enable_finance_
         end
       end
 
-      context "when the contract period has started" do
+      context "when the contract period has started but is not frozen" do
         let(:contract_period) { FactoryBot.create(:contract_period, :current) }
+
+        it "allows the create" do
+          expect {
+            perform_enqueued_jobs { post index_path, params: { statement: params } }
+          }.to change(Statement, :count).by(1)
+        end
+      end
+
+      context "when the contract period is frozen" do
+        let(:contract_period) { FactoryBot.create(:contract_period, :current, :with_payments_frozen) }
 
         it "blocks the create, redirecting to the index" do
           expect {

--- a/spec/views/admin/finance/active_lead_providers/statements/index.html.erb_spec.rb
+++ b/spec/views/admin/finance/active_lead_providers/statements/index.html.erb_spec.rb
@@ -58,9 +58,23 @@ RSpec.describe "admin/finance/active_lead_providers/statements/index.html.erb" d
     expect(rendered).not_to have_selector("a[aria-disabled='true']", text: "Add statement")
   end
 
-  context "when the contract period has already started" do
+  context "when the contract period has already started but is not frozen" do
     let(:contract_period) do
       FactoryBot.create(:contract_period, year: 2020, started_on: Date.new(2020, 6, 1), finished_on: Date.new(2021, 5, 31))
+    end
+
+    it "renders the add button in an enabled state" do
+      render
+
+      expect(rendered).to have_link("Add statement", href: new_admin_contract_period_active_lead_provider_statement_path(contract_period, active_lead_provider))
+      expect(rendered).not_to have_selector("a[aria-disabled='true']", text: "Add statement")
+    end
+  end
+
+  context "when the contract period is frozen" do
+    let(:contract_period) do
+      FactoryBot.create(:contract_period, year: 2020, started_on: Date.new(2020, 6, 1), finished_on: Date.new(2021, 5, 31),
+                                          payments_frozen_at: Time.zone.now)
     end
 
     it "renders the add button in a disabled state" do


### PR DESCRIPTION
### Context

Resolves https://github.com.mcas.ms/DFE-Digital/register-ects-project-board/issues/3332

### Changes proposed in this pull request

It is possible to add **Statements** after a **ContractPeriod** has started as long as it is not frozen.

### Guidance to review

* Editing and Deleting is still not possible after a ContractPeriod has started, there is a ticket to review broad in-flight modifications.
* It is technically possible for a **ContractPeriod** to be _frozen_ before a **ContractPeriod** has started, which would prevent adding new **Statements**.