### PR TITLE
[3404] Support future EOI contract period changes (Slice 7)

### DIFF
--- a/app/services/admin/teachers/training_periods/change_contract_period/eligibility.rb
+++ b/app/services/admin/teachers/training_periods/change_contract_period/eligibility.rb
@@ -14,14 +14,9 @@ module Admin
             return false if finished_before_today?
             return false if blocked_by_current_active_period?
 
-            if eoi_only?
-              return current_active_period? if no_future_periods?
-
-              return false
-            end
-
             return current_active_period? if no_future_periods?
             return only_future_period? if no_current_active_period?
+            return future_period? if eoi_only?
 
             future_period? && same_partnership_as_current_active_period?
           end

--- a/app/services/admin/teachers/training_periods/change_contract_period/eligibility.rb
+++ b/app/services/admin/teachers/training_periods/change_contract_period/eligibility.rb
@@ -14,11 +14,14 @@ module Admin
             return false if finished_before_today?
             return false if blocked_by_current_active_period?
 
-            return current_active_period? if no_future_periods?
-            return only_future_period? if no_current_active_period?
-            return future_period? if eoi_only?
-
-            future_period? && same_partnership_as_current_active_period?
+            case future_periods.count
+            when 0
+              current_active_period?
+            when 1
+              single_future_period_changeable?
+            else
+              false
+            end
           end
 
         private
@@ -48,20 +51,17 @@ module Admin
             current_active_period == training_period
           end
 
-          def no_future_periods?
-            future_periods.empty?
-          end
-
           def no_current_active_period?
             current_active_period.blank?
           end
 
-          def only_future_period?
+          def training_period_is_the_only_future_period?
             future_periods == [training_period]
           end
 
-          def future_period?
-            future_periods.include?(training_period)
+          def single_future_period_changeable?
+            training_period_is_the_only_future_period? &&
+              (no_current_active_period? || eoi_only? || same_partnership_as_current_active_period?)
           end
 
           def same_partnership_as_current_active_period?

--- a/app/services/admin/teachers/training_periods/change_contract_period/future_period.rb
+++ b/app/services/admin/teachers/training_periods/change_contract_period/future_period.rb
@@ -5,6 +5,7 @@ module Admin
         class FuturePeriod
           class UnsupportedTrainingPeriodError < StandardError; end
           class ScheduleNotFoundError < StandardError; end
+          class ActiveLeadProviderNotFoundError < StandardError; end
 
           attr_reader :training_period, :contract_period, :school_partnership, :author
 
@@ -26,13 +27,15 @@ module Admin
                     "No equivalent schedule found for #{training_period.schedule.identifier} in contract period #{contract_period.year}"
             end
 
+            if training_period.only_expression_of_interest? && equivalent_active_lead_provider.blank?
+              raise ActiveLeadProviderNotFoundError,
+                    "No active lead provider found for #{training_period.expression_of_interest_lead_provider.name} in contract period #{contract_period.year}"
+            end
+
             ActiveRecord::Base.transaction do
               previous_contract_period = current_contract_period
 
-              training_period.update!(
-                school_partnership:,
-                schedule: equivalent_schedule
-              )
+              training_period.update!(training_period_attributes)
 
               record_contract_period_changed_event!(from_contract_period: previous_contract_period)
               training_period
@@ -53,8 +56,37 @@ module Admin
             )
           end
 
+          def training_period_attributes
+            {
+              school_partnership: replacement_school_partnership,
+              schedule: equivalent_schedule,
+              **expression_of_interest_attributes
+            }
+          end
+
+          def replacement_school_partnership
+            return if training_period.only_expression_of_interest?
+
+            school_partnership
+          end
+
+          def expression_of_interest_attributes
+            return {} unless training_period.only_expression_of_interest?
+
+            { expression_of_interest: equivalent_active_lead_provider }
+          end
+
+          def equivalent_active_lead_provider
+            return unless training_period.only_expression_of_interest?
+
+            @equivalent_active_lead_provider ||= ActiveLeadProvider.find_by(
+              lead_provider: training_period.expression_of_interest_lead_provider,
+              contract_period:
+            )
+          end
+
           def current_contract_period
