### PR TITLE
[4111] Create Teachers::Merge service

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -61,6 +61,7 @@ class Event < ApplicationRecord
     teacher_defers_training_period
     teacher_resumes_training_period
     teacher_registration_undone
+    teacher_merged
     teacher_withdraws_training_period
     teacher_changes_schedule_training_period
     teacher_training_period_contract_period_changed

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -20,6 +20,7 @@ class Teacher < ApplicationRecord
   }
   enum :anonymisation_reason, {
     registered_in_error: "registered_in_error",
+    teacher_record_merged: "teacher_record_merged",
   }
 
   # Associations

--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -150,6 +150,36 @@ module Events
       new(event_type:, author:, teacher:, heading:, body:, happened_at:).record_event!
     end
 
+    def self.record_teacher_merged_events!(author:, source:, destination:, body: nil, zendesk_ticket_id: nil, happened_at: Time.zone.now)
+      source_name = Teachers::Name.new(source).full_name
+      destination_name = Teachers::Name.new(destination).full_name
+
+      common = { event_type: :teacher_merged, author:, zendesk_ticket_id:, happened_at: }
+
+      new(
+        **common,
+        teacher: destination,
+        heading: "Records were merged into #{destination_name} from #{source_name}",
+        body: <<~BODY.squish
+          Records were merged in from #{source_name}
+          (TRN #{source.trn}, participant #{source.api_id}, teacher #{source.id}), which was then anonymised.
+          Destination: #{destination_name} (TRN #{destination.trn}, participant #{destination.api_id}, teacher #{destination.id}).
+          #{body}
+        BODY
+      ).record_event!
+
+      new(
+        **common,
+        teacher: source,
+        heading: "#{source_name} was merged into #{destination_name} and anonymised",
+        body: <<~BODY.squish
+          This record (TRN #{source.trn}, participant #{source.api_id}) was merged into
+          #{destination_name} (TRN #{destination.trn}, participant #{destination.api_id}, teacher #{destination.id}) and anonymised.
+          #{body}
+        BODY
+      ).record_event!
+    end
+
     def self.record_teacher_passes_induction_event!(author:, appropriate_body_period:, induction_period:, ect_at_school_period:, mentorship_period:, training_period:, teacher:, body: nil, zendesk_ticket_id: nil)
       fail(NoInductionPeriod) unless induction_period
 

--- a/app/services/teachers/merge.rb
+++ b/app/services/teachers/merge.rb
@@ -1,0 +1,70 @@
+module Teachers
+  class Merge
+    class MergeError < StandardError; end
+
+    attr_reader :author, :source, :destination, :event_note, :zendesk_ticket_id
+
+    def initialize(author:, source:, destination:, event_note: nil, zendesk_ticket_id: nil)
+      @author = author
+      @source = source
+      @destination = destination
+      @event_note = event_note
+      @zendesk_ticket_id = zendesk_ticket_id
+    end
+
+    def merge!
+      ensure_distinct_teachers
+
+      ActiveRecord::Base.transaction do
+        move_school_periods
+        move_induction_records
+        record_teacher_id_change
+        refresh_metadata
+        record_merge_events
+        anonymise_source
+      end
+
+      destination
+    end
+
+  private
+
+    def ensure_distinct_teachers
+      raise MergeError, "Cannot merge a teacher into itself" if source == destination
+    end
+
+    def move_school_periods
+      source.ect_at_school_periods.find_each { |period| period.update!(teacher: destination) }
+      source.mentor_at_school_periods.find_each { |period| period.update!(teacher: destination) }
+    end
+
+    def move_induction_records
+      source.induction_periods.find_each { |period| period.update!(teacher: destination) }
+      source.induction_extensions.find_each { |extension| extension.update!(teacher: destination) }
+    end
+
+    def record_teacher_id_change
+      TeacherIdChange.create!(
+        teacher: destination,
+        api_from_teacher_id: source.api_id,
+        api_to_teacher_id: destination.api_id
+      )
+    end
+
+    # The declarative refresh hook only re-points the destination's metadata on
+    # reassignment, so refresh the destination explicitly and tear down the
+    # stale source rows so their latest_*_training_period_id FKs don't dangle
+    def refresh_metadata
+      source.lead_provider_metadata.destroy_all
+      Metadata::Manager.new.refresh_metadata!([destination])
+    end
+
+    def record_merge_events
+      Events::Record.record_teacher_merged_events!(author:, source:, destination:, body: event_note, zendesk_ticket_id:)
+    end
+
+    def anonymise_source
+      Teachers::Anonymise.new(teacher: source.reload, reason: :teacher_record_merged).anonymise!
+    end
+  end
+end

--- a/app/services/teachers/merge.rb
+++ b/app/services/teachers/merge.rb
@@ -18,6 +18,7 @@ module Teachers
       ActiveRecord::Base.transaction do
         move_school_periods
         move_induction_records
+        move_teacher_id_changes
         record_teacher_id_change
         refresh_metadata
         record_merge_events
@@ -41,6 +42,10 @@ module Teachers
     def move_induction_records
       source.induction_periods.find_each { |period| period.update!(teacher: destination) }
       source.induction_extensions.find_each { |extension| extension.update!(teacher: destination) }
+    end
+
+    def move_teacher_id_changes
+      source.teacher_id_changes.find_each { |change| change.update!(teacher: destination) }
     end
 
     def record_teacher_id_change

--- a/db/migrate/20260622120000_add_teacher_record_merged_anonymisation_reason.rb
+++ b/db/migrate/20260622120000_add_teacher_record_merged_anonymisation_reason.rb
@@ -1,0 +1,9 @@
+class AddTeacherRecordMergedAnonymisationReason < ActiveRecord::Migration[8.1]
+  def up
+    add_enum_value :anonymisation_reasons, "teacher_record_merged"
+  end
+
+  def down
+    # enum values can't be removed in PostgreSQL
+  end
+end

--- a/db/migrate/20260622120000_add_teacher_record_merged_anonymisation_reason.rb
+++ b/db/migrate/20260622120000_add_teacher_record_merged_anonymisation_reason.rb
@@ -5,5 +5,6 @@ class AddTeacherRecordMergedAnonymisationReason < ActiveRecord::Migration[8.1]
 
   def down
     # enum values can't be removed in PostgreSQL
+    raise ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_15_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_22_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -20,8 +20,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_120000) do
 
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
+  create_enum "anonymisation_reasons", ["registered_in_error", "teacher_record_merged"]
   create_enum "appropriate_body_type", ["local_authority", "national", "teaching_school_hub"]
-  create_enum "anonymisation_reasons", ["registered_in_error"]
   create_enum "batch_status", ["pending", "processing", "processed", "completing", "completed", "failed"]
   create_enum "batch_type", ["action", "claim"]
   create_enum "contract_types", ["ecf", "ittecf_ectp"]
@@ -839,13 +839,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_120000) do
   end
 
   create_table "teachers", force: :cascade do |t|
