### PR TITLE
[4031] Part 3 - Switch calculators over

### DIFF
--- a/app/components/admin/statements/clawbacks_component.rb
+++ b/app/components/admin/statements/clawbacks_component.rb
@@ -65,7 +65,7 @@ module Admin
 
         case calculator
         when PaymentCalculator::Banded
-          "#{declaration_type_label} (Band #{declaration_type_output.band_term.letter})"
+          "#{declaration_type_label} (Band #{declaration_type_output.band_term.band.letter})"
         when PaymentCalculator::FlatRate
           declaration_type_label
         end

--- a/app/components/admin/statements/output_payments_component/banded_presenter.rb
+++ b/app/components/admin/statements/output_payments_component/banded_presenter.rb
@@ -5,7 +5,7 @@ module Admin
         def caption_text = "Early career teacher (ECT) output payments"
         def total_label = "ECTs output payment total"
         def fee_label = "Fee per ECT"
-        def columns = band_terms.map { "Band #{it.letter}" }
+        def columns = band_terms.map { "Band #{it.band.letter}" }
 
         def row_pairs
           grouped_outputs.map { |display_type, outputs| row_pair(display_type, outputs) }

--- a/app/components/admin/statements/provider_targets_component/banded_fee_component.rb
+++ b/app/components/admin/statements/provider_targets_component/banded_fee_component.rb
@@ -97,6 +97,6 @@ module Admin::Statements
     def uplift_target_ratio = banded_fee_structure.uplift_target_ratio
     def uplift_target_percentage = uplift_target_ratio * 100
     def uplift_amount = banded_fee_structure.uplift_fee_per_declaration
-    def band_term_label(band_term) = "Band #{band_term.letter}"
+    def band_term_label(band_term) = "Band #{band_term.band.letter}"
   end
 end

--- a/app/components/admin/statements/provider_targets_component/banded_fee_component.rb
+++ b/app/components/admin/statements/provider_targets_component/banded_fee_component.rb
@@ -57,8 +57,8 @@ module Admin::Statements
             band_terms.each do |band_term|
               body.with_row do |row|
                 row.with_cell { band_term_label(band_term) }
-                row.with_cell(numeric: true, text: band_term.min_declarations)
-                row.with_cell(numeric: true, text: band_term.max_declarations)
+                row.with_cell(numeric: true, text: band_term.band.min_declarations)
+                row.with_cell(numeric: true, text: band_term.band.max_declarations)
                 row.with_cell(numeric: true, text: number_to_pounds(band_term.fee_per_declaration))
               end
             end
@@ -97,7 +97,6 @@ module Admin::Statements
     def uplift_target_ratio = banded_fee_structure.uplift_target_ratio
     def uplift_target_percentage = uplift_target_ratio * 100
     def uplift_amount = banded_fee_structure.uplift_fee_per_declaration
-
     def band_term_label(band_term) = "Band #{band_term.letter}"
   end
 end

--- a/app/controllers/admin/finance/active_lead_providers/contracts_controller.rb
+++ b/app/controllers/admin/finance/active_lead_providers/contracts_controller.rb
@@ -35,7 +35,13 @@ module Admin::Finance::ActiveLeadProviders
 
     def set_contract
       @contract = @active_lead_provider.contracts
-        .includes(:statements, :flat_rate_fee_structure, banded_fee_structure: :band_terms)
+        .includes(
+          :statements,
+          :flat_rate_fee_structure,
+          banded_fee_structure: {
+            band_terms: :band
+          }
+        )
         .find(params.expect(:id))
     end
   end

--- a/app/models/active_lead_provider/band.rb
+++ b/app/models/active_lead_provider/band.rb
@@ -50,6 +50,11 @@ class ActiveLeadProvider::Band < ApplicationRecord
     min_declarations + capacity - 1
   end
 
+  # @return [String] A, B, C...
+  def letter
+    ("A".ord + allocation_order - 1).chr
+  end
+
 private
 
   # Read-only

--- a/app/models/contract/banded_fee_structure.rb
+++ b/app/models/contract/banded_fee_structure.rb
@@ -5,6 +5,7 @@ class Contract::BandedFeeStructure < ApplicationRecord
   belongs_to :contract
 
   has_many :band_terms,
+           -> { order(band_id: :asc) },
            class_name: "Contract::BandedFeeStructure::BandTerm",
            inverse_of: :banded_fee_structure,
            dependent: :destroy

--- a/app/models/contract/banded_fee_structure.rb
+++ b/app/models/contract/banded_fee_structure.rb
@@ -5,7 +5,6 @@ class Contract::BandedFeeStructure < ApplicationRecord
   belongs_to :contract
 
   has_many :band_terms,
-           -> { order(min_declarations: :asc) },
            class_name: "Contract::BandedFeeStructure::BandTerm",
            inverse_of: :banded_fee_structure,
            dependent: :destroy

--- a/app/models/contract/banded_fee_structure.rb
+++ b/app/models/contract/banded_fee_structure.rb
@@ -10,6 +10,10 @@ class Contract::BandedFeeStructure < ApplicationRecord
            inverse_of: :banded_fee_structure,
            dependent: :destroy
 
+  has_many :bands,
+           through: :band_terms,
+           source: :band
+
   # Validations
   validates :contract_id, uniqueness: { message: "Contract with the same banded fee structure already exist" }
 

--- a/app/models/contract/banded_fee_structure/band_term.rb
+++ b/app/models/contract/banded_fee_structure/band_term.rb
@@ -9,7 +9,6 @@ class Contract::BandedFeeStructure::BandTerm < ApplicationRecord
              class_name: "ActiveLeadProvider::Band"
 
   # Validations