-            @current_contract_period ||= training_period.contract_period
+            @current_contract_period ||= training_period.contract_period || training_period.expression_of_interest_contract_period
           end
 
           def record_contract_period_changed_event!(from_contract_period:)

--- a/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/check_answers_step.rb
+++ b/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/check_answers_step.rb
@@ -23,7 +23,8 @@ module Admin
                  FuturePeriodChange::ScheduleNotFoundError
             errors.add(:base, "A matching schedule could not be found for the selected contract period")
             false
-          rescue CurrentActivePeriodChange::ActiveLeadProviderNotFoundError
+          rescue CurrentActivePeriodChange::ActiveLeadProviderNotFoundError,
+                 FuturePeriodChange::ActiveLeadProviderNotFoundError
             errors.add(:base, "An active lead provider could not be found for the selected contract period")
             false
           end

--- a/spec/requests/admin/teachers/training_periods/change_contract_period_wizard_spec.rb
+++ b/spec/requests/admin/teachers/training_periods/change_contract_period_wizard_spec.rb
@@ -50,6 +50,18 @@ RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardCont
       started_on: today.prev_month
     )
   end
+  let(:future_eoi_only_training_period) do
+    FactoryBot.create(
+      :training_period,
+      :ongoing,
+      :with_only_expression_of_interest,
+      ect_at_school_period:,
+      expression_of_interest: active_lead_provider,
+      schedule:,
+      started_on: today.next_month,
+      finished_on: nil
+    )
+  end
   let(:training_period) do
     FactoryBot.create(
       :training_period,
@@ -220,6 +232,19 @@ RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardCont
         expect(response).to redirect_to(path_for_step("check-answers"))
       end
     end
+
+    context "when the future period only has an expression of interest" do
+      let(:training_period) { future_eoi_only_training_period }
+
+      it "redirects to check answers" do
+        post(
+          path_for_step("select-contract-period"),
+          params: { select_contract_period: { contract_period_year: target_contract_period.year } }
+        )
+
+        expect(response).to redirect_to(path_for_step("check-answers"))
+      end
+    end
   end
 
   describe "GET select-partnership" do
@@ -336,6 +361,24 @@ RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardCont
         expect(page).to have_summary_list_row("Existing contract period", value: current_contract_period.year.to_s)
         expect(page).to have_summary_list_row("New contract period", value: target_contract_period.year.to_s)
         expect(page).to have_summary_list_row("Lead provider", value: "Target Lead Provider")
+        expect(page).to have_summary_list_row("Delivery partner", value: "No delivery partner confirmed")
+      end
+    end
+
+    context "when the future period only has an expression of interest" do
+      let(:eoi_lead_provider) { FactoryBot.create(:lead_provider, name: "Target Lead Provider") }
+      let(:training_period) { future_eoi_only_training_period }
+
+      it "renders the CYA page after the contract period has been selected" do
+        post(
+          path_for_step("select-contract-period"),
+          params: { select_contract_period: { contract_period_year: target_contract_period.year } }
+        )
+
+        get path_for_step("check-answers")
+        page = Capybara.string(response.body)
+
+        expect(response).to have_http_status(:ok)
         expect(page).to have_summary_list_row("Delivery partner", value: "No delivery partner confirmed")
       end
     end
@@ -465,6 +508,41 @@ RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardCont
         follow_redirect!
 
         expect(response.body).to include("Contract period changed")
+      end
+
+      context "when the future period only has an expression of interest" do
+        let(:training_period) { future_eoi_only_training_period }
+        let(:future_eoi_only_training_period) do
+          FactoryBot.create(
+            :training_period,
+            :ongoing,
+            :with_only_expression_of_interest,
+            ect_at_school_period: future_ect_at_school_period,
+            expression_of_interest: active_lead_provider,
+            schedule:,
+            started_on: future_started_on,
+            finished_on: nil
+          )
+        end
+
+        it "applies the contract period change in place and redirects to the training tab" do
+          target_schedule
+
+          post(
+            path_for_step("select-contract-period"),
+            params: { select_contract_period: { contract_period_year: target_contract_period.year } }
+          )
+
+          expect {
+            post path_for_step("check-answers"), params: { check_answers: {} }
+          }.not_to change(TrainingPeriod, :count)
+
+          expect(response).to redirect_to(admin_teacher_training_path(teacher))
+          training_period.reload
+
+          expect(training_period.school_partnership).to be_nil
+          expect(training_period.expression_of_interest).to eq(target_active_lead_provider)
+        end
       end
     end
   end

--- a/spec/services/admin/teachers/training_periods/change_contract_period/eligibility_spec.rb
+++ b/spec/services/admin/teachers/training_periods/change_contract_period/eligibility_spec.rb
@@ -115,6 +115,8 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriod::Eligibili
 
   context "when there are current and future EOI only periods" do
     let(:future_started_on) { today.next_month }
+    let(:future_finished_on) { nil }
+    let(:future_at_school_period_finished_on) { nil }
     let(:finished_on) { future_started_on.yesterday }
 
     let(:training_period) { eoi_only_training_period }
@@ -128,11 +130,11 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriod::Eligibili
           teacher:,
           school:,
           started_on: future_started_on,
-          finished_on: nil
+          finished_on: future_at_school_period_finished_on
         ),
         expression_of_interest: training_period.expression_of_interest,
         started_on: future_started_on,
