### PR TITLE
[3404] Add contract period change links and feature tests (Slice 9)

### DIFF
--- a/app/components/admin/teachers/training_summary_component.rb
+++ b/app/components/admin/teachers/training_summary_component.rb
@@ -10,6 +10,8 @@ module Admin
       end
 
       def call
+        summary_rows = rows
+
         govuk_summary_card(title: card_title) do |card|
           if show_move_partnership_link?
             card.with_action { helpers.govuk_link_to("Move to a different partnership", move_partnership_path) }
@@ -17,11 +19,12 @@ module Admin
 
           helpers.safe_join([
             status_inset_text,
-            helpers.govuk_summary_list(actions: false) do |list|
-              rows.each do |row|
+            helpers.govuk_summary_list(actions: summary_rows.any? { |row| row[:action].present? }) do |list|
+              summary_rows.each do |row|
                 list.with_row do |r|
                   r.with_key(text: row.dig(:key, :text)) if row[:key].present?
                   r.with_value(text: row.dig(:value, :text))
+                  r.with_action(**row[:action]) if row[:action].present?
                 end
               end
             end
@@ -55,7 +58,7 @@ module Admin
           summary_row("Lead provider", lead_provider_text),
           summary_row("Delivery partner", delivery_partner_text),
           summary_row("School", training_school_name),
-          summary_row("Contract period", contract_period_text),
+          summary_row("Contract period", contract_period_text, action: contract_period_change_action),
           training_programme_row,
           summary_row("Schedule", schedule_text),
           summary_row("Start date", start_date_text),
@@ -192,10 +195,28 @@ module Admin
           training_period.finished_on.nil?
       end
 
-      def summary_row(label, value)
+      def contract_period_change_action
+        return unless change_contract_period_eligible?
+
+        {
+          text: "Change",
+          href: admin_teacher_training_period_change_contract_period_wizard_select_contract_period_path(training_period.teacher_id, training_period),
+          visually_hidden_text: "contract period",
+          classes: "govuk-link--no-visited-state"
+        }
+      end
+
+      def change_contract_period_eligible?
+        @change_contract_period_eligible ||= Admin::Teachers::TrainingPeriods::ChangeContractPeriod::Eligibility
+          .new(training_period:)
+          .eligible?
+      end
+
+      def summary_row(label, value, action: nil)
         {
           key: { text: label },
-          value: { text: value.presence || not_available_text }
+          value: { text: value.presence || not_available_text },
+          action:
         }
       end
 

--- a/spec/components/admin/teachers/training_summary_component_spec.rb
+++ b/spec/components/admin/teachers/training_summary_component_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Admin::Teachers::TrainingSummaryComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
   subject(:rendered) { render_inline(described_class.new(training_period:, show_api_row: true)) }
 
   describe "provider-led training periods" do
@@ -286,6 +288,57 @@ RSpec.describe Admin::Teachers::TrainingSummaryComponent, type: :component do
     it "does not show the API data row" do
       expect(rendered_content).not_to have_css("dt", text: "API response")
       expect(rendered_content).not_to include("data")
+    end
+  end
+
+  describe "contract period change link" do
+    context "when the training period is an eligible ECT period" do
+      let(:training_period) do
+        FactoryBot.create(
+          :training_period,
+          :ongoing,
+          ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)
+        )
+      end
+
+      before { rendered }
+
+      it "shows a change link for the contract period row" do
+        expect(rendered_content).to have_link(
+          "Change",
+          href: admin_teacher_training_period_change_contract_period_wizard_select_contract_period_path(training_period.teacher.id, training_period.id)
+        )
+      end
+    end
+
+    context "when the training period is an eligible mentor period" do
+      let(:training_period) do
+        FactoryBot.create(
+          :training_period,
+          :for_mentor,
+          :ongoing,
+          mentor_at_school_period: FactoryBot.create(:mentor_at_school_period, :ongoing)
+        )
+      end
+
+      before { rendered }
+
+      it "shows a change link for the contract period row" do
+        expect(rendered_content).to have_link(
+          "Change",
+          href: admin_teacher_training_period_change_contract_period_wizard_select_contract_period_path(training_period.teacher.id, training_period.id)
+        )
+      end
+    end
+
+    context "when the training period is ineligible" do
+      let(:training_period) { FactoryBot.create(:training_period, :finished) }
+
+      before { rendered }
+
+      it "does not show a change link for the contract period row" do
+        expect(rendered_content).not_to have_link("Change")
+      end
     end
   end
 

--- a/spec/components/admin/teachers/training_summary_component_spec.rb
+++ b/spec/components/admin/teachers/training_summary_component_spec.rb
@@ -296,6 +296,7 @@ RSpec.describe Admin::Teachers::TrainingSummaryComponent, type: :component do
       let(:training_period) do
         FactoryBot.create(
           :training_period,
+          :provider_led,
           :ongoing,
           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)
         )
