### PR TITLE
[3404] Include original frozen contract period option (Slice 8)

### DIFF
--- a/app/services/admin/teachers/training_periods/change_contract_period/available_contract_periods.rb
+++ b/app/services/admin/teachers/training_periods/change_contract_period/available_contract_periods.rb
@@ -1,0 +1,71 @@
+module Admin
+  module Teachers
+    module TrainingPeriods
+      module ChangeContractPeriod
+        class AvailableContractPeriods
+          FROZEN_CONTRACT_PERIOD_YEARS = [2021, 2022].freeze
+
+          class UnexpectedTrainingPeriodTypeError < StandardError; end
+
+          attr_reader :training_period
+
+          def initialize(training_period:)
+            @training_period = training_period
+          end
+
+          def contract_periods
+            scope = base_scope.most_recent_first
+            scope = scope.where.not(year: existing_contract_period.year) if existing_contract_period
+            scope = scope.where.not(year: excluded_frozen_years)
+            scope = scope.where(year: equivalent_active_lead_providers.select(:contract_period_year)) if eoi_only?
+            scope
+          end
+
+        private
+
+          def teacher
+            training_period.teacher
+          end
+
+          def base_scope
+            if original_frozen_contract_period_year.in?(FROZEN_CONTRACT_PERIOD_YEARS)
+              ContractPeriod.enabled.or(ContractPeriod.where(year: original_frozen_contract_period_year))
+            else
+              ContractPeriod.enabled
+            end
+          end
+
+          def excluded_frozen_years
+            if original_frozen_contract_period_year.in?(FROZEN_CONTRACT_PERIOD_YEARS)
+              FROZEN_CONTRACT_PERIOD_YEARS - [original_frozen_contract_period_year]
+            else
+              FROZEN_CONTRACT_PERIOD_YEARS
+            end
+          end
+
+          def existing_contract_period
+            @existing_contract_period ||= training_period.contract_period || training_period.expression_of_interest_contract_period
+          end
+
+          def eoi_only?
+            training_period.only_expression_of_interest?
+          end
+
+          def equivalent_active_lead_providers
+            ActiveLeadProvider.where(lead_provider: training_period.expression_of_interest_lead_provider)
+          end
+
+          def original_frozen_contract_period_year
+            if training_period.for_ect?
+              teacher.ect_payments_frozen_year
+            elsif training_period.for_mentor?
+              teacher.mentor_payments_frozen_year
+            else
+              raise UnexpectedTrainingPeriodTypeError, "Training period was neither ECT nor Mentor"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard.rb
+++ b/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard.rb
@@ -3,8 +3,6 @@ module Admin
     module TrainingPeriods
       module ChangeContractPeriodWizard
         class Wizard < ApplicationWizard
-          class UnexpectedTrainingPeriodTypeError < StandardError; end
-
           PartnershipOption = Data.define(:id, :name)
 
           attr_accessor :store, :teacher_id, :training_period_id, :author
@@ -52,24 +50,9 @@ module Admin
           delegate :school, to: :training_period
 
           def contract_periods
-            scope = if original_frozen_contract_period_year.in?([2021, 2022])
-                      ContractPeriod.enabled.or(ContractPeriod.where(year: original_frozen_contract_period_year))
-                    else
-                      ContractPeriod.enabled
-                    end
-
-            scope = scope.most_recent_first
-            scope = scope.where.not(year: existing_contract_period.year) if existing_contract_period
-
-            scope = if original_frozen_contract_period_year.in?([2021, 2022])
-                      scope.where.not(year: [2021, 2022] - [original_frozen_contract_period_year])
-                    else
-                      scope.where.not(year: [2021, 2022])
-                    end
-
-            scope = scope.where(year: equivalent_active_lead_providers.select(:contract_period_year)) if eoi_only?
-
-            scope
+            ChangeContractPeriod::AvailableContractPeriods
+              .new(training_period:)
+              .contract_periods
           end
 
           def selected_contract_period
@@ -140,20 +123,6 @@ module Admin
 
           def eoi_only?
             training_period.only_expression_of_interest?
-          end
-
-          def equivalent_active_lead_providers
-            ActiveLeadProvider.where(lead_provider: training_period.expression_of_interest_lead_provider)
-          end
-
-          def original_frozen_contract_period_year
-            if training_period.for_ect?
-              teacher.ect_payments_frozen_year
-            elsif training_period.for_mentor?
-              teacher.mentor_payments_frozen_year
-            else
-              raise UnexpectedTrainingPeriodTypeError, "Training period was neither ECT nor Mentor"
-            end
           end
 
           def selected_contract_period_allowed?

--- a/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard.rb
+++ b/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard.rb
@@ -52,7 +52,13 @@ module Admin
           delegate :school, to: :training_period
 
           def contract_periods
