### PR TITLE
Validate induction period dates the same as other intervals

### DIFF
--- a/app/models/induction_period.rb
+++ b/app/models/induction_period.rb
@@ -80,15 +80,6 @@ class InductionPeriod < ApplicationRecord
 
 private
 
-  # Overriden from `app/models/concerns/interval.rb` since the range has not yet
-  # been migrated to inclusive ends.
-  # TODO: remove this override once the range is migrated.
-  def valid_date_order?
-    return true if incomplete?
-
-    started_on < finished_on
-  end
-
   # Ensure admin users inserting new induction periods include end dates.
   def end_date_admin_only
     return unless inserting_induction_period? && finished_on.blank?


### PR DESCRIPTION
Before c4c88645de47f8446dfe272f28a69f3f92c83215, we needed to override the date order validation for induction periods. This was because the range was still defined with an exclusive end.

Now that the range uses inclusives ends like the rest of our `Period` models, we can remove this validation override.