-
   validates :fee_per_declaration,
             presence: { message: "Fee per declaration is required" },
             numericality: {

--- a/app/models/contract/banded_fee_structure/band_term.rb
+++ b/app/models/contract/banded_fee_structure/band_term.rb
@@ -32,8 +32,6 @@ class Contract::BandedFeeStructure::BandTerm < ApplicationRecord
   validate :sum_of_ratios_equals_one,
            if: -> { output_fee_ratio? && service_fee_ratio? }
 
-  def letter = ("A".ord + banded_fee_structure.band_terms.index(self)).chr
-
 private
 
   def sum_of_ratios_equals_one

--- a/app/models/contract/banded_fee_structure/band_term.rb
+++ b/app/models/contract/banded_fee_structure/band_term.rb
@@ -5,29 +5,10 @@ class Contract::BandedFeeStructure::BandTerm < ApplicationRecord
   belongs_to :banded_fee_structure,
              class_name: "Contract::BandedFeeStructure"
 
-  # TODO: enforce "null: false" for active_lead_provider_band_id and remove optional
   belongs_to :band,
-             class_name: "ActiveLeadProvider::Band",
-             optional: true
+             class_name: "ActiveLeadProvider::Band"
 
   # Validations
-
-  # DEPRECATE
-  validates :min_declarations,
-            presence: { message: "Min declarations is required" },
-            numericality: {
-              greater_than: 0,
-              only_integer: true,
-              message: "Min declarations must be a number greater than zero"
-            }
-  # DEPRECATE
-  validates :max_declarations,
-            presence: { message: "Max declarations is required" },
-            numericality: {
-              greater_than: :min_declarations,
-              only_integer: true,
-              message: "Max declarations must be a number greater than min declarations"
-            }
 
   validates :fee_per_declaration,
             presence: { message: "Fee per declaration is required" },
@@ -50,75 +31,13 @@ class Contract::BandedFeeStructure::BandTerm < ApplicationRecord
 
   validate :sum_of_ratios_equals_one,
            if: -> { output_fee_ratio? && service_fee_ratio? }
-  # DEPRECATE
-  validate :declaration_boundaries_sequential_without_gaps,
-           if: -> { min_declarations? && max_declarations? }
-  # DEPRECATE
-  validate :first_band_min_declarations_is_one
-  validate :band_consistency_across_active_lead_provider
 
   def letter = ("A".ord + banded_fee_structure.band_terms.index(self)).chr
-
-  # TODO: DEPRECATE Contract::BandedFeeStructure::BandTerm#capacity
-  def capacity
-    max_declarations - min_declarations + 1
-  end
 
 private
 
   def sum_of_ratios_equals_one
     errors.add(:base, "Sum of ratios must equal 1") unless
       (output_fee_ratio + service_fee_ratio).to_d == 1.0.to_d
-  end
-
-  # DEPRECATE
-  def first_band_min_declarations_is_one
-    first_band_term = banded_fee_structure&.band_terms&.first || self
-
-    return if first_band_term.min_declarations == 1
-
-    errors.add(:min_declarations, "The first band's min declarations must be 1")
-  end
-
-  # DEPRECATE
-  def declaration_boundaries_sequential_without_gaps
-    return unless banded_fee_structure
-
-    ordered_terms = banded_fee_structure
-      .band_terms
-      .where.not(id:)
-      .to_a
-      .push(self)
-      .sort_by(&:min_declarations)
-
-    return if ordered_terms.each_cons(2).all? { |a, b| a.max_declarations + 1 == b.min_declarations }
-
-    errors.add(:base, "Declaration boundaries must be sequential without gaps")
-  end
-
-  # As the banded calculations take into account previous statements for
-  # the same active lead provider, we need to ensure that the bands remain
-  # consistent across all contracts associated with the same active lead provider.
-  def band_consistency_across_active_lead_provider
-    active_lead_provider = banded_fee_structure&.contract&.active_lead_provider
-    return unless active_lead_provider
-
-    band_terms_for_active_lead_provider = self.class
-        .joins(banded_fee_structure: { contract: :active_lead_provider })
-        .where(contracts: { active_lead_provider: })
-        .where.not(id:)
-        .to_a
-        .push(self)
-
-    attributes_to_ignore = %w[id banded_fee_structure_id created_at updated_at band_id].freeze
-    unique_band_terms_by_index = band_terms_for_active_lead_provider
-      .group_by { it.banded_fee_structure.band_terms.index(it) || it.banded_fee_structure.band_terms.count }
-      .transform_values { |band_terms| band_terms.map { it.attributes.except(*attributes_to_ignore) }.uniq }
-
-    inconsistent_band_terms = unique_band_terms_by_index.select { |_, band_terms| band_terms.size > 1 }
-
-    inconsistent_band_terms.each_key do |index|
-      errors.add(:base, "Band at index #{index} is inconsistent across statements for the same active lead provider")
-    end
   end
 end

--- a/app/models/contract/banded_fee_structure/band_term.rb
+++ b/app/models/contract/banded_fee_structure/band_term.rb
@@ -31,7 +31,16 @@ class Contract::BandedFeeStructure::BandTerm < ApplicationRecord
   validate :sum_of_ratios_equals_one,
            if: -> { output_fee_ratio? && service_fee_ratio? }
 
+  validate :band_belongs_to_contracts_active_lead_provider
+
 private
+
+  def band_belongs_to_contracts_active_lead_provider
+    return unless band && banded_fee_structure&.contract
+    return if band.active_lead_provider == banded_fee_structure.contract.active_lead_provider
+
+    errors.add(:band, "must belong to the contract's active lead provider")
+  end
 
   def sum_of_ratios_equals_one
     errors.add(:base, "Sum of ratios must equal 1") unless

--- a/app/services/active_lead_providers/seed_from_previous.rb
+++ b/app/services/active_lead_providers/seed_from_previous.rb
@@ -71,10 +71,12 @@ private
   end
 
   def create_new_contract
-    # Bands and fee structures validate by querying the database for their
-    # already-persisted siblings (see create_banded_fee_structure), so the graph
-    # has to be created as it's built — assembling it in memory and saving once
-    # would run those validations before the siblings exist.
+    # The banded fee structure cannot be attached after the contract is saved because
+    # Contract validates its presence at creation time, and the duped fee structure's
+    # old contract_id cannot simply be nulled as it violates a DB constraint.
+    #
+    # This ensures the contract_id is populated at save and avoids cross-ALP band references.
+    #
     previous_contract = previous_latest_contract
 
     active_lead_provider.contracts.create!(
@@ -91,18 +93,25 @@ private
   def build_banded_fee_structure(previous_fee_structure)
     return unless previous_fee_structure
 
-    previous_fee_structure.dup.tap do |new_fee_structure|
-      new_fee_structure.contract_id = nil
-      previous_fee_structure.band_terms.each { |term| new_fee_structure.band_terms << term.dup }
+    new_fee_structure = previous_fee_structure.dup
+
+    previous_fee_structure.band_terms.each do |previous_term|
+      new_band = active_lead_provider.bands.create!(capacity: previous_term.band.capacity)
+      new_fee_structure.band_terms.build(
+        band: new_band,
+        fee_per_declaration: previous_term.fee_per_declaration,
+        output_fee_ratio: previous_term.output_fee_ratio,
+        service_fee_ratio: previous_term.service_fee_ratio
+      )
     end
+
+    new_fee_structure
   end
 
   def build_flat_rate_fee_structure(previous_fee_structure)
     return unless previous_fee_structure
 
-    previous_fee_structure.dup.tap do |new_fee_structure|
-      new_fee_structure.contract_id = nil
-    end
+    previous_fee_structure.dup
   end
 
   def build_new_statements

--- a/app/services/payment_calculator/banded/band_allocation.rb
+++ b/app/services/payment_calculator/banded/band_allocation.rb
@@ -16,7 +16,9 @@ module PaymentCalculator
     end
 
     # @return [Integer]
-    delegate :capacity, to: :band_term
+    def capacity
+      band_term.band.capacity
+    end
 
     def net_billable_count
       (previous_billable_count + billable_count) - (previous_refundable_count + refundable_count)

--- a/app/services/payment_calculator/banded/band_allocation.rb
+++ b/app/services/payment_calculator/banded/band_allocation.rb
@@ -1,13 +1,13 @@
 module PaymentCalculator
   class Banded::BandAllocation
-    attr_reader :band_term, :declaration_type,
+    attr_reader :band, :declaration_type,
                 :previous_billable_count, :previous_refundable_count,
                 :billable_count, :refundable_count
 
-    # @param band_term [Contract::BandedFeeStructure::BandTerm]
+    # @param band [ActiveLeadProvider::Band]
     # @param declaration_type [String]
-    def initialize(band_term:, declaration_type:)
-      @band_term = band_term
+    def initialize(band:, declaration_type:)
+      @band = band
       @declaration_type = declaration_type
       @previous_billable_count = 0
       @previous_refundable_count = 0
@@ -16,9 +16,7 @@ module PaymentCalculator
     end
 
     # @return [Integer]
-    def capacity
-      band_term.band.capacity
-    end
+    delegate :capacity, to: :band
 
     def net_billable_count
       (previous_billable_count + billable_count) - (previous_refundable_count + refundable_count)

--- a/app/services/payment_calculator/banded/band_allocator.rb
+++ b/app/services/payment_calculator/banded/band_allocator.rb
@@ -21,9 +21,7 @@ module PaymentCalculator
     include ActiveModel::Model
     include ActiveModel::Attributes
 
-    # ordered by :allocation_order
-    attribute :band_terms                       # ordered bands by min/max count
-
+    attribute :bands                            # ordered by allocation_order
     attribute :billable_declarations            # current statement billable
     attribute :refundable_declarations          # current statement refundable
     attribute :previous_billable_declarations   # previous statements billable
@@ -42,8 +40,8 @@ module PaymentCalculator
     def build_band_allocations_by_declaration_type
       # Initialize band allocations for every (declaration_type, band) pair
       declaration_types.flat_map do |declaration_type|
-        allocations = band_terms.map do |band_term|
-          Banded::BandAllocation.new(band_term:, declaration_type:)
+        allocations = bands.map do |band|
+          Banded::BandAllocation.new(band:, declaration_type:)
         end
 
         # Run allocate for each declaration type

--- a/app/services/payment_calculator/banded/declaration_type_output.rb
+++ b/app/services/payment_calculator/banded/declaration_type_output.rb
@@ -20,7 +20,10 @@ module PaymentCalculator
     # @return [PaymentCalculator::Banded::BandAllocation]
     attribute :band_allocation
 
-    delegate :declaration_type, :band_term, :billable_count, :refundable_count, to: :band_allocation
+    # @return [Contract::BandedFeeStructure::BandTerm]
+    attribute :band_term
+
+    delegate :declaration_type, :band, :billable_count, :refundable_count, to: :band_allocation
 
     def type_adjusted_fee_per_declaration
       fee_proportion * band_term.output_fee_ratio * band_term.fee_per_declaration

--- a/app/services/payment_calculator/banded/outputs.rb
+++ b/app/services/payment_calculator/banded/outputs.rb
@@ -11,7 +11,8 @@ module PaymentCalculator
 
     def declaration_type_outputs
       @declaration_type_outputs ||= band_allocations_by_declaration_type.map do |band_allocation|
-        Banded::DeclarationTypeOutput.new(band_allocation:)
+        band_term = banded_fee_structure.band_terms.find_by(band: band_allocation.band)
+        Banded::DeclarationTypeOutput.new(band_allocation:, band_term:)
       end
     end
 
@@ -35,7 +36,7 @@ module PaymentCalculator
 
     def band_allocator
       Banded::BandAllocator.new(
-        band_terms:,
+        bands:,
         billable_declarations:,
         refundable_declarations:,
         previous_billable_declarations:,
@@ -47,6 +48,6 @@ module PaymentCalculator
       @band_allocations_by_declaration_type ||= band_allocator.band_allocations_by_declaration_type
     end
 
-    delegate :band_terms, to: :banded_fee_structure, private: true
+    delegate :bands, to: :banded_fee_structure, private: true
   end
 end

--- a/app/services/payment_calculator/service_fees.rb
+++ b/app/services/payment_calculator/service_fees.rb
@@ -29,7 +29,7 @@ module PaymentCalculator
       remaining = recruitment_target
 
       band_terms.sum do |band_term|
-        filled = [remaining, band_term.capacity].min
+        filled = [remaining, band_term.band.capacity].min
         remaining -= filled
 
         filled * band_term.fee_per_declaration * band_term.service_fee_ratio
@@ -47,7 +47,7 @@ module PaymentCalculator
     end
 
     def first_band_term_capacity
-      band_terms.first.capacity
+      band_terms.first.band.capacity
     end
   end
 end

--- a/app/services/payment_calculator/service_fees.rb
+++ b/app/services/payment_calculator/service_fees.rb
@@ -39,14 +39,14 @@ module PaymentCalculator
     # Deducts setup_fee proportionally based on how many Band A slots are filled.
     # When Band A is fully filled this equals the full setup_fee.
     def setup_fee_deduction
-      filled_in_first_band_term * setup_fee / first_band_term_capacity.to_d
+      first_band_allocation_count * setup_fee / first_band_capacity.to_d
     end
 
-    def filled_in_first_band_term
-      [recruitment_target, first_band_term_capacity].min
+    def first_band_allocation_count
+      [recruitment_target, first_band_capacity].min
     end
 
-    def first_band_term_capacity
+    def first_band_capacity
       band_terms.first.band.capacity
     end
   end

--- a/app/services/statements/declaration_selection.rb
+++ b/app/services/statements/declaration_selection.rb
@@ -54,7 +54,7 @@ module Statements
       filtered_previous_refundable = calculator.declaration_selector.call(previous_refundable_declarations)
 
       allocations = PaymentCalculator::Banded::BandAllocator.new(
-        band_terms: calculator.banded_fee_structure.band_terms,
+        bands: calculator.banded_fee_structure.bands,
         billable_declarations: filtered_current_billable,
         refundable_declarations: filtered_current_refundable,
         previous_billable_declarations: filtered_previous_billable,

--- a/db/migrate/20260622081540_replace_null_restrictions_for_contract_band_terms.rb
+++ b/db/migrate/20260622081540_replace_null_restrictions_for_contract_band_terms.rb
@@ -1,0 +1,8 @@
+class ReplaceNullRestrictionsForContractBandTerms < ActiveRecord::Migration[8.1]
+  # rubocop:disable Rails/BulkChangeTable
+  def change
+    change_column_null :contract_banded_fee_structure_band_terms, :band_id, false
+    change_column_null :contract_banded_fee_structure_band_terms, :max_declarations, true
+  end
+  # rubocop:enable Rails/BulkChangeTable
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -157,11 +157,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_02_065431) do
   end
 
   create_table "contract_banded_fee_structure_band_terms", force: :cascade do |t|
-    t.bigint "band_id"
+    t.bigint "band_id", null: false
     t.bigint "banded_fee_structure_id", null: false
     t.datetime "created_at", null: false
     t.decimal "fee_per_declaration", precision: 12, scale: 2, null: false
-    t.integer "max_declarations", null: false
+    t.integer "max_declarations"
     t.integer "min_declarations", default: 1, null: false
     t.decimal "output_fee_ratio", precision: 3, scale: 2, null: false
     t.decimal "service_fee_ratio", precision: 3, scale: 2, null: false

--- a/db/seeds/lead_providers.rb
+++ b/db/seeds/lead_providers.rb
@@ -24,7 +24,10 @@ lead_providers_data.each do |data|
 
   data[:years].each do |year|
     contract_period = ContractPeriod.find_by!(year:)
-    ActiveLeadProvider.find_or_create_by!(lead_provider:, contract_period:)
+    active_lead_provider = ActiveLeadProvider.find_or_create_by!(lead_provider:, contract_period:)
+    FactoryBot.create_list(:active_lead_provider_band, 3,
+                           active_lead_provider:,
+                           capacity: 81)
   end
 
   token = lead_provider.name.parameterize

--- a/spec/components/admin/statements/clawbacks_component_spec.rb
+++ b/spec/components/admin/statements/clawbacks_component_spec.rb
@@ -3,41 +3,46 @@ RSpec.describe Admin::Statements::ClawbacksComponent, type: :component do
 
   let(:statement) { FactoryBot.create(:statement, contract:) }
 
+  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
+
   let(:banded_fee_structure) do
-    FactoryBot.build_stubbed(:contract_banded_fee_structure, :with_band_terms,
-                             declaration_boundaries: [
-                               { min: 1, max: 10 },
-                               { min: 11, max: 20 },
-                             ])
+    FactoryBot.build(:contract_banded_fee_structure,
+                     band_terms: [
+                       FactoryBot.build(:contract_banded_fee_structure_band_term,
+                                        band: FactoryBot.create(:active_lead_provider_band,
+                                                                active_lead_provider:)),
+                       FactoryBot.build(:contract_banded_fee_structure_band_term,
+                                        band: FactoryBot.create(:active_lead_provider_band,
+                                                                active_lead_provider:)),
+                     ])
   end
 
   let(:banded_outputs) do
-    band_terms = banded_fee_structure.band_terms
     banded_declaration_type_outputs = [
       double(
         declaration_type: "started",
-        band_term: band_terms.first,
+        band_term: banded_fee_structure.band_terms.first,
         refundable_count: 10,
         type_adjusted_fee_per_declaration: 15,
         total_refundable_amount: 150
       ),
       double(
         declaration_type: "started",
-        band_term: band_terms.second,
+        band_term: banded_fee_structure.band_terms.second,
         refundable_count: 10,
         type_adjusted_fee_per_declaration: 15,
         total_refundable_amount: 150
       ),
       double(
         declaration_type: "completed",
-        band_term: band_terms.first,
+        band_term: banded_fee_structure.band_terms.first,
         refundable_count: 5,
         type_adjusted_fee_per_declaration: 20,
         total_refundable_amount: 100
       ),
       double(
         declaration_type: "completed",
-        band_term: band_terms.second,
+        band_term: banded_fee_structure.band_terms.second,
         refundable_count: 0,
         type_adjusted_fee_per_declaration: 20,
         total_refundable_amount: 0
@@ -210,13 +215,5 @@ RSpec.describe Admin::Statements::ClawbacksComponent, type: :component do
         )
       end
     end
-  end
-
-private
-
-  def band(from:, to:)
-    FactoryBot.build_stubbed(:contract_banded_fee_structure_band_term,
-                             min_declarations: from,
-                             max_declarations: to)
   end
 end

--- a/spec/components/admin/statements/output_payments_component_spec.rb
+++ b/spec/components/admin/statements/output_payments_component_spec.rb
@@ -1,23 +1,30 @@
 RSpec.describe Admin::Statements::OutputPaymentsComponent, type: :component do
   subject(:component) { described_class.new(statement:) }
 
+  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
   let(:statement) { FactoryBot.create(:statement, contract:) }
 
-  let(:banded_fee_structure) { FactoryBot.build(:contract_banded_fee_structure, band_terms:) }
-
   let(:band_terms) do
-    [
-      { min: 1, max: 10, fee: 100 },
-      { min: 11, max: 20, fee: 75 },
-      { min: 21, max: 30, fee: 50 },
-    ].map do |attrs|
+    [100, 75, 50].map do |fee_per_declaration|
+      band = FactoryBot.create(:active_lead_provider_band,
+                               active_lead_provider:,
+                               capacity:)
+
       FactoryBot.build(:contract_banded_fee_structure_band_term,
-                       min_declarations: attrs[:min],
-                       max_declarations: attrs[:max],
-                       fee_per_declaration: attrs[:fee],
-                       output_fee_ratio: 0.8,
-                       service_fee_ratio: 0.2)
+                       fee_per_declaration:,
+                       output_fee_ratio:,
+                       service_fee_ratio:,
+                       band:)
     end
+  end
+
+  let(:output_fee_ratio) { 0.8 }
+  let(:service_fee_ratio) { 0.2 }
+  let(:capacity) { 10 }
+
+  let(:banded_fee_structure) do
+    FactoryBot.build(:contract_banded_fee_structure,
+                     band_terms:)
   end
 
   let(:banded_outputs) do
@@ -25,7 +32,7 @@ RSpec.describe Admin::Statements::OutputPaymentsComponent, type: :component do
     billable_counts = { "started" => [10, 8, 5], "completed" => [3, 0, 0] }
 
     declaration_type_outputs = Declaration.declaration_types.keys.flat_map do |declaration_type|
-      band_terms.map.with_index do |band_term, i|
+      banded_fee_structure.band_terms.map.with_index do |band_term, i|
         count = billable_counts.dig(declaration_type, i) || 0
         fee = fee_proportions[declaration_type] * band_term.output_fee_ratio * band_term.fee_per_declaration
 

--- a/spec/components/admin/statements/provider_targets_component/banded_fee_component_spec.rb
+++ b/spec/components/admin/statements/provider_targets_component/banded_fee_component_spec.rb
@@ -1,22 +1,30 @@
 RSpec.describe Admin::Statements::ProviderTargetsComponent::BandedFeeComponent, type: :component do
   subject(:component) { described_class.new(contract:) }
 
+  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
+
   let(:uplift_target_ratio) { 0.33 }
 
   let(:banded_fee_structure) do
-    FactoryBot.build_stubbed(
-      :contract_banded_fee_structure,
-      :with_band_terms,
-      recruitment_target: 2500,
-      uplift_fee_per_declaration: 50,
-      uplift_target_ratio:,
-      setup_fee: 5000,
-      declaration_boundaries: [
-        { min: 1, max: 50 },
-        { min: 51, max: 100 },
-        { min: 101, max: 150 }
-      ]
-    )
+    FactoryBot.build(:contract_banded_fee_structure,
+                     recruitment_target: 2500,
+                     uplift_fee_per_declaration: 50,
+                     uplift_target_ratio:,
+                     setup_fee: 5000,
+                     band_terms: [
+                       FactoryBot.build(:contract_banded_fee_structure_band_term,
+                                        band: active_lead_provider_bands.first),
+                       FactoryBot.build(:contract_banded_fee_structure_band_term,
+                                        band: active_lead_provider_bands.second),
+                       FactoryBot.build(:contract_banded_fee_structure_band_term,
+                                        band: active_lead_provider_bands.third),
+                     ])
+  end
+
+  let(:active_lead_provider_bands) do
+    FactoryBot.create_list(:active_lead_provider_band, 3,
+                           active_lead_provider:,
+                           capacity: 50)
   end
 
   before { render_inline(component) }

--- a/spec/factories/contract/banded_fee_structure/band_term_factory.rb
+++ b/spec/factories/contract/banded_fee_structure/band_term_factory.rb
@@ -1,22 +1,10 @@
 FactoryBot.define do
   factory :contract_banded_fee_structure_band_term, class: "Contract::BandedFeeStructure::BandTerm" do
     association :banded_fee_structure, factory: :contract_banded_fee_structure
-
-    min_declarations { 1 } # DEPRECATE
-    max_declarations { 100 } # DEPRECATE
+    association :band, factory: :active_lead_provider_band
 
     fee_per_declaration { Faker::Number.between(from: 20, to: 200) }
     output_fee_ratio { 0.75 }
     service_fee_ratio { 0.25 }
-
-    before(:create) do |band_term|
-      # need to factory ALP bands
-      band_term.banded_fee_structure&.bands&.reset
-
-      # if band.band.nil? && band.banded_fee_structure
-      #   active_lead_provider = band.banded_fee_structure.contract.active_lead_provider
-      #   band.band = active_lead_provider.bands.find_or_create_by!(allocation_order: 1) { |b| b.capacity = 100 }
-      # end
-    end
   end
 end

--- a/spec/factories/contract/banded_fee_structure_factory.rb
+++ b/spec/factories/contract/banded_fee_structure_factory.rb
@@ -5,5 +5,20 @@ FactoryBot.define do
     uplift_target_ratio { 0.33 }
     monthly_service_fee { Faker::Number.between(from: 0, to: 20_000) }
     setup_fee { Faker::Number.between(from: 1_000, to: 50_000) }
+
+    trait :with_bands_and_band_terms do
+      transient do
+        active_lead_provider { nil }
+      end
+      after(:create) do |banded_fee_structure, evaluator|
+        alp = evaluator.active_lead_provider || banded_fee_structure.contract.active_lead_provider
+
+        FactoryBot.create_list(:active_lead_provider_band, 4, active_lead_provider: alp).each do |band|
+          FactoryBot.create(:contract_banded_fee_structure_band_term,
+                            banded_fee_structure:,
+                            band:)
+        end
+      end
+    end
   end
 end

--- a/spec/factories/contract/banded_fee_structure_factory.rb
+++ b/spec/factories/contract/banded_fee_structure_factory.rb
@@ -5,31 +5,5 @@ FactoryBot.define do
     uplift_target_ratio { 0.33 }
     monthly_service_fee { Faker::Number.between(from: 0, to: 20_000) }
     setup_fee { Faker::Number.between(from: 1_000, to: 50_000) }
-
-    trait :with_band_terms do
-      transient do
-        declaration_boundaries do
-          min = 1
-
-          Array.new(3) do
-            max = min + 80
-            { min:, max: }.tap { min = max + 1 }
-          end
-        end
-      end
-
-      band_terms do
-        declaration_boundaries.map do |boundary|
-          association(
-            :contract_banded_fee_structure_band_term,
-            banded_fee_structure: instance,
-            min_declarations: boundary[:min],
-            max_declarations: boundary[:max],
-            fee_per_declaration: boundary[:max] + 100,
-            strategy: :build
-          )
-        end
-      end
-    end
   end
 end

--- a/spec/factories/contract_factory.rb
+++ b/spec/factories/contract_factory.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     trait(:for_ecf) do
       contract_type { "ecf" }
       ecf_contract_version { "1" }
-      association :banded_fee_structure, :with_band_terms, factory: :contract_banded_fee_structure, strategy: :build
+      association :banded_fee_structure, factory: :contract_banded_fee_structure, strategy: :build
       flat_rate_fee_structure { nil }
     end
 
@@ -15,7 +15,7 @@ FactoryBot.define do
       contract_type { "ittecf_ectp" }
       ecf_contract_version { "1" }
       ecf_mentor_contract_version { "2" }
-      association :banded_fee_structure, :with_band_terms, factory: :contract_banded_fee_structure, strategy: :build
+      association :banded_fee_structure, factory: :contract_banded_fee_structure, strategy: :build
       association :flat_rate_fee_structure, factory: :contract_flat_rate_fee_structure, strategy: :build
     end
   end

--- a/spec/models/active_lead_provider/band_spec.rb
+++ b/spec/models/active_lead_provider/band_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe ActiveLeadProvider::Band, type: :model do
   end
 
   describe "#letter" do
-    let(:contract) { FactoryBot.create(:contract, :for_ecf) }
+    let(:contract) { FactoryBot.create(:contract, :for_ecf, active_lead_provider:) }
     let(:active_lead_provider_bands) do
       FactoryBot.create_list(:active_lead_provider_band, 6,
                              active_lead_provider:)

--- a/spec/models/active_lead_provider/band_spec.rb
+++ b/spec/models/active_lead_provider/band_spec.rb
@@ -134,4 +134,33 @@ RSpec.describe ActiveLeadProvider::Band, type: :model do
       end
     end
   end
+
+  describe "#letter" do
+    let(:banded_fee_structure) do
+      FactoryBot.build(:contract_banded_fee_structure,
+                       band_terms: [
+                         FactoryBot.build(:contract_banded_fee_structure_band_term,
+                                          band: active_lead_provider_bands.first),
+                         FactoryBot.build(:contract_banded_fee_structure_band_term,
+                                          band: active_lead_provider_bands.second),
+                         FactoryBot.build(:contract_banded_fee_structure_band_term,
+                                          band: active_lead_provider_bands.third),
+                         FactoryBot.build(:contract_banded_fee_structure_band_term,
+                                          band: active_lead_provider_bands.fourth)
+                       ])
+    end
+
+    let(:active_lead_provider_bands) do
+      FactoryBot.create_list(:active_lead_provider_band, 4,
+                             active_lead_provider:)
+    end
+
+    let(:band_letters) do
+      banded_fee_structure.band_terms.map { |band_term| band_term.band.letter }
+    end
+
+    it "letters bands alphabetically in boundary order" do
+      expect(band_letters).to eq(%w[A B C D])
+    end
+  end
 end

--- a/spec/models/active_lead_provider/band_spec.rb
+++ b/spec/models/active_lead_provider/band_spec.rb
@@ -136,31 +136,23 @@ RSpec.describe ActiveLeadProvider::Band, type: :model do
   end
 
   describe "#letter" do
-    let(:banded_fee_structure) do
-      FactoryBot.build(:contract_banded_fee_structure,
-                       band_terms: [
-                         FactoryBot.build(:contract_banded_fee_structure_band_term,
-                                          band: active_lead_provider_bands.first),
-                         FactoryBot.build(:contract_banded_fee_structure_band_term,
-                                          band: active_lead_provider_bands.second),
-                         FactoryBot.build(:contract_banded_fee_structure_band_term,
-                                          band: active_lead_provider_bands.third),
-                         FactoryBot.build(:contract_banded_fee_structure_band_term,
-                                          band: active_lead_provider_bands.fourth)
-                       ])
-    end
-
+    let(:contract) { FactoryBot.create(:contract, :for_ecf) }
     let(:active_lead_provider_bands) do
-      FactoryBot.create_list(:active_lead_provider_band, 4,
+      FactoryBot.create_list(:active_lead_provider_band, 6,
                              active_lead_provider:)
     end
 
-    let(:band_letters) do
-      banded_fee_structure.band_terms.map { |band_term| band_term.band.letter }
+    before do
+      active_lead_provider_bands.each do |band|
+        FactoryBot.create(:contract_banded_fee_structure_band_term,
+                          banded_fee_structure: contract.banded_fee_structure,
+                          band:)
+      end
     end
 
-    it "letters bands alphabetically in boundary order" do
-      expect(band_letters).to eq(%w[A B C D])
+    it "bands alphabetically in allocation order" do
+      expect(active_lead_provider.bands.map(&:letter)).to eq(%w[A B C D E F])
+      expect(contract.banded_fee_structure.bands.map(&:letter)).to eq(%w[A B C D E F])
     end
   end
 end

--- a/spec/models/contract/banded_fee_structure/band_term_spec.rb
+++ b/spec/models/contract/banded_fee_structure/band_term_spec.rb
@@ -43,31 +43,4 @@ RSpec.describe Contract::BandedFeeStructure::BandTerm, type: :model do
       end
     end
   end
-
-  describe "#letter" do
-    let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
-
-    let(:banded_fee_structure) do
-      FactoryBot.build(:contract_banded_fee_structure,
-                       band_terms: [
-                         FactoryBot.build(:contract_banded_fee_structure_band_term,
-                                          band: active_lead_provider_bands.first),
-                         FactoryBot.build(:contract_banded_fee_structure_band_term,
-                                          band: active_lead_provider_bands.second),
-                         FactoryBot.build(:contract_banded_fee_structure_band_term,
-                                          band: active_lead_provider_bands.third),
-                         FactoryBot.build(:contract_banded_fee_structure_band_term,
-                                          band: active_lead_provider_bands.fourth)
-                       ])
-    end
-
-    let(:active_lead_provider_bands) do
-      FactoryBot.create_list(:active_lead_provider_band, 4,
-                             active_lead_provider:)
-    end
-
-    it "letters bands alphabetically in boundary order" do
-      expect(banded_fee_structure.band_terms.map(&:letter)).to eq(%w[A B C D])
-    end
-  end
 end

--- a/spec/models/contract/banded_fee_structure/band_term_spec.rb
+++ b/spec/models/contract/banded_fee_structure/band_term_spec.rb
@@ -1,16 +1,10 @@
 RSpec.describe Contract::BandedFeeStructure::BandTerm, type: :model do
   describe "associations" do
-    it { is_expected.to belong_to(:band).class_name("ActiveLeadProvider::Band").optional }
+    it { is_expected.to belong_to(:band).class_name("ActiveLeadProvider::Band") }
     it { is_expected.to belong_to(:banded_fee_structure).class_name("Contract::BandedFeeStructure") }
   end
 
   describe "validations" do
-    it { is_expected.to validate_presence_of(:min_declarations).with_message("Min declarations is required") }
-    it { is_expected.to validate_numericality_of(:min_declarations).is_greater_than(0).only_integer.with_message("Min declarations must be a number greater than zero") }
-
-    it { is_expected.to validate_presence_of(:max_declarations).with_message("Max declarations is required") }
-    it { is_expected.to validate_numericality_of(:max_declarations).is_greater_than(:min_declarations).only_integer.with_message("Max declarations must be a number greater than min declarations") }
-
     it { is_expected.to validate_presence_of(:fee_per_declaration).with_message("Fee per declaration is required") }
     it { is_expected.to validate_numericality_of(:fee_per_declaration).is_greater_than(0).with_message("Fee per declaration must be a number greater than zero") }
 
@@ -48,186 +42,32 @@ RSpec.describe Contract::BandedFeeStructure::BandTerm, type: :model do
         it { is_expected.to be_valid }
       end
     end
-
-    describe "sequential band declaration boundaries" do
-      subject(:term) do
-        FactoryBot.build(:contract_banded_fee_structure_band_term,
-                         banded_fee_structure:,
-                         min_declarations:,
-                         max_declarations:)
-      end
-
-      let!(:contract) { FactoryBot.create(:contract, :for_ecf, banded_fee_structure:) }
-
-      let(:banded_fee_structure) do
-        FactoryBot.build(:contract_banded_fee_structure, :with_band_terms,
-                         declaration_boundaries: [
-                           { min: 1, max: 100 },
-                           { min: 101, max: 200 },
-                           { min: 201, max: 300 },
-                         ])
-      end
-
-      context "when the band term's min declarations is less than the " \
-              "previous band term's max declarations" do
-        let(:min_declarations) { 250 }
-        let(:max_declarations) { 400 }
-
-        it "is expected to be invalid" do
-          expect(term).to be_invalid
-          expect(term.errors[:base]).to include("Declaration boundaries must be sequential without gaps")
-        end
-      end
-
-      context "when the band term's min declarations is greater than the " \
-              "previous band term's max declarations but there is a gap" do
-        let(:min_declarations) { 350 }
-        let(:max_declarations) { 450 }
-
-        it "is expected to be invalid" do
-          expect(term).to be_invalid
-          expect(term.errors[:base]).to include("Declaration boundaries must be sequential without gaps")
-        end
-      end
-
-      context "when the band term's min declarations is greater than the " \
-              "previous band term's max declarations and there is no gap" do
-        let(:min_declarations) { 301 }
-        let(:max_declarations) { 400 }
-
-        it { is_expected.to be_valid }
-      end
-
-      context "when the banded fee structure has no band terms yet " \
-              "and the band term's min declarations is not 1" do
-        let(:banded_fee_structure) { FactoryBot.build(:contract_banded_fee_structure) }
-        let(:min_declarations) { 2 }
-        let(:max_declarations) { 400 }
-
-        it "is expected to be invalid" do
-          expect(term).to be_invalid
-          expect(term.errors[:min_declarations]).to include("The first band's min declarations must be 1")
-        end
-      end
-
-      context "when the banded fee structure has no band terms yet " \
-              "and the band's min declarations is 1" do
-        let(:banded_fee_structure) { FactoryBot.build(:contract_banded_fee_structure) }
-        let(:min_declarations) { 1 }
-        let(:max_declarations) { 400 }
-
-        it { is_expected.to be_valid }
-      end
-
-      context "when updating an existing band" do
-        let(:banded_fee_structure) { FactoryBot.build(:contract_banded_fee_structure, :with_band_terms) }
-
-        it "is valid if the updated band still has sequential declaration boundaries" do
-          band_term = banded_fee_structure.band_terms.last
-          band_term.max_declarations += 50
-
-          expect(band_term).to be_valid
-        end
-
-        it "is invalid if the updated band no longer has sequential declaration boundaries" do
-          band_term = banded_fee_structure.band_terms.last
-          band_term.min_declarations = 1
-
-          expect(band_term).to be_invalid
-          expect(band_term.errors[:base]).to include("Declaration boundaries must be sequential without gaps")
-        end
-      end
-    end
-
-    describe "band consistency across active lead providers" do
-      let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
-
-      it "is valid when creating the first band for the active lead provider" do
-        banded_fee_structure = FactoryBot.build(:contract_banded_fee_structure)
-        band_term = FactoryBot.build(:contract_banded_fee_structure_band_term, banded_fee_structure:)
-        FactoryBot.create(:contract, :for_ecf, active_lead_provider:, banded_fee_structure:)
-        expect(band_term).to be_valid
-      end
-
-      it "is valid when creating bands for another contract for the same active lead provider when the bands are consistent" do
-        banded_fee_structure = FactoryBot.build(:contract_banded_fee_structure)
-        FactoryBot.build(:contract_banded_fee_structure_band_term, banded_fee_structure:, fee_per_declaration: 100)
-        FactoryBot.create(:contract, :for_ecf, active_lead_provider:, banded_fee_structure:)
-
-        new_banded_fee_structure = FactoryBot.build(:contract_banded_fee_structure)
-        new_band_term = FactoryBot.build(:contract_banded_fee_structure_band_term, banded_fee_structure: new_banded_fee_structure, fee_per_declaration: 100)
-        FactoryBot.create(:contract, :for_ecf, active_lead_provider:, banded_fee_structure: new_banded_fee_structure)
-
-        expect(new_band_term).to be_valid
-      end
-
-      it "is invalid when creating bands for another contract for the same active lead provider when the bands are not consistent" do
-        band_terms = [
-          FactoryBot.build(:contract_banded_fee_structure_band_term, fee_per_declaration: 100, min_declarations: 1, max_declarations: 2),
-          FactoryBot.build(:contract_banded_fee_structure_band_term, fee_per_declaration: 150, min_declarations: 3, max_declarations: 4)
-        ]
-        banded_fee_structure = FactoryBot.build(:contract_banded_fee_structure, band_terms:)
-        FactoryBot.create(:contract, :for_ecf, active_lead_provider:, banded_fee_structure:)
-
-        new_band_term = FactoryBot.build(:contract_banded_fee_structure_band_term, fee_per_declaration: 150, min_declarations: 1, max_declarations: 2)
-        new_banded_fee_structure = FactoryBot.build(:contract_banded_fee_structure, band_terms: [new_band_term])
-        FactoryBot.create(:contract, :for_ecf, active_lead_provider:, banded_fee_structure: new_banded_fee_structure)
-
-        expect(new_band_term).to be_invalid
-        expect(new_band_term.errors[:base]).to include(/Band at index 0 is inconsistent across statements for the same active lead provider/)
-
-        new_band_term.fee_per_declaration = 100
-        expect(new_band_term).to be_valid
-        new_band_term.save!
-
-        new_band_term = FactoryBot.build(:contract_banded_fee_structure_band_term, banded_fee_structure: new_banded_fee_structure, fee_per_declaration: 150, min_declarations: 3, max_declarations: 5)
-        expect(new_band_term).to be_invalid
-        expect(new_band_term.errors[:base]).to include(/Band at index 1 is inconsistent across statements for the same active lead provider/)
-
-        new_band_term.max_declarations = 4
-        expect(new_band_term).to be_valid
-      end
-
-      it "is invalid when updating a band such that it becomes inconsistent with bands for the same active lead provider" do
-        band_term = FactoryBot.build(:contract_banded_fee_structure_band_term, fee_per_declaration: 100)
-        banded_fee_structure = FactoryBot.build(:contract_banded_fee_structure, band_terms: [band_term])
-        FactoryBot.create(:contract, :for_ecf, active_lead_provider:, banded_fee_structure:)
-
-        new_band_term = FactoryBot.build(:contract_banded_fee_structure_band_term, fee_per_declaration: 100)
-        new_banded_fee_structure = FactoryBot.build(:contract_banded_fee_structure, band_terms: [new_band_term])
-        FactoryBot.create(:contract, :for_ecf, active_lead_provider:, banded_fee_structure: new_banded_fee_structure)
-
-        new_band_term.fee_per_declaration = 150
-
-        expect(new_band_term).to be_invalid
-        expect(new_band_term.errors[:base]).to include(/Band at index 0 is inconsistent across statements for the same active lead provider/)
-
-        new_band_term.fee_per_declaration = 100
-        expect(new_band_term).to be_valid
-      end
-    end
   end
 
   describe "#letter" do
+    let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
+
     let(:banded_fee_structure) do
-      FactoryBot.build_stubbed(:contract_banded_fee_structure, :with_band_terms,
-                               declaration_boundaries: [
-                                 { min: 1, max: 100 },
-                                 { min: 301, max: 400 },
-                                 { min: 101, max: 200 },
-                                 { min: 201, max: 300 },
-                               ])
+      FactoryBot.build(:contract_banded_fee_structure,
+                       band_terms: [
+                         FactoryBot.build(:contract_banded_fee_structure_band_term,
+                                          band: active_lead_provider_bands.first),
+                         FactoryBot.build(:contract_banded_fee_structure_band_term,
+                                          band: active_lead_provider_bands.second),
+                         FactoryBot.build(:contract_banded_fee_structure_band_term,
+                                          band: active_lead_provider_bands.third),
+                         FactoryBot.build(:contract_banded_fee_structure_band_term,
+                                          band: active_lead_provider_bands.fourth)
+                       ])
+    end
+
+    let(:active_lead_provider_bands) do
+      FactoryBot.create_list(:active_lead_provider_band, 4,
+                             active_lead_provider:)
     end
 
     it "letters bands alphabetically in boundary order" do
       expect(banded_fee_structure.band_terms.map(&:letter)).to eq(%w[A B C D])
-    end
-  end
-
-  describe "#capacity" do
-    it "returns max_declarations - min_declarations + 1" do
-      band_term = FactoryBot.build_stubbed(:contract_banded_fee_structure_band_term, min_declarations: 1, max_declarations: 100)
-      expect(band_term.capacity).to eq(100)
     end
   end
 end

--- a/spec/models/contract/banded_fee_structure/band_term_spec.rb
+++ b/spec/models/contract/banded_fee_structure/band_term_spec.rb
@@ -42,5 +42,36 @@ RSpec.describe Contract::BandedFeeStructure::BandTerm, type: :model do
         it { is_expected.to be_valid }
       end
     end
+
+    describe "#band_belongs_to_contracts_active_lead_provider" do
+      subject(:band_term) do
+        FactoryBot.create(:contract_banded_fee_structure_band_term,
+                          banded_fee_structure: contract.banded_fee_structure,
+                          band:)
+      end
+
+      let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
+      let!(:contract) { FactoryBot.create(:contract, :for_ecf, active_lead_provider:) }
+
+      context "when the band and contract ALP match" do
+        let!(:band) { FactoryBot.create(:active_lead_provider_band, active_lead_provider:) }
+
+        it "is valid" do
+          expect(band.active_lead_provider).to eq(contract.active_lead_provider)
+          expect(band_term).to be_valid
+        end
+      end
+
+      context "when the band and contract ALP do not match" do
+        let!(:band) { FactoryBot.create(:active_lead_provider_band) }
+
+        it "raises an error" do
+          expect(band.active_lead_provider).not_to eq(contract.active_lead_provider)
+          expect { band_term }.to raise_error(
+            ActiveRecord::RecordInvalid, "Validation failed: Band must belong to the contract's active lead provider"
+          )
+        end
+      end
+    end
   end
 end

--- a/spec/models/contract/banded_fee_structure_spec.rb
+++ b/spec/models/contract/banded_fee_structure_spec.rb
@@ -1,7 +1,6 @@
 RSpec.describe Contract::BandedFeeStructure, type: :model do
   describe "associations" do
-    # TODO: DEPRECATE min/max
-    it { is_expected.to have_many(:band_terms).order(min_declarations: :asc).class_name("Contract::BandedFeeStructure::BandTerm").inverse_of(:banded_fee_structure).dependent(:destroy) }
+    it { is_expected.to have_many(:band_terms).class_name("Contract::BandedFeeStructure::BandTerm").inverse_of(:banded_fee_structure).dependent(:destroy) }
     it { is_expected.to belong_to(:contract) }
   end
 

--- a/spec/models/contract/banded_fee_structure_spec.rb
+++ b/spec/models/contract/banded_fee_structure_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Contract::BandedFeeStructure, type: :model do
   describe "associations" do
-    it { is_expected.to have_many(:band_terms).class_name("Contract::BandedFeeStructure::BandTerm").inverse_of(:banded_fee_structure).dependent(:destroy) }
+    it { is_expected.to have_many(:band_terms).order(band_id: :asc).class_name("Contract::BandedFeeStructure::BandTerm").inverse_of(:banded_fee_structure).dependent(:destroy) }
     it { is_expected.to belong_to(:contract) }
   end
 

--- a/spec/requests/admin/finance/statements/statements_spec.rb
+++ b/spec/requests/admin/finance/statements/statements_spec.rb
@@ -132,51 +132,58 @@ RSpec.describe "Admin finance statements index", type: :request do
 
       let(:contract_period) { FactoryBot.create(:contract_period, year: 2024) }
       let(:lead_provider) { FactoryBot.create(:lead_provider) }
-      let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:, contract_period:) }
-      let(:banded_fee_structure) do
-        band_term = FactoryBot.build(:contract_banded_fee_structure_band_term,
-                                     min_declarations: 1,
-                                     max_declarations: 100)
-        FactoryBot.build(:contract_banded_fee_structure, band_terms: [band_term])
+
+      let(:active_lead_provider) do
+        FactoryBot.create(:active_lead_provider,
+                          lead_provider:,
+                          contract_period:)
       end
-      let(:contract) { FactoryBot.create(:contract, :for_ecf, active_lead_provider:, banded_fee_structure:) }
+
+      let(:band) do
+        FactoryBot.create(:active_lead_provider_band,
+                          active_lead_provider:)
+      end
+
+      let(:band_term) do
+        FactoryBot.build(:contract_banded_fee_structure_band_term,
+                         band:)
+      end
+
+      let(:banded_fee_structure) do
+        FactoryBot.build(:contract_banded_fee_structure,
+                         band_terms: [band_term])
+      end
+
+      let(:contract) do
+        FactoryBot.create(:contract, :for_ecf,
+                          active_lead_provider:,
+                          banded_fee_structure:)
+      end
       let!(:statement) do
-        FactoryBot.create(
-          :statement,
-          :paid,
-          contract:,
-          active_lead_provider:,
-          month: 11,
-          year: 2024
-        )
+        FactoryBot.create(:statement, :paid,
+                          contract:,
+                          active_lead_provider:,
+                          month: 11,
+                          year: 2024)
       end
       let(:delivery_partner) { FactoryBot.create(:delivery_partner) }
       let(:school_partnership) do
-        FactoryBot.create(
-          :school_partnership,
-          lead_provider_delivery_partnership: FactoryBot.create(
-            :lead_provider_delivery_partnership,
-            active_lead_provider:,
-            delivery_partner:
-          )
-        )
+        FactoryBot.create(:school_partnership,
+                          lead_provider_delivery_partnership: FactoryBot.create(:lead_provider_delivery_partnership,
+                                                                                active_lead_provider:,
+                                                                                delivery_partner:))
       end
       let(:training_period) do
-        FactoryBot.create(
-          :training_period,
-          :ongoing,
-          school_partnership:,
-          started_on: Date.new(2024, 10, 1),
-          ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on: Date.new(2024, 10, 1))
-        )
+        FactoryBot.create(:training_period, :ongoing,
+                          school_partnership:,
+                          started_on: Date.new(2024, 10, 1),
+                          ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing,
+                                                                  started_on: Date.new(2024, 10, 1)))
       end
       let!(:declaration) do
