### PR TITLE
Contract CRUD

### DIFF
--- a/app/controllers/admin/finance/active_lead_providers/contracts_controller.rb
+++ b/app/controllers/admin/finance/active_lead_providers/contracts_controller.rb
@@ -3,7 +3,8 @@ module Admin::Finance::ActiveLeadProviders
     layout "full"
 
     before_action :set_active_lead_provider
-    before_action :set_contract, only: %i[show]
+    before_action :set_contract, only: %i[show edit update delete destroy]
+    before_action :redirect_unless_editable, only: %i[new create edit update delete destroy]
 
     def index
       @breadcrumbs = {
@@ -25,6 +26,50 @@ module Admin::Finance::ActiveLeadProviders
       }
     end
 
+    def new
+      @contract = ::Contracts::Build.new(active_lead_provider: @active_lead_provider).call
+    end
+
+    def create
+      @contract = ::Contracts::Create.new(
+        author: current_user,
+        active_lead_provider: @active_lead_provider,
+        params: contract_params
+      ).call
+
+      redirect_to contract_path(@contract), notice: "Contract added"
+    rescue ActiveRecord::RecordInvalid => e
+      @contract = e.record
+      render :new, status: :unprocessable_content
+    end
+
+    def edit
+      # This is idiomatic Rails, so we need a comment to keep sonarcube happy.
+    end
+
+    def update
+      ::Contracts::Update.new(
+        author: current_user,
+        contract: @contract,
+        params: contract_params
+      ).call
+
+      redirect_to contract_path(@contract), notice: "Contract updated"
+    rescue ActiveRecord::RecordInvalid
+      render :edit, status: :unprocessable_content
+    end
+
+    def delete
+      # This is our project specific pattern, so we need a comment to keep sonarcube happy.
+    end
+
+    def destroy
+      ::Contracts::Destroy.new(author: current_user, contract: @contract).call
+      redirect_to contracts_path, notice: "Contract deleted"
+    rescue ::Contracts::Destroy::DeletionError => e
+      redirect_to contract_path(@contract), flash: { error: e.message }
+    end
+
   private
 
     def set_active_lead_provider
@@ -37,6 +82,61 @@ module Admin::Finance::ActiveLeadProviders
       @contract = @active_lead_provider.contracts
         .includes(:statements, :flat_rate_fee_structure, banded_fee_structure: :band_terms)
         .find(params.expect(:id))
+    end
+
+    def redirect_unless_editable
+      unless @active_lead_provider.editable?
+        redirect_to contracts_path,
+                    flash: { error: "Contracts cannot be changed once the contract period has started" }
+      end
+    end
+
+    def contract_params
+      params.expect(
+        contract: [
+          :contract_type,
+          :ecf_contract_version,
+          :ecf_mentor_contract_version,
+          :vat_rate,
+          {
+            banded_fee_structure_attributes: [
+              :id,
+              :recruitment_target,
+              :uplift_fee_per_declaration,
+              :monthly_service_fee,
+              :setup_fee,
+              {
+                bands_attributes: %i[
+                  id
+                  min_declarations
+                  max_declarations
+                  fee_per_declaration
+                  output_fee_percentage
+                  service_fee_percentage
+                  _destroy
+                ]
+              },
+            ],
+            flat_rate_fee_structure_attributes: %i[
+              id
+              recruitment_target
+              fee_per_declaration
+            ]
+          },
+        ]
+      )
+    end
+
+    def contract_path(contract)
+      admin_contract_period_active_lead_provider_contract_path(
+        @active_lead_provider.contract_period, @active_lead_provider, contract
+      )
+    end
+
+    def contracts_path
+      admin_contract_period_active_lead_provider_contracts_path(
+        @active_lead_provider.contract_period, @active_lead_provider
+      )
     end
   end
 end

