### PR TITLE
Schools cannot use previous choices without an appropriate body

### DIFF
--- a/app/wizards/schools/register_ect_wizard/use_previous_ect_choices_step.rb
+++ b/app/wizards/schools/register_ect_wizard/use_previous_ect_choices_step.rb
@@ -37,6 +37,7 @@ module Schools
       def provider_led_reusable?
         return false unless school.provider_led_training_programme_chosen?
         return false if school.last_chosen_lead_provider.blank?
+        return false if school.last_chosen_appropriate_body_id.blank?
 
         reusable_partnership_id.present? || reusable_expression_of_interest?
       end

--- a/spec/features/schools/ects/register/registering_an_ect_backdated_start_date_spec.rb
+++ b/spec/features/schools/ects/register/registering_an_ect_backdated_start_date_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Registering an ECT - backdated start date" do
   end
 
   def given_i_am_logged_in_as_a_state_funded_school_user_with_previous_choices
-    context = build_school_with_reusable_provider_led_partnership
+    context = build_school_with_previous_provider_led_choices
 
     @current_school = context.school
     @current_contract_period = context.current_contract_period

--- a/spec/features/schools/ects/register/registering_an_ect_provider_led_spec.rb
+++ b/spec/features/schools/ects/register/registering_an_ect_provider_led_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Registering an ECT with provider-led training" do
   end
 
   def given_i_have_reached_the_training_programme_step
-    context = build_school_with_reusable_provider_led_partnership
+    context = build_school_with_previous_provider_led_choices
 
     @school = context.school
     @current_contract_period = context.current_contract_period

--- a/spec/features/schools/ects/register/reuse/no_reuse_spec.rb
+++ b/spec/features/schools/ects/register/reuse/no_reuse_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "Registering an ECT - no reuse" do
   end
 
   def given_i_am_logged_in_as_a_state_funded_school_user_with_previous_choices
-    context = build_school_with_reusable_provider_led_partnership
+    context = build_school_with_previous_provider_led_choices
 
     @current_school = context.school
     @current_contract_period = context.current_contract_period

--- a/spec/features/schools/ects/register/reuse/not_available_spec.rb
+++ b/spec/features/schools/ects/register/reuse/not_available_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Registering an ECT - reuse not available" do
   end
 
   def given_i_am_logged_in_as_a_state_funded_school_user_with_no_reusable_choices
-    context = build_school_with_reusable_provider_led_partnership
+    context = build_school_with_previous_provider_led_choices
 
     @current_school = context.school
     @current_contract_period = context.current_contract_period

--- a/spec/features/schools/ects/register/reuse/partnership_spec.rb
+++ b/spec/features/schools/ects/register/reuse/partnership_spec.rb
@@ -36,8 +36,50 @@ RSpec.describe "Registering an ECT - reuse previous partnership" do
     and_the_new_training_period_uses_the_reused_partnership
   end
 
-  def given_i_am_logged_in_as_a_state_funded_school_user_with_previous_choices
-    context = build_school_with_reusable_provider_led_partnership
+  context "when the school has no last chosen appropriate body" do
+    scenario "does not offer reuse" do
+      given_i_am_logged_in_as_a_state_funded_school_user_with_previous_choices(
+        last_chosen_appropriate_body_present: false
+      )
+      and_i_am_on_the_schools_ects_index_page
+      and_i_start_adding_an_ect
+      and_i_click_continue
+      and_i_submit_the_find_ect_form
+      and_i_choose_that_the_details_are_correct
+      and_i_click_confirm_and_continue
+      then_i_am_on_the_email_address_page
+
+      and_i_enter_the_ect_email_address
+      and_i_click_continue
+      then_i_am_on_the_start_date_page
+
+      and_i_enter_a_valid_start_date
+      and_i_click_continue
+      then_i_am_on_the_working_pattern_page
+
+      and_i_select_full_time
+      and_i_click_continue
+      then_i_am_on_the_appropriate_body_page
+
+      and_i_select_an_appropriate_body
+      and_i_click_continue
+      then_i_am_on_the_training_programme_page
+
+      and_i_select_school_led
+      and_i_click_continue
+      then_i_am_on_the_check_answers_page
+      and_i_see_check_answers_when_reuse_is_not_available
+
+      and_i_click_confirm_details
+      then_i_am_on_the_confirmation_page
+      and_the_new_training_period_uses_manual_choices
+    end
+  end
+
+  def given_i_am_logged_in_as_a_state_funded_school_user_with_previous_choices(last_chosen_appropriate_body_present: true)
+    context = build_school_with_previous_provider_led_choices(
+      last_chosen_appropriate_body_present:
+    )
 
     @current_school = context.school
     @current_contract_period = context.current_contract_period
