### PR TITLE
Fix 3 ECT training records

### DIFF
--- a/db/scripts/migration_data_fixes.csv
+++ b/db/scripts/migration_data_fixes.csv
@@ -3,9 +3,9 @@ TrainingPeriod,136739,delete
 TrainingPeriod,136734,update,"finished_on,2024-06-15,withdrawal_reason,moved_school,withdrawn_at,2025-03-10T16:40:33Z"
 TrainingPeriod,216622,delete
 TrainingPeriod,216619,update,"finished_on,2023-12-21,withdrawal_reason,other,withdrawn_at,2026-02-18T13:00:48Z"
-ECTAtSchoolPeriod,86079,update,"finished_on,2023-12-21,reported_leaving_by_school_id,16862"
 MentorshipPeriod,97533,update,"finished_on,2023-12-21"
+ECTAtSchoolPeriod,86079,update,"finished_on,2023-12-21,reported_leaving_by_school_id,16862"
 TrainingPeriod,130224,delete
 TrainingPeriod,130216,update,"finished_on,2024-03-10,withdrawal_reason,other,withdrawn_at,2026-02-18T12:00:22Z"
-ECTAtSchoolPeriod,4340,update,"finished_on,2024-03-10,reported_leaving_by_school_id,23699"
 MentorshipPeriod,4956,update,"finished_on,2024-03-10"
+ECTAtSchoolPeriod,4340,update,"finished_on,2024-03-10,reported_leaving_by_school_id,23699"

--- a/db/scripts/migration_data_fixes.csv
+++ b/db/scripts/migration_data_fixes.csv
@@ -1,11 +1,11 @@
 object_type,object_id,action,attributes
-TrainingPeriod,136739,delete
 TrainingPeriod,136734,update,"finished_on,2024-06-15,withdrawal_reason,moved_school,withdrawn_at,2025-03-10T16:40:33Z"
-TrainingPeriod,216622,delete
+TrainingPeriod,136739,delete
 TrainingPeriod,216619,update,"finished_on,2023-12-21,withdrawal_reason,other,withdrawn_at,2026-02-18T13:00:48Z"
 MentorshipPeriod,97533,update,"finished_on,2023-12-21"
 ECTAtSchoolPeriod,86079,update,"finished_on,2023-12-21,reported_leaving_by_school_id,16862"
-TrainingPeriod,130224,delete
+TrainingPeriod,216622,delete
 TrainingPeriod,130216,update,"finished_on,2024-03-10,withdrawal_reason,other,withdrawn_at,2026-02-18T12:00:22Z"
 MentorshipPeriod,4956,update,"finished_on,2024-03-10"
 ECTAtSchoolPeriod,4340,update,"finished_on,2024-03-10,reported_leaving_by_school_id,23699"
+TrainingPeriod,130224,delete

--- a/db/scripts/migration_data_fixes.csv
+++ b/db/scripts/migration_data_fixes.csv
@@ -1,3 +1,7 @@
 object_type,object_id,action,attributes
 TrainingPeriod,136739,delete
 TrainingPeriod,136734,update,"finished_on,2024-06-15,withdrawal_reason,moved_school,withdrawn_at,2025-03-10T16:40:33Z"
+TrainingPeriod,216622,delete
+TrainingPeriod,216619,update,"finished_on,2023-12-21,withdrawal_reason,other,withdrawn_at,2026-02-18T13:00:48Z"
+ECTAtSchoolPeriod,86079,update,"finished_on,2023-12-21,reported_leaving_by_school_id,16862"
+MentorshipPeriod,97533,update,"finished_on,2023-12-21"

--- a/db/scripts/migration_data_fixes.csv
+++ b/db/scripts/migration_data_fixes.csv
@@ -1,9 +1,9 @@
 object_type,object_id,action,attributes
 TrainingPeriod,136734,update,"finished_on,2024-06-15,withdrawal_reason,moved_school,withdrawn_at,2025-03-10T16:40:33Z"
 TrainingPeriod,136739,delete
-TrainingPeriod,216619,update,"finished_on,2023-12-21,withdrawal_reason,other,withdrawn_at,2026-02-18T13:00:48Z"
-MentorshipPeriod,97533,update,"finished_on,2023-12-21"
-ECTAtSchoolPeriod,86079,update,"finished_on,2023-12-21,reported_leaving_by_school_id,16862"
+TrainingPeriod,216619,update,"finished_on,2023-12-31,withdrawal_reason,other,withdrawn_at,2026-02-18T13:00:48Z"
+MentorshipPeriod,97533,update,"finished_on,2023-12-31"
+ECTAtSchoolPeriod,86079,update,"finished_on,2023-12-31,reported_leaving_by_school_id,16862"
 TrainingPeriod,216622,delete
 TrainingPeriod,130216,update,"finished_on,2024-03-10,withdrawal_reason,other,withdrawn_at,2026-02-18T12:00:22Z"
 MentorshipPeriod,4956,update,"finished_on,2024-03-10"