+    t.enum "anonymisation_reason", enum_type: "anonymisation_reasons"
+    t.datetime "anonymised_at"
     t.uuid "api_ect_training_record_id", default: -> { "gen_random_uuid()" }, null: false
     t.uuid "api_id", default: -> { "gen_random_uuid()" }, null: false
     t.uuid "api_mentor_training_record_id", default: -> { "gen_random_uuid()" }, null: false
     t.datetime "api_unfunded_mentor_updated_at", default: -> { "CURRENT_TIMESTAMP" }
     t.datetime "api_updated_at", default: -> { "CURRENT_TIMESTAMP" }
-    t.datetime "anonymised_at"
-    t.enum "anonymisation_reason", enum_type: "anonymisation_reasons"
     t.string "corrected_name"
     t.datetime "created_at", null: false
     t.date "ect_became_ineligible_for_funding_on"

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -180,6 +180,48 @@ RSpec.describe Events::Record do
     end
   end
 
+  describe ".record_teacher_merged_events!" do
+    let(:author) { Events::SystemAuthor.new }
+    let(:author_params) { { author_type: "system" } }
+    let(:source) { FactoryBot.create(:teacher, trs_first_name: "Source", trs_last_name: "Teacher") }
+    let(:destination) { FactoryBot.create(:teacher, trs_first_name: "Destination", trs_last_name: "Teacher") }
+
+    it "queues a RecordEventJob on the destination referencing both teachers' api_ids" do
+      Events::Record.record_teacher_merged_events!(author:, source:, destination:)
+
+      expect(RecordEventJob).to have_received(:perform_later).with(
+        hash_including(
+          teacher: destination,
+          event_type: :teacher_merged,
+          heading: "Records were merged into #{Teachers::Name.new(destination).full_name} from #{Teachers::Name.new(source).full_name}",
+          body: a_string_including(source.api_id).and(a_string_including(destination.api_id))
+        )
+      )
+    end
+
+    it "queues a RecordEventJob on the source referencing both teachers' api_ids" do
+      Events::Record.record_teacher_merged_events!(author:, source:, destination:)
+
+      expect(RecordEventJob).to have_received(:perform_later).with(
+        hash_including(
+          teacher: source,
+          event_type: :teacher_merged,
+          heading: "#{Teachers::Name.new(source).full_name} was merged into #{Teachers::Name.new(destination).full_name} and anonymised",
+          body: a_string_including(source.api_id).and(a_string_including(destination.api_id))
+        )
+      )
+    end
+
+    it "appends the supplied note to both event bodies" do
+      Events::Record.record_teacher_merged_events!(author:, source:, destination:, body: "See ticket")
+
+      expect(RecordEventJob).to have_received(:perform_later)
+        .with(hash_including(teacher: destination, body: a_string_ending_with("See ticket")))
+      expect(RecordEventJob).to have_received(:perform_later)
+        .with(hash_including(teacher: source, body: a_string_ending_with("See ticket")))
+    end
+  end
+
   describe ".record_teacher_passes_induction_event!" do
     let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher:) }
     let(:mentorship_period) { FactoryBot.create(:mentorship_period, mentee: ect_at_school_period, mentor:) }

