### PR TITLE
[3404] Allow contract period changes for EOI only training periods (Slice 5)

### DIFF
--- a/app/services/admin/teachers/training_periods/change_contract_period/current_active_period.rb
+++ b/app/services/admin/teachers/training_periods/change_contract_period/current_active_period.rb
@@ -5,6 +5,7 @@ module Admin
         class CurrentActivePeriod
           class UnsupportedTrainingPeriodError < StandardError; end
           class ScheduleNotFoundError < StandardError; end
+          class ActiveLeadProviderNotFoundError < StandardError; end
 
           attr_reader :training_period, :contract_period, :school_partnership, :author
 
@@ -24,6 +25,11 @@ module Admin
             if equivalent_schedule.blank?
               raise ScheduleNotFoundError,
                     "No equivalent schedule found for #{training_period.schedule.identifier} in contract period #{contract_period.year}"
+            end
+
+            if training_period.only_expression_of_interest? && equivalent_active_lead_provider.blank?
+              raise ActiveLeadProviderNotFoundError,
+                    "No active lead provider found for #{training_period.expression_of_interest_lead_provider.name} in contract period #{contract_period.year}"
             end
 
             ActiveRecord::Base.transaction do
@@ -78,11 +84,32 @@ module Admin
               period: training_period.at_school_period,
               started_on: Time.zone.today,
               finished_on:,
-              school_partnership:,
-              expression_of_interest: nil,
+              school_partnership: replacement_school_partnership,
+              expression_of_interest: replacement_expression_of_interest,
               schedule: equivalent_schedule,
               author:
             ).call
+          end
+
+          def replacement_school_partnership
+            return if training_period.only_expression_of_interest?
+
+            school_partnership
+          end
+
+          def replacement_expression_of_interest
+            return unless training_period.only_expression_of_interest?
+
+            equivalent_active_lead_provider
+          end
+
+          def equivalent_active_lead_provider
+            return unless training_period.only_expression_of_interest?
+
+            @equivalent_active_lead_provider ||= ActiveLeadProvider.find_by(
+              lead_provider: training_period.expression_of_interest_lead_provider,
+              contract_period:
+            )
           end
 
           def record_contract_period_changed_event!(new_training_period:)
@@ -97,7 +124,7 @@ module Admin
           end
 
           def current_contract_period
-            @current_contract_period ||= training_period.contract_period
+            @current_contract_period ||= training_period.contract_period || training_period.expression_of_interest_contract_period
           end
 
           def track_payments_frozen_year!

--- a/app/services/admin/teachers/training_periods/change_contract_period/eligibility.rb
+++ b/app/services/admin/teachers/training_periods/change_contract_period/eligibility.rb
@@ -10,9 +10,15 @@ module Admin
           end
 
           def eligible?
-            return false unless provider_led_with_partnership?
+            return false unless provider_led_with_partnership_or_eoi?
             return false if finished_before_today?
             return false if blocked_by_current_active_period?
+
+            if eoi_only?
+              return current_active_period? if no_future_periods?
+
+              return false
+            end
 
             return current_active_period? if no_future_periods?
             return only_future_period? if no_current_active_period?
@@ -21,7 +27,7 @@ module Admin
           end
 
           def current_active_period_changeable?
-            return false unless provider_led_with_partnership?
+            return false unless provider_led_with_partnership_or_eoi?
             return false if finished_before_today?
             return false unless current_active_period?
             return false unless current_active_period_started_before_today?
@@ -43,9 +49,9 @@ module Admin
             @future_periods ||= relationships.future_periods.to_a
           end
 
-          def provider_led_with_partnership?
+          def provider_led_with_partnership_or_eoi?
             training_period.provider_led_training_programme? &&
-              training_period.school_partnership.present?
+              (training_period.school_partnership.present? || training_period.only_expression_of_interest?)
           end
 
           def blocked_by_current_active_period?
