### PR TITLE
Fix flaky API release notes spec

### DIFF
--- a/spec/requests/api/release_notes_spec.rb
+++ b/spec/requests/api/release_notes_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe "Release Notes" do
     end
 
     context "with valid slug" do
-      let(:note) { api_release_notes.sample }
+      let(:slug) { "2026-06-17-schedules-can-be-changed-to-reduced-after-ects-have-completed-induction" }
+      let(:note) { api_release_notes.find { it.slug == slug } }
 
       it "renders the note" do
         get(api_guidance_release_note_path(note.slug))


### PR DESCRIPTION
This fails when the note retrieved with `#sample` contains characters that are escaped.

The offending title here is: `Added new withdrawal reason 'changed_lead_provider'`

And the resulting markup is:

```html
<h1 class="govuk-heading-l">Added new withdrawal reason &#39;changed_lead_provider&#39;</h1>
```

Fix by specifying a known good note and eliminating randomness.
