### PR TITLE
Fix failures on main

### DIFF
--- a/spec/factories/statement_factory.rb
+++ b/spec/factories/statement_factory.rb
@@ -27,7 +27,10 @@ FactoryBot.define do
     month { month_year_pair[:month] }
     year { month_year_pair[:year] }
     deadline_date { Date.new(year, month, 1).prev_day }
-    payment_date { Date.new(year, month, 25) }
+    payment_date do
+      payment_month = deadline_date.next_month
+      Date.new(payment_month.year, payment_month.month, 25)
+    end
     output_fee
 
     trait :open do


### PR DESCRIPTION
## Summary

Update the statement factory so the default payment date is derived from the deadline date.

This keeps statements built by the factory valid when specs override `deadline_date`, now that statements validate payment dates must be later than deadline dates.