### PR TITLE
Restore print hiding for shared footer

### DIFF
--- a/app/views/layouts/shared/_page.html.erb
+++ b/app/views/layouts/shared/_page.html.erb
@@ -24,6 +24,8 @@
       </main>
     </div>
 
-    <%= render partial: "layouts/shared/footer" %>
+    <div class="govuk-!-display-none-print">
+      <%= render partial: "layouts/shared/footer" %>
+    </div>
   </body>
 <% end %>


### PR DESCRIPTION
## Summary

Restores the print hidden wrapper around the shared footer so footer links and session details do not appear when printing or saving financial statements as a PDF.

This was lost during the layout refactor that moved common layout markup into `layouts/shared/_page`.


| Before | After |
|--------|-------|
|<img width="530" height="667" alt="image" src="https://github.com/user-attachments/assets/21d3b624-e39b-4f75-97bc-9f42396f0578" />|<img width="504" height="674" alt="image" src="https://github.com/user-attachments/assets/0266f1ae-a49b-46ee-ab36-eefa16048c3f" />|

