### PR TITLE
Disable blocking migration inplace

### DIFF
--- a/db/migrate/20260612111906_backfill_active_lead_provider_bands.rb
+++ b/db/migrate/20260612111906_backfill_active_lead_provider_bands.rb
@@ -1,24 +1,9 @@
 class BackfillActiveLeadProviderBands < ActiveRecord::Migration[8.1]
   def up
-    Contract::BandedFeeStructure::Band
-      .includes(banded_fee_structure: { contract: :active_lead_provider })
-      .find_each do |original_band|
-        active_lead_provider = original_band.banded_fee_structure.contract.active_lead_provider
-
-        allocation_order = original_band.banded_fee_structure.bands.sort_by(&:min_declarations).index(original_band) + 1
-        alp_band = ActiveLeadProvider::Band.find_or_initialize_by(active_lead_provider:, allocation_order:)
-
-        if alp_band.new_record? || original_band.capacity > alp_band.capacity
-          alp_band.capacity = original_band.capacity
-          alp_band.save!
-        end
-
-        original_band.update_column(:band_id, alp_band.id)
-      end
+    # no-op
   end
 
   def down
-    Contract::BandedFeeStructure::Band.update_all(band_id: nil)
-    ActiveLeadProvider::Band.delete_all
+    # no-op
   end
 end


### PR DESCRIPTION
### Context

A [failed deployment](https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/28181490107/job/83481363880) and subsequent code changes have blocked the pipeline. Mia culpa. 

### Changes proposed in this pull request

Allow pending migrations to complete by deactivating the offending code.
We will instead backfill the data in a script via the console.

### Guidance to review