-        FactoryBot.create(
-          :declaration,
-          :paid,
-          training_period:,
-          payment_statement: statement
-        )
+        FactoryBot.create(:declaration, :paid,
+                          training_period:,
+                          payment_statement: statement)
       end
       let!(:unrelated_declaration) { FactoryBot.create(:declaration, :paid) }
 
@@ -192,15 +199,11 @@ RSpec.describe "Admin finance statements index", type: :request do
 
       context "when the statement is for service fees" do
         let!(:statement) do
-          FactoryBot.create(
-            :statement,
-            :paid,
-            :service_fee,
-            contract:,
-            active_lead_provider:,
-            month: 11,
-            year: 2024
-          )
+          FactoryBot.create(:statement, :paid, :service_fee,
+                            contract:,
+                            active_lead_provider:,
+                            month: 11,
+                            year: 2024)
         end
 
         it "returns not found" do

--- a/spec/services/active_lead_providers/seed_from_previous_spec.rb
+++ b/spec/services/active_lead_providers/seed_from_previous_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe ActiveLeadProviders::SeedFromPrevious do
         end
 
         it "builds terms for the new banded_fee_structure" do
-          band_term_attributes = %i[min_declarations max_declarations fee_per_declaration output_fee_ratio service_fee_ratio]
+          band_term_attributes = %i[fee_per_declaration output_fee_ratio service_fee_ratio]
           expect(new_contract.banded_fee_structure.band_terms.map { |t| t.slice(*band_term_attributes) })
             .to match_array(previous_contract.banded_fee_structure.band_terms.map { |t| t.slice(*band_term_attributes) })
           expect(new_contract.banded_fee_structure.band_terms).not_to include(*previous_contract.banded_fee_structure.band_terms)
