### PR TITLE
Remove redundant guard clause in `ReviewMentorEligibilityStep`

### DIFF
--- a/app/wizards/schools/assign_existing_mentor_wizard/review_mentor_eligibility_step.rb
+++ b/app/wizards/schools/assign_existing_mentor_wizard/review_mentor_eligibility_step.rb
@@ -19,8 +19,6 @@ module Schools
       end
 
       def create_mentor_training_period!
-        return unless lead_provider
-
         ActiveRecord::Base.transaction do
           training_period = TrainingPeriods::Create.provider_led(
             period: mentor_at_school_period,

--- a/app/wizards/schools/assign_existing_mentor_wizard/review_mentor_eligibility_step.rb
+++ b/app/wizards/schools/assign_existing_mentor_wizard/review_mentor_eligibility_step.rb
@@ -9,24 +9,27 @@ module Schools
     private
 
       def persist
-        AssignMentor.new(
-          ect: wizard.context.ect_at_school_period,
-          mentor: wizard.context.mentor_at_school_period,
-          author: wizard.author
-        ).assign!
-
+        assign_mentor!
         create_mentor_training_period!
+      end
+
+      def assign_mentor!
+        AssignMentor.new(
+          ect: ect_at_school_period,
+          mentor: mentor_at_school_period,
+          author:
+        ).assign!
       end
 
       def create_mentor_training_period!
         ActiveRecord::Base.transaction do
           training_period = TrainingPeriods::Create.provider_led(
             period: mentor_at_school_period,
-            started_on:,
+            started_on: mentor_at_school_period.started_on,
             school_partnership: earliest_matching_school_partnership,
             expression_of_interest:,
-            mentee: wizard.context.ect_at_school_period,
-            author: wizard.author
+            mentee: ect_at_school_period,
+            author:
           ).call
 
           record_training_period_event!(training_period)
@@ -35,34 +38,31 @@ module Schools
 
       def record_training_period_event!(training_period)
         Events::Record.record_teacher_starts_training_period_event!(
-          author: wizard.author,
+          author:,
           teacher: mentor_at_school_period.teacher,
           school: mentor_at_school_period.school,
           training_period:,
           mentor_at_school_period:,
           ect_at_school_period: nil,
-          happened_at: started_on
+          happened_at: mentor_at_school_period.started_on
         )
       end
 
-      def mentor_at_school_period
-        wizard.context.mentor_at_school_period
-      end
+      def ect_at_school_period = wizard.context.ect_at_school_period
+      def mentor_at_school_period = wizard.context.mentor_at_school_period
+      def author = wizard.author
 
+      # TrainingPeriodSources definitions
       def lead_provider
-        @lead_provider ||= ect_current_lead_provider
+        @lead_provider ||= lead_provider_for_current_ect_training
       end
 
-      def ect_current_lead_provider
-        ECTAtSchoolPeriods::CurrentTraining.new(wizard.context.ect_at_school_period).lead_provider_via_school_partnership_or_eoi
-      end
+      def school = mentor_at_school_period.school
 
-      def started_on
-        mentor_at_school_period.started_on
-      end
-
-      def school
-        mentor_at_school_period.school
+      def lead_provider_for_current_ect_training
+        ECTAtSchoolPeriods::CurrentTraining
+          .new(ect_at_school_period)
+          .lead_provider_via_school_partnership_or_eoi
       end
     end
   end


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/4097

### Changes proposed in this pull request

#### Remove redundant early return
It's hard to discern **why** this guard clause exists. And I don't want to tear
something down just because I don't understand it.

But after doing some extensive mapping of the mentor assignment journeys in
[Excalidraw] it looks like this branch is redundant.

The only entrypoint to the `Schools::AssignExistingMentorWizard` journey is by
submitting the mentorships form (i.e `Schools::MentorshipsController`).

The wizard is kicked off if the chosen mentor is eligible for their first
provider led training. By definition, that can only be true if the ECT in
question is undertaking provider-led training.

If an ECT is doing provider-led training, then they will have either a school
partnership or an expression of interest. So they will have a lead provider too,
whether that's through the school partnership or the expression of interest.

I can't see a scenario in which the ECT would not have a lead provider, so the
guard clause seems like it has no bearing on anything.

This removes the guard clause, with the intention of simplifying this journey
slightly.

[Excalidraw]: https://excalidraw.com/#json=iIK7sogwBa6ZtXmI9B5-Z,DwPh88qnr0Xwu4Tv_ySGqQ

#### Refactor for readability
This refactors the `ReviewMentorEligibilityStep` in the
`Schools::AssignExistingMentorWizard` to make things a little easier to read.

For now, the method definitions needed for the `TrainingPeriodSources` concern
are grouped together with a comment.

Down the line, I think things would be clearer and easier to unpick if we
rethink that abstraction. Especially since we are using it in places alongside
the `Schedules::Reuse` concern.

We've run into a number of bugs with `ContractPeriod` assignment since going
live, and we've made a bunch of changes in this area.

### Guidance to review

- [ ] Verify mentor assignment (and training eligibility/training period creation) behaviour is as expected 