-            scope = ContractPeriod.enabled.most_recent_first
+            scope = if original_frozen_contract_period_year.in?([2021, 2022])
+                      ContractPeriod.enabled.or(ContractPeriod.where(year: original_frozen_contract_period_year))
+                    else
+                      ContractPeriod.enabled
+                    end
+
+            scope = scope.most_recent_first
             scope = scope.where.not(year: existing_contract_period.year) if existing_contract_period
 
             scope = if original_frozen_contract_period_year.in?([2021, 2022])

--- a/spec/services/admin/teachers/training_periods/change_contract_period/available_contract_periods_spec.rb
+++ b/spec/services/admin/teachers/training_periods/change_contract_period/available_contract_periods_spec.rb
@@ -1,0 +1,112 @@
+RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriod::AvailableContractPeriods do
+  subject(:available_contract_periods) { described_class.new(training_period:) }
+
+  let(:ect_payments_frozen_year) { nil }
+  let(:mentor_payments_frozen_year) { nil }
+  let(:teacher) do
+    FactoryBot.create(
+      :teacher,
+      ect_payments_frozen_year:,
+      mentor_payments_frozen_year:
+    )
+  end
+  let(:school) { FactoryBot.create(:school) }
+  let(:current_contract_period) { FactoryBot.create(:contract_period, year: 2025) }
+  let(:target_contract_period) { FactoryBot.create(:contract_period, year: 2026) }
+  let(:other_contract_period) { FactoryBot.create(:contract_period, year: 2027) }
+  let(:lead_provider) { FactoryBot.create(:lead_provider) }
+  let(:delivery_partner) { FactoryBot.create(:delivery_partner) }
+  let(:school_partnership) do
+    FactoryBot.create(
+      :school_partnership,
+      :for_year,
+      year: current_contract_period.year,
+      school:,
+      lead_provider:,
+      delivery_partner:
+    )
+  end
+  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:) }
+  let(:schedule) { FactoryBot.create(:schedule, contract_period: current_contract_period) }
+  let(:training_period) do
+    FactoryBot.create(
+      :training_period,
+      :ongoing,
+      ect_at_school_period:,
+      school_partnership:,
+      schedule:
+    )
+  end
+
+  describe "#contract_periods" do
+    let!(:contract_period_2021) { FactoryBot.create(:contract_period, year: 2021, enabled: false) }
+    let!(:contract_period_2022) { FactoryBot.create(:contract_period, year: 2022, enabled: false) }
+    let!(:disabled_contract_period) { FactoryBot.create(:contract_period, year: 2028, enabled: false) }
+
+    it "returns enabled contract periods excluding the current and frozen years" do
+      expect(available_contract_periods.contract_periods).to contain_exactly(target_contract_period, other_contract_period)
+    end
+
+    context "when the original frozen contract period is 2021" do
+      let(:ect_payments_frozen_year) { contract_period_2021.year }
+
+      it "includes the original disabled frozen contract period and excludes the other disabled years" do
+        expect(available_contract_periods.contract_periods)
+          .to contain_exactly(contract_period_2021, target_contract_period, other_contract_period)
+      end
+    end
+
+    context "when the original frozen contract period is 2022" do
+      let(:ect_payments_frozen_year) { contract_period_2022.year }
+
+      it "includes the original disabled frozen contract period and excludes the other disabled years" do
+        expect(available_contract_periods.contract_periods)
+          .to contain_exactly(contract_period_2022, target_contract_period, other_contract_period)
+      end
+    end
+
+    context "when the training period is for a mentor with an original frozen contract period" do
+      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:, school:) }
+      let(:training_period) do
+        FactoryBot.create(
+          :training_period,
+          :ongoing,
+          :for_mentor,
+          mentor_at_school_period:,
+          school_partnership:,
+          schedule:
+        )
+      end
+
+      let(:mentor_payments_frozen_year) { contract_period_2021.year }
+
+      it "uses the mentor frozen year when filtering contract periods" do
+        expect(available_contract_periods.contract_periods)
+          .to contain_exactly(contract_period_2021, target_contract_period, other_contract_period)
+      end
+    end
+
+    context "for an EOI only training period" do
+      before do
+        FactoryBot.create(:active_lead_provider, lead_provider: active_lead_provider.lead_provider, contract_period: target_contract_period)
+        FactoryBot.create(:active_lead_provider, contract_period: other_contract_period)
+      end
+
+      let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, contract_period: current_contract_period) }
+      let(:training_period) do
+        FactoryBot.create(
+          :training_period,
+          :ongoing,
+          :with_only_expression_of_interest,
+          ect_at_school_period:,
+          expression_of_interest: active_lead_provider,
+          schedule:
+        )
+      end
+
+      it "only returns contract periods with an equivalent active lead provider" do
+        expect(available_contract_periods.contract_periods).to contain_exactly(target_contract_period)
+      end
+    end
+  end
+end

--- a/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard_spec.rb
+++ b/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard_spec.rb
@@ -116,8 +116,8 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Wiz
   end
 
   describe "#contract_periods" do