@@ -177,6 +177,14 @@ private
   def create_subordinate_records(active_lead_provider)
     FactoryBot.create_list(:lead_provider_delivery_partnership, 3, active_lead_provider:)
     contract = FactoryBot.create(:contract, :for_ittecf_ectp, active_lead_provider:)
+
+    3.times do
+      band = FactoryBot.create(:active_lead_provider_band, active_lead_provider:)
+      FactoryBot.create(:contract_banded_fee_structure_band_term,
+                        banded_fee_structure: contract.banded_fee_structure,
+                        band:)
+    end
+
     contract_year = active_lead_provider.contract_period.year
     date = Date.new(contract_year, 11, 1)
     # Statements span November of contract_year through August three years later

--- a/spec/services/active_lead_providers/seed_from_previous_spec.rb
+++ b/spec/services/active_lead_providers/seed_from_previous_spec.rb
@@ -58,11 +58,19 @@ RSpec.describe ActiveLeadProviders::SeedFromPrevious do
           expect(new_contract.banded_fee_structure).not_to eq(previous_contract.banded_fee_structure)
         end
 
-        it "builds terms for the new banded_fee_structure" do
+        it "builds terms for the new banded_fee_structure, based on the previous" do
           band_term_attributes = %i[fee_per_declaration output_fee_ratio service_fee_ratio]
           expect(new_contract.banded_fee_structure.band_terms.map { |t| t.slice(*band_term_attributes) })