--- a/db/scripts/migration_data_fixes.csv
+++ b/db/scripts/migration_data_fixes.csv
@@ -1,2 +1,3 @@
 object_type,object_id,action,attributes
-MentorshipPeriod,178967,update,"started_on,2024-01-01,finished_on,2026-04-01"
+TrainingPeriod,136739,delete
+TrainingPeriod,136734,update,"finished_on,2024-06-15,withdrawal_reason,moved_school,withdrawn_at,2025-03-10T16:40:33Z"

--- a/db/scripts/migration_data_fixes.csv
+++ b/db/scripts/migration_data_fixes.csv
@@ -5,3 +5,7 @@ TrainingPeriod,216622,delete
 TrainingPeriod,216619,update,"finished_on,2023-12-21,withdrawal_reason,other,withdrawn_at,2026-02-18T13:00:48Z"
 ECTAtSchoolPeriod,86079,update,"finished_on,2023-12-21,reported_leaving_by_school_id,16862"
 MentorshipPeriod,97533,update,"finished_on,2023-12-21"
+TrainingPeriod,130224,delete
+TrainingPeriod,130216,update,"finished_on,2024-03-10,withdrawal_reason,other,withdrawn_at,2026-02-18T12:00:22Z"
+ECTAtSchoolPeriod,4340,update,"finished_on,2024-03-10,reported_leaving_by_school_id,23699"
+MentorshipPeriod,4956,update,"finished_on,2024-03-10"


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/4115
https://github.com/DFE-Digital/register-ects-project-board/issues/4109
https://github.com/DFE-Digital/register-ects-project-board/issues/4107

### Changes proposed in this pull request

#### (4115) Amend training periods for Teacher `2053286`
As per this [support ticket][ticket1], we want to amend training periods for
this teacher so the school can report the teacher as leaving.

There was a trigger misfire in ECF1 that resulted in an erroneous training
period being created with EDT.

We need to:

- remove the latest training period (ID: 136739)
- update the next latest training period (ID: 136734) to finish on the same date
  as their induction period ended and copy across the withdrawal details from 136739

Now, the school should be able to report the teacher as leaving correctly.

Since this is a correction of data created in error, we decided we ought not to
create any Events.

[ticket1]: https://github.com/DFE-Digital/register-ects-project-board/issues/4115

#### (4109) Amend training periods for Teacher `1856262`
As per this [support ticket][ticket2], we want to amend training, ECT, and
mentorship periods for this teacher to reflect that they left the school on
31/12/2023.

Again, this erroneous training period arose from a misfiring trigger in ECF1.

To remedy this, we need to:

- remove the latest training period (ID: 216622)
- update the next latest training period (ID: 216619) to finish on 31/12/2023
  and copy across the withdrawal details from 216622
- update the latest ect at school period (ID: 86079) to finish on the same date,
  and reflect the school reported them as leaving
- update the associated mentorship period (ID: 97533) to finish on the same date

Now, the training record for the teacher will correctly reflect the fact they
left the school.

Since this is a correction of data created in error, we decided we ought not to
create any Events.

[ticket2]: https://github.com/DFE-Digital/register-ects-project-board/issues/4109

#### (4107) Amend training periods for Teacher `2086874`
As per this [support ticket][ticket3], we want to amend training, ECT, and
mentorship periods for this teacher to reflect that they left the school on
10/03/2024.

Again, this erroneous training period arose from a misfiring trigger in ECF1.

To remedy this, we need to:

- remove the latest training period (ID: 130224)
- update the next latest training period (ID: 130216) to finish on 10/03/2024
  and copy across the withdrawal details from 130224
- update the latest ect at school period (ID: 4340) to finish on the same date,
  and reflect the school reported them as leaving
- update the associated mentorship period (ID: 4956) to finish on the same date

Now, the training record for the teacher will correctly reflect the fact they
left the school.

Since this is a correction of data created in error, we decided we ought not to
create any Events.

[ticket3]: https://github.com/DFE-Digital/register-ects-project-board/issues/4107

### Guidance to review

- [ ] Check the admin console to verify TRNs and URNs
- [ ] Use blazer to retrieve relevant records
- [ ] Deploy to migration and run `bin/rails runner db/scripts/migration_data_fixes.rb`
- [ ] Confirm data is as expected for 
  - [ ] Teacher `2053286`
  - [ ] Teacher `1856262`
  - [ ] Teacher `2086874`
- [ ] Deploy to production and run `bin/rails runner db/scripts/migration_data_fixes.rb`