--- a/app/javascript/controllers/band_controller.js
+++ b/app/javascript/controllers/band_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class BandController extends Controller {
+  static targets = ["outputPercentage", "servicePercentage"]
+
+  connect() {
+    const target = this.servicePercentageTarget
+    target.readOnly = true
+    target.tabIndex = -1
+    target.style.opacity = "0.5"
+    target.style.cursor = "not-allowed"
+    target.style.backgroundColor = "transparent"
+  }
+
+  updateServiceFee() {
+    const output = Number.parseFloat(this.outputPercentageTarget.value)
+    this.servicePercentageTarget.value = Number.isNaN(output) ? "" : (100 - output).toFixed(2)
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -2,4 +2,7 @@
 // Run that command whenever you add a new controller or create them with
 // ./bin/rails generate stimulus controllerName
 
-// import { application } from "./application"
+import { application } from "./application"
+import BandController from "./band_controller"
+
+application.register("band", BandController)

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -15,6 +15,9 @@ class Contract < ApplicationRecord
   has_one :banded_fee_structure, class_name: "Contract::BandedFeeStructure", inverse_of: :contract, dependent: :destroy
   has_many :statements, inverse_of: :contract
 
+  accepts_nested_attributes_for :banded_fee_structure
+  accepts_nested_attributes_for :flat_rate_fee_structure, reject_if: :all_blank
+
   # Validations
   validates :active_lead_provider, presence: { message: "An active lead provider must be set" }
   validates :contract_type,

--- a/app/models/contract/banded_fee_structure.rb
+++ b/app/models/contract/banded_fee_structure.rb
@@ -10,6 +10,8 @@ class Contract::BandedFeeStructure < ApplicationRecord
            inverse_of: :banded_fee_structure,
            dependent: :destroy
 
+  accepts_nested_attributes_for :bands, allow_destroy: true
+
   # Validations
   validates :contract_id, uniqueness: { message: "Contract with the same banded fee structure already exist" }
 

--- a/app/models/contract/banded_fee_structure/band_term.rb
+++ b/app/models/contract/banded_fee_structure/band_term.rb
@@ -64,6 +64,22 @@ class Contract::BandedFeeStructure::BandTerm < ApplicationRecord
     max_declarations - min_declarations + 1
   end
 
+  def output_fee_percentage
+    (output_fee_ratio * 100).to_i if output_fee_ratio
+  end
+
+  def output_fee_percentage=(val)
+    self.output_fee_ratio = val.present? ? val.to_d / 100 : nil
+  end
+
+  def service_fee_percentage
+    (service_fee_ratio * 100).to_i if service_fee_ratio
+  end
+
+  def service_fee_percentage=(val)
+    self.service_fee_ratio = val.present? ? val.to_d / 100 : nil
+  end
+
 private
 
   def sum_of_ratios_equals_one

--- a/app/services/contracts/build.rb
+++ b/app/services/contracts/build.rb
@@ -1,0 +1,33 @@
+module Contracts
+  class Build
+    attr_reader :active_lead_provider
+
+    def initialize(active_lead_provider:)
+      @active_lead_provider = active_lead_provider
+    end
+
+    def call
+      contract = active_lead_provider.contracts.build
+      banded_fee_structure = contract.build_banded_fee_structure
+
+      # Temporarily seed bands from the previous contract's band_structure until
+      # ActiveLeadProvider::Band is implemented and can provide this data directly.
+      existing_contract = active_lead_provider.contracts
+                            .joins(banded_fee_structure: :bands)
+                            .includes(banded_fee_structure: :bands)
+                            .first
+
+      if existing_contract&.banded_fee_structure&.bands&.any?
+        existing_contract.banded_fee_structure.bands.each do |band|
+          banded_fee_structure.bands.build(band.attributes.slice("min_declarations", "max_declarations",
+                                                                 "fee_per_declaration", "output_fee_ratio", "service_fee_ratio"))
+        end
+      else
+        banded_fee_structure.bands.build
+      end
+
+      contract.build_flat_rate_fee_structure
+      contract
+    end
+  end
+end

--- a/app/services/contracts/create.rb
+++ b/app/services/contracts/create.rb
@@ -1,0 +1,18 @@
+module Contracts
+  class Create
+    attr_reader :author, :active_lead_provider, :params
+
+    def initialize(author:, active_lead_provider:, params:)
+      @author = author
+      @active_lead_provider = active_lead_provider
+      @params = params
+    end
+
+    def call
+      contract = active_lead_provider.contracts.build(params)
+      contract.save!
+      Events::Record.record_contract_created_event!(author:, contract:)
+      contract
+    end
+  end
+end

--- a/app/services/contracts/destroy.rb
+++ b/app/services/contracts/destroy.rb
@@ -1,0 +1,20 @@
+module Contracts
+  class Destroy
+    class DeletionError < StandardError; end
+
+    attr_reader :author, :contract
+
+    def initialize(author:, contract:)
+      @author = author
+      @contract = contract
+    end
+
+    def call
+      raise DeletionError, "Cannot delete a contract that has statements" if contract.statements.any?
+
+      active_lead_provider = contract.active_lead_provider
+      contract.destroy!
+      Events::Record.record_contract_deleted_event!(author:, active_lead_provider:)
+    end
+  end
+end

--- a/app/services/contracts/update.rb
+++ b/app/services/contracts/update.rb
@@ -1,0 +1,19 @@
+module Contracts
+  class Update
+    attr_reader :author, :contract, :params
+
+    def initialize(author:, contract:, params:)
+      @author = author
+      @contract = contract
+      @params = params
+    end
+
+    def call
+      contract.assign_attributes(params)
+      modifications = contract.changes
+      contract.save!
+      Events::Record.record_contract_updated_event!(author:, contract:, modifications:)
+      contract
+    end
+  end
+end

--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -1019,6 +1019,35 @@ module Events
       new(event_type:, author:, heading:, lead_provider:, happened_at:).record_event!
     end
 
+    # Contract Events
+
+    def self.record_contract_created_event!(author:, contract:, happened_at: Time.zone.now)
+      event_type = :contract_created
+      active_lead_provider = contract.active_lead_provider
+      lead_provider = active_lead_provider.lead_provider
+      heading = "Contract created: #{contract.description} for #{lead_provider.name}"
+
+      new(event_type:, author:, heading:, active_lead_provider:, lead_provider:, happened_at:).record_event!
+    end
+
+    def self.record_contract_updated_event!(author:, contract:, modifications:, happened_at: Time.zone.now)
+      event_type = :contract_updated
+      active_lead_provider = contract.active_lead_provider
+      lead_provider = active_lead_provider.lead_provider
+      heading = "Contract updated: #{contract.description} for #{lead_provider.name}"
+
+      new(event_type:, author:, heading:, active_lead_provider:, lead_provider:, happened_at:, modifications:).record_event!
+    end
+
+    def self.record_contract_deleted_event!(author:, active_lead_provider:, happened_at: Time.zone.now)
+      event_type = :contract_deleted
+      lead_provider = active_lead_provider.lead_provider
+      contract_period = active_lead_provider.contract_period
+      heading = "Contract deleted for #{lead_provider.name} in #{contract_period.year}"
+
+      new(event_type:, author:, heading:, active_lead_provider:, lead_provider:, happened_at:).record_event!
+    end
+
     # Delivery Partner Events
 
     def self.record_delivery_partner_created_event!(author:, delivery_partner:, happened_at: Time.zone.now)

--- a/app/views/admin/finance/active_lead_providers/contracts/_fields.html.erb
+++ b/app/views/admin/finance/active_lead_providers/contracts/_fields.html.erb
@@ -1,0 +1,111 @@
+<%= content_for(:error_summary) { form.govuk_error_summary } %>
+
+<%= form.govuk_collection_radio_buttons :contract_type,
+      Contract.contract_types.keys,
+      :itself,
+      ->(type) { type.humanize.upcase },
+      legend: { text: "Contract type", size: "s" } %>
+
+<%= form.govuk_text_field :ecf_contract_version,
+      label: { text: "ECF contract version", size: "s" },
+      width: 10 %>
+
+<%= form.govuk_text_field :ecf_mentor_contract_version,
+      label: { text: "ECF mentor contract version", size: "s" },
+      hint: { text: "Required for ITTECF_ECTP contracts only" },
+      width: 10 %>
+
+<%= form.govuk_text_field :vat_rate,
+      label: { text: "VAT rate (enter as a decimal, e.g. 0.2 for 20%)", size: "s" },
+      width: 5,
+      inputmode: "decimal" %>
+
+<%= govuk_section_break(visible: true, size: "m") %>
+
+<h2 class="govuk-heading-m">Flat rate fee structure</h2>
+
+<p class="govuk-hint">Required for ITTECF_ECTP contracts only. Leave blank for ECF contracts.</p>
+
+<%= form.fields_for :flat_rate_fee_structure do |frs| %>
+  <%= frs.govuk_text_field :recruitment_target,
+        label: { text: "Mentors recruitment target", size: "s" },
+        width: 10,
+        inputmode: "numeric" %>
+
+  <%= frs.govuk_text_field :fee_per_declaration,
+        label: { text: "Fee per declaration (£)", size: "s" },
+        width: 10,
+        inputmode: "decimal" %>
+<% end %>
+
+<%= govuk_section_break(visible: true, size: "m") %>
+
+<h2 class="govuk-heading-m">Banded fee structure</h2>
+
+<%= form.fields_for :banded_fee_structure do |bfs| %>
+  <%= bfs.govuk_text_field :recruitment_target,
+        label: { text: "Recruitment target", size: "s" },
+        width: 10,
+        inputmode: "numeric" %>
+
+  <%= bfs.govuk_text_field :uplift_fee_per_declaration,
+        label: { text: "Uplift fee per declaration (£)", size: "s" },
+        width: 10,
+        inputmode: "decimal" %>
+
+  <%= bfs.govuk_text_field :monthly_service_fee,
+        label: { text: "Monthly service fee (£, optional)", size: "s" },
+        width: 10,
+        inputmode: "decimal" %>
+
+  <%= bfs.govuk_text_field :setup_fee,
+        label: { text: "Setup fee (£)", size: "s" },
+        width: 10,
+        inputmode: "decimal" %>
+
+  <h3 class="govuk-heading-s">Bands</h3>
+
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">Band</th>
+        <th scope="col" class="govuk-table__header">Min declarations</th>
+        <th scope="col" class="govuk-table__header">Max declarations</th>
+        <th scope="col" class="govuk-table__header">Service fee (%)</th>
+        <th scope="col" class="govuk-table__header">Output fee (%)</th>
+        <th scope="col" class="govuk-table__header">Fee per declaration (£)</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      <% bfs.object.bands.each_with_index do |band, index| %>
+        <%= bfs.fields_for :bands, band do |bf| %>
+          <tr class="govuk-table__row" data-controller="band">
+            <th scope="row" class="govuk-table__header"><%= ("A".ord + index).chr %></th>
+            <td class="govuk-table__cell"><%= band.min_declarations %></td>
+            <td class="govuk-table__cell"><%= band.max_declarations %></td>
+            <td class="govuk-table__cell">
+              <%= bf.text_field :service_fee_percentage,
+                    class: "govuk-input govuk-input--width-5",
+                    inputmode: "numeric",
+                    aria: { label: "Band #{("A".ord + index).chr} service fee percentage" },
+                    data: { band_target: "servicePercentage" } %>
+            </td>
+            <td class="govuk-table__cell">
+              <%= bf.text_field :output_fee_percentage,
+                    class: "govuk-input govuk-input--width-5 #{" govuk-input--error" if bf.object.errors[:output_fee_ratio].any?}",
+                    aria: { label: "Band #{("A".ord + index).chr} output fee percentage" },
+                    inputmode: "decimal",
+                    data: { band_target: "outputPercentage", action: "input->band#updateServiceFee" } %>
+            </td>
+            <td class="govuk-table__cell">
+              <%= bf.text_field :fee_per_declaration,
+                    class: "govuk-input govuk-input--width-10 #{" govuk-input--error" if bf.object.errors[:fee_per_declaration].any?}",
+                    inputmode: "decimal",
+                    aria: { label: "Band #{("A".ord + index).chr} fee per declaration" } %>
+            </td>
+          </tr>
+        <% end %>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/admin/finance/active_lead_providers/contracts/delete.html.erb
+++ b/app/views/admin/finance/active_lead_providers/contracts/delete.html.erb
@@ -1,0 +1,43 @@
+<% contract_path = admin_contract_period_active_lead_provider_contract_path(@active_lead_provider.contract_period, @active_lead_provider, @contract) %>
+
+<% page_data(
+  title: "Delete contract",
+  caption: @active_lead_provider.lead_provider_name,
+  backlink_href: contract_path
+) %>
+
+<%= govuk_summary_list do |summary_list| %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: "Contract type") %>
+    <% row.with_value(text: @contract.contract_type.humanize.upcase) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: "Created") %>
+    <% row.with_value(text: @contract.created_at.to_date.to_fs(:govuk)) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: "Statement period") %>
+    <% row.with_value(text: @contract.statement_range_description) %>
+  <% end %>
+<% end %>
+
+<% if @contract.statements.any? %>
+  <%= govuk_warning_text do %>
+    This contract has statements and cannot be deleted.
+  <% end %>
+
+  <%= govuk_button_link_to "Return to contract", contract_path, secondary: true %>
+<% else %>
+  <%= govuk_warning_text do %>
+    Are you sure you want to delete this contract?<br>
+    This action cannot be undone.
+  <% end %>
+
+  <div class="govuk-button-group">
+    <%= govuk_button_to "Delete contract",
+          admin_contract_period_active_lead_provider_contract_path(@active_lead_provider.contract_period, @active_lead_provider, @contract),
+          method: :delete,
+          warning: true %>
+    <%= govuk_button_link_to "Cancel", contract_path, secondary: true %>
+  </div>
+<% end %>

