### PR TITLE
[4130] Exclude closed and proposed_to_open schools from comms queries

### DIFF
--- a/db/seeds/blazer_queries/school_comms.rb
+++ b/db/seeds/blazer_queries/school_comms.rb
@@ -61,6 +61,7 @@ module BlazerQueries
             LEFT JOIN dfe_sign_in_organisations dsi ON dsi.urn = s.urn::text
             WHERE #{eligible_sql}
               AND #{not_a_childrens_centre_sql}
+              AND #{open_school_sql}
             ORDER BY gs.name;
           SQL
         }
@@ -84,6 +85,7 @@ module BlazerQueries
             WHERE #{eligible_sql}
               AND #{not_a_childrens_centre_sql}
               AND #{not_opted_out_sql}
+              AND #{open_school_sql}
             ORDER BY gs.name;
           SQL
         }
@@ -105,6 +107,7 @@ module BlazerQueries
             INNER JOIN gias_schools gs ON gs.urn = s.urn
             WHERE #{eligible_sql}
               AND #{not_a_childrens_centre_sql}
+              AND #{open_school_sql}
             ORDER BY gs.name;
           SQL
         }
@@ -127,6 +130,7 @@ module BlazerQueries
             FROM schools s
             INNER JOIN gias_schools gs ON gs.urn = s.urn
             WHERE #{not_a_childrens_centre_sql}
+              AND #{open_school_sql}
               AND #{not_opted_out_sql}
               AND #{has_current_partnership_sql}
               AND #{no_participants_this_period_sql}
@@ -144,6 +148,12 @@ module BlazerQueries
       def not_a_childrens_centre_sql
         list = GIAS::Types::CHILDRENS_CENTRE_TYPES.map { quote it }.join(", ")
         "gs.type_name NOT IN (#{list})"
+      end
+
+      # mirrors GIAS::School#open?
+      def open_school_sql
+        statuses = %w[open proposed_to_close].map { quote it }.join(", ")
+        "gs.status IN (#{statuses})"
       end
 
       def not_opted_out_sql

--- a/spec/seeds/blazer_queries/school_comms_spec.rb
+++ b/spec/seeds/blazer_queries/school_comms_spec.rb
@@ -11,12 +11,13 @@ RSpec.describe BlazerQueries::SchoolComms do
 
   # Build a school + its GIAS record with full control over the bits the
   # queries filter and select on, avoiding the randomness in the factories.
-  def create_school(urn:, type_name: "Community school", eligible: true, contact_email: nil, **school_attrs)
+  def create_school(urn:, type_name: "Community school", eligible: true, contact_email: nil, status: "open", **school_attrs)
     gias_school = FactoryBot.create(
       :gias_school,
       urn:,
       type_name:,
       eligible:,
+      status:,
       primary_contact_email: contact_email
     )
     FactoryBot.create(:school, urn:, gias_school:, create_contract_period: false, **school_attrs)
@@ -63,6 +64,14 @@ RSpec.describe BlazerQueries::SchoolComms do
       definitions.each do |definition|
         expect(definition[:statement]).to include(
           "gs.type_name NOT IN ('Children''s centre', 'Children''s centre linked site')"
+        )
+      end
+    end
+
+    it "only contacts open and 'proposed to close' schools everywhere (#4130)" do
+      definitions.each do |definition|
+        expect(definition[:statement]).to include(
+          "gs.status IN ('open', 'proposed_to_close')"
         )
       end
     end
@@ -168,6 +177,17 @@ RSpec.describe BlazerQueries::SchoolComms do
       urns = run(name).map { |row| row["urn"].to_i }
 
       expect(urns).to eq [100_013]
+    end
+
+    it "excludes closed and proposed-to-open schools" do
+      create_school(urn: 100_030, status: "open")
+      create_school(urn: 100_031, status: "proposed_to_close")
+      create_school(urn: 100_032, status: "closed")
+      create_school(urn: 100_033, status: "proposed_to_open")
+
+      urns = run(name).map { |row| row["urn"].to_i }
+
+      expect(urns).to contain_exactly(100_030, 100_031)
     end
 
     # Guards against the hand-written eligible_sql drifting from School.eligible.


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/4130

### Changes proposed in this pull request

Exclude schools with "closed" and "proposed_to_open" status from comms queries