-            .to match_array(previous_contract.banded_fee_structure.band_terms.map { |t| t.slice(*band_term_attributes) })
+          .to match_array(previous_contract.banded_fee_structure.band_terms.map { |t| t.slice(*band_term_attributes) })
           expect(new_contract.banded_fee_structure.band_terms).not_to include(*previous_contract.banded_fee_structure.band_terms)
+        end
+
+        it "builds bands for the new banded_fee_structure, based on the previous" do
+          band_attributes = %i[allocation_order capacity]
+          expect(new_contract.banded_fee_structure.bands.map { |t| t.slice(*band_attributes) })
+            .to match_array(previous_contract.banded_fee_structure.bands.map { |t| t.slice(*band_attributes) })
+          expect(new_contract.banded_fee_structure.bands).not_to include(*previous_contract.banded_fee_structure.bands)
+          expect(new_contract.banded_fee_structure.bands.first.active_lead_provider.lead_provider).to eq(previous_contract.banded_fee_structure.bands.first.active_lead_provider.lead_provider)
         end
 
         it "builds a new flat_rate_fee_structure for the new contract, based on the previous" do

--- a/spec/services/payment_calculator/banded/band_allocation_spec.rb
+++ b/spec/services/payment_calculator/banded/band_allocation_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe PaymentCalculator::Banded::BandAllocation do
-  subject(:allocation) { described_class.new(band_term:, declaration_type: "started") }
+  subject(:allocation) { described_class.new(band:, declaration_type: "started") }
 