--- a/app/views/admin/finance/active_lead_providers/contracts/edit.html.erb
+++ b/app/views/admin/finance/active_lead_providers/contracts/edit.html.erb
@@ -1,0 +1,13 @@
+<% page_data(
+  title: "Edit contract",
+  caption: @active_lead_provider.lead_provider_name,
+  error: @contract.errors.present?,
+  backlink_href: admin_contract_period_active_lead_provider_contract_path(@active_lead_provider.contract_period, @active_lead_provider, @contract)
+) %>
+
+<%= form_with model: @contract,
+              url: admin_contract_period_active_lead_provider_contract_path(@active_lead_provider.contract_period, @active_lead_provider, @contract),
+              method: :patch do |f| %>
+  <%= render "fields", form: f %>
+  <%= f.govuk_submit "Save contract" %>
+<% end %>

--- a/app/views/admin/finance/active_lead_providers/contracts/index.html.erb
+++ b/app/views/admin/finance/active_lead_providers/contracts/index.html.erb
@@ -31,8 +31,8 @@
           <% if @active_lead_provider.editable? %>
             <% row.with_cell do %>
               <%= govuk_button_to "Delete",
-                    "#",
-                    method: :delete,
+                    delete_admin_contract_period_active_lead_provider_contract_path(@active_lead_provider.contract_period, @active_lead_provider, contract),
+                    method: :get,
                     secondary: true,
                     disabled: contract.statements.any?,
                     visually_hidden_suffix: contract.contract_type.humanize.upcase,
