### PR TITLE
Fix statements with invalid dates

### DIFF
--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -34,6 +34,11 @@ class Statement < ApplicationRecord
   validate :unique_lead_provider_month_year
   validates :deadline_date, presence: { message: "Deadline date must be specified" }
   validate :deadline_date_in_the_past
+  validates :payment_date,
+            comparison: {
+              greater_than: :deadline_date,
+              message: "Payment date must be later than the deadline date"
+            }
 
   # Scopes
   scope :with_fee_type, ->(fee_type) { where(fee_type:) }

--- a/db/scripts/fix_invalid_statement_dates.rb
+++ b/db/scripts/fix_invalid_statement_dates.rb
@@ -1,0 +1,21 @@
+# We have some statements where the payment date is on or before the deadline date.
+# This script will correct these by moving the payment date to the last day
+# of the following month.
+
+ActiveRecord::Base.transaction do
+  invalid_statements = Statement.where("payment_date <= deadline_date")
+  changes = []
+
+  invalid_statements.find_each do |statement|
+    new_payment_date = statement.deadline_date.next_month.end_of_month
+    changes << { id: statement.id, deadline_date: statement.deadline_date, old_payment_date: statement.payment_date, new_payment_date: }
+    statement.update!(payment_date: new_payment_date)
+  end
+
+  Rails.logger.debug("Updated statements:")
+  changes.each do |it|
+    Rails.logger.debug("Statement ID: #{it[:id]}, Deadline Date: #{it[:deadline_date]}, Old Payment Date: #{it[:old_payment_date]}, New Payment Date: #{it[:new_payment_date]}")
+  end
+
+  raise "Failed to fix all statements" if Statement.where("payment_date <= deadline_date").exists?
+end

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -24,6 +24,7 @@ describe Statement do
     it { is_expected.not_to allow_value(nil).for(:status).with_message("Choose a valid status") }
     it { is_expected.to validate_inclusion_of(:fee_type).in_array(described_class.fee_types.keys).with_message("Fee type must be output or service") }
     it { is_expected.to validate_inclusion_of(:status).in_array(described_class.statuses.keys).with_message("Choose a valid status") }
+    it { is_expected.to validate_comparison_of(:payment_date).is_greater_than(:deadline_date).with_message("Payment date must be later than the deadline date") }
 
     describe "uniqueness of month and year for the same active lead provider" do
       let(:active_lead_provider) { contract.active_lead_provider }
@@ -40,7 +41,7 @@ describe Statement do
       it "is valid to create another statement with the same month and year for a different active lead provider" do
         other_active_lead_provider = FactoryBot.create(:active_lead_provider)
         other_contract = FactoryBot.create(:contract, active_lead_provider: other_active_lead_provider)
-        statement = described_class.new(contract: other_contract, month: 5, year: 2024, deadline_date: Date.new(2024, 5, 1).prev_day)
+        statement = described_class.new(contract: other_contract, month: 5, year: 2024, deadline_date: Date.new(2024, 5, 1).prev_day, payment_date: Date.new(2024, 5, 25))
 
         expect(statement).to be_valid
       end

--- a/spec/serializers/api/statement_serializer_spec.rb
+++ b/spec/serializers/api/statement_serializer_spec.rb
@@ -11,7 +11,7 @@ describe API::StatementSerializer, type: :serializer do
       month: 7,
       year: 2023,
       deadline_date: Date.new(2023, 7, 1),
-      payment_date: Date.new(2023, 7, 1),
+      payment_date: Date.new(2023, 7, 2),
       created_at:,
       api_updated_at:
     )
@@ -34,7 +34,7 @@ describe API::StatementSerializer, type: :serializer do
       expect(attributes["month"]).to eq("July")
       expect(attributes["year"]).to eq("2023")
       expect(attributes["cut_off_date"]).to eq("2023-07-01")
-      expect(attributes["payment_date"]).to eq("2023-07-01")
+      expect(attributes["payment_date"]).to eq("2023-07-02")
       expect(attributes["created_at"]).to eq(created_at.utc.rfc3339)
       expect(attributes["updated_at"]).to eq(api_updated_at.utc.rfc3339)
     end

--- a/spec/services/api/declarations/create_spec.rb
+++ b/spec/services/api/declarations/create_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe API::Declarations::Create, type: :model do
         end
 
         describe "frozen contract period validations" do