@@ -75,6 +81,10 @@ module Admin
           def same_partnership_as_current_active_period?
             current_active_period.lead_provider_delivery_partnership.present? &&
               current_active_period.lead_provider_delivery_partnership == training_period.lead_provider_delivery_partnership
+          end
+
+          def eoi_only?
+            training_period.only_expression_of_interest?
           end
 
           def current_active_period_started_before_today?

--- a/app/views/admin/teachers/training_periods/change_contract_period_wizard/check_answers.html.erb
+++ b/app/views/admin/teachers/training_periods/change_contract_period_wizard/check_answers.html.erb
@@ -20,9 +20,21 @@
           <%= row.with_value { @wizard.selected_contract_period.year.to_s } %>
         <% end %>
 
-        <%= list.with_row do |row| %>
-          <%= row.with_key { "Partnership" } %>
-          <%= row.with_value { @wizard.selected_partnership_name } %>
+        <% if @wizard.partnership_selection_required? %>
+          <%= list.with_row do |row| %>
+            <%= row.with_key { "Partnership" } %>
+            <%= row.with_value { @wizard.selected_partnership_name } %>
+          <% end %>
+        <% else %>
+          <%= list.with_row do |row| %>
+            <%= row.with_key { "Lead provider" } %>
+            <%= row.with_value { @wizard.selected_lead_provider_name } %>
+          <% end %>
+
+          <%= list.with_row do |row| %>
+            <%= row.with_key { "Delivery partner" } %>
+            <%= row.with_value { "No delivery partner confirmed" } %>
+          <% end %>
         <% end %>
       <% end %>
 

--- a/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/check_answers_step.rb
+++ b/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/check_answers_step.rb
@@ -5,9 +5,11 @@ module Admin
         class CheckAnswersStep < Step
           CurrentActivePeriodChange = ::Admin::Teachers::TrainingPeriods::ChangeContractPeriod::CurrentActivePeriod
 
-          self.expected_store_keys = %i[contract_period_year school_partnership_id]
+          self.expected_store_keys = %i[contract_period_year]
 
-          def previous_step = :select_partnership
+          def previous_step
+            wizard.partnership_selection_required? ? :select_partnership : :select_contract_period
+          end
 
           def save!
             service.change_contract_period!
@@ -17,6 +19,9 @@ module Admin
             false
           rescue CurrentActivePeriodChange::ScheduleNotFoundError
             errors.add(:base, "A matching schedule could not be found for the selected contract period")
+            false
+          rescue CurrentActivePeriodChange::ActiveLeadProviderNotFoundError
+            errors.add(:base, "An active lead provider could not be found for the selected contract period")
             false
           end
 

--- a/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/select_contract_period_step.rb
+++ b/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/select_contract_period_step.rb
@@ -11,6 +11,8 @@ module Admin
           def self.permitted_params = %i[contract_period_year]
 
           def next_step
+            return :check_answers unless wizard.partnership_selection_required?
+
             wizard.school_partnerships.exists? ? :select_partnership : :no_partnerships
           end
 

--- a/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard.rb
+++ b/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard.rb
@@ -24,6 +24,7 @@ module Admin
             steps = [:select_contract_period]
             return steps unless selected_contract_period_allowed?
 
+            return steps << :check_answers if eoi_only?
             return steps << :no_partnerships unless school_partnerships.exists?
 
             steps << :select_partnership
@@ -52,13 +53,17 @@ module Admin
 
           def contract_periods
             scope = ContractPeriod.enabled.most_recent_first
-            scope = scope.where.not(year: current_contract_period.year) if current_contract_period
+            scope = scope.where.not(year: existing_contract_period.year) if existing_contract_period
 
-            if original_frozen_contract_period_year.in?([2021, 2022])
-              scope.where.not(year: [2021, 2022] - [original_frozen_contract_period_year])
-            else
-              scope.where.not(year: [2021, 2022])
-            end
+            scope = if original_frozen_contract_period_year.in?([2021, 2022])
+                      scope.where.not(year: [2021, 2022] - [original_frozen_contract_period_year])
+                    else
+                      scope.where.not(year: [2021, 2022])
+                    end
+
+            scope = scope.where(year: equivalent_active_lead_providers.select(:contract_period_year)) if eoi_only?
+
+            scope
           end
 
           def selected_contract_period