@@ -47,6 +47,6 @@
 
 <% if @active_lead_provider.editable? %>
   <div class="govuk-!-text-align-right">
-    <%= govuk_button_link_to "Add contract", "#" %>
+    <%= govuk_button_link_to "Add contract", new_admin_contract_period_active_lead_provider_contract_path(@active_lead_provider.contract_period, @active_lead_provider) %>
   </div>
 <% end %>

--- a/app/views/admin/finance/active_lead_providers/contracts/new.html.erb
+++ b/app/views/admin/finance/active_lead_providers/contracts/new.html.erb
@@ -1,0 +1,12 @@
+<% page_data(
+  title: "Add contract",
+  caption: @active_lead_provider.lead_provider_name,
+  error: @contract.errors.present?,
+  backlink_href: admin_contract_period_active_lead_provider_contracts_path(@active_lead_provider.contract_period, @active_lead_provider)
+) %>
+
+<%= form_with model: @contract,
+              url: admin_contract_period_active_lead_provider_contracts_path(@active_lead_provider.contract_period, @active_lead_provider) do |f| %>
+  <%= render "fields", form: f %>
+  <%= f.govuk_submit "Save contract" %>
+<% end %>

--- a/app/views/admin/finance/active_lead_providers/contracts/show.html.erb
+++ b/app/views/admin/finance/active_lead_providers/contracts/show.html.erb
@@ -41,10 +41,10 @@
 
 <% if @contract.editable? %>
   <div class="govuk-button-group govuk-!-margin-top-6">
