### PR TITLE
Fix failure on main

### DIFF
--- a/spec/services/declarations/clawback_spec.rb
+++ b/spec/services/declarations/clawback_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Declarations::Clawback do
 
   before do
     # make payment statement precede clawback statement
-    declaration.payment_statement.update!(deadline_date: Date.yesterday)
+    declaration.payment_statement.update!(deadline_date: Date.yesterday, payment_date: Date.current)
   end
 
   describe "#clawback" do


### PR DESCRIPTION
## summary

The spec was updating an existing payment statement deadline without also updating the payment date. Now that statements validate that payment dates must be later than deadline dates, that setup can make the statement invalid before the clawback behaviour is exercised.

Keep the change scoped to the failing setup by setting the payment date alongside the overridden deadline date.