-        finished_on: nil
+        finished_on: future_finished_on
       )
     end
 
@@ -142,6 +144,34 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriod::Eligibili
 
     it "makes the future period eligible" do
       expect(described_class.new(training_period: future_training_period)).to be_eligible
+    end
+
+    context "when there is more than one future period" do
+      let(:second_future_started_on) { future_started_on.next_month }
+      let(:future_finished_on) { second_future_started_on.yesterday }
+      let(:future_at_school_period_finished_on) { second_future_started_on.yesterday }
+      let!(:second_future_training_period) do
+        FactoryBot.create(
+          :training_period,
+          :with_only_expression_of_interest,
+          ect_at_school_period: FactoryBot.create(
+            :ect_at_school_period,
+            teacher:,
+            school:,
+            started_on: second_future_started_on,
+            finished_on: nil
+          ),
+          expression_of_interest: training_period.expression_of_interest,
+          started_on: second_future_started_on,
+          finished_on: nil
+        )
+      end
+
+      it "does not make any related periods eligible" do
+        expect(eligibility).not_to be_eligible
+        expect(described_class.new(training_period: future_training_period)).not_to be_eligible
+        expect(described_class.new(training_period: second_future_training_period)).not_to be_eligible
+      end
     end
   end
 
@@ -184,7 +214,7 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriod::Eligibili
     let(:second_future_started_on) { started_on.next_month }
     let(:finished_on) { second_future_started_on.yesterday }
 