-  let(:band_term) do
-    FactoryBot.build_stubbed(:contract_banded_fee_structure_band_term)
+  let(:band) do
+    FactoryBot.build(:active_lead_provider_band)
   end
 
   describe "#capacity" do

--- a/spec/services/payment_calculator/banded/band_allocation_spec.rb
+++ b/spec/services/payment_calculator/banded/band_allocation_spec.rb
@@ -2,9 +2,7 @@ RSpec.describe PaymentCalculator::Banded::BandAllocation do
   subject(:allocation) { described_class.new(band_term:, declaration_type: "started") }
 
   let(:band_term) do
-    FactoryBot.build_stubbed(:contract_banded_fee_structure_band_term,
-                             min_declarations: 1,
-                             max_declarations: 100)
+    FactoryBot.build_stubbed(:contract_banded_fee_structure_band_term)
   end
 
   describe "#capacity" do

--- a/spec/services/payment_calculator/banded/band_allocator_spec.rb
+++ b/spec/services/payment_calculator/banded/band_allocator_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe PaymentCalculator::Banded::BandAllocator do
     )
   end
 
-  let!(:contract) { FactoryBot.create(:contract, banded_fee_structure:) }
+  let!(:contract) { FactoryBot.create(:contract, banded_fee_structure:, active_lead_provider:) }
   let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
   let(:fee_per_declaration) { 100.0 }
   let(:banded_fee_structure) do

