### PR TITLE
Fix `SchoolContractPeriod` metadata not refreshing

### DIFF
--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -64,7 +64,7 @@ class TrainingPeriod < ApplicationRecord
           school_partnership_id
         ]
 
-  refresh_metadata -> { at_school_period.school }, on_event: %i[create destroy update], when_changing: %i[school_partnership_id expression_of_interest_id]
+  refresh_metadata -> { at_school_period.school }, on_event: %i[create destroy update], when_changing: %i[school_partnership_id expression_of_interest_id started_on]
   refresh_metadata -> { teacher }, on_event: %i[create destroy update], when_changing: %i[started_on finished_on withdrawn_at deferred_at school_partnership_id]
 
   # Validations

--- a/spec/models/training_period_spec.rb
+++ b/spec/models/training_period_spec.rb
@@ -28,7 +28,7 @@ describe TrainingPeriod do
       let(:instance) { FactoryBot.create(:training_period, ect_at_school_period:, school_partnership:, **period_boundaries) }
       let!(:target) { FactoryBot.create(:school) }
 
-      it_behaves_like "a declarative metadata model", on_event: %i[create destroy update], when_changing: %i[school_partnership_id expression_of_interest_id]
+      it_behaves_like "a declarative metadata model", on_event: %i[create destroy update], when_changing: %i[school_partnership_id expression_of_interest_id started_on]
     end
 
     context "when target is teacher" do


### PR DESCRIPTION
### Context

We have some alerts in Sentry where instances of the `SchoolContractPeriod` metadata are being updated during the nightly metadata refresh integrity check job.

The `induction_programme_choice` is moving from `not_yet_known` to `school_led`.

### Changes proposed in this pull request

- Fix `SchoolContractPeriod` metadata not refreshing

Update `refresh_metadata` to include `started_on`, so that the `induction_programme_choice` is correctly re-calculated.

### Guidance to review

We made a fairly recent change to scope training periods to the particular contract periods when determining the school led status (see #2734). We did not, however, update the `refresh_metadata` declaration to include `started_on`, so I expect this is how the issue is arising.