@@ -316,6 +317,7 @@ RSpec.describe Admin::Teachers::TrainingSummaryComponent, type: :component do
         FactoryBot.create(
           :training_period,
           :for_mentor,
+          :provider_led,
           :ongoing,
           mentor_at_school_period: FactoryBot.create(:mentor_at_school_period, :ongoing)
         )
@@ -332,7 +334,7 @@ RSpec.describe Admin::Teachers::TrainingSummaryComponent, type: :component do
     end
 
     context "when the training period is ineligible" do
-      let(:training_period) { FactoryBot.create(:training_period, :finished) }
+      let(:training_period) { FactoryBot.create(:training_period, :provider_led, :finished) }
 
       before { rendered }
 

--- a/spec/features/admin/teachers/change_contract_period_spec.rb
+++ b/spec/features/admin/teachers/change_contract_period_spec.rb
@@ -1,0 +1,220 @@
+describe "Admin changes a teacher's contract period" do
+  around do |example|
+    travel_to(Date.new(2026, 2, 1)) { example.run }
+  end
+
+  it "finishes the current active provider-led training period and starts a replacement using a matching partnership" do
+    given_there_is_a_school
+    and_there_is_a_teacher
+    and_there_are_contract_periods_and_schedules
+    and_there_is_a_current_active_provider_led_training_period
+    and_i_am_logged_in_as_an_admin
+
+    when_i_visit_the_training_tab
+    then_i_can_start_the_contract_period_change_journey
+
+    when_i_select_the_new_contract_period
+    then_i_can_choose_the_matching_partnership
+
+    when_i_select_the_matching_partnership
+    then_i_see_the_check_answers_page
+
+    when_i_confirm_the_contract_period_change
+    then_i_see_the_contract_period_changed_banner_on_the_training_tab
+    and_the_old_training_period_is_finished
+    and_a_replacement_training_period_is_created
+  end
+
+  it "updates a future starting EOI only training period in place" do
+    given_there_is_a_school
+    and_there_is_a_teacher
+    and_there_are_contract_periods_and_schedules
+    and_there_is_a_future_starting_eoi_only_training_period
+    and_i_am_logged_in_as_an_admin
+
+    when_i_visit_the_training_tab
+    then_i_can_start_the_contract_period_change_journey
+
+    when_i_select_the_new_contract_period
+    then_i_skip_partnership_selection_and_see_check_answers
+
+    when_i_confirm_the_contract_period_change
+    then_i_see_the_contract_period_changed_banner_on_the_training_tab
+    and_the_same_future_training_period_is_updated_in_place
+    and_the_future_training_period_remains_eoi_only
+  end
+
+private
+
+  def given_there_is_a_school
+    @school = FactoryBot.create(:school)
+  end
+
+  def and_there_is_a_teacher
+    @teacher = FactoryBot.create(
+      :teacher,
+      trs_first_name: "Bruce",
+      trs_last_name: "Wayne"
+    )
+    @teacher_name = Teachers::Name.new(@teacher).full_name
+    @ect_at_school_period = FactoryBot.create(
+      :ect_at_school_period,
+      :ongoing,
+      teacher: @teacher,
+      school: @school,
+      started_on: Date.current.prev_year
+    )
+  end
+
+  def and_there_are_contract_periods_and_schedules
+    @current_contract_period = FactoryBot.create(:contract_period, year: 2025)
+    @target_contract_period = FactoryBot.create(:contract_period, year: 2026)
+    @current_schedule = FactoryBot.create(:schedule, contract_period: @current_contract_period)
+    @target_schedule = FactoryBot.create(
+      :schedule,
+      contract_period: @target_contract_period,
+      identifier: @current_schedule.identifier
+    )
+  end
+
+  def and_there_is_a_current_active_provider_led_training_period
+    lead_provider = FactoryBot.create(:lead_provider, name: "Best Lead Provider")
+    delivery_partner = FactoryBot.create(:delivery_partner, name: "Trusted Delivery Partner")
+
+    @current_school_partnership = FactoryBot.create(
+      :school_partnership,
+      :for_year,
+      year: @current_contract_period.year,
+      school: @school,
+      lead_provider:,
+      delivery_partner:
+    )
+    @target_school_partnership = FactoryBot.create(
+      :school_partnership,
+      :for_year,
+      year: @target_contract_period.year,
+      school: @school,
+      lead_provider:,
+      delivery_partner:
+    )
+    @target_partnership_name = "#{lead_provider.name} & #{delivery_partner.name}"
+    @training_period = FactoryBot.create(
+      :training_period,
+      :ongoing,
+      ect_at_school_period: @ect_at_school_period,
+      school_partnership: @current_school_partnership,
+      schedule: @current_schedule,
+      started_on: Date.current.prev_month
+    )
+  end
+
+  def and_there_is_a_future_starting_eoi_only_training_period
+    lead_provider = FactoryBot.create(:lead_provider, name: "EOI Lead Provider")
+    current_active_lead_provider = FactoryBot.create(
+      :active_lead_provider,
+      lead_provider:,
+      contract_period: @current_contract_period
+    )
+    @target_active_lead_provider = FactoryBot.create(
+      :active_lead_provider,
+      lead_provider:,
+      contract_period: @target_contract_period
+    )
+    @training_period = FactoryBot.create(
+      :training_period,
+      :ongoing,
+      :with_only_expression_of_interest,
+      ect_at_school_period: @ect_at_school_period,
+      expression_of_interest: current_active_lead_provider,
+      schedule: @current_schedule,
+      started_on: Date.current.next_month,
+      finished_on: nil
+    )
+    @original_training_period_id = @training_period.id
+    @original_training_period_count = TrainingPeriod.where(ect_at_school_period: @ect_at_school_period).count
+  end
+
+  def and_i_am_logged_in_as_an_admin
+    sign_in_as_dfe_user(role: :admin)
+  end
+
+  def when_i_visit_the_training_tab
+    page.goto(admin_teacher_training_path(@teacher))
+  end
+
+  def then_i_can_start_the_contract_period_change_journey
+    contract_period_row = page.locator(".govuk-summary-list__row", hasText: "Contract period")
+    contract_period_row.get_by_role("link", name: "Change").click
+
+    expect(page.locator("h1", hasText: "Select new contract period for #{@teacher_name}")).to be_visible
+  end
+
+  def when_i_select_the_new_contract_period
+    page.get_by_label(@target_contract_period.year.to_s).check
+    page.get_by_role("button", name: "Continue").click
+  end
+
+  def then_i_can_choose_the_matching_partnership
+    expect(page.locator("h1", hasText: "Select #{@target_contract_period.year} partnership for #{@teacher_name}")).to be_visible
+    expect(page.get_by_label(@target_partnership_name)).to be_visible
+  end
+
+  def when_i_select_the_matching_partnership
+    page.get_by_label(@target_partnership_name).check
+    page.get_by_role("button", name: "Continue").click
+  end
+
+  def then_i_see_the_check_answers_page
+    expect(page.locator("h1", hasText: "Confirm contract period change for #{@teacher_name}")).to be_visible
+    expect(page.locator(".govuk-summary-list__row", hasText: "Existing contract period")).to have_text(@current_contract_period.year.to_s)
+    expect(page.locator(".govuk-summary-list__row", hasText: "New contract period")).to have_text(@target_contract_period.year.to_s)
+    expect(page.locator(".govuk-summary-list__row", hasText: "Partnership")).to have_text(@target_partnership_name)
+  end
+
+  def then_i_skip_partnership_selection_and_see_check_answers
+    expect(page.locator("h1", hasText: "Confirm contract period change for #{@teacher_name}")).to be_visible
+    expect(page.locator(".govuk-summary-list__row", hasText: "Existing contract period")).to have_text(@current_contract_period.year.to_s)
+    expect(page.locator(".govuk-summary-list__row", hasText: "New contract period")).to have_text(@target_contract_period.year.to_s)
+    expect(page.locator(".govuk-summary-list__row", hasText: "Lead provider")).to have_text("EOI Lead Provider")
+    expect(page.locator(".govuk-summary-list__row", hasText: "Delivery partner")).to have_text("No delivery partner confirmed")
+  end
+
+  def when_i_confirm_the_contract_period_change
+    page.get_by_role("button", name: "Confirm").click
+  end
+
+  def then_i_see_the_contract_period_changed_banner_on_the_training_tab
+    expect(page.locator("h2", hasText: "Training")).to be_visible
+    expect(page.locator(".govuk-notification-banner__content")).to have_text("Contract period changed")
+  end
+
+  def and_the_old_training_period_is_finished
+    expect(@training_period.reload.finished_on).to eq(Date.current.yesterday)
+  end
+
+  def and_a_replacement_training_period_is_created
+    replacement_training_period = TrainingPeriod
+      .where(ect_at_school_period: @ect_at_school_period)
+      .where.not(id: @training_period.id)
+      .sole
+
+    expect(replacement_training_period.started_on).to eq(Date.current)
+    expect(replacement_training_period.contract_period).to eq(@target_contract_period)
+    expect(replacement_training_period.school_partnership).to eq(@target_school_partnership)
+    expect(replacement_training_period.schedule).to eq(@target_schedule)
+  end
+
+  def and_the_same_future_training_period_is_updated_in_place
+    @training_period.reload
+
+    expect(@training_period.id).to eq(@original_training_period_id)
+    expect(TrainingPeriod.where(ect_at_school_period: @ect_at_school_period).count).to eq(@original_training_period_count)
+    expect(@training_period.schedule).to eq(@target_schedule)
+  end
+
+  def and_the_future_training_period_remains_eoi_only
+    expect(@training_period.school_partnership).to be_nil
+    expect(@training_period.expression_of_interest).to eq(@target_active_lead_provider)
+    expect(@training_period.expression_of_interest_contract_period).to eq(@target_contract_period)
+  end
+end