@@ -165,6 +207,44 @@ RSpec.describe "Registering an ECT - reuse previous partnership" do
 
     expect(training_period.training_programme).to eq("provider_led")
     expect(training_period.school_partnership).to eq(@current_school_partnership)
+    expect(training_period.expression_of_interest).to be_nil
+  end
+
+  def then_i_am_on_the_appropriate_body_page
+    expect(page).to have_path("/school/register-ect/state-school-appropriate-body")
+  end
+
+  def and_i_select_an_appropriate_body
+    page.get_by_role("combobox", name: "Enter appropriate body name")
+        .first
+        .select_option(value: @appropriate_body_name)
+  end
+
+  def then_i_am_on_the_training_programme_page
+    expect(page).to have_path("/school/register-ect/training-programme")
+  end
+
+  def and_i_select_school_led
+    page.get_by_label("School-led").check
+  end
+
+  def and_i_see_check_answers_when_reuse_is_not_available
+    expect(page.get_by_text("9876543")).to be_visible
+    expect(page.get_by_text("Kirk Van Houten")).to be_visible
+    expect(page.get_by_text("example@example.com")).to be_visible
+    expect(page.get_by_text(@entered_start_date.strftime("%B %Y"))).to be_visible
+    expect(page.get_by_text("School-led")).to be_visible
+    expect(page.get_by_text(@appropriate_body_name)).to be_visible
+  end
+
+  def and_the_new_training_period_uses_manual_choices
+    ect_at_school_period = ECTAtSchoolPeriod.where(school: @current_school, teacher: @teacher).order(:created_at).last
+    expect(ect_at_school_period).to be_present
+
+    training_period = ect_at_school_period.training_periods.order(:created_at).last
+    expect(training_period).to be_present
+    expect(training_period.training_programme).to eq("school_led")
+    expect(training_period.school_partnership).to be_nil
     expect(training_period.expression_of_interest).to be_nil
   end
 end

--- a/spec/support/reusable_partnership_helpers.rb
+++ b/spec/support/reusable_partnership_helpers.rb
@@ -9,8 +9,9 @@ module ReusablePartnershipHelpers
     keyword_init: true
   )
 
-  def build_school_with_reusable_provider_led_partnership(
-    current_year: Time.zone.today.year
+  def build_school_with_previous_provider_led_choices(
+    current_year: Time.zone.today.year,
+    last_chosen_appropriate_body_present: true
   )
     previous_year = current_year - 1
 
@@ -60,13 +61,23 @@ module ReusablePartnershipHelpers
       delivery_partner:
     )
 
