### PR TITLE
Remove `#sanitize` from page titles

### DIFF
--- a/app/views/layouts/shared/_head.html.erb
+++ b/app/views/layouts/shared/_head.html.erb
@@ -1,5 +1,5 @@
 <head>
-  <% page_title_parts = [sanitize(yield(:page_title).presence), "Register early career teachers", "GOV.UK"].compact.join(' - ') %>
+  <% page_title_parts = [yield(:page_title).presence, "Register early career teachers", "GOV.UK"].compact.join(' - ') %>
   <%= tag.title(page_title_parts) %>
 
   <%= csrf_meta_tags %>

--- a/spec/requests/admin/schools/overviews/show_spec.rb
+++ b/spec/requests/admin/schools/overviews/show_spec.rb
@@ -1,0 +1,27 @@
+describe "Admin::Schools::OverviewsController" do
+  let(:title_suffix) { "- Register early career teachers - GOV.UK" }
+  let(:school_name) { "Some School" }
+  let(:gias_school) { FactoryBot.create(:gias_school, name: school_name) }
+  let(:school) { FactoryBot.create(:school, gias_school:) }
+
+  include_context "sign in as DfE user"
+
+  describe "GET /admin/schools/:urn/overview" do
+    it "displays the school name in the title" do
+      get "/admin/schools/#{school.urn}/overview"
+
+      expect(response.body).to match("<title>#{school_name} #{title_suffix}</title>")
+    end
+
+    context "when the school name contains characters that need to be sanitized" do
+      let(:school_name) { "All Saints' Infants & Junior School" }
+      let(:sanitized_school_name) { "All Saints&#39; Infants &amp; Junior School" }
+
+      it "displays the school name in the title" do
+        get "/admin/schools/#{school.urn}/overview"
+
+        expect(response.body).to match("<title>#{sanitized_school_name} #{title_suffix}</title>")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Calling `#sanitize` when constructing `page_title_parts` means we double-sanitize the title and end up with something like this:

```html
<title>Some Junior, Infant &amp;amp; Nursery School - Register early career teachers - GOV.UK</title>
```

When we actually want this:

```html
<title>Some Junior, Infant &amp; Nursery School - Register early career teachers - GOV.UK</title>
```

This is a bit tricky to test, and while it's a partial used everywhere and the bug happens on all pages school/organisation names are the most likely offenders.

Fixes #3107