--- a/spec/features/admin/teachers/change_contract_period_spec.rb
+++ b/spec/features/admin/teachers/change_contract_period_spec.rb
@@ -122,7 +122,6 @@ private
     )
     @training_period = FactoryBot.create(
       :training_period,
-      :ongoing,
       :with_only_expression_of_interest,
       ect_at_school_period: @ect_at_school_period,
       expression_of_interest: current_active_lead_provider,


### PR DESCRIPTION
## What

Following on from #3155, this is the 9th and final slice of the contract period change journey for admins.

This PR:

- adds the change link to eligible contract period rows on the admin teacher training tab
- uses `ChangeContractPeriod::Eligibility` as the source of truth for displaying the link
- supports both ECT and Mentor training periods
- adds feature test coverage for:
  - current active provider-led training periods, where the existing period is finished and a replacement is created
  - future starting EOI only training periods, where the existing future period is updated in place

## Screenshot

| `/training` |
|------------|
|<img width="557" height="570" alt="image" src="https://github.com/user-attachments/assets/d44250ab-f3b5-489b-84d6-18b70469893f" />|

## Eligibility Decision Table

| Scenario | Change link | Where |
|---|---|---|
| Current active period with no future starting periods | Yes | Current active period |
| Current active period + one future starting period with same LP/DP | Yes | Future starting period |
| Current active period + one future starting EOI only period | Yes | Future starting period |
| Current active period + one future starting period with different LP/DP | No | Nowhere |
| Only one future starting period and no other training periods | Yes | Future starting period |
| More than one future starting period | No | Nowhere |
| School-led period | No | Nowhere |
| Finished period | No | Nowhere |

## Journey Flow

```mermaid
flowchart TD
  A[Training tab change link] --> B[Select new contract period]

  B --> C{EOI only?}
  C -- Yes --> D[Check answers]

  C -- No --> E{Matching partnership?}
  E -- No --> F[No partnerships page]
  F --> G[Link to add school partnership journey]

  E -- Yes --> H[Select partnership]
  H --> D

  D --> I[Confirm]
  I --> J{Future starting period?}

  J -- Yes --> K[Update future period in place]
  J -- No --> L[Finish current period and create replacement]

  K --> M[Record contract period changed event]
  L --> M
  M --> N[Training tab with success banner]

classDef entry fill:#e8f1ff,stroke:#1d70b8,color:#0b0c0c;
classDef decision fill:#fff2cc,stroke:#b58800,color:#0b0c0c;
classDef success fill:#e6f4ea,stroke:#00703c,color:#0b0c0c;
classDef mutation fill:#f3e8ff,stroke:#6f42c1,color:#0b0c0c;

class A,B,D,F,G,H,I entry;
class C,E,J decision;
class K,L,M mutation;
class N success;
```

## Not Included

This PR does not:

- change the contract period option rules
- change the eligibility rules
- change the mutation behaviour