--- a/spec/services/payment_calculator/banded/band_allocator_spec.rb
+++ b/spec/services/payment_calculator/banded/band_allocator_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe PaymentCalculator::Banded::BandAllocator do
   subject(:allocator) do
     described_class.new(
-      band_terms:,
+      band_terms: banded_fee_structure.band_terms,
       billable_declarations: Declaration.where(id: current_billable_ids),
       refundable_declarations: Declaration.where(id: current_refundable_ids),
       previous_billable_declarations: Declaration.where(id: previous_billable_ids),
@@ -10,11 +10,28 @@ RSpec.describe PaymentCalculator::Banded::BandAllocator do
   end
 
   let!(:contract) { FactoryBot.create(:contract, banded_fee_structure:) }
-  let(:banded_fee_structure) { FactoryBot.build(:contract_banded_fee_structure, band_terms: [band_term_a, band_term_b, band_term_c]) }
-  let(:band_term_a) { FactoryBot.build(:contract_banded_fee_structure_band_term, min_declarations: 1, max_declarations: 2) }
-  let(:band_term_b) { FactoryBot.build(:contract_banded_fee_structure_band_term, min_declarations: 3, max_declarations: 4) }
-  let(:band_term_c) { FactoryBot.build(:contract_banded_fee_structure_band_term, min_declarations: 5, max_declarations: 6) }
-  let(:band_terms) { banded_fee_structure.band_terms.order(:min_declarations) }
+  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
+  let(:fee_per_declaration) { 100.0 }
+  let(:banded_fee_structure) do
+    FactoryBot.build(:contract_banded_fee_structure,
+                     band_terms: [
+                       FactoryBot.build(:contract_banded_fee_structure_band_term,
+                                        band: active_lead_provider_bands.first,
+                                        fee_per_declaration:),
+                       FactoryBot.build(:contract_banded_fee_structure_band_term,
+                                        band: active_lead_provider_bands.second,
+                                        fee_per_declaration:),
+                       FactoryBot.build(:contract_banded_fee_structure_band_term,
+                                        band: active_lead_provider_bands.third,
+                                        fee_per_declaration:)
+                     ])
+  end
+
+  let(:active_lead_provider_bands) do
+    FactoryBot.create_list(:active_lead_provider_band, 3,
+                           active_lead_provider:,
+                           capacity: 2)
+  end
 
   let(:current_billable_ids) { [] }
   let(:current_refundable_ids) { [] }

--- a/spec/services/payment_calculator/banded/band_allocator_spec.rb
+++ b/spec/services/payment_calculator/banded/band_allocator_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe PaymentCalculator::Banded::BandAllocator do
   subject(:allocator) do
     described_class.new(
-      band_terms: banded_fee_structure.band_terms,
+      bands: banded_fee_structure.bands,
       billable_declarations: Declaration.where(id: current_billable_ids),
       refundable_declarations: Declaration.where(id: current_refundable_ids),
       previous_billable_declarations: Declaration.where(id: previous_billable_ids),

--- a/spec/services/payment_calculator/banded/declaration_type_output_spec.rb
+++ b/spec/services/payment_calculator/banded/declaration_type_output_spec.rb
@@ -1,14 +1,28 @@
 RSpec.describe PaymentCalculator::Banded::DeclarationTypeOutput do
-  subject(:instance) { described_class.new(band_allocation:) }
+  subject(:instance) { described_class.new(band_allocation:, band_term:) }
 
   let(:band_allocation) do
-    PaymentCalculator::Banded::BandAllocation.new(band_term:, declaration_type:)
+    PaymentCalculator::Banded::BandAllocation.new(band:, declaration_type:)
   end
+
+  let(:band) do
+    FactoryBot.create(:active_lead_provider_band)
+  end
+
   let(:band_term) do
-    FactoryBot.build_stubbed(:contract_banded_fee_structure_band_term,
-                             fee_per_declaration: 150,
-                             output_fee_ratio: 0.5)
+    FactoryBot.create(:contract_banded_fee_structure_band_term,
+                      band:,
+                      banded_fee_structure: contract.banded_fee_structure,
+                      fee_per_declaration: 150,
+                      service_fee_ratio: 0.5,
+                      output_fee_ratio: 0.5)
   end
+
+  let(:contract) do
+    FactoryBot.create(:contract,
+                      active_lead_provider: band.active_lead_provider)
+  end
+
   let(:declaration_type) { "started" }
 
   it { is_expected.to delegate_method(:declaration_type).to(:band_allocation) }

--- a/spec/services/payment_calculator/banded/outputs_spec.rb
+++ b/spec/services/payment_calculator/banded/outputs_spec.rb
@@ -12,10 +12,28 @@ RSpec.describe PaymentCalculator::Banded::Outputs do
   let(:billable_declarations) { Declaration.billable.where.not(id: previous_billable_declarations.pluck(:id)) }
   let(:refundable_declarations) { Declaration.refundable }
   let!(:contract) { FactoryBot.create(:contract, :for_ecf, banded_fee_structure:) }
-  let(:banded_fee_structure) { FactoryBot.build(:contract_banded_fee_structure, band_terms: [band_term_a, band_term_b, band_term_c]) }
-  let(:band_term_a) { FactoryBot.build(:contract_banded_fee_structure_band_term, min_declarations: 1, max_declarations: 2, fee_per_declaration: 100.0) }
-  let(:band_term_b) { FactoryBot.build(:contract_banded_fee_structure_band_term, min_declarations: 3, max_declarations: 4, fee_per_declaration: 100.0) }
-  let(:band_term_c) { FactoryBot.build(:contract_banded_fee_structure_band_term, min_declarations: 5, max_declarations: 6, fee_per_declaration: 100.0) }
+
+  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
+  let(:fee_per_declaration) { 100.0 }
+  let(:banded_fee_structure) do
+    FactoryBot.build(:contract_banded_fee_structure, band_terms: [
+      FactoryBot.build(:contract_banded_fee_structure_band_term,
+                       band: active_lead_provider_bands.first,
+                       fee_per_declaration:),
+      FactoryBot.build(:contract_banded_fee_structure_band_term,
+                       band: active_lead_provider_bands.second,
+                       fee_per_declaration:),
+      FactoryBot.build(:contract_banded_fee_structure_band_term,
+                       band: active_lead_provider_bands.third,
+                       fee_per_declaration:)
+    ])
+  end
+
+  let(:active_lead_provider_bands) do
+    FactoryBot.create_list(:active_lead_provider_band, 3,
+                           active_lead_provider:,
+                           capacity: 2)
+  end
 
   before do
     FactoryBot.create_list(:declaration, 5, :eligible)
@@ -30,7 +48,7 @@ RSpec.describe PaymentCalculator::Banded::Outputs do
 
   describe "#total_billable_amount" do
     it "sums billable amounts across all declaration types" do
-      # 5x eligible/started declarations (0.20 fee proportion)
+      # 5x billable/started declarations (0.20 fee proportion)
       # 0.75 output fee ratio
       # 100.0 fee per declaration
       expect(outputs.total_billable_amount).to eq(5 * 0.75 * 100.0 * 0.20)

--- a/spec/services/payment_calculator/banded/outputs_spec.rb
+++ b/spec/services/payment_calculator/banded/outputs_spec.rb
@@ -11,9 +11,12 @@ RSpec.describe PaymentCalculator::Banded::Outputs do
   let(:previous_refundable_declarations) { Declaration.none }
   let(:billable_declarations) { Declaration.billable.where.not(id: previous_billable_declarations.pluck(:id)) }
   let(:refundable_declarations) { Declaration.refundable }
-  let!(:contract) { FactoryBot.create(:contract, :for_ecf, banded_fee_structure:) }
-
   let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
+  let!(:contract) do
+    FactoryBot.create(:contract, :for_ecf,
+                      banded_fee_structure:,
+                      active_lead_provider:)
+  end
   let(:fee_per_declaration) { 100.0 }
   let(:banded_fee_structure) do
     FactoryBot.build(:contract_banded_fee_structure, band_terms: [

--- a/spec/services/payment_calculator/banded_spec.rb
+++ b/spec/services/payment_calculator/banded_spec.rb
@@ -54,105 +54,74 @@ RSpec.describe PaymentCalculator::Banded do
   end
 
   let(:banded_fee_structure) do
-    FactoryBot.build(
-      :contract_banded_fee_structure,
-      :with_band_terms,
-      monthly_service_fee: 1_000,
-      setup_fee: 500,
-      uplift_fee_per_declaration: 50,
-      recruitment_target: 100,
-      declaration_boundaries: [{ min: 1, max: 200 }]
-    )
+    FactoryBot.build(:contract_banded_fee_structure,
+                     monthly_service_fee: 1_000,
+                     setup_fee: 500,
+                     uplift_fee_per_declaration: 50,
+                     recruitment_target: 100)
   end
 
   let(:ect_training_period) do
-    FactoryBot.create(
-      :training_period,
-      :for_ect,
-      :with_active_lead_provider,
-      active_lead_provider:
-    )
+    FactoryBot.create(:training_period, :for_ect, :with_active_lead_provider,
+                      active_lead_provider:)
   end
   let(:mentor_training_period) do
-    FactoryBot.create(
-      :training_period,
-      :for_mentor,
-      :with_active_lead_provider,
-      active_lead_provider:
-    )
+    FactoryBot.create(:training_period, :for_mentor,
+                      :with_active_lead_provider,
+                      active_lead_provider:)
   end
   let!(:billable_declaration) do
-    FactoryBot.create(
-      :declaration,
-      :payable,
-      declaration_type: :started,
-      training_period: ect_training_period,
-      payment_statement: statement_july
-    )
+    FactoryBot.create(:declaration, :payable,
+                      declaration_type: :started,
+                      training_period: ect_training_period,
+                      payment_statement: statement_july)
   end
   let!(:refundable_declaration) do
-    FactoryBot.create(
-      :declaration,
-      payment_status: :paid,
-      clawback_status: :awaiting_clawback,
-      declaration_type: :completed,
-      training_period: ect_training_period,
-      payment_statement: statement_may,
-      clawback_statement: statement_july
-    )
+    FactoryBot.create(:declaration,
+                      payment_status: :paid,
+                      clawback_status: :awaiting_clawback,
+                      declaration_type: :completed,
+                      training_period: ect_training_period,
+                      payment_statement: statement_may,
+                      clawback_statement: statement_july)
   end
   let!(:non_billable_declaration) do
-    FactoryBot.create(
-      :declaration,
-      :no_payment,
-      declaration_type: :completed,
-      training_period: ect_training_period,
-      payment_statement: statement_july
-    )
+    FactoryBot.create(:declaration, :no_payment,
+                      declaration_type: :completed,
+                      training_period: ect_training_period,
+                      payment_statement: statement_july)
   end
 
   let(:declaration_selector) { ->(declarations) { declarations } }
 
   describe "#outputs" do
     let(:previous_training_period) do
-      FactoryBot.create(
-        :training_period,
-        :for_ect,
-        :with_active_lead_provider,
-        active_lead_provider:
-      )
+      FactoryBot.create(:training_period, :for_ect, :with_active_lead_provider,
+                        active_lead_provider:)
     end
 
     let!(:previous_billable_declaration) do
-      FactoryBot.create(
-        :declaration,
-        :payable,
-        declaration_type: :started,
-        training_period: previous_training_period,
-        payment_statement: statement_june
-      )
+      FactoryBot.create(:declaration, :payable,
+                        declaration_type: :started,
+                        training_period: previous_training_period,
+                        payment_statement: statement_june)
     end
 
     let!(:previous_refundable_declaration) do
-      FactoryBot.create(
-        :declaration,
-        payment_status: :paid,
-        clawback_status: :awaiting_clawback,
-        declaration_type: :completed,
-        training_period: previous_training_period,
-        payment_statement: statement_may,
-        clawback_statement: statement_june
-      )
+      FactoryBot.create(:declaration,
+                        payment_status: :paid,
+                        clawback_status: :awaiting_clawback,
+                        declaration_type: :completed,
+                        training_period: previous_training_period,
+                        payment_statement: statement_may,
+                        clawback_statement: statement_june)
     end
 
     let!(:previous_non_billable_declaration) do
-      FactoryBot.create(
-        :declaration,
-        :no_payment,
-        declaration_type: "retained-1",
-        training_period: previous_training_period,
-        payment_statement: statement_june
-      )
+      FactoryBot.create(:declaration, :no_payment,
+                        declaration_type: "retained-1",
+                        training_period: previous_training_period,
+                        payment_statement: statement_june)
     end
 
     it "initializes with the current statement billable declarations" do

--- a/spec/services/payment_calculator/service_fees_spec.rb
+++ b/spec/services/payment_calculator/service_fees_spec.rb
@@ -1,22 +1,24 @@
 RSpec.describe PaymentCalculator::ServiceFees do
   subject(:service_fees) { described_class.new(banded_fee_structure:) }
 
+  let(:banded_fee_structure) do
+    FactoryBot.build(:contract_banded_fee_structure,
+                     recruitment_target:,
+                     setup_fee: 500,
+                     band_terms:)
+  end
+  let(:band_terms) do
+    [
+      FactoryBot.build(:contract_banded_fee_structure_band_term,
+                       fee_per_declaration: 800,
+                       service_fee_ratio: 0.40,
+                       output_fee_ratio: 0.60)
+    ]
+  end
+
   describe "#monthly_amount" do
     context "with a single band" do
-      let(:banded_fee_structure) do
-        FactoryBot.build(:contract_banded_fee_structure,
-                         recruitment_target: 100,
-                         setup_fee: 500,
-                         band_terms: [band_term])
-      end
-      let!(:band_term) do
-        FactoryBot.build(:contract_banded_fee_structure_band_term,
-                         min_declarations: 1,
-                         max_declarations: 100,
-                         fee_per_declaration: 800,
-                         service_fee_ratio: 0.40,
-                         output_fee_ratio: 0.60)
-      end
+      let(:recruitment_target) { 100 }
 
       it "returns (band_totals - setup_fee_deduction) / 29" do
         # band_totals:         100 * 800 * 0.40 = 32,000
@@ -28,27 +30,18 @@ RSpec.describe PaymentCalculator::ServiceFees do
     end
 
     context "with multiple bands" do
-      let(:banded_fee_structure) do
-        FactoryBot.build(:contract_banded_fee_structure,
-                         recruitment_target: 150,
-                         setup_fee: 500,
-                         band_terms: [term_a, term_b])
-      end
-      let!(:term_a) do
-        FactoryBot.build(:contract_banded_fee_structure_band_term,
-                         min_declarations: 1,
-                         max_declarations: 100,
-                         fee_per_declaration: 800,
-                         service_fee_ratio: 0.40,
-                         output_fee_ratio: 0.60)
-      end
-      let!(:term_b) do
-        FactoryBot.build(:contract_banded_fee_structure_band_term,
-                         min_declarations: 101,
-                         max_declarations: 200,
-                         fee_per_declaration: 600,
-                         service_fee_ratio: 0.40,
-                         output_fee_ratio: 0.60)
+      let(:recruitment_target) { 150 }
+      let(:band_terms) do
+        [
+          FactoryBot.build(:contract_banded_fee_structure_band_term,
+                           fee_per_declaration: 800,
+                           service_fee_ratio: 0.40,
+                           output_fee_ratio: 0.60),
+          FactoryBot.build(:contract_banded_fee_structure_band_term,
+                           fee_per_declaration: 600,
+                           service_fee_ratio: 0.40,
+                           output_fee_ratio: 0.60)
+        ]
       end
 
       it "deducts setup fee from first band only" do
@@ -61,20 +54,7 @@ RSpec.describe PaymentCalculator::ServiceFees do
     end
 
     context "when recruitment target is less than first band capacity" do
-      let(:banded_fee_structure) do
-        FactoryBot.build(:contract_banded_fee_structure,
-                         recruitment_target: 50,
-                         setup_fee: 500,
-                         band_terms: [term])
-      end
-      let!(:term) do
-        FactoryBot.build(:contract_banded_fee_structure_band_term,
-                         min_declarations: 1,
-                         max_declarations: 100,
-                         fee_per_declaration: 800,
-                         service_fee_ratio: 0.40,
-                         output_fee_ratio: 0.60)
-      end
+      let(:recruitment_target) { 50 }
 
       it "deducts setup fee proportionally to filled slots" do
         # band_totals:         50 * 800 * 0.40 = 16,000

--- a/spec/services/statements/declaration_selection_spec.rb
+++ b/spec/services/statements/declaration_selection_spec.rb
@@ -6,21 +6,22 @@ RSpec.describe Statements::DeclarationSelection do
   let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:, contract_period:) }
 
   let(:band_max) { 10 }
-  let(:band_terms) do
-    FactoryBot.build_list(:contract_banded_fee_structure_band_term, 1,
-                          min_declarations: 1,
-                          max_declarations: band_max,
-                          fee_per_declaration: 100,
-                          output_fee_ratio: 1.0,
-                          service_fee_ratio: 0.0)
-  end
   let(:banded_fee_structure) do
     FactoryBot.build(:contract_banded_fee_structure,
                      recruitment_target: 10,
                      uplift_fee_per_declaration: 0,
                      monthly_service_fee: 0,
                      setup_fee: 0,
-                     band_terms:)
+                     band_terms: [
+                       FactoryBot.build(:contract_banded_fee_structure_band_term,
+                                        band: active_lead_provider_band)
+                     ])
+  end
+
+  let(:active_lead_provider_band) do
+    FactoryBot.create(:active_lead_provider_band,
+                      active_lead_provider:,
+                      capacity: band_max)
   end
 
   let(:contract) do
@@ -560,24 +561,19 @@ RSpec.describe Statements::DeclarationSelection do
     let(:band_max) { 2 }
 
     let(:qualifying_previous_statement) do
-      FactoryBot.create(
-        :statement,
-        :paid,
-        contract:,
-        active_lead_provider:,
-        month: 10,
-        year: 2024,
-        payment_date: Date.new(2024, 10, 25),
-        deadline_date: Date.new(2024, 9, 30)
-      )
+      FactoryBot.create(:statement, :paid,
+                        contract:,
+                        active_lead_provider:,
+                        month: 10,
+                        year: 2024,
+                        payment_date: Date.new(2024, 10, 25),
+                        deadline_date: Date.new(2024, 9, 30))
     end
     let(:other_lead_provider) { FactoryBot.create(:lead_provider) }
     let(:other_active_lead_provider) do
-      FactoryBot.create(
-        :active_lead_provider,
-        lead_provider: other_lead_provider,
-        contract_period:
-      )
+      FactoryBot.create(:active_lead_provider,
+                        lead_provider: other_lead_provider,
+                        contract_period:)
     end
     let(:other_contract) { FactoryBot.create(:contract, :for_ecf, active_lead_provider: other_active_lead_provider) }
     let(:other_previous_statement) do

--- a/spec/services/statements/declarations_csv_spec.rb
+++ b/spec/services/statements/declarations_csv_spec.rb
@@ -12,9 +12,7 @@ RSpec.describe Statements::DeclarationsCSV do
   let(:banded_fee_structure) do
     FactoryBot.build(:contract_banded_fee_structure).tap do |structure|
       FactoryBot.build(:contract_banded_fee_structure_band_term,
-                       banded_fee_structure: structure,
-                       min_declarations: 1,
-                       max_declarations: 100)
+                       banded_fee_structure: structure)
     end
   end
   let(:contract) { FactoryBot.create(:contract, :for_ecf, active_lead_provider:, banded_fee_structure:) }

