### PR TITLE
Anonymise teacher merge event message on source teacher

### DIFF
--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -171,9 +171,9 @@ module Events
       new(
         **common,
         teacher: source,
-        heading: "#{source_name} was merged into #{destination_name} and anonymised",
+        heading: "Teacher record was merged into #{destination_name} and anonymised",
         body: <<~BODY.squish
-          This record (TRN #{source.trn}, participant #{source.api_id}) was merged into
+          This record was merged into
           #{destination_name} (TRN #{destination.trn}, participant #{destination.api_id}, teacher #{destination.id}) and anonymised.
           #{body}
         BODY

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -206,8 +206,8 @@ RSpec.describe Events::Record do
         hash_including(
           teacher: source,
           event_type: :teacher_merged,
-          heading: "#{Teachers::Name.new(source).full_name} was merged into #{Teachers::Name.new(destination).full_name} and anonymised",
-          body: a_string_including(source.api_id).and(a_string_including(destination.api_id))
+          heading: "Teacher record was merged into #{Teachers::Name.new(destination).full_name} and anonymised",
+          body: a_string_including(destination.api_id)
         )
       )
     end


### PR DESCRIPTION
### Context

Follow on from #3127

### Changes proposed in this pull request

Tiny amendment to anonymise the source teacher's details in the merge event recorded on the source teacher.

n.b. updated message agreed with @Aaminap and @mason-emily 