### PR TITLE
Drop the `govuk-template--rebranded` class

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -90,6 +90,6 @@ module ApplicationHelper
   end
 
   def govuk_html_element(&block)
-    tag.html(lang: "en", class: %w[govuk-template govuk-template--rebranded], &block)
+    tag.html(lang: "en", class: "govuk-template", &block)
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -286,8 +286,8 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(subject).to match(%r{<html.*#{content}</html>})
     end
 
-    it "includes both the govuk-template and govuk-template--rebranded classes" do
-      expect(subject).to include("govuk-template govuk-template--rebranded")
+    it "includes the govuk-template class" do
+      expect(subject).to include("govuk-template")
     end
 
     it "defaults to english" do


### PR DESCRIPTION
It's not needed [post govuk-frontend 6.0.0](https://github.com/alphagov/govuk-frontend/releases/tag/v6.0.0-rc.0).