-    <%= govuk_button_link_to "Edit", "#" %>
+    <%= govuk_button_link_to "Edit", edit_admin_contract_period_active_lead_provider_contract_path(@active_lead_provider.contract_period, @active_lead_provider, @contract) %>
     <%= govuk_button_to "Delete",
-          "#",
-          method: :delete,
+          delete_admin_contract_period_active_lead_provider_contract_path(@active_lead_provider.contract_period, @active_lead_provider, @contract),
+          method: :get,
           secondary: true,
           disabled: @contract.statements.any? %>
   </div>

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -123,7 +123,9 @@ namespace :admin do
               resources :statements, only: %i[index show new create edit update destroy], controller: "active_lead_providers/statements" do
                 member { get :delete }
               end
-              resources :contracts, only: %i[index show], controller: "active_lead_providers/contracts"
+              resources :contracts, only: %i[index show new create edit update destroy], controller: "active_lead_providers/contracts" do
+                member { get :delete }
+              end
               resources :lead_provider_delivery_partnerships, only: %i[index new create destroy], controller: "active_lead_providers/lead_provider_delivery_partnerships" do
                 member { get :delete }
               end

--- a/spec/models/contract/banded_fee_structure/band_term_spec.rb
+++ b/spec/models/contract/banded_fee_structure/band_term_spec.rb
@@ -169,16 +169,21 @@ RSpec.describe Contract::BandedFeeStructure::BandTerm, type: :model do
         banded_fee_structure = FactoryBot.build(:contract_banded_fee_structure, band_terms:)
         FactoryBot.create(:contract, :for_ecf, active_lead_provider:, banded_fee_structure:)
 