--- a/spec/services/teachers/merge_spec.rb
+++ b/spec/services/teachers/merge_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Teachers::Merge do
         expect(anonymiser).to have_received(:anonymise!)
       end
 
-      it "retains the source teacher's api_id so API consumers can still follow stored references" do
+      it "retains the source teacher's api_id (the recorded id-change maps back to it)" do
         expect { service.merge! }.not_to(change { source.reload.api_id })
       end
 
@@ -71,6 +71,26 @@ RSpec.describe Teachers::Merge do
         expect(change.teacher).to eq(destination)
         expect(change.api_from_teacher_id).to eq(source_api_id)
         expect(change.api_to_teacher_id).to eq(destination.api_id)
+      end
+
+      it "moves the source's existing teacher_id_changes onto the destination" do
+        earlier_change = FactoryBot.create(:teacher_id_change, teacher: source)
+
+        service.merge!
+
+        expect(earlier_change.reload.teacher).to eq(destination)
+      end
+
+      it "surfaces the old participant id on the destination so API consumers can follow it" do
+        lead_provider = FactoryBot.create(:lead_provider)
+        source_api_id = source.api_id
+
+        service.merge!
+
+        response = JSON.parse(API::TeacherSerializer.render(destination.reload, lead_provider_id: lead_provider.id))
+        expect(response["attributes"]["participant_id_changes"]).to include(
+          a_hash_including("from_participant_id" => source_api_id, "to_participant_id" => destination.api_id)
+        )
       end
 
       it "populates the destination's metadata (which the model hooks do not do on reassignment)" do