-          let!(:payment_statement) { FactoryBot.create(:statement, :open, active_lead_provider:, deadline_date: 1.month.from_now) }
+          let!(:payment_statement) { FactoryBot.create(:statement, :open, active_lead_provider:, deadline_date: 1.month.from_now, payment_date: 2.months.from_now) }
           let(:eligible_at_field) { "#{trainee_type}_first_became_eligible_for_training_at" }
 
           context "when teacher's latest ongoing training period is in a frozen contract period and participant is eligible for funding" do
@@ -649,7 +649,7 @@ RSpec.describe API::Declarations::Create, type: :model do
           end
 
           let(:service) { instance_double(Declarations::Create) }
-          let!(:payment_statement) { FactoryBot.create(:statement, :open, active_lead_provider:, deadline_date: 1.month.from_now) }
+          let!(:payment_statement) { FactoryBot.create(:statement, :open, active_lead_provider:, deadline_date: 1.month.from_now, payment_date: 2.months.from_now) }
           let!(:mentorship_period) do
             if trainee_type == :ect
               mentor = FactoryBot.create(

--- a/spec/services/api/statements/query_spec.rb
+++ b/spec/services/api/statements/query_spec.rb
@@ -43,9 +43,9 @@ RSpec.describe API::Statements::Query do
     end
 
     it "orders statements by payment date in ascending order" do
-      statement1 = FactoryBot.create(:statement, payment_date: 2.days.ago)
-      statement2 = FactoryBot.create(:statement, payment_date: 1.day.ago)
-      statement3 = FactoryBot.create(:statement, payment_date: Time.zone.now)
+      statement1 = FactoryBot.create(:statement, deadline_date: 3.days.ago, payment_date: 2.days.ago)
+      statement2 = FactoryBot.create(:statement, deadline_date: 2.days.ago, payment_date: 1.day.ago)
+      statement3 = FactoryBot.create(:statement, deadline_date: 1.day.ago, payment_date: Time.zone.now)
 
       query = described_class.new
 
@@ -220,8 +220,8 @@ RSpec.describe API::Statements::Query do
     end
 
     describe "ordering" do
-      let!(:statement1) { FactoryBot.create(:statement, year: 2025, month: 4, payment_date: "2024-01-01") }
-      let!(:statement2) { FactoryBot.create(:statement, year: 2024, month: 8, payment_date: "2025-01-01") }
+      let!(:statement1) { FactoryBot.create(:statement, year: 2025, month: 4, deadline_date: "2023-12-01", payment_date: "2024-01-01") }
+      let!(:statement2) { FactoryBot.create(:statement, year: 2024, month: 8, deadline_date: "2024-12-01", payment_date: "2025-01-01") }
 
       describe "default order" do
         it "returns statements in correct order" do

--- a/spec/services/statements/declaration_selection_spec.rb
+++ b/spec/services/statements/declaration_selection_spec.rb
@@ -518,7 +518,7 @@ RSpec.describe Statements::DeclarationSelection do
         month: 12,
         year: 2024,
         payment_date: statement.payment_date,
-        deadline_date: Date.new(2024, 11, 30)
+        deadline_date: statement.payment_date.prev_month.beginning_of_month
       )
     end
 

--- a/spec/services/statements/search_spec.rb
+++ b/spec/services/statements/search_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe Statements::Search do
     end
 
     it "orders statements by payment date in ascending order" do
-      statement1 = FactoryBot.create(:statement, payment_date: 2.days.ago)
-      statement2 = FactoryBot.create(:statement, payment_date: 1.day.ago)
-      statement3 = FactoryBot.create(:statement, payment_date: Time.zone.now)
+      statement1 = FactoryBot.create(:statement, deadline_date: 3.days.ago, payment_date: 2.days.ago)
+      statement2 = FactoryBot.create(:statement, deadline_date: 2.days.ago, payment_date: 1.day.ago)
+      statement3 = FactoryBot.create(:statement, deadline_date: 1.day.ago, payment_date: Time.zone.now)
 
       search = described_class.new
 
@@ -281,8 +281,8 @@ RSpec.describe Statements::Search do
     end
 
     describe "ordering" do