-        new_band_term = FactoryBot.build(:contract_banded_fee_structure_band_term, fee_per_declaration: 150, min_declarations: 1, max_declarations: 2)
-        new_banded_fee_structure = FactoryBot.build(:contract_banded_fee_structure, band_terms: [new_band_term])
+        # Create a second contract with an empty banded fee structure so we can test
+        # adding bands to it individually (autosave now prevents creating a contract
+        # with inconsistent bands in a single save).
+        new_banded_fee_structure = FactoryBot.build(:contract_banded_fee_structure)
         FactoryBot.create(:contract, :for_ecf, active_lead_provider:, banded_fee_structure: new_banded_fee_structure)
 
+        new_band_term = FactoryBot.build(:contract_banded_fee_structure_band_term, banded_fee_structure: new_banded_fee_structure, fee_per_declaration: 150, min_declarations: 1, max_declarations: 2)
         expect(new_band_term).to be_invalid
         expect(new_band_term.errors[:base]).to include(/Band at index 0 is inconsistent across statements for the same active lead provider/)
 
         new_band_term.fee_per_declaration = 100
         expect(new_band_term).to be_valid
         new_band_term.save!
+        # Reload so first_band_min_declarations_is_one sees the saved band term rather than the cached empty collection.
+        new_banded_fee_structure.band_terms.reload
 
         new_band_term = FactoryBot.build(:contract_banded_fee_structure_band_term, banded_fee_structure: new_banded_fee_structure, fee_per_declaration: 150, min_declarations: 3, max_declarations: 5)
         expect(new_band_term).to be_invalid

