### PR TITLE
[3404] Restrict partnership options & add no partnership path (Slice 4)

### DIFF
--- a/app/views/admin/teachers/training_periods/change_contract_period_wizard/no_partnerships.html.erb
+++ b/app/views/admin/teachers/training_periods/change_contract_period_wizard/no_partnerships.html.erb
@@ -1,0 +1,16 @@
+<% page_data(
+  title: "There are no partnerships set up for #{@wizard.selected_contract_period.year}",
+  backlink_href: @wizard.previous_step_path
+) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <p class="govuk-body">
+      You need to add a partnership for <%= @wizard.school.name %> in the <%= @wizard.selected_contract_period.year %> contract period before you can change <%= @wizard.teacher_name %>’s contract period.
+    </p>
+
+    <p class="govuk-body">
+      <%= govuk_link_to("Add a partnership for #{@wizard.school.name}", admin_school_partnerships_path(@wizard.school.urn)) %>
+    </p>
+  </div>
+</div>

--- a/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/no_partnerships_step.rb
+++ b/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/no_partnerships_step.rb
@@ -1,0 +1,11 @@
+module Admin
+  module Teachers
+    module TrainingPeriods
+      module ChangeContractPeriodWizard
+        class NoPartnershipsStep < Step
+          def previous_step = :select_contract_period
+        end
+      end
+    end
+  end
+end

--- a/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/select_contract_period_step.rb
+++ b/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/select_contract_period_step.rb
@@ -10,7 +10,9 @@ module Admin
 
           def self.permitted_params = %i[contract_period_year]
 
-          def next_step = :select_partnership
+          def next_step
+            wizard.school_partnerships.exists? ? :select_partnership : :no_partnerships
+          end
 
         private
 

--- a/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard.rb
+++ b/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard.rb
@@ -13,6 +13,7 @@ module Admin
             [{
               select_contract_period: SelectContractPeriodStep,
               select_partnership: SelectPartnershipStep,
+              no_partnerships: NoPartnershipsStep,
               check_answers: CheckAnswersStep
             }]
           end
@@ -22,6 +23,8 @@ module Admin
           def allowed_steps
             steps = [:select_contract_period]
             return steps unless selected_contract_period_allowed?
+
+            return steps << :no_partnerships unless school_partnerships.exists?
 
             steps << :select_partnership
             return steps unless selected_school_partnership_allowed?

--- a/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard.rb
+++ b/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard.rb
@@ -74,7 +74,12 @@ module Admin
             return SchoolPartnership.none unless selected_contract_period
 
             SchoolPartnerships::Search
-              .new(school:, contract_period: selected_contract_period)
+              .new(
+                school:,
+                contract_period: selected_contract_period,
+                lead_provider: training_period.lead_provider,
+                delivery_partner: training_period.delivery_partner
+              )
               .school_partnerships
           end
 

--- a/spec/requests/admin/teachers/training_periods/change_contract_period_wizard_spec.rb
+++ b/spec/requests/admin/teachers/training_periods/change_contract_period_wizard_spec.rb
@@ -119,6 +119,19 @@ RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardCont
 
       expect(response).to redirect_to(path_for_step("select-partnership"))
     end
+
+    context "when there are no partnerships for the current lead provider and delivery partner" do
+      let(:target_school_partnership) { nil }
+
+      it "redirects to the no partnerships page" do
+        post(
+          path_for_step("select-contract-period"),
+          params: { select_contract_period: { contract_period_year: target_contract_period.year } }
+        )
+
+        expect(response).to redirect_to(path_for_step("no-partnerships"))
+      end
+    end
   end
 
   describe "GET select-partnership" do
@@ -170,6 +183,23 @@ RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardCont
       expect(response).to have_http_status(:unprocessable_content)
       expect(page).to have_text("There is a problem")
       expect(page).to have_text("Select a partnership")
+    end
+  end
+
+  describe "GET no-partnerships" do
+    let(:target_school_partnership) { nil }
+
+    it "renders the no partnerships page after a contract period has been selected" do
+      post(
+        path_for_step("select-contract-period"),
+        params: { select_contract_period: { contract_period_year: target_contract_period.year } }
+      )
+      follow_redirect!
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("There are no partnerships set up for #{target_contract_period.year}")
+      expect(response.body).to include("You need to add a partnership for #{school.name} in the #{target_contract_period.year} contract period before you can change #{teacher_name}’s contract period.")
+      expect(response.body).to include(admin_school_partnerships_path(school.urn))
     end
   end
 

--- a/spec/requests/admin/teachers/training_periods/change_contract_period_wizard_spec.rb
+++ b/spec/requests/admin/teachers/training_periods/change_contract_period_wizard_spec.rb
@@ -14,7 +14,17 @@ RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardCont
       school:
     )
   end