@@ -108,7 +113,7 @@ module Admin
           end
 
           def existing_contract_period
-            training_period.contract_period
+            training_period.contract_period || training_period.expression_of_interest_contract_period
           end
 
           def selected_partnership_name
@@ -117,10 +122,22 @@ module Admin
             "#{selected_school_partnership.lead_provider.name} & #{selected_school_partnership.delivery_partner.name}"
           end
 
+          def selected_lead_provider_name
+            training_period.expression_of_interest_lead_provider.name
+          end
+
+          def partnership_selection_required?
+            !eoi_only?
+          end
+
         private
 
-          def current_contract_period
-            training_period.contract_period
+          def eoi_only?
+            training_period.only_expression_of_interest?
+          end
+
+          def equivalent_active_lead_providers
+            ActiveLeadProvider.where(lead_provider: training_period.expression_of_interest_lead_provider)
           end
 
           def original_frozen_contract_period_year

--- a/spec/requests/admin/teachers/training_periods/change_contract_period_wizard_spec.rb
+++ b/spec/requests/admin/teachers/training_periods/change_contract_period_wizard_spec.rb
@@ -147,6 +147,19 @@ RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardCont
         expect(response).to redirect_to(path_for_step("no-partnerships"))
       end
     end
+
+    context "when the current period only has an expression of interest" do
+      let(:training_period) { eoi_only_training_period }
+
+      it "redirects to check answers" do
+        post(
+          path_for_step("select-contract-period"),
+          params: { select_contract_period: { contract_period_year: target_contract_period.year } }
+        )
+
+        expect(response).to redirect_to(path_for_step("check-answers"))
+      end
+    end
   end
 
   describe "GET select-partnership" do
@@ -299,6 +312,30 @@ RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardCont
 
       expect(response).to have_http_status(:unprocessable_content)
       expect(response.body).to include("A matching schedule could not be found for the selected contract period")
+    end
+
+    context "when the current period only has an expression of interest" do
+      let(:training_period) { eoi_only_training_period }
+
+      it "creates a replacement expression of interest only training period" do
+        target_schedule
+
+        post(
+          path_for_step("select-contract-period"),
+          params: { select_contract_period: { contract_period_year: target_contract_period.year } }
+        )
+
+        expect {
+          post path_for_step("check-answers"), params: { check_answers: {} }
+        }.to change { TrainingPeriod.where(ect_at_school_period:).count }.by(1)
+
+        expect(response).to redirect_to(admin_teacher_training_path(teacher))
+        expect(training_period.reload.finished_on).to eq(today.yesterday)
+        expect(replacement_training_period.school_partnership).to be_nil
+        expect(replacement_training_period.expression_of_interest).to eq(target_active_lead_provider)
+        expect(replacement_training_period.expression_of_interest_contract_period).to eq(target_contract_period)
+        expect(replacement_training_period.schedule).to eq(target_schedule)
+      end
     end
   end
 

--- a/spec/requests/admin/teachers/training_periods/change_contract_period_wizard_spec.rb
+++ b/spec/requests/admin/teachers/training_periods/change_contract_period_wizard_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardController", type: :request do
   include_context "sign in as DfE user"
+  include HaveSummaryListRow
 
   let(:today) { Date.new(2026, 2, 1) }
   let(:teacher) { FactoryBot.create(:teacher) }
@@ -35,6 +36,20 @@ RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardCont
   let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:) }
   let(:schedule) { FactoryBot.create(:schedule, contract_period: current_contract_period) }
   let(:target_schedule) { FactoryBot.create(:schedule, contract_period: target_contract_period, identifier: schedule.identifier) }