-    school = FactoryBot.create(
-      :school,
-      :state_funded,
-      :provider_led_last_chosen,
-      :teaching_school_hub_ab_last_chosen,
-      last_chosen_lead_provider: lead_provider
-    )
+    school = if last_chosen_appropriate_body_present
+               FactoryBot.create(
+                 :school,
+                 :state_funded,
+                 :provider_led_last_chosen,
+                 :teaching_school_hub_ab_last_chosen,
+                 last_chosen_lead_provider: lead_provider
+               )
+             else
+               FactoryBot.create(
+                 :school,
+                 :state_funded,
+                 :provider_led_last_chosen,
+                 last_chosen_appropriate_body: nil,
+                 last_chosen_lead_provider: lead_provider
+               )
+             end
 
     previous_school_partnership = FactoryBot.create(
       :school_partnership,

--- a/spec/wizards/schools/register_ect_wizard/use_previous_ect_choices_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/use_previous_ect_choices_step_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Schools::RegisterECTWizard::UsePreviousECTChoicesStep, type: :mod
 
   let(:use_previous_ect_choices) { true }
   let(:step_params) { {} }
-  let(:school) { FactoryBot.create(:school) }
+  let(:school) { FactoryBot.create(:school, :teaching_school_hub_ab_last_chosen) }
   let(:store) do
     FactoryBot.build(
       :session_repository,
@@ -154,6 +154,12 @@ RSpec.describe Schools::RegisterECTWizard::UsePreviousECTChoicesStep, type: :mod
             expect(step.allowed?).to be(true)
           end
         end
+
+        context "and the last chosen appropriate body is missing" do
+          before { school.update(last_chosen_appropriate_body: nil) }
+
+          it { is_expected.not_to be_allowed }
+        end
       end
 
       context "and previous provider-led training was in a payments-frozen contract period" do
@@ -201,6 +207,12 @@ RSpec.describe Schools::RegisterECTWizard::UsePreviousECTChoicesStep, type: :mod
               .and_call_original
 
             expect(step.allowed?).to be(true)
+          end
+
+          context "and the last chosen appropriate body is missing" do
+            before { school.update(last_chosen_appropriate_body: nil) }
+
+            it { is_expected.not_to be_allowed }
           end
         end
 
@@ -526,6 +538,12 @@ RSpec.describe Schools::RegisterECTWizard::UsePreviousECTChoicesStep, type: :mod
             expect(step.allowed?).to be(true)
           end
         end
+
+        context "and the last chosen appropriate body is missing" do
+          before { school.update(last_chosen_appropriate_body: nil) }
+
+          it { is_expected.not_to be_allowed }
+        end
       end
 
       context "but there is no reusable partnership and no EOI" do
@@ -615,6 +633,12 @@ RSpec.describe Schools::RegisterECTWizard::UsePreviousECTChoicesStep, type: :mod
 
       it "treats reuse as available via school EOI" do
         expect(step.reusable_available?).to be(true)
+      end
+
+      context "and the last chosen appropriate body is missing" do
+        before { school.update(last_chosen_appropriate_body: nil) }
+
+        it { is_expected.not_to be_allowed }
       end
     end
   end

--- a/spec/wizards/schools/register_ect_wizard/wizard_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/wizard_spec.rb
@@ -330,7 +330,8 @@ RSpec.describe Schools::RegisterECTWizard::Wizard do
       before do
         school.update!(
           last_chosen_training_programme: "provider_led",
-          last_chosen_lead_provider: lead_provider
+          last_chosen_lead_provider: lead_provider,
+          last_chosen_appropriate_body: FactoryBot.build(:appropriate_body_period)
         )
 
         wizard.ect.update!(
@@ -358,6 +359,14 @@ RSpec.describe Schools::RegisterECTWizard::Wizard do
 
       it "includes use_previous_ect_choices step" do
         expect(wizard.allowed_steps).to include(:use_previous_ect_choices)
+      end
+
+      context "but the last_chosen_appropriate_body is missing" do
+        before { school.update(last_chosen_appropriate_body: nil) }
+
+        it "does not include use_previous_ect_choices step" do
+          expect(wizard.allowed_steps).not_to include(:use_previous_ect_choices)
+        end
       end
 
       context "and user chooses to use previous choices" do


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/4116

### Changes proposed in this pull request

Before, schools could choose to use previous choices even if they did not have a last chosen appropriate body.

This lead to some [errors].

There are a bunch of schools without a last chosen appropriate body. This means, if they are allowed to choose to reuse their last choices, we end up trying to register an ECT with a `school_reported_appropriate_body` of `nil`.

Since we validate that ECTs at state funded schools must have a teaching school hub appropriate body, this led to errors being raised and users unable to register ECTs.

This reworks the logic in the `use_previous_ect_choices` step so that a school is only presented with that option if they have previously chosen an appropriate body.

[errors]: https://dfe-teacher-services.sentry.io/issues/7324885372/events/6941e9f94d104b7d8d2fc7aa47766591/


### Guidance to review