-      let!(:statement1) { FactoryBot.create(:statement, year: 2025, month: 4, payment_date: "2024-01-01", deadline_date: "2025-01-01") }
-      let!(:statement2) { FactoryBot.create(:statement, year: 2024, month: 8, payment_date: "2025-01-01", deadline_date: "2024-01-01") }
+      let!(:statement1) { FactoryBot.create(:statement, year: 2025, month: 4, payment_date: "2024-01-01", deadline_date: "2023-01-01") }
+      let!(:statement2) { FactoryBot.create(:statement, year: 2024, month: 8, payment_date: "2025-01-01", deadline_date: "2022-01-01") }
 
       describe "default order" do
         it "returns statements in correct order" do


### PR DESCRIPTION
### Context

We have a number of statements within the database that have invalid dates, such that the `deadline_date` is on or after the `payment_date`.

This should not be possible; the payment date should always be later than the deadline date.

### Changes proposed in this pull request

Add validation to prevent any additional statements from being added with incorrect dates.

Add a script to fix the existing statements by moving the payment date to be the last day of the month following the deadline date.

### Guidance to review

Script tested on migration environment:

```
Statement ID: 15, Deadline Date: 2024-12-31, Old Payment Date: 2024-01-25, New Payment Date: 2025-01-31
Statement ID: 38, Deadline Date: 2021-11-30, Old Payment Date: 2021-11-30, New Payment Date: 2021-12-31
Statement ID: 153, Deadline Date: 2024-12-31, Old Payment Date: 2024-01-25, New Payment Date: 2025-01-31
Statement ID: 157, Deadline Date: 2021-11-30, Old Payment Date: 2021-11-30, New Payment Date: 2021-12-31
Statement ID: 161, Deadline Date: 2023-12-31, Old Payment Date: 2023-01-25, New Payment Date: 2024-01-31
Statement ID: 237, Deadline Date: 2027-12-31, Old Payment Date: 2027-01-31, New Payment Date: 2028-01-31
Statement ID: 284, Deadline Date: 2024-12-31, Old Payment Date: 2024-01-25, New Payment Date: 2025-01-31
Statement ID: 301, Deadline Date: 2024-12-31, Old Payment Date: 2024-01-25, New Payment Date: 2025-01-31
Statement ID: 404, Deadline Date: 2027-12-31, Old Payment Date: 2027-01-31, New Payment Date: 2028-01-31
Statement ID: 446, Deadline Date: 2027-12-31, Old Payment Date: 2027-01-31, New Payment Date: 2028-01-31
Statement ID: 508, Deadline Date: 2023-12-31, Old Payment Date: 2023-01-25, New Payment Date: 2024-01-31
Statement ID: 536, Deadline Date: 2023-12-31, Old Payment Date: 2023-01-25, New Payment Date: 2024-01-31
Statement ID: 546, Deadline Date: 2023-12-31, Old Payment Date: 2023-01-25, New Payment Date: 2024-01-31
Statement ID: 578, Deadline Date: 2021-11-30, Old Payment Date: 2021-11-30, New Payment Date: 2021-12-31
Statement ID: 596, Deadline Date: 2021-11-30, Old Payment Date: 2021-11-30, New Payment Date: 2021-12-31
Statement ID: 732, Deadline Date: 2027-12-31, Old Payment Date: 2027-01-31, New Payment Date: 2028-01-31
Statement ID: 795, Deadline Date: 2021-11-30, Old Payment Date: 2021-11-30, New Payment Date: 2021-12-31
Statement ID: 797, Deadline Date: 2023-12-31, Old Payment Date: 2023-01-25, New Payment Date: 2024-01-31
Statement ID: 863, Deadline Date: 2024-12-31, Old Payment Date: 2024-01-25, New Payment Date: 2025-01-31
Statement ID: 886, Deadline Date: 2023-12-31, Old Payment Date: 2023-01-25, New Payment Date: 2024-01-31
Statement ID: 890, Deadline Date: 2024-12-31, Old Payment Date: 2024-01-25, New Payment Date: 2025-01-31
Statement ID: 894, Deadline Date: 2027-12-31, Old Payment Date: 2027-01-31, New Payment Date: 2028-01-31
Statement ID: 910, Deadline Date: 2027-12-31, Old Payment Date: 2027-01-31, New Payment Date: 2028-01-31
Statement ID: 922, Deadline Date: 2021-11-30, Old Payment Date: 2021-11-30, New Payment Date: 2021-12-31
```