### PR TITLE
Fix issue with empty metadata changes

### DIFF
--- a/app/services/metadata/handlers/base.rb
+++ b/app/services/metadata/handlers/base.rb
@@ -54,13 +54,11 @@ module Metadata::Handlers
     def alert_on_changes(metadata)
       return unless @alert_on_changes
 
-      Rails.logger.warn("[Metadata] (#{metadata.class.name}: #{metadata.id}) - Alert - saved_changes: #{metadata.saved_changes.inspect}")
-
       relevant_changes = alertable_changes(metadata.saved_changes)
 
-      return unless relevant_changes.any?
-
-      Rails.logger.warn("[Metadata] (#{metadata.class.name}: #{metadata.id}) - Alert - relevant_changes: #{relevant_changes.inspect}")
+      # if alertable_changes filters the changes we may be left with updated_at
+      # as the only change and that would then not be relevant on it's own
+      return unless relevant_changes.except(:updated_at).any?
 
       attrs = {
         class: metadata.class.name,

--- a/spec/services/metadata/handlers/teacher_spec.rb
+++ b/spec/services/metadata/handlers/teacher_spec.rb
@@ -343,6 +343,54 @@ RSpec.describe Metadata::Handlers::Teacher do
             )
           end
 
+          it "updated_at is included in relevant_changes when it is not the only change" do
+            described_class.new(teacher1).refresh_metadata!
+
+            metadata = Metadata::TeacherLeadProvider.find_by!(teacher: teacher1, lead_provider: lead_provider1)
+
+            Metadata::Base.bypass_update_restrictions do
+              metadata.update!(latest_ect_contract_period_year: nil, latest_ect_training_period_id: nil)
+            end
+
+            scope = instance_double(Sentry::Scope, set_context: nil)
+            allow(Sentry).to receive(:with_scope).and_yield(scope)
+
+            handler.track_changes!
+            refresh_metadata
+
+            expect(scope).to have_received(:set_context).with(
+              "metadata_changes",
+              a_hash_including(
+                relevant_changes: a_hash_including(
+                  "updated_at",
+                  "latest_ect_contract_period_year",
+                  "latest_ect_training_period_id"
+                )
+              )
+            )
+          end
+
+          context "when the only change is to ect_assigned_mentor_latest_school_period_id" do
+            it "does not alert on the dangling updated_at change" do
+              described_class.new(teacher1).refresh_metadata!
+
+              metadata = Metadata::TeacherLeadProvider.find_by!(teacher: teacher1, lead_provider: lead_provider1)
+
+              Metadata::Base.bypass_update_restrictions do
+                metadata.update!(ect_assigned_mentor_latest_school_period_id: nil)
+              end
+
+              handler.track_changes!
+
+              scope = instance_double(Sentry::Scope, set_context: nil)
+              allow(Sentry).to receive(:with_scope).and_yield(scope)
+
+              refresh_metadata
+
+              expect(scope).not_to have_received(:set_context)
+            end
+          end
+
           context "when there is also an ongoing mentorship period" do
             let!(:ongoing_mentorship_period) do
               FactoryBot.create(


### PR DESCRIPTION
### Context

We have been seeing alerts in Sentry regarding the overnight metadata refresh job which is detecting changes to `Metadata::TeacherLeadProvider` records that were effectively empty (only the `updated_at` for the metadata record changing).

Upon investigation it appears that we are filtering out `ect_assigned_mentor_latest_school_period_id` from the list attribute changes detected for ongoing and future mentorship periods.  If that attribute is the only change detected to the metadata record, an alert is triggered solely for the `updated_at` timestamp which is not desired.
e.g.
An update results in these attribute changes made to the metadata record:

```ruby
{
  ect_assigned_mentor_latest_school_period_id: [1234, nil],
  updated_at: ["2026-05-21 16:37:44 BST +01:00", "2026-06-22 11:54:31 BST +01:00"]
}
```

when the changes are filtered, we end up with these changes

```ruby
{
  updated_at: ["2026-05-21 16:37:44 BST +01:00", "2026-06-22 11:54:31 BST +01:00"]
}
```

This is triggering an alert which is just meaningless noise.

This fix checks if `updated_at` is the only changed attribute post filtering and if so prevents an alert from being triggered.

### Changes proposed in this pull request

* Add a guard to check if `updated_at` is the only relevant change and prevent a Sentry alert if it is
* Updates the specs to show this and also that otherwise `updated_at` is included in the alert.
* Removes the extra logging added to track down the issue.

### Guidance to review
