### PR TITLE
Clear mentor completion attributes so provider can restart training in correct cohort year

### DIFF
--- a/db/scripts/migration_data_fixes.csv
+++ b/db/scripts/migration_data_fixes.csv
@@ -1,2 +1,3 @@
 object_type,object_id,action,attributes
 Teacher,215355,update,"mentor_became_ineligible_for_funding_on,,mentor_became_ineligible_for_funding_reason,"
+Teacher,103755,update,"mentor_became_ineligible_for_funding_on,,mentor_became_ineligible_for_funding_reason,"

--- a/db/scripts/migration_data_fixes.csv
+++ b/db/scripts/migration_data_fixes.csv
@@ -1,3 +1,5 @@
 object_type,object_id,action,attributes
 Teacher,215355,update,"mentor_became_ineligible_for_funding_on,,mentor_became_ineligible_for_funding_reason,"
+TrainingPeriod,124102,update,"finished_on,"
 Teacher,103755,update,"mentor_became_ineligible_for_funding_on,,mentor_became_ineligible_for_funding_reason,"
+TrainingPeriod,451,update,"finished_on,"

--- a/db/scripts/migration_data_fixes.csv
+++ b/db/scripts/migration_data_fixes.csv
@@ -1,11 +1,2 @@
 object_type,object_id,action,attributes
-TrainingPeriod,136734,update,"finished_on,2024-06-15,withdrawal_reason,moved_school,withdrawn_at,2025-03-10T16:40:33Z"
-TrainingPeriod,136739,delete
-TrainingPeriod,216619,update,"finished_on,2023-12-31,withdrawal_reason,other,withdrawn_at,2026-02-18T13:00:48Z"
-MentorshipPeriod,97533,update,"finished_on,2023-12-31"
-ECTAtSchoolPeriod,86079,update,"finished_on,2023-12-31,reported_leaving_by_school_id,16862"
-TrainingPeriod,216622,delete
-TrainingPeriod,130216,update,"finished_on,2024-03-10,withdrawal_reason,other,withdrawn_at,2026-02-18T12:00:22Z"
-MentorshipPeriod,4956,update,"finished_on,2024-03-10"
-ECTAtSchoolPeriod,4340,update,"finished_on,2024-03-10,reported_leaving_by_school_id,23699"
-TrainingPeriod,130224,delete
+Teacher,215355,update,"mentor_became_ineligible_for_funding_on,,mentor_became_ineligible_for_funding_reason,"


### PR DESCRIPTION
### Context

A mentor from 2022 cohort has restarted training in 2025.  The provider cannot move them correctly as the completion attributes are set, so we have to remove the `mentor_became_ineligible_for_funding_on` and `mentor_became_ineligible_for_funding_reason` values to enable this.

In addition the `TrainingPeriod` needs to be reopened in order for the provider to submit a change-schedule request over the API.

Added a second mentor that needed to be restarted as above

### Changes proposed in this pull request

Use the son-of-patch `migration_fixes.csv` to remove the values from the teacher's records.

### Guidance to review

Tested on migration and the patching works as expected.

Testing the provider being able to restart their training in a new cohort:

- The first mentor can be restarted in the 2025 cohort via the change-schedule endpoint

- The 2nd mentor requires a school partnership with their provider for 2026 to enable the change-schedule request to complete successfully.