--- a/spec/services/contracts/build_spec.rb
+++ b/spec/services/contracts/build_spec.rb
@@ -1,0 +1,45 @@
+describe Contracts::Build do
+  subject(:service) { described_class.new(active_lead_provider:) }
+
+  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
+
+  describe "#call" do
+    subject(:contract) { service.call }
+
+    it "returns an unpersisted contract for the active lead provider" do
+      expect(contract).not_to be_persisted
+      expect(contract.active_lead_provider).to eq(active_lead_provider)
+    end
+
+    it "builds a flat_rate_fee_structure" do
+      expect(contract.flat_rate_fee_structure).to be_present
+    end
+
+    context "when the active lead provider has no existing contracts with bands" do
+      it "builds a single empty band" do
+        expect(contract.banded_fee_structure.bands.size).to eq(1)
+      end
+    end
+
+    context "when the active lead provider has an existing contract with bands" do
+      let!(:existing_contract) { FactoryBot.create(:contract, active_lead_provider:) }
+
+      it "seeds bands from the existing contract's band structure" do
+        existing_bands = existing_contract.banded_fee_structure.bands
+        built_bands = contract.banded_fee_structure.bands
+
+        expect(built_bands.size).to eq(existing_bands.size)
+
+        existing_bands.each_with_index do |existing_band, i|
+          expect(built_bands[i]).to have_attributes(
+            min_declarations: existing_band.min_declarations,
+            max_declarations: existing_band.max_declarations,
+            fee_per_declaration: existing_band.fee_per_declaration,
+            output_fee_ratio: existing_band.output_fee_ratio,
+            service_fee_ratio: existing_band.service_fee_ratio
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/services/contracts/create_spec.rb
+++ b/spec/services/contracts/create_spec.rb
@@ -1,0 +1,41 @@
+describe Contracts::Create do
+  subject(:service) { described_class.new(author:, active_lead_provider:, params:) }
+
+  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
+  let(:user) { FactoryBot.create(:user, :admin) }
+  let(:author) { Sessions::Users::DfEPersona.new(email: user.email) }
+  let(:params) do
+    {
+      contract_type: "ittecf_ectp",
+      ecf_contract_version: "1",
+      ecf_mentor_contract_version: "2",
+      banded_fee_structure_attributes: {
+        recruitment_target: 1_000,
+        uplift_fee_per_declaration: 50,
+        monthly_service_fee: 5_000,
+        setup_fee: 10_000,
+        bands_attributes: [
+          { min_declarations: 1, max_declarations: 100, fee_per_declaration: 200, output_fee_ratio: 0.75, service_fee_ratio: 0.25 },
+        ],
+      },
+      flat_rate_fee_structure_attributes: {
+        recruitment_target: 500,
+        fee_per_declaration: 100,
+      },
+    }
+  end
+
+  before { allow(Events::Record).to receive(:record_contract_created_event!) }
+
+  it "creates and returns a contract for the active lead provider, and records the created event" do
+    contract = nil
+    expect { contract = service.call }.to change(Contract, :count).by(1)
+
+    expect(contract).to be_persisted
+    expect(contract.active_lead_provider).to eq(active_lead_provider)
+    expect(contract.banded_fee_structure).to have_attributes(recruitment_target: 1_000)
+    expect(contract.banded_fee_structure.bands.size).to eq(1)
+    expect(contract.flat_rate_fee_structure).to have_attributes(recruitment_target: 500)
+    expect(Events::Record).to have_received(:record_contract_created_event!).with(author:, contract:)
+  end
+end

--- a/spec/services/contracts/destroy_spec.rb
+++ b/spec/services/contracts/destroy_spec.rb
@@ -1,0 +1,32 @@
+describe Contracts::Destroy do
+  subject(:service) { described_class.new(author:, contract:) }
+
+  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
+  let(:contract) { FactoryBot.create(:contract, active_lead_provider:) }
+  let(:user) { FactoryBot.create(:user, :admin) }
+  let(:author) { Sessions::Users::DfEPersona.new(email: user.email) }
+
+  before { allow(Events::Record).to receive(:record_contract_deleted_event!) }
+
+  it "destroys the contract, its banded fee structure and bands, and records the deleted event" do
+    banded_fee_structure_id = contract.banded_fee_structure.id
+    band_ids = contract.banded_fee_structure.bands.pluck(:id)
+
+    service.call
+
+    expect(Contract).not_to exist(contract.id)
+    expect(Contract::BandedFeeStructure).not_to exist(banded_fee_structure_id)
+    expect(Contract::BandedFeeStructure::Band.where(id: band_ids)).not_to exist
+    expect(Events::Record).to have_received(:record_contract_deleted_event!).with(author:, active_lead_provider:)
+  end
+
+  context "when the contract has statements" do
+    before { FactoryBot.create(:statement, contract:, active_lead_provider:) }
+
+    it "raises a DeletionError and does not destroy the contract" do
+      expect { service.call }.to raise_error(Contracts::Destroy::DeletionError, "Cannot delete a contract that has statements")
+
+      expect(Contract).to exist(contract.id)
+    end
+  end
+end

--- a/spec/services/contracts/update_spec.rb
+++ b/spec/services/contracts/update_spec.rb
@@ -1,0 +1,31 @@
+describe Contracts::Update do
+  subject(:service) { described_class.new(author:, contract:, params:) }
+
+  let(:contract) { FactoryBot.create(:contract) }
+  let(:user) { FactoryBot.create(:user, :admin) }
+  let(:author) { Sessions::Users::DfEPersona.new(email: user.email) }
+  let(:params) do
+    {
+      ecf_contract_version: "updated-version",
+      banded_fee_structure_attributes: {
+        id: contract.banded_fee_structure.id,
+        recruitment_target: 9_999,
+      },
+    }
+  end
+
+  before { allow(Events::Record).to receive(:record_contract_updated_event!) }
+
+  it "updates the contract and its nested fee structures, records the updated event with modifications, and returns the contract" do
+    result = service.call
+
+    expect(result).to eq(contract)
+    expect(result.ecf_contract_version).to eq("updated-version")
+    expect(result.banded_fee_structure.recruitment_target).to eq(9_999)
+    expect(Events::Record).to have_received(:record_contract_updated_event!).with(
+      author:,
+      contract:,
+      modifications: include("ecf_contract_version")
+    )
+  end
+end


### PR DESCRIPTION
### Context

Resolves https://github.com/DFE-Digital/register-ects-project-board/issues/4050

### Changes proposed in this pull request

Create, update, and delete **Contracts** for a given **ActiveLeadProvider**.

#### Big create / edit form:

<img width="638" height="1167" alt="Screenshot 2026-06-24 at 15 27 32" src="https://github.com/user-attachments/assets/b9c49e96-d9be-4017-a960-6fb3b9591771" />


### Guidance to review

* Standard Rails controller, accepts nested attributes for **FlatRateFeeStructure** and **BandedFeeStructure** and **Bands** (or what will become **BandTerms** when that PR comes in).
* Currently attempts to default to any existing **Band** structure, this will go away when the **ActiveLeadProvider::Band** is implemented. We can also then check that the **ActiveLeadProvider** is `banded?` as a pre-requisite for setting up a **Contract**.