### PR TITLE
Add migration to backfill data

### DIFF
--- a/db/migrate/20260618144509_backfill_uplift_target_ratio_on_contract_banded_fee_structures.rb
+++ b/db/migrate/20260618144509_backfill_uplift_target_ratio_on_contract_banded_fee_structures.rb
@@ -17,5 +17,8 @@ class BackfillUpliftTargetRatioOnContractBandedFeeStructures < ActiveRecord::Mig
     end
   end
 
-  def down = nil
+  def down
+    raise ActiveRecord::IrreversibleMigration,
+          "The original uplift target ratio values cannot be restored"
+  end
 end

--- a/db/migrate/20260618144509_backfill_uplift_target_ratio_on_contract_banded_fee_structures.rb
+++ b/db/migrate/20260618144509_backfill_uplift_target_ratio_on_contract_banded_fee_structures.rb
@@ -1,0 +1,21 @@
+class BackfillUpliftTargetRatioOnContractBandedFeeStructures < ActiveRecord::Migration[8.1]
+  UPLIFT_TARGET_RATIOS_BY_YEAR = {
+    2021 => 0.33,
+    2022 => 0.33,
+    2023 => 0.33,
+    2024 => 0.4,
+    2025 => 0.0
+  }.freeze
+
+  def up
+    UPLIFT_TARGET_RATIOS_BY_YEAR.each do |year, uplift_target_ratio|
+      Contract::BandedFeeStructure
+        .joins(contract: :active_lead_provider)
+        .where(active_lead_providers: { contract_period_year: year })
+        .where(contracts: { contract_type: "ecf" })
+        .update_all(uplift_target_ratio:)
+    end
+  end
+
+  def down = nil
+end


### PR DESCRIPTION
### Context
This PR branches off `fix/uplift-target-ratio` - no longer - it was updated to main

This PR adds the data backfill for existing ECF contract banded fee structures, using the uplift target values confirmed from ECF production CallOffContract.uplift_target data (see **Back fill data investigation** below)

### Changes proposed in this pull request
- Adds a data migration to backfill contract_banded_fee_structures.uplift_target_ratio.
- Updates only banded fee structures linked to contracts with contract_type = "ecf".
- Backfills the ECF-confirmed cohort-level uplift target ratios:
   - 2021: 0.33
   - 2022: 0.33
   - 2023: 0.33
   - 2024: 0.4
   - 2025: 0.0

### Guidance to review
Check that the cohort-level mapping matches the ECF production CallOffContract.uplift_target values

### Back fill data investigation

I checked the ECF source data in production. ECF stores the value on CallOffContract.uplift_target as a ratio, for example 0.33, 0.4, or 0.0.

The ECF contract export used these fields:

ecf_contract_id | lead_provider | cohort | version | recruitment_target | uplift_target | uplift_amount | monthly_service_fee | set_up_fee

The relevant value for the RECT backfill is uplift_target.

From the ECF production data, the uplift target appears to be cohort-based:

2021 => 0.33
2022 => 0.33
2023 => 0.33
2024 => 0.4
2025 => 0.0

Examples from the ECF export:

A | 2021 | 0.0.1 | recruitment_target: 10000 | uplift_target: 0.33 | uplift_amount: 100.0
A | 2024 | 0.0.4 | recruitment_target: 11500 | uplift_target: 0.4  | uplift_amount: 100.0
U | 2025 | 0.0.2 | recruitment_target: 5498  | uplift_target: 0.0  | uplift_amount: 0.0

I also checked the RECT side using the migrated contract data. The RECT export used these fields:

rect_contract_id | lead_provider | cohort | ecf_contract_version | recruitment_target | uplift_fee_per_declaration | monthly_service_fee | setup_fee

The RECT values line up with the ECF values using:

RECT recruitment_target             => ECF recruitment_target
RECT uplift_fee_per_declaration     => ECF uplift_amount
RECT monthly_service_fee            => ECF monthly_service_fee
RECT setup_fee                      => ECF set_up_fee
RECT contract period year/cohort    => ECF cohort

This confirms that the value to store in RECT is:

contract_banded_fee_structures.uplift_target_ratio = call_off_contracts.uplift_target

No conversion should happen during the backfill. The value should be stored as a ratio and only converted for display in the component, so:

0.33 => 33%
0.4  => 40%
0.0  => 0%

### Backfill approach

The backfill migration will update only ECF contract banded fee structures, using the cohort-level mapping confirmed from ECF production:

{
  2021 => 0.33,
  2022 => 0.33,
  2023 => 0.33,
  2024 => 0.4,
  2025 => 0.0
}

The migration filters by:
contracts.contract_type = "ecf"
and:
active_lead_providers.contract_period_year

I tested this locally in RECT dev. Before the backfill, ECF contract banded fee structures had uplift_target_ratio: nil. After running the migration locally, the grouped values were:

{
  [2021, 0.33] => 14,
  [2022, 0.33] => 12,
  [2023, 0.33] => 13,
  [2024, 0.4]  => 11
}

My local dev data did not include 2025 ECF rows, but the ECF production data confirms 2025 should be backfilled as 0.0.

I also checked that non-ECF contract banded fee structures were not updated:

Contract::BandedFeeStructure
  .joins(:contract)
  .where.not(contracts: { contract_type: "ecf" })
  .where.not(uplift_target_ratio: nil)
  .count
=> 0
