### PR TITLE
Better contract description

### DIFF
--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -45,9 +45,7 @@ class Contract < ApplicationRecord
     vat_rate
   end
 
-  def description
-    "#{contract_type.humanize.upcase} (created #{created_at.to_fs(:govuk)})"
-  end
+  def description = "#{contract_type.humanize.upcase} #{statement_range_description}"
 
   def statement_range_description
     first = statements.min_by { |s| [s.year, s.month] }

--- a/spec/models/contract_spec.rb
+++ b/spec/models/contract_spec.rb
@@ -135,18 +135,21 @@ describe Contract do
   describe "#description" do
     subject(:description) { contract.description }
 
-    around { |example| travel_to(Time.zone.local(2026, 1, 15, 14, 30)) { example.run } }
-
-    context "when the contract type is `ITTECF_ECTP`" do
+    context "when the contract type is `ITTECF_ECTP` with no statements" do
       let(:contract) { FactoryBot.create(:contract, :for_ittecf_ectp) }
 
-      it { is_expected.to eq("ITTECF ECTP (created 15 January 2026, 2:30pm)") }
+      it { is_expected.to eq("ITTECF ECTP No statements") }
     end
 
-    context "when the contract type is `ECF`" do
+    context "when the contract type is `ECF` with statements" do
       let(:contract) { FactoryBot.create(:contract, :for_ecf) }
 
-      it { is_expected.to eq("ECF (created 15 January 2026, 2:30pm)") }
+      before do
+        FactoryBot.create(:statement, contract:, month: 1, year: 2025)
+        FactoryBot.create(:statement, contract:, month: 5, year: 2026)
+      end
+
+      it { is_expected.to eq("ECF January 2025 - May 2026") }
     end
   end
 end


### PR DESCRIPTION
### Context

It is currently hard to distinguish contracts.

<img width="500" height="250" alt="image" src="https://github.com/user-attachments/assets/d9bcaad2-fd39-40e6-89f1-86ea6965a339" />


### Changes proposed in this pull request

Since a contracts primary distinguishing feature is the statements it contains we change the contract description to include the statement range.

### Guidance to review

* None