-    before do
+    let!(:second_future_training_period) do
       FactoryBot.create(
         :training_period,
         ect_at_school_period: FactoryBot.create(
@@ -200,8 +230,9 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriod::Eligibili
       )
     end
 
-    it "is not eligible" do
+    it "does not make either future period eligible" do
       expect(eligibility).not_to be_eligible
+      expect(described_class.new(training_period: second_future_training_period)).not_to be_eligible
     end
   end
 
@@ -220,6 +251,32 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriod::Eligibili
 
     it "does not make the current active period eligible" do
       expect(described_class.new(training_period: current_training_period)).not_to be_eligible
+    end
+
+    context "when there is more than one future period" do
+      let(:second_future_started_on) { started_on.next_month }
+      let(:finished_on) { second_future_started_on.yesterday }
+      let!(:second_future_training_period) do
+        FactoryBot.create(
+          :training_period,
+          ect_at_school_period: FactoryBot.create(
+            :ect_at_school_period,
+            teacher:,
+            school:,
+            started_on: second_future_started_on,
+            finished_on: nil
+          ),
+          school_partnership:,
+          started_on: second_future_started_on,
+          finished_on: nil
+        )
+      end
+
+      it "does not make any related periods eligible" do
+        expect(eligibility).not_to be_eligible
+        expect(described_class.new(training_period: current_training_period)).not_to be_eligible
+        expect(described_class.new(training_period: second_future_training_period)).not_to be_eligible
+      end
     end
   end
 

--- a/spec/services/admin/teachers/training_periods/change_contract_period/eligibility_spec.rb
+++ b/spec/services/admin/teachers/training_periods/change_contract_period/eligibility_spec.rb
@@ -53,6 +53,15 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriod::Eligibili
       finished_on:
     )
   end