-    let!(:contract_period_2021) { FactoryBot.create(:contract_period, year: 2021) }
-    let!(:contract_period_2022) { FactoryBot.create(:contract_period, year: 2022) }
+    let!(:contract_period_2021) { FactoryBot.create(:contract_period, year: 2021, enabled: false) }
+    let!(:contract_period_2022) { FactoryBot.create(:contract_period, year: 2022, enabled: false) }
     let!(:disabled_contract_period) { FactoryBot.create(:contract_period, year: 2028, enabled: false) }
 
     it "returns enabled contract periods excluding the current and frozen years" do
@@ -129,7 +129,7 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Wiz
         teacher.update!(ect_payments_frozen_year: contract_period_2021.year)
       end
 
-      it "keeps the original frozen contract period" do
+      it "includes the original disabled frozen contract period and excludes the other disabled years" do
         expect(wizard.contract_periods)
           .to contain_exactly(contract_period_2021, target_contract_period, other_contract_period)
       end
@@ -140,7 +140,7 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Wiz
         teacher.update!(ect_payments_frozen_year: contract_period_2022.year)
       end
 
-      it "keeps the original frozen contract period" do
+      it "includes the original disabled frozen contract period and excludes the other disabled years" do
         expect(wizard.contract_periods)
           .to contain_exactly(contract_period_2022, target_contract_period, other_contract_period)
       end

--- a/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard_spec.rb
+++ b/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard_spec.rb
@@ -116,57 +116,23 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Wiz
   end
 
   describe "#contract_periods" do
-    let!(:contract_period_2021) { FactoryBot.create(:contract_period, year: 2021, enabled: false) }
-    let!(:contract_period_2022) { FactoryBot.create(:contract_period, year: 2022, enabled: false) }
-    let!(:disabled_contract_period) { FactoryBot.create(:contract_period, year: 2028, enabled: false) }
-
-    it "returns enabled contract periods excluding the current and frozen years" do
-      expect(wizard.contract_periods).to contain_exactly(target_contract_period, other_contract_period)
+    let(:contract_periods) { [target_contract_period] }
+    let(:available_contract_periods) do
+      instance_double(
+        Admin::Teachers::TrainingPeriods::ChangeContractPeriod::AvailableContractPeriods,
+        contract_periods:
+      )
     end
 
-    context "when the original frozen contract period is 2021" do
-      before do
-        teacher.update!(ect_payments_frozen_year: contract_period_2021.year)
-      end
+    it "delegates to AvailableContractPeriods" do
+      allow(Admin::Teachers::TrainingPeriods::ChangeContractPeriod::AvailableContractPeriods)
+        .to receive(:new)
+        .and_return(available_contract_periods)
 
-      it "includes the original disabled frozen contract period and excludes the other disabled years" do
-        expect(wizard.contract_periods)
-          .to contain_exactly(contract_period_2021, target_contract_period, other_contract_period)
-      end
-    end
-
-    context "when the original frozen contract period is 2022" do
-      before do
-        teacher.update!(ect_payments_frozen_year: contract_period_2022.year)
-      end
-
-      it "includes the original disabled frozen contract period and excludes the other disabled years" do
-        expect(wizard.contract_periods)
-          .to contain_exactly(contract_period_2022, target_contract_period, other_contract_period)
-      end
-    end
-
-    context "for an EOI only training period" do
-      let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, contract_period: current_contract_period) }
-      let(:training_period) do
-        FactoryBot.create(
-          :training_period,
-          :ongoing,
-          :with_only_expression_of_interest,
-          ect_at_school_period:,
-          expression_of_interest: active_lead_provider,
-          schedule:
-        )
-      end
-
-      before do
-        FactoryBot.create(:active_lead_provider, lead_provider: active_lead_provider.lead_provider, contract_period: target_contract_period)
-        FactoryBot.create(:active_lead_provider, contract_period: other_contract_period)
-      end
-
-      it "only returns contract periods with an equivalent active lead provider" do
-        expect(wizard.contract_periods).to contain_exactly(target_contract_period)
-      end
+      expect(wizard.contract_periods).to eq(contract_periods)
+      expect(Admin::Teachers::TrainingPeriods::ChangeContractPeriod::AvailableContractPeriods)
+        .to have_received(:new)
+        .with(training_period: wizard.training_period)
     end
   end
 


### PR DESCRIPTION
## What

Following on from #3146, this is the 8th slice of the contract period change journey for admins.

The `2021` and `2022` contract periods are disabled in production. The wizard was starting from enabled contract periods, which meant the participant's original frozen contract period was filtered out before the frozen year exception could apply.

This PR updates the wizard so that:

- enabled contract periods are still shown
- the participants original frozen 2021/2022 contract period is shown, even though it is disabled
- the other frozen contract period remains hidden
- unrelated disabled contract periods remain hidden

## Not included

This PR does not:

- display the change link on the training tab
- change the mutation behaviour
- change the no partnerships journey