+  let(:eoi_lead_provider) { FactoryBot.create(:lead_provider) }
+  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider: eoi_lead_provider, contract_period: current_contract_period) }
+  let!(:target_active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider: eoi_lead_provider, contract_period: target_contract_period) }
+  let(:eoi_only_training_period) do
+    FactoryBot.create(
+      :training_period,
+      :ongoing,
+      :with_only_expression_of_interest,
+      ect_at_school_period:,
+      expression_of_interest: active_lead_provider,
+      schedule:,
+      started_on: today.prev_month
+    )
+  end
   let(:training_period) do
     FactoryBot.create(
       :training_period,
@@ -225,9 +240,31 @@ RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardCont
 
       expect(response).to have_http_status(:ok)
       expect(page).to have_text("Confirm contract period change for #{teacher_name}")
-      expect(page).to have_text(current_contract_period.year.to_s)
-      expect(page).to have_text(target_contract_period.year.to_s)
-      expect(page).to have_text(partnership_name)
+      expect(page).to have_summary_list_row("Existing contract period", value: current_contract_period.year.to_s)
+      expect(page).to have_summary_list_row("New contract period", value: target_contract_period.year.to_s)
+      expect(page).to have_summary_list_row("Partnership", value: partnership_name)
+    end
+
+    context "when the current period only has an expression of interest" do
+      let(:eoi_lead_provider) { FactoryBot.create(:lead_provider, name: "Target Lead Provider") }
+      let(:training_period) { eoi_only_training_period }
+
+      it "renders the CYA page after the contract period has been selected" do
+        post(
+          path_for_step("select-contract-period"),
+          params: { select_contract_period: { contract_period_year: target_contract_period.year } }
+        )
+
+        get path_for_step("check-answers")
+        page = Capybara.string(response.body)
+
+        expect(response).to have_http_status(:ok)
+        expect(page).to have_text("Confirm contract period change for #{teacher_name}")
+        expect(page).to have_summary_list_row("Existing contract period", value: current_contract_period.year.to_s)
+        expect(page).to have_summary_list_row("New contract period", value: target_contract_period.year.to_s)
+        expect(page).to have_summary_list_row("Lead provider", value: "Target Lead Provider")
+        expect(page).to have_summary_list_row("Delivery partner", value: "No delivery partner confirmed")
+      end
     end
   end
 

--- a/spec/services/admin/teachers/training_periods/change_contract_period/current_active_period_spec.rb
+++ b/spec/services/admin/teachers/training_periods/change_contract_period/current_active_period_spec.rb
@@ -72,6 +72,50 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriod::CurrentAc
     }.not_to(change { Event.where(event_type: "teacher_changes_schedule_training_period").count })
   end
 
+  context "when the current training period only has an expression of interest" do
+    let(:target_school_partnership) { nil }
+    let(:current_active_lead_provider) do
+      FactoryBot.create(:active_lead_provider, contract_period: current_contract_period)
+    end
+    let!(:target_active_lead_provider) do
+      FactoryBot.create(:active_lead_provider, lead_provider: current_active_lead_provider.lead_provider, contract_period: target_contract_period)
+    end
+    let!(:training_period) do
+      FactoryBot.create(
+        :training_period,
+        :ongoing,
+        :with_only_expression_of_interest,
+        ect_at_school_period:,
+        expression_of_interest: current_active_lead_provider,
+        schedule:,
+        started_on:,
+        finished_on:
+      )
+    end
+
+    it "ends the current period and creates a replacement with the equivalent active lead provider" do
+      replacement_training_period = nil
+
+      expect {
+        replacement_training_period = service_call
+      }
+        .to change(TrainingPeriod, :count).by(1)
+        .and change { Event.where(event_type: "teacher_training_period_contract_period_changed").count }.by(1)
+
+      event = Event.where(event_type: "teacher_training_period_contract_period_changed").sole
+
+      expect(training_period.reload.finished_on).to eq(today.yesterday)
+      expect(replacement_training_period.started_on).to eq(today)
+      expect(replacement_training_period.finished_on).to be_nil
+      expect(replacement_training_period.school_partnership).to be_nil
+      expect(replacement_training_period.expression_of_interest).to eq(target_active_lead_provider)
+      expect(replacement_training_period.expression_of_interest.lead_provider).to eq(current_active_lead_provider.lead_provider)
+      expect(replacement_training_period.expression_of_interest_contract_period).to eq(target_contract_period)
+      expect(replacement_training_period.schedule).to eq(target_schedule)
+      expect(event.metadata["new_training_period_id"]).to eq(replacement_training_period.id)
+    end
+  end
+
   context "when the current training period has a future end date" do
     let(:finished_on) { today.next_month }
 

