### PR TITLE
Ensure an ECTs school reported appropriate body is active

### DIFF
--- a/app/helpers/appropriate_body_helper.rb
+++ b/app/helpers/appropriate_body_helper.rb
@@ -1,12 +1,8 @@
 module AppropriateBodyHelper
   FormChoice = Data.define(:identifier, :name)
 
-  # TODO: appropriate_bodies_options_for_collection shows inaccurate and inactive TSHs
   def appropriate_bodies_options_for_collection
-    AppropriateBodyPeriod
-      .teaching_school_hub
-      .where.not(dfe_sign_in_organisation_id: nil)
-      .select(:id, :name)
+    AppropriateBodyPeriod.teaching_school_hub.active.select(:id, :name)
   end
 
   # @return [Array<FormChoice>]

--- a/app/models/appropriate_body_period.rb
+++ b/app/models/appropriate_body_period.rb
@@ -47,4 +47,7 @@ class AppropriateBodyPeriod < ApplicationRecord
   # TODO: consider removing once view components accept the new AB object not the ABP
   # @return [School]
   delegate :lead_school, to: :appropriate_body, allow_nil: true
+
+  # Predicates
+  def active? = dfe_sign_in_organisation_id.present?
 end

--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -17,13 +17,18 @@ class ECTAtSchoolPeriod < ApplicationRecord
   has_one :latest_mentorship_period, -> { latest_first }, class_name: "MentorshipPeriod"
 
   # Validations
-  validate :appropriate_body_for_independent_school,
-           if: -> { school&.independent? },
-           on: :register_ect
+  with_options on: :register_ect do
+    validates :school_reported_appropriate_body_id, presence: true
 
-  validate :appropriate_body_for_state_funded_school,
-           if: -> { school&.state_funded? },
-           on: :register_ect
+    validate :appropriate_body_active,
+             if: -> { school_reported_appropriate_body.present? }
+
+    validate :appropriate_body_for_independent_school,
+             if: -> { school_reported_appropriate_body.present? && school&.independent? }
+
+    validate :appropriate_body_for_state_funded_school,
+             if: -> { school_reported_appropriate_body.present? && school&.state_funded? }
+  end
 
   validate :teacher_distinct_period
 
@@ -131,14 +136,20 @@ class ECTAtSchoolPeriod < ApplicationRecord
 
 private
 
+  def appropriate_body_active
+    return if school_reported_appropriate_body.active?
+
+    errors.add(:school_reported_appropriate_body_id, "Must be active")
+  end
+
   def appropriate_body_for_independent_school
-    return if school_reported_appropriate_body&.national? || school_reported_appropriate_body&.teaching_school_hub?
+    return if school_reported_appropriate_body.national? || school_reported_appropriate_body.teaching_school_hub?
 
     errors.add(:school_reported_appropriate_body_id, "Must be national or teaching school hub")
   end
 
   def appropriate_body_for_state_funded_school
-    return if school_reported_appropriate_body&.teaching_school_hub?
+    return if school_reported_appropriate_body.teaching_school_hub?
 
     errors.add(:school_reported_appropriate_body_id, "Must be teaching school hub")
   end

--- a/spec/models/appropriate_body_period_spec.rb
+++ b/spec/models/appropriate_body_period_spec.rb
@@ -39,6 +39,32 @@ describe AppropriateBodyPeriod do
     end
   end
 
+  describe "predicates" do
+    describe "#active?" do
+      context "when `dfe_sign_in_organisation_id` is present" do
+        subject(:appropriate_body_period) do
+          FactoryBot.build_stubbed(
+            :appropriate_body_period,
+            dfe_sign_in_organisation_id: SecureRandom.uuid
+          )
+        end
+
+        it { is_expected.to be_active }
+      end
+
+      context "when `dfe_sign_in_organisation_id` is missing" do
+        subject(:appropriate_body_period) do
+          FactoryBot.build_stubbed(
+            :appropriate_body_period,
+            dfe_sign_in_organisation_id: nil
+          )
+        end
+
+        it { is_expected.not_to be_active }
+      end
+    end
+  end
+
   describe "validations" do
     subject(:appropriate_body_period) { FactoryBot.build(:appropriate_body_period) }
 

