### PR TITLE
Format UUIDs consistently in the admin section

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -194,14 +194,23 @@ $_current-link-border-width: govuk-spacing(1);
   overflow-wrap: break-word;
 }
 
-.app-mono {
-  padding: 2px 5px;
-  font-family: monospace;
-  background-color: $govuk-template-background-colour;
-  white-space: pre-wrap;
-}
-
 .govuk-table__row--no-border > th,
 .govuk-table__row--no-border > td {
   border-bottom: 0;
+}
+
+code {
+  background: $govuk-template-background-colour;
+  padding-inline: .4rem;
+}
+
+pre {
+  background: $govuk-template-background-colour;
+  white-space: pre-wrap;
+  @include govuk-font($size: 16);
+
+  code {
+    background: inherit;
+    padding-inline: initial;
+  }
 }

--- a/app/assets/stylesheets/admin/teachers.scss
+++ b/app/assets/stylesheets/admin/teachers.scss
@@ -1,13 +1,5 @@
 @use "govuk-frontend/dist/govuk" as *;
 
-.app-code {
-  padding: 2px 5px;
-  font-family: monospace;
-  background-color: $govuk-template-background-colour;
-  white-space: pre-wrap;
-  font-size: 0.8em;
-}
-
 .app-teachers-filters {
   @include govuk-media-query($from: tablet) {
     align-items: flex-end;

--- a/app/components/admin/appropriate_bodies/details_component.html.erb
+++ b/app/components/admin/appropriate_bodies/details_component.html.erb
@@ -22,7 +22,7 @@
 
     sl.with_row do |row|
       row.with_key(text: 'DfE Sign-in organisation ID')
-      row.with_value(text: tag.code(appropriate_body.dfe_sign_in_organisation_id))
+      row.with_value(text: helpers.format_uuid(appropriate_body.dfe_sign_in_organisation_id))
       row.with_action(
         text: 'View',
         href: admin_dsi_org_path(appropriate_body.dfe_sign_in_organisation.uuid),

--- a/app/components/admin/schools/partnerships_summary_component.html.erb
+++ b/app/components/admin/schools/partnerships_summary_component.html.erb
@@ -27,7 +27,7 @@
 
           <% list.with_row do |row| %>
             <% row.with_key(text: "Partnership API ID") %>
-            <% row.with_value { school_partnership.api_id } %>
+            <% row.with_value { helpers.format_uuid(school_partnership.api_id) } %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/components/admin/teachers/overview_summary_component.rb
+++ b/app/components/admin/teachers/overview_summary_component.rb
@@ -71,7 +71,7 @@ module Admin
       end
 
       def api_participant_id_row
-        { key: "API participant ID", value: content_tag(:code, teacher.api_participant_id, class: "app-code") }
+        { key: "API participant ID", value: helpers.format_uuid(teacher.api_participant_id) }
       end
 
       def current_school_value

--- a/app/components/admin/teachers/training_summary_component.rb
+++ b/app/components/admin/teachers/training_summary_component.rb
@@ -140,9 +140,7 @@ module Admin
 
       def api_response_text
         govuk_details(summary_text: "See this participant as they appear over the API for #{lead_provider&.name}") do
-          content_tag(:pre, class: "app-code") do
-            content_tag(:code, formatted_teacher)
-          end
+          tag.pre { tag.code(formatted_teacher) }
         end
       end
 

--- a/app/components/schools/ects/listing_card_component.rb
+++ b/app/components/schools/ects/listing_card_component.rb
@@ -169,7 +169,7 @@ module Schools
             text: safe_join(
               [
                 govuk_tag(text: tag_text, colour:),
-                content_tag(:p, message, class: "govuk-body govuk-!-margin-top-2")
+                tag.p(message, class: "govuk-body govuk-!-margin-top-2")
               ]
             )
           }

--- a/app/components/shared/top_search_component.rb
+++ b/app/components/shared/top_search_component.rb
@@ -19,7 +19,7 @@ module Shared
     def call
       form_with(method: :get, url: form_url, html: { class: "app-search-form" }) do |f|
         safe_join([
-          content_tag(:div, class: "govuk-form-group") do
+          tag.div(class: "govuk-form-group") do
             f.govuk_text_field(
               query_param,
               value: search_value,

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -48,4 +48,10 @@ module AdminHelper
 
     User::ROLES.map { |k, v| role_option.new(identifier: k, name: v) }
   end
+
+  def format_uuid(uuid)
+    return if uuid.blank?
+
+    tag.code(uuid)
+  end
 end

--- a/app/views/admin/delivery_partners/show.html.erb
+++ b/app/views/admin/delivery_partners/show.html.erb
@@ -1,11 +1,11 @@
 <% page_data(title: @delivery_partner.name, breadcrumbs: @breadcrumbs, backlink_href: admin_delivery_partners_path(page: @page, q: @q)) %>
 
-<p class='govuk-body'>
+<p class="govuk-body">
   <%= govuk_link_to('Change delivery partner name', edit_admin_delivery_partner_path(@delivery_partner)) %>
 </p>
 
-<p class='govuk-body'>
-  API ID: <span class="govuk-body app-mono"><%= @delivery_partner.api_id %></span>
+<p class="govuk-body">
+  API ID: <%= format_uuid(@delivery_partner.api_id) %>
 </p>
 
 <%= render(Admin::LeadProviderPartnershipsTableComponent.new(

--- a/app/views/admin/finance/voids/new.html.erb
+++ b/app/views/admin/finance/voids/new.html.erb
@@ -9,7 +9,7 @@
       govuk_summary_list(actions: false) do |summary_list|
         summary_list.with_row do |row|
           row.with_key { "Declaration ID" }
-          row.with_value { tag.span(@declaration.api_id, class: "app-mono") }
+          row.with_value { format_uuid(@declaration.api_id) }
         end
 
         summary_list.with_row do |row|

--- a/app/views/admin/finance/voids/new.html.erb
+++ b/app/views/admin/finance/voids/new.html.erb
@@ -14,12 +14,12 @@
 
         summary_list.with_row do |row|
           row.with_key { "Course identifier" }
-          row.with_value { tag.span(declaration_course_identifier(@declaration), class: "app-mono") }
+          row.with_value { tag.code(declaration_course_identifier(@declaration)) }
         end
 
         summary_list.with_row do |row|
           row.with_key { "Declaration type" }
-          row.with_value { tag.span(@declaration.declaration_type, class: "app-mono") }
+          row.with_value { tag.code(@declaration.declaration_type) }
         end
 
         summary_list.with_row do |row|
@@ -44,7 +44,11 @@
 
         summary_list.with_row do |row|
           row.with_key { "Evidence held" }
-          row.with_value { tag.span(@declaration.evidence_type, class: "app-mono") }
+          row.with_value do
+            if @declaration.evidence_type.present?
+              tag.code(@declaration.evidence_type)
+            end
+          end
         end
       end
     %>

--- a/app/views/admin/teachers/declarations/_declaration.html.erb
+++ b/app/views/admin/teachers/declarations/_declaration.html.erb
@@ -1,7 +1,7 @@
 <%= govuk_details do |details| %>
   <% details.with_summary_html do %>
     <span class="govuk-details__summary-text govuk-!-margin-right-2"><%= declaration.declaration_type %></span>
-    <span class="govuk-body app-mono"><%= declaration.api_id %></span>
+    <%= format_uuid(declaration.api_id) %>
     <%= declaration_state_tag(declaration) %>
   <% end %>
 

--- a/app/views/admin/teachers/declarations/_declaration.html.erb
+++ b/app/views/admin/teachers/declarations/_declaration.html.erb
@@ -9,17 +9,17 @@
     govuk_summary_list(actions: false, classes: "govuk-!-margin-bottom-0") do |summary_list|
       summary_list.with_row do |row|
         row.with_key { "Declaration ID" }
-        row.with_value { tag.span(declaration.api_id, class: "govuk-!-margin-0 app-mono") }
+        row.with_value { format_uuid(declaration.api_id) }
       end
 
       summary_list.with_row do |row|
         row.with_key { "Course identifier" }
-        row.with_value { tag.span(declaration_course_identifier(declaration), class: "govuk-!-margin-0 app-mono") }
+        row.with_value { tag.code(declaration_course_identifier(declaration)) }
       end
 
       summary_list.with_row do |row|
         row.with_key { "Declaration type" }
-        row.with_value { tag.span(declaration.declaration_type, class: "govuk-!-margin-0 app-mono") }
+        row.with_value { tag.code(declaration.declaration_type) }
       end
 
       summary_list.with_row do |row|
@@ -44,7 +44,7 @@
 
       summary_list.with_row do |row|
         row.with_key { "Evidence held" }
-        row.with_value { tag.span(declaration.evidence_type, class: "govuk-!-margin-0 app-mono") }
+        row.with_value { tag.code(declaration.evidence_type) }
       end
     end
   %>

--- a/spec/components/admin/teachers/overview_summary_component_spec.rb
+++ b/spec/components/admin/teachers/overview_summary_component_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Admin::Teachers::OverviewSummaryComponent, type: :component do
     end
 
     it "shows the API participant ID in a code block" do
-      expect(rendered.css("code.app-code").text).to eq(teacher.api_id)
+      expect(rendered.css("code").text).to eq(teacher.api_id)
     end
   end
 

--- a/spec/helpers/admin_helper_spec.rb
+++ b/spec/helpers/admin_helper_spec.rb
@@ -35,4 +35,18 @@ describe AdminHelper do
       expect(timeline[:current]).to be(true)
     end
   end
+
+  describe "#format_uuid" do
+    it "wraps the input in code tags" do
+      uuid = SecureRandom.uuid
+
+      expect(format_uuid(uuid)).to eql("<code>#{uuid}</code>")
+    end
+
+    it "returns nil if the uuid is missing" do
+      uuid = nil
+
+      expect(format_uuid(uuid)).to be_nil
+    end
+  end
 end

--- a/spec/views/admin/delivery_partners/show.html.erb_spec.rb
+++ b/spec/views/admin/delivery_partners/show.html.erb_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "admin/delivery_partners/show.html.erb" do
   it "shows the delivery partner API ID" do
     render
 
-    expect(rendered).to have_css("span.app-mono", text: delivery_partner.api_id)
+    expect(rendered).to have_css("code", text: delivery_partner.api_id)
   end
 
   it "includes backlink with preserved page and query parameters" do


### PR DESCRIPTION
### Context

This resumes @peterdavidhamilton's work from #2628 which I hijacked and crashed.

Replaces the `.app-code` and `.app-mono` CSS class use with `<code>` and `<pre>` and introduces a new helper method, `format_uuid` which will make consistently formatting all UUIDs in the application easier.

The styles should look/feel more or less how they did before.

Fixes #2317 

### Changes proposed in this pull request

- **Add format_uuid helper that wraps uuids in `<code>`**
- **Use format_uuid on all the UUID values in admin**
- **Replace .app-mono and .app-code with code/pre styles**
- **Replace hardcoded content_tag with direct tag helpers**