--- a/spec/services/admin/teachers/training_periods/change_contract_period/eligibility_spec.rb
+++ b/spec/services/admin/teachers/training_periods/change_contract_period/eligibility_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriod::Eligibili
     end
   end
 
-  context "when the training period has no partnership" do
+  context "when the training period only has an expression of interest" do
     let(:training_period) do
       FactoryBot.create(
         :training_period,
@@ -107,8 +107,34 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriod::Eligibili
       )
     end
 
-    it "is not eligible" do
-      expect(eligibility).not_to be_eligible
+    it "is eligible" do
+      expect(eligibility).to be_eligible
+    end
+
+    context "when there is a future period" do
+      let(:future_started_on) { today.next_month }
+      let(:finished_on) { future_started_on.yesterday }
+
+      before do
+        FactoryBot.create(
+          :training_period,
+          :with_only_expression_of_interest,
+          ect_at_school_period: FactoryBot.create(
+            :ect_at_school_period,
+            teacher:,
+            school:,
+            started_on: future_started_on,
+            finished_on: nil
+          ),
+          expression_of_interest: training_period.expression_of_interest,
+          started_on: future_started_on,
+          finished_on: nil
+        )
+      end
+
+      it "is not eligible" do
+        expect(eligibility).not_to be_eligible
+      end
     end
   end
 
@@ -243,6 +269,22 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriod::Eligibili
   describe "#current_active_period_changeable?" do
     it "is changeable for a provider-led active current period with no future periods" do
       expect(eligibility).to be_current_active_period_changeable
+    end
+
+    context "when the provider-led active current period only has an expression of interest" do
+      let(:training_period) do
+        FactoryBot.create(
+          :training_period,
+          :with_only_expression_of_interest,
+          ect_at_school_period:,
+          started_on:,
+          finished_on:
+        )
+      end
+
+      it "is changeable" do
+        expect(eligibility).to be_current_active_period_changeable
+      end
     end
 
     context "when the training period starts today" do

--- a/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/check_answers_step_spec.rb
+++ b/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/check_answers_step_spec.rb
@@ -4,14 +4,24 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Che
   let(:wizard) do
     instance_double(
       Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Wizard,
-      store:
+      store:,
+      partnership_selection_required?: partnership_selection_required
     )
   end
   let(:store) { FactoryBot.build(:session_repository) }
+  let(:partnership_selection_required) { true }
 
   describe "#previous_step" do
     it "returns select partnership" do
       expect(step.previous_step).to eq(:select_partnership)
+    end
+
+    context "when the partnership selection is skipped" do
+      let(:partnership_selection_required) { false }
+
+      it "returns select contract period" do
+        expect(step.previous_step).to eq(:select_contract_period)
+      end
     end
   end
 end

--- a/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/select_contract_period_step_spec.rb
+++ b/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/select_contract_period_step_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Sel
       Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Wizard,
       store:,
       contract_periods:,
-      school_partnerships:
+      school_partnerships:,
+      partnership_selection_required?: partnership_selection_required
     )
   end
   let(:store) { FactoryBot.build(:session_repository) }
@@ -15,6 +16,7 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Sel
   let(:contract_periods) { ContractPeriod.where(year: available_contract_period.year) }
   let(:available_school_partnership) { FactoryBot.create(:school_partnership) }
   let(:school_partnerships) { SchoolPartnership.where(id: available_school_partnership.id) }
