### PR TITLE
[4031] Part 4 - Retire old database fields

### DIFF
--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -330,8 +330,6 @@
   - id
   - banded_fee_structure_id
   - band_id
-  - min_declarations # DEPRECATE
-  - max_declarations # DEPRECATE
   - fee_per_declaration
   - output_fee_ratio
   - service_fee_ratio

--- a/db/migrate/20260624144629_drop_banded_structure_band_term_min_max.rb
+++ b/db/migrate/20260624144629_drop_banded_structure_band_term_min_max.rb
@@ -1,0 +1,8 @@
+class DropBandedStructureBandTermMinMax < ActiveRecord::Migration[8.1]
+  def change
+    change_table :contract_banded_fee_structure_band_terms, bulk: true do |t|
+      t.remove :min_declarations, type: :integer
+      t.remove :max_declarations, type: :integer
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -161,8 +161,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_02_065431) do
     t.bigint "banded_fee_structure_id", null: false
     t.datetime "created_at", null: false
     t.decimal "fee_per_declaration", precision: 12, scale: 2, null: false
-    t.integer "max_declarations"
-    t.integer "min_declarations", default: 1, null: false
     t.decimal "output_fee_ratio", precision: 3, scale: 2, null: false
     t.decimal "service_fee_ratio", precision: 3, scale: 2, null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/4031

[Band modelling](https://github.com/DFE-Digital/register-ects-project-board/issues/4031)

- [part 1](https://github.com/DFE-Digital/register-early-career-teachers-public/pull/3080)
- [part 2](https://github.com/DFE-Digital/register-early-career-teachers-public/pull/3115)
- [part 3](https://github.com/DFE-Digital/register-early-career-teachers-public/pull/3131)
- part 4 (this PR)
- [part 5](https://github.com/DFE-Digital/register-early-career-teachers-public/pull/3178)

### Changes proposed in this pull request

The data has been migrated in part 1, reconnected in part 3 and can now be removed.

⚠️ **NB: This PR is destructive.**

### Guidance to review

Calculators should be functioning and reports/statements displaying correct values using the ALP bands min/max values.