--- a/spec/views/admin/finance/active_lead_providers/contracts/index.html.erb_spec.rb
+++ b/spec/views/admin/finance/active_lead_providers/contracts/index.html.erb_spec.rb
@@ -4,6 +4,9 @@ RSpec.describe "admin/finance/active_lead_providers/contracts/index.html.erb" do
   let(:contract) { FactoryBot.create(:contract, active_lead_provider:) }
 
   before do
+    create_band_terms_for(contract.banded_fee_structure)
+    create_band_terms_for(ecf_contract.banded_fee_structure)
+
     assign(:active_lead_provider, active_lead_provider)
     assign(:contracts, [contract])
     assign(:breadcrumbs, {
@@ -60,6 +63,20 @@ RSpec.describe "admin/finance/active_lead_providers/contracts/index.html.erb" do
 
       expect(rendered).to have_content("No contracts found")
       expect(rendered).not_to have_css(".govuk-table")
+    end
+  end
+
+private
+
+  def create_band_terms_for(banded_fee_structure)
+    3.times do
+      band = FactoryBot.create(:active_lead_provider_band,
+                               active_lead_provider:,
+                               capacity: 2)
+      FactoryBot.create(:contract_banded_fee_structure_band_term,
+                        banded_fee_structure:,
+                        band:,
+                        fee_per_declaration: 100.0)
     end
   end
 end

--- a/spec/views/admin/finance/active_lead_providers/contracts/index.html.erb_spec.rb
+++ b/spec/views/admin/finance/active_lead_providers/contracts/index.html.erb_spec.rb
@@ -4,8 +4,14 @@ RSpec.describe "admin/finance/active_lead_providers/contracts/index.html.erb" do
   let(:contract) { FactoryBot.create(:contract, active_lead_provider:) }
 
   before do
-    create_band_terms_for(contract.banded_fee_structure)
-    create_band_terms_for(ecf_contract.banded_fee_structure)
+    3.times do
+      FactoryBot.create(:contract_banded_fee_structure_band_term,
+                        band: FactoryBot.create(:active_lead_provider_band,
+                                                active_lead_provider:,
+                                                capacity: 2),
+                        banded_fee_structure: contract.banded_fee_structure,
+                        fee_per_declaration: 100.0)
+    end
 
     assign(:active_lead_provider, active_lead_provider)
     assign(:contracts, [contract])
@@ -63,20 +69,6 @@ RSpec.describe "admin/finance/active_lead_providers/contracts/index.html.erb" do
 
       expect(rendered).to have_content("No contracts found")
       expect(rendered).not_to have_css(".govuk-table")
-    end
-  end
-
-private
-
-  def create_band_terms_for(banded_fee_structure)
-    3.times do
-      band = FactoryBot.create(:active_lead_provider_band,
-                               active_lead_provider:,
-                               capacity: 2)
-      FactoryBot.create(:contract_banded_fee_structure_band_term,
-                        banded_fee_structure:,
-                        band:,
-                        fee_per_declaration: 100.0)
     end
   end
 end

--- a/spec/views/admin/finance/statements/show.html.erb_spec.rb
+++ b/spec/views/admin/finance/statements/show.html.erb_spec.rb
@@ -2,16 +2,13 @@ RSpec.describe "admin/finance/statements/show.html.erb" do
   let(:contract_trait) { :for_ecf }
   let!(:contract_period) { FactoryBot.create(:contract_period, year: 2025) }
   let(:contract) do
-    FactoryBot.create(
-      :contract,
-      contract_trait,
-      active_lead_provider:,
-      banded_fee_structure:
-    )
+    FactoryBot.create(:contract, contract_trait,
+                      active_lead_provider:,
+                      banded_fee_structure:)
   end
 
   let(:banded_fee_structure) do
-    FactoryBot.build(:contract_banded_fee_structure, :with_band_terms)
+    FactoryBot.build(:contract_banded_fee_structure)
   end
 
   let(:lead_provider) { FactoryBot.create(:lead_provider, name: "Some LP") }


### PR DESCRIPTION
### Context

[Band modelling](https://github.com/DFE-Digital/register-ects-project-board/issues/4031)

- [part 1](https://github.com/DFE-Digital/register-early-career-teachers-public/pull/3080)
- [part 2](https://github.com/DFE-Digital/register-early-career-teachers-public/pull/3115)
- part 3 (this PR)
- [part 4](https://github.com/DFE-Digital/register-early-career-teachers-public/pull/3148)
- [part 5](https://github.com/DFE-Digital/register-early-career-teachers-public/pull/3178)

### Changes proposed in this pull request

Migrate calculators to use `ActiveLeadProvider::Band#capacity`

- Enforce an ALP band per term and relax restriction on max values
- Remove traits that build declaration boundaries
- Update specs to create ALP bands
- Update methods to fetch capacity from ALP band
- Retire min/max methods and validations from the term

### Guidance to review

<img width="1054" height="479" alt="Screenshot 2026-07-03 at 10 41 56" src="https://github.com/user-attachments/assets/c2c3d8ab-723b-4c25-a4f4-7d03cdaa87bc" />

<img width="1322" height="170" alt="Screenshot 2026-07-03 at 10 41 27" src="https://github.com/user-attachments/assets/a75cbc6e-b6d4-413c-805a-928368de7d11" />