--- a/spec/models/ect_at_school_period_spec.rb
+++ b/spec/models/ect_at_school_period_spec.rb
@@ -190,28 +190,25 @@ describe ECTAtSchoolPeriod do
 
     context "school_reported_appropriate_body_id on :register_ect" do
       context ":register_ect context" do
+        it { is_expected.to validate_presence_of(:school_reported_appropriate_body_id).on(:register_ect) }
+
         context "when the school is independent" do
           context "when national ab chosen" do
-            subject { FactoryBot.create(:ect_at_school_period, :independent_school, :national_ab) }
+            subject { FactoryBot.build_stubbed(:ect_at_school_period, :independent_school, :national_ab) }
 
             it { is_expected.to be_valid(:register_ect) }
           end
 
           context "when teaching school hub ab chosen" do
-            subject { FactoryBot.create(:ect_at_school_period, :independent_school, :teaching_school_hub_ab) }
+            subject { FactoryBot.build_stubbed(:ect_at_school_period, :independent_school, :teaching_school_hub_ab) }
 
             it { is_expected.to be_valid(:register_ect) }
           end
 
           context "when local authority ab chosen" do
-            subject { FactoryBot.build(:ect_at_school_period, :independent_school, :local_authority_ab) }
+            subject { FactoryBot.build_stubbed(:ect_at_school_period, :independent_school, :local_authority_ab) }
 
-            before { subject.valid?(:register_ect) }
-
-            it do
-              expect(subject.errors.messages[:school_reported_appropriate_body_id])
-                .to contain_exactly("Must be national or teaching school hub")
-            end
+            it { is_expected.to have_error(:school_reported_appropriate_body_id, "Must be national or teaching school hub", :register_ect) }
           end
         end
 
@@ -221,12 +218,7 @@ describe ECTAtSchoolPeriod do
           context "when national ab chosen" do
             subject { FactoryBot.build(:ect_at_school_period, :state_funded_school, :national_ab) }
 
-            before { subject.valid?(:register_ect) }
-
-            it do
-              expect(subject.errors.messages[:school_reported_appropriate_body_id])
-                .to contain_exactly("Must be teaching school hub")
-            end
+            it { is_expected.to have_error(:school_reported_appropriate_body_id, "Must be teaching school hub", :register_ect) }
           end
 
           context "when teaching school hub ab chosen" do
@@ -238,12 +230,7 @@ describe ECTAtSchoolPeriod do
           context "when local authority ab chosen" do
             subject { FactoryBot.build(:ect_at_school_period, :state_funded_school, :local_authority_ab) }
 
-            before { subject.valid?(:register_ect) }
-
-            it do
-              expect(subject.errors.messages[:school_reported_appropriate_body_id])
-                .to contain_exactly("Must be teaching school hub")
-            end
+            it { is_expected.to have_error(:school_reported_appropriate_body_id, "Must be teaching school hub", :register_ect) }
           end
         end
       end


### PR DESCRIPTION
This follows up the work in #3099 and adds some validations to the `ECTAtSchoolPeriod` model to ensure that the `school_reported_appropriate_body` is active.

This validation applies in the context of registering an ECT.

We already validated _implicitly_ that the `school_reported_appropriate_body` was present and _explicitly_ that it was a `teaching_school_hub` AB (for state-funded schools) or a `national` or `teaching_school_hub` AB (for independent schools).

This tweaks those validations so we add an explicit error message when the `school_reported_appropriate_body` is missing. We also validate that the AB is active.

This brings the validations inline with the scope we use to filter out inactive ABs when we present options to the school when they choose an appropriate body in the register ECT journey.