-  let(:target_school_partnership) do
+  let!(:target_school_partnership) do
+    FactoryBot.create(
+      :school_partnership,
+      :for_year,
+      year: target_contract_period.year,
+      school:,
+      lead_provider: school_partnership.lead_provider,
+      delivery_partner: school_partnership.delivery_partner
+    )
+  end
+  let(:different_school_partnership) do
     FactoryBot.create(
       :school_partnership,
       :for_year,
@@ -142,6 +152,24 @@ RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardCont
       select_contract_period_and_partnership
 
       expect(response).to redirect_to(path_for_step("check-answers"))
+    end
+
+    it "validates the selected partnership uses the current lead provider and delivery partner" do
+      post(
+        path_for_step("select-contract-period"),
+        params: { select_contract_period: { contract_period_year: target_contract_period.year } }
+      )
+
+      post(
+        path_for_step("select-partnership"),
+        params: { select_partnership: { school_partnership_id: different_school_partnership.id } }
+      )
+
+      page = Capybara.string(response.body)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(page).to have_text("There is a problem")
+      expect(page).to have_text("Select a partnership")
     end
   end
 

--- a/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/select_contract_period_step_spec.rb
+++ b/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/select_contract_period_step_spec.rb
@@ -5,13 +5,16 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Sel
     instance_double(
       Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Wizard,
       store:,
-      contract_periods:
+      contract_periods:,
+      school_partnerships:
     )
   end
   let(:store) { FactoryBot.build(:session_repository) }
   let(:available_contract_period) { FactoryBot.create(:contract_period, year: 2026) }
   let(:other_contract_period) { FactoryBot.create(:contract_period, year: 2027) }
   let(:contract_periods) { ContractPeriod.where(year: available_contract_period.year) }
+  let(:available_school_partnership) { FactoryBot.create(:school_partnership) }
+  let(:school_partnerships) { SchoolPartnership.where(id: available_school_partnership.id) }
   let(:contract_period_year) { available_contract_period.year }
 
   before do
@@ -68,6 +71,20 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Sel
 
     context "when contract period is available" do
       it { is_expected.to be_valid }
+    end
+  end
+
+  describe "#next_step" do
+    it "returns select partnership when a school partnership is available" do
+      expect(step.next_step).to eq(:select_partnership)
+    end
+
+    context "when no school partnership is available" do
+      let(:school_partnerships) { SchoolPartnership.none }
+
+      it "returns no partnerships" do
+        expect(step.next_step).to eq(:no_partnerships)
+      end
     end
   end
 end

--- a/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard_spec.rb
+++ b/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard_spec.rb
@@ -5,20 +5,26 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Wiz
   let(:current_contract_period) { FactoryBot.create(:contract_period, year: 2025) }
   let(:target_contract_period) { FactoryBot.create(:contract_period, year: 2026) }
   let(:other_contract_period) { FactoryBot.create(:contract_period, year: 2027) }
+  let(:lead_provider) { FactoryBot.create(:lead_provider) }
+  let(:delivery_partner) { FactoryBot.create(:delivery_partner) }
   let(:school_partnership) do
     FactoryBot.create(
       :school_partnership,
       :for_year,
       year: current_contract_period.year,
-      school:
+      school:,
+      lead_provider:,
+      delivery_partner:
     )
   end
-  let(:target_school_partnership) do
+  let!(:target_school_partnership) do
     FactoryBot.create(
       :school_partnership,
       :for_year,
       year: target_contract_period.year,
-      school:
+      school:,
+      lead_provider:,
+      delivery_partner:
     )
   end
   let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:) }
@@ -53,6 +59,14 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Wiz
       before { store.contract_period_year = target_contract_period.year }
 
       it { is_expected.to eq(%i[select_contract_period select_partnership]) }
+    end
+
+    context "when an available contract period has no partnerships for the current lead provider and delivery partner" do
+      let(:target_school_partnership) { nil }
+
+      before { store.contract_period_year = target_contract_period.year }
+
+      it { is_expected.to eq(%i[select_contract_period no_partnerships]) }
     end
 
     context "when an available contract period and partnership have been selected" do
@@ -140,7 +154,7 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Wiz
     context "when a contract period has been selected" do
       before { store.contract_period_year = target_contract_period.year }
 
-      it "returns school partnerships for the selected contract period and school" do
+      it "returns school partnerships for the selected contract period, school, lead provider and delivery partner" do
         expect(wizard.school_partnerships).to contain_exactly(target_school_partnership)
       end
     end


### PR DESCRIPTION
## What

Following on from #3103, this is the 4th slice of the contract period change journey for admins.

This introduces:

- partnership options restricted to those matching the training period's current lead provider and delivery partner
- a no partnerships dead end page when the selected contract period has no matching partnership
- routing from contract period selection to the 'no partnerships' page when needed

## Screenshot

| `/no-partnerships` |
|------------|
|<img width="1084" height="583" alt="image" src="https://github.com/user-attachments/assets/9c1570bb-1dfd-4d36-a01f-3693eb8bdc38" />|

## Not included

This PR does not:

- display the change link on the training tab
- add future period mutation behaviour
- change contract period eligibility for EOI participants
- change the existing current active mutation behaviour