+  let(:eoi_only_training_period) do
+    FactoryBot.create(
+      :training_period,
+      :with_only_expression_of_interest,
+      ect_at_school_period:,
+      started_on:,
+      finished_on:
+    )
+  end
   let(:current_ect_at_school_period) do
     FactoryBot.create(
       :ect_at_school_period,
@@ -97,44 +106,42 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriod::Eligibili
   end
 
   context "when the training period only has an expression of interest" do
-    let(:training_period) do
-      FactoryBot.create(
-        :training_period,
-        :with_only_expression_of_interest,
-        ect_at_school_period:,
-        started_on:,
-        finished_on:
-      )
-    end
+    let(:training_period) { eoi_only_training_period }
 
     it "is eligible" do
       expect(eligibility).to be_eligible
     end
+  end
 
-    context "when there is a future period" do
-      let(:future_started_on) { today.next_month }
-      let(:finished_on) { future_started_on.yesterday }
+  context "when there are current and future EOI only periods" do
+    let(:future_started_on) { today.next_month }
+    let(:finished_on) { future_started_on.yesterday }
 
-      before do
-        FactoryBot.create(
-          :training_period,
-          :with_only_expression_of_interest,
-          ect_at_school_period: FactoryBot.create(
-            :ect_at_school_period,
-            teacher:,
-            school:,
-            started_on: future_started_on,
-            finished_on: nil
-          ),
-          expression_of_interest: training_period.expression_of_interest,
+    let(:training_period) { eoi_only_training_period }
+
+    let!(:future_training_period) do
+      FactoryBot.create(
+        :training_period,
+        :with_only_expression_of_interest,
+        ect_at_school_period: FactoryBot.create(
+          :ect_at_school_period,
+          teacher:,
+          school:,
           started_on: future_started_on,
           finished_on: nil
-        )
-      end
+        ),
+        expression_of_interest: training_period.expression_of_interest,
+        started_on: future_started_on,
+        finished_on: nil
+      )
+    end
 
-      it "is not eligible" do
-        expect(eligibility).not_to be_eligible
-      end
+    it "does not make the current period eligible" do
+      expect(eligibility).not_to be_eligible
+    end
+
+    it "makes the future period eligible" do
+      expect(described_class.new(training_period: future_training_period)).to be_eligible
     end
   end
 

--- a/spec/services/admin/teachers/training_periods/change_contract_period/future_period_spec.rb
+++ b/spec/services/admin/teachers/training_periods/change_contract_period/future_period_spec.rb
@@ -122,6 +122,76 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriod::FuturePer
     end
   end
 
+  context "when the future training period only has an expression of interest" do
+    let(:target_school_partnership) { nil }
+    let(:current_active_lead_provider) do
+      FactoryBot.create(:active_lead_provider, contract_period: current_contract_period)
+    end
+    let!(:target_active_lead_provider) do
+      FactoryBot.create(:active_lead_provider, lead_provider: current_active_lead_provider.lead_provider, contract_period: target_contract_period)
+    end
+    let!(:current_training_period) do
+      FactoryBot.create(
+        :training_period,
+        :with_only_expression_of_interest,
+        ect_at_school_period: current_ect_at_school_period,
+        expression_of_interest: current_active_lead_provider,
+        schedule:,
+        started_on: today.prev_month,
+        finished_on: future_started_on.yesterday
+      )
+    end
+    let!(:training_period) do
+      FactoryBot.create(
+        :training_period,
+        :with_only_expression_of_interest,
+        ect_at_school_period: future_ect_at_school_period,
+        expression_of_interest: current_active_lead_provider,
+        schedule:,
+        started_on: future_started_on,
+        finished_on: future_finished_on
+      )
+    end
+
+    it "updates the future training period in place with the equivalent active lead provider" do
+      expect {
+        service_call
+      }
+        .to not_change(TrainingPeriod, :count)
+        .and change { Event.where(event_type: "teacher_training_period_contract_period_changed").count }.by(1)
+
+      event = Event.where(event_type: "teacher_training_period_contract_period_changed").sole
+
+      expect(training_period.reload).to have_attributes(
+        teacher_id: teacher.id,
+        ect_at_school_period_id: future_ect_at_school_period.id,
+        mentor_at_school_period_id: nil,
+        started_on: future_started_on,
+        finished_on: future_finished_on
+      )
+      expect(training_period.school_partnership).to be_nil
+      expect(training_period.expression_of_interest).to eq(target_active_lead_provider)
+      expect(training_period.expression_of_interest_contract_period).to eq(target_contract_period)
+      expect(training_period.schedule).to eq(target_schedule)
+      expect(event.contract_period).to eq(current_contract_period)
+      expect(event.metadata["new_training_period_id"]).to eq(training_period.id)
+      expect(event.metadata["to_contract_period_id"]).to eq(target_contract_period.id)
+    end
+
+    context "when there is no equivalent active lead provider in the selected contract period" do
+      let!(:target_active_lead_provider) { nil }
+
+      it "raises an active lead provider not found error" do
+        expect {
+          service_call
+        }.to raise_error(
+          described_class::ActiveLeadProviderNotFoundError,
+          "No active lead provider found for #{current_active_lead_provider.lead_provider.name} in contract period #{target_contract_period.year}"
+        )
+      end
+    end
+  end
+
   context "when the future training period has a different LP/DP from the current active period" do
     let(:other_delivery_partner) { FactoryBot.create(:delivery_partner) }
     let(:current_school_partnership) do

--- a/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/check_answers_step_spec.rb
+++ b/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/check_answers_step_spec.rb
@@ -79,6 +79,19 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Che
           expect(step.errors[:base]).to include("A matching schedule could not be found for the selected contract period")
         end
       end
+
+      context "when the training period has no equivalent active lead provider" do
+        before do
+          allow(change_service).to receive(:change_contract_period!).and_raise(
+            service_class::ActiveLeadProviderNotFoundError
+          )
+        end
+
+        it "adds an active lead provider error" do
+          expect(step.save!).to be(false)
+          expect(step.errors[:base]).to include("An active lead provider could not be found for the selected contract period")
+        end
+      end
     end
 
     context "when using the current active period change service" do


### PR DESCRIPTION
## What

Following on from #3136, this is the 7th slice of the contract period change journey for admins.

This introduces the following for EOI only training periods:

- eligibility
- future period mutation support
- updating the EOI to the equivalent active lead provider in the selected contract period
- keeping the training period EOI only, with no school partnership selected
- check answers handling for missing equivalent active lead providers

## Not included

This PR does not:

- display the change link on the training tab
- change the no partnerships journey
- allow changing lead provider or delivery partner through this journey
- change current active mutation behaviour