--- a/spec/services/teachers/merge_spec.rb
+++ b/spec/services/teachers/merge_spec.rb
@@ -1,0 +1,131 @@
+RSpec.describe Teachers::Merge do
+  subject(:service) do
+    described_class.new(author:, source:, destination:)
+  end
+
+  let(:author) { Events::SystemAuthor.new }
+  let(:source) { FactoryBot.create(:teacher, :with_realistic_name) }
+  let(:destination) { FactoryBot.create(:teacher, :with_realistic_name) }
+
+  describe "#merge!" do
+    context "when the destination has no conflicting records (clean merge)" do
+      let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: source) }
+      let!(:ect_training_period) { FactoryBot.create(:training_period, :for_ect, :with_active_lead_provider, ect_at_school_period:, started_on: ect_at_school_period.started_on, finished_on: nil) }
+      let!(:ect_declaration) { FactoryBot.create(:declaration, training_period: ect_training_period) }
+
+      let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: source) }
+      let!(:mentor_training_period) { FactoryBot.create(:training_period, :for_mentor, :with_active_lead_provider, mentor_at_school_period:, started_on: mentor_at_school_period.started_on, finished_on: nil) }
+      let!(:mentor_declaration) { FactoryBot.create(:declaration, training_period: mentor_training_period) }
+
+      let!(:induction_period) { FactoryBot.create(:induction_period, teacher: source) }
+      let!(:induction_extension) { FactoryBot.create(:induction_extension, teacher: source) }
+
+      it "returns the destination teacher" do
+        expect(service.merge!).to eq(destination)
+      end
+
+      it "moves the at-school periods to the destination teacher" do
+        service.merge!
+
+        expect(ect_at_school_period.reload.teacher).to eq(destination)
+        expect(mentor_at_school_period.reload.teacher).to eq(destination)
+        expect(source.reload.ect_at_school_periods).to be_empty
+        expect(source.mentor_at_school_periods).to be_empty
+      end
+
+      it "moves the induction records to the destination teacher" do
+        service.merge!
+
+        expect(induction_period.reload.teacher).to eq(destination)
+        expect(induction_extension.reload.teacher).to eq(destination)
+        expect(source.reload.induction_periods).to be_empty
+        expect(source.induction_extensions).to be_empty
+      end
+
+      it "moves the declarations with their training periods to the destination teacher" do
+        service.merge!
+
+        expect(ect_declaration.reload.training_period.teacher).to eq(destination)
+        expect(mentor_declaration.reload.training_period.teacher).to eq(destination)
+      end
+
+      it "anonymises the source teacher" do
+        anonymiser = instance_double(Teachers::Anonymise, anonymise!: true)
+        allow(Teachers::Anonymise).to receive(:new).with(teacher: source, reason: :teacher_record_merged).and_return(anonymiser)
+
+        service.merge!
+
+        expect(anonymiser).to have_received(:anonymise!)
+      end
+
+      it "retains the source teacher's api_id so API consumers can still follow stored references" do
+        expect { service.merge! }.not_to(change { source.reload.api_id })
+      end
+
+      it "records a TeacherIdChange from the source participant to the destination participant" do
+        source_api_id = source.api_id
+
+        expect { service.merge! }.to change(TeacherIdChange, :count).by(1)
+
+        change = TeacherIdChange.last
+        expect(change.teacher).to eq(destination)
+        expect(change.api_from_teacher_id).to eq(source_api_id)
+        expect(change.api_to_teacher_id).to eq(destination.api_id)
+      end
+
+      it "populates the destination's metadata (which the model hooks do not do on reassignment)" do
+        expect { service.merge! }.to change { destination.reload.lead_provider_metadata.count }.from(0)
+      end
+
+      it "tears down the source's now-stale metadata (which the model hooks leave behind)" do
+        Metadata::Manager.new.refresh_metadata!([source])
+        expect(source.lead_provider_metadata.reload).not_to be_empty
+
+        expect { service.merge! }.to change { source.reload.lead_provider_metadata.count }.to(0)
+      end
+
+      it "records the merge events before anonymising" do
+        allow(Events::Record).to receive(:record_teacher_merged_events!).and_call_original
+
+        service.merge!
+
+        expect(Events::Record).to have_received(:record_teacher_merged_events!)
+          .with(author:, source:, destination:, body: nil, zendesk_ticket_id: nil)
+      end
+    end
+
+    context "when the destination already has an overlapping period" do
+      let!(:source_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: source) }
+      let!(:destination_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: destination) }
+
+      it "raises and rolls back the whole merge" do
+        expect { service.merge! }.to raise_error(ActiveRecord::RecordInvalid)
+
+        expect(source_period.reload.teacher).to eq(source)
+        expect(source.reload.anonymised_at).to be_nil
+        expect(TeacherIdChange.where(teacher: destination)).to be_empty
+      end
+    end
+
+    context "when the source and destination are the same teacher" do
+      subject(:service) { described_class.new(author:, source:, destination: source) }
+
+      it "raises a MergeError" do
+        expect { service.merge! }.to raise_error(described_class::MergeError, /into itself/)
+      end
+    end
+
+    describe "declaration participant identity via the API serializer" do
+      let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: source) }
+      let!(:ect_training_period) { FactoryBot.create(:training_period, :for_ect, :with_active_lead_provider, ect_at_school_period:, started_on: ect_at_school_period.started_on, finished_on: nil) }
+      let!(:declaration) { FactoryBot.create(:declaration, training_period: ect_training_period) }
+
+      it "reports the moved declaration under the destination participant id" do
+        service.merge!
+
+        json = JSON.parse(API::DeclarationSerializer.render(declaration.reload))
+        expect(json.dig("attributes", "participant_id")).to eq(destination.api_id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/4111

### Changes proposed in this pull request

To deal with support requests, sometimes we need to merge a teacher's records into another one. This PR creates a service to handle that work.

### Guidance to review

n.b. there's an admin UI coming down the pipe so I've left this console-driven for now.