+  let(:partnership_selection_required) { true }
   let(:contract_period_year) { available_contract_period.year }
 
   before do
@@ -84,6 +86,14 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Sel
 
       it "returns no partnerships" do
         expect(step.next_step).to eq(:no_partnerships)
+      end
+    end
+
+    context "when partnership selection is not required" do
+      let(:partnership_selection_required) { false }
+
+      it "returns check answers" do
+        expect(step.next_step).to eq(:check_answers)
       end
     end
   end

--- a/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard_spec.rb
+++ b/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard_spec.rb
@@ -78,6 +78,27 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Wiz
       it { is_expected.to eq(%i[select_contract_period select_partnership check_answers]) }
     end
 
+    context "when an EOI only period has a valid contract period selection" do
+      let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, contract_period: current_contract_period) }
+      let(:training_period) do
+        FactoryBot.create(
+          :training_period,
+          :ongoing,
+          :with_only_expression_of_interest,
+          ect_at_school_period:,
+          expression_of_interest: active_lead_provider,
+          schedule:
+        )
+      end
+
+      before do
+        FactoryBot.create(:active_lead_provider, lead_provider: active_lead_provider.lead_provider, contract_period: target_contract_period)
+        store.contract_period_year = target_contract_period.year
+      end
+
+      it { is_expected.to eq(%i[select_contract_period check_answers]) }
+    end
+
     context "when an unavailable contract period has been selected" do
       before { store.contract_period_year = current_contract_period.year }
 
@@ -122,6 +143,28 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Wiz
       it "keeps the original frozen contract period" do
         expect(wizard.contract_periods)
           .to contain_exactly(contract_period_2022, target_contract_period, other_contract_period)
+      end
+    end
+
+    context "for an EOI only training period" do
+      let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, contract_period: current_contract_period) }
+      let(:training_period) do
+        FactoryBot.create(
+          :training_period,
+          :ongoing,
+          :with_only_expression_of_interest,
+          ect_at_school_period:,
+          expression_of_interest: active_lead_provider,
+          schedule:
+        )
+      end
+
+      before do
+        FactoryBot.create(:active_lead_provider, lead_provider: active_lead_provider.lead_provider, contract_period: target_contract_period)
+      end
+
+      it "only returns contract periods with an equivalent active lead provider" do
+        expect(wizard.contract_periods).to contain_exactly(target_contract_period)
       end
     end
   end

--- a/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard_spec.rb
+++ b/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard_spec.rb
@@ -161,6 +161,7 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Wiz
 
       before do
         FactoryBot.create(:active_lead_provider, lead_provider: active_lead_provider.lead_provider, contract_period: target_contract_period)
+        FactoryBot.create(:active_lead_provider, contract_period: other_contract_period)
       end
 
       it "only returns contract periods with an equivalent active lead provider" do


### PR DESCRIPTION
## What

Following on from #3114, this is the 5th slice of the contract period change journey for admins.

This introduces:

- eligibility for current active EOI only training periods
- contract period options restricted to years where the current lead provider has an active lead provider record
- skipping the school partnership selection step for EOI only periods
- CYA content for EOI only periods showing:
  - lead provider
  - delivery partner as `No delivery partner confirmed`
 - mutation support to create the replacement training period with the equivalent active lead provider in the selected contract period

This slice keeps the controller on `current_active_period_changeable?` because we only handle current active mutations for now. Once future period changes are in, we can drop `current_active_period_changeable?` and make `eligible?` the source of truth.

## Screenshot

| `/check-answers` |
|------------|
|<img width="1182" height="757" alt="image" src="https://github.com/user-attachments/assets/42821b99-925c-4c81-ae6f-fed02a936586" />|

## Not included

This PR does not:

- display the change link on the training tab
- add future period mutation behaviour
- allow changing the lead provider for EOI only periods
- turn an EOI only period into a confirmed school partnership
