### PR TITLE
[3996] Extract teacher anonymisation into independent service

### DIFF
--- a/app/services/teachers/anonymise.rb
+++ b/app/services/teachers/anonymise.rb
@@ -1,0 +1,32 @@
+module Teachers
+  class Anonymise
+    class NotPermittedError < StandardError; end
+
+    attr_reader :teacher, :reason
+
+    def initialize(teacher:, reason:)
+      @teacher = teacher
+      @reason = reason
+    end
+
+    def anonymise!
+      raise NotPermittedError, "Teacher still has registrations or induction periods" unless permitted?
+
+      teacher.update!(
+        trs_first_name: nil,
+        trs_last_name: nil,
+        corrected_name: nil,
+        trn: nil,
+        trnless: true,
+        anonymisation_reason: reason,
+        anonymised_at: Time.zone.now
+      )
+    end
+
+    def permitted?
+      teacher.induction_periods.none? &&
+        teacher.ect_at_school_periods.reload.none? &&
+        teacher.mentor_at_school_periods.reload.none?
+    end
+  end
+end

--- a/app/services/teachers/undo_registration.rb
+++ b/app/services/teachers/undo_registration.rb
@@ -17,7 +17,7 @@ module Teachers
           finish_periods!
         else
           delete_periods!
-          anonymise_teacher! if anonymise_teacher?
+          anonymiser.anonymise! if anonymiser.permitted?
         end
 
         record_undo_registration_event!
@@ -27,6 +27,10 @@ module Teachers
     end
 
   private
+
+    def anonymiser
+      @anonymiser ||= Teachers::Anonymise.new(teacher:, reason:)
+    end
 
     def billable_or_refundable_declarations_exist?
       Declaration.where(training_period: training_periods)
@@ -48,24 +52,6 @@ module Teachers
       mentorship_periods.find_each(&:destroy!)
       training_periods.find_each(&:destroy!)
       at_school_period.destroy!
-    end
-
-    def anonymise_teacher!
-      teacher.update!(
-        trs_first_name: nil,
-        trs_last_name: nil,
-        corrected_name: nil,
-        trn: nil,
-        trnless: true,
-        anonymisation_reason: reason,
-        anonymised_at: Time.zone.now
-      )
-    end
-
-    def anonymise_teacher?
-      teacher.induction_periods.none? &&
-        teacher.ect_at_school_periods.reload.none? &&
-        teacher.mentor_at_school_periods.reload.none?
     end
 
     def record_undo_registration_event!

--- a/spec/services/teachers/anonymise_spec.rb
+++ b/spec/services/teachers/anonymise_spec.rb
@@ -1,0 +1,88 @@
+RSpec.describe Teachers::Anonymise do
+  subject(:service) { described_class.new(teacher:, reason: :registered_in_error) }
+
+  let(:teacher) { FactoryBot.create(:teacher) }
+
+  describe "#permitted?" do
+    context "when the teacher has no induction periods or registrations" do
+      it { is_expected.to be_permitted }
+    end
+
+    context "when the teacher has an induction period" do
+      before { FactoryBot.create(:induction_period, teacher:) }
+
+      it { is_expected.not_to be_permitted }
+    end
+
+    context "when the teacher has an ECT at school period" do
+      before { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:) }
+
+      it { is_expected.not_to be_permitted }
+    end
+
+    context "when the teacher has a mentor at school period" do
+      before { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:) }
+
+      it { is_expected.not_to be_permitted }
+    end
+  end
+
+  describe "#anonymise!" do
+    context "when permitted" do
+      it "anonymises the teacher" do
+        service.anonymise!
+        teacher.reload
+
+        expect(teacher.trs_first_name).to be_nil
+        expect(teacher.trs_last_name).to be_nil
+        expect(teacher.corrected_name).to be_nil
+        expect(teacher.trn).to be_nil
+        expect(teacher.trnless).to be(true)
+      end
+
+      it "sets the anonymisation reason" do
+        service.anonymise!
+
+        expect(teacher.reload.anonymisation_reason).to eq("registered_in_error")
+      end
+
+      it "sets anonymised_at" do
+        freeze_time do
+          service.anonymise!
+
+          expect(teacher.reload.anonymised_at).to eq(Time.zone.now)
+        end
+      end
+
+      it "preserves api ids" do
+        original_api_id = teacher.api_id
+        original_ect_id = teacher.api_ect_training_record_id
+        original_mentor_id = teacher.api_mentor_training_record_id
+
+        service.anonymise!
+        teacher.reload
+
+        expect(teacher.api_id).to eq(original_api_id)
+        expect(teacher.api_ect_training_record_id).to eq(original_ect_id)
+        expect(teacher.api_mentor_training_record_id).to eq(original_mentor_id)
+      end
+    end
+
+    context "when not permitted" do
+      before { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:) }
+
+      it "raises NotPermittedError" do
+        expect { service.anonymise! }.to raise_error(Teachers::Anonymise::NotPermittedError)
+      end
+
+      it "does not anonymise the teacher" do
+        expect { service.anonymise! }.to raise_error(Teachers::Anonymise::NotPermittedError)
+        teacher.reload
+
+        expect(teacher.trs_first_name).to be_present
+        expect(teacher.anonymisation_reason).to be_nil
+        expect(teacher.anonymised_at).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/teachers/undo_registration_spec.rb
+++ b/spec/services/teachers/undo_registration_spec.rb
@@ -286,53 +286,10 @@ RSpec.describe Teachers::UndoRegistration do
           expect { teacher.reload }.not_to raise_error
         end
 
-        it "preserves api_id" do
-          teacher = ect_at_school_period.teacher
-          original = teacher.api_id
-          undo_registration
-
-          expect(teacher.reload.api_id).to eq(original)
-        end
-
-        it "preserves api_ect_training_record_id" do
-          teacher = ect_at_school_period.teacher
-          original = teacher.api_ect_training_record_id
-          undo_registration
-
-          expect(teacher.reload.api_ect_training_record_id).to eq(original)
-        end
-
-        it "preserves api_mentor_training_record_id" do
-          teacher = ect_at_school_period.teacher
-          original = teacher.api_mentor_training_record_id
-          undo_registration
-
-          expect(teacher.reload.api_mentor_training_record_id).to eq(original)
-        end
-
         it "anonymises the teacher" do
           undo_registration
-          teacher = ect_at_school_period.teacher.reload
 
-          expect(teacher.trs_first_name).to be_nil
-          expect(teacher.trs_last_name).to be_nil
-          expect(teacher.corrected_name).to be_nil
-          expect(teacher.trn).to be_nil
-          expect(teacher.trnless).to be(true)
-        end
-
-        it "sets the anonymisation reason" do
-          undo_registration
-
-          expect(ect_at_school_period.teacher.reload.anonymisation_reason).to eq("registered_in_error")
-        end
-
-        it "sets anonymised_at" do
-          freeze_time do
-            undo_registration
-
-            expect(ect_at_school_period.teacher.reload.anonymised_at).to eq(Time.zone.now)
-          end
+          expect(ect_at_school_period.teacher.reload.anonymised_at).to be_present
         end
       end
     end
@@ -432,53 +389,10 @@ RSpec.describe Teachers::UndoRegistration do
           expect { teacher.reload }.not_to raise_error
         end
 
-        it "preserves api_id" do
-          teacher = mentor_at_school_period.teacher
-          original = teacher.api_id
-          undo_registration
-
-          expect(teacher.reload.api_id).to eq(original)
-        end
-
-        it "preserves api_ect_training_record_id" do
-          teacher = mentor_at_school_period.teacher
-          original = teacher.api_ect_training_record_id
-          undo_registration
-
-          expect(teacher.reload.api_ect_training_record_id).to eq(original)
-        end
-
-        it "preserves api_mentor_training_record_id" do
-          teacher = mentor_at_school_period.teacher
-          original = teacher.api_mentor_training_record_id
-          undo_registration
-
-          expect(teacher.reload.api_mentor_training_record_id).to eq(original)
-        end
-
         it "anonymises the teacher" do
           undo_registration
-          teacher = mentor_at_school_period.teacher.reload
 
-          expect(teacher.trs_first_name).to be_nil
-          expect(teacher.trs_last_name).to be_nil
-          expect(teacher.corrected_name).to be_nil
-          expect(teacher.trn).to be_nil
-          expect(teacher.trnless).to be(true)
-        end
-
-        it "sets the anonymisation reason" do
-          undo_registration
-
-          expect(mentor_at_school_period.teacher.reload.anonymisation_reason).to eq("registered_in_error")
-        end
-
-        it "sets anonymised_at" do
-          freeze_time do
-            undo_registration
-
-            expect(mentor_at_school_period.teacher.reload.anonymised_at).to eq(Time.zone.now)
-          end
+          expect(mentor_at_school_period.teacher.reload.anonymised_at).to be_present
         end
       end
     end


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/3996

### Changes proposed in this pull request

To close the linked ticket, we need to be able to anonymise teachers who may not have any `ECTAtSchoolPeriod` or `MentorAtSchoolPeriod` and therefore can't use the `UndoRegistration` service.

This PR extracts that functionality into a dedicated service that can be called separately, without changing the behaviour of `UndoRegistration`.