### PR TITLE
Relax permissions in the opening registration screens

### DIFF
--- a/app/models/active_lead_provider.rb
+++ b/app/models/active_lead_provider.rb
@@ -35,5 +35,6 @@ class ActiveLeadProvider < ApplicationRecord
   }
 
   delegate :name, to: :lead_provider, prefix: true
-  delegate :editable?, to: :contract_period
+
+  def editable? = !contract_period.payments_frozen?
 end

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -33,7 +33,9 @@ class Statement < ApplicationRecord
   validates :api_id, uniqueness: { case_sensitive: false, message: "API id already exists for another statement" }
   validate :unique_lead_provider_month_year
   validates :deadline_date, presence: { message: "Deadline date must be specified" }
-  validate :deadline_date_in_the_past
+  validates :deadline_date, comparison: { greater_than: Date.current, message: "Deadline date must be in the future" }, on: :service_create
+  validate :deadline_date_remains_in_future, on: :update
+  validate :deadline_date_in_the_past, if: :payable_or_paid?
   validates :payment_date,
             comparison: {
               greater_than: :deadline_date,
@@ -110,8 +112,18 @@ private
     errors.add(:base, "Statement with the same month and year already exists for this active lead provider")
   end
 
+  def payable_or_paid?
+    payable? || paid?
+  end
+
+  def deadline_date_remains_in_future
+    return unless will_save_change_to_deadline_date?
+    return if deadline_date.after?(Date.current)
+
+    errors.add(:deadline_date, "Deadline date must remain in the future")
+  end
+
   def deadline_date_in_the_past
-    return unless payable? || paid?
     return if deadline_date.before?(Date.current)
 
     errors.add(:deadline_date, "Deadline date must be in the past")

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -3,6 +3,10 @@ class Statement < ApplicationRecord
 
   VALID_FEE_TYPES = %w[output service].freeze
 
+  # In factories and seed data we need to be able to create statements with
+  # a deadline date in the past, so we allow this to be overridden in those cases.
+  attr_accessor :allow_creation_with_past_deadline_date
+
   # Associations
   belongs_to :contract
   has_many :adjustments, dependent: :destroy
@@ -33,7 +37,7 @@ class Statement < ApplicationRecord
   validates :api_id, uniqueness: { case_sensitive: false, message: "API id already exists for another statement" }
   validate :unique_lead_provider_month_year
   validates :deadline_date, presence: { message: "Deadline date must be specified" }
-  validates :deadline_date, comparison: { greater_than: Date.current, message: "Deadline date must be in the future" }, on: :service_create
+  validates :deadline_date, comparison: { greater_than: Date.current, message: "Deadline date must be in the future" }, on: :create, unless: :allow_creation_with_past_deadline_date
   validate :deadline_date_remains_in_future, on: :update
   validate :deadline_date_in_the_past, if: :payable_or_paid?
   validates :payment_date,

--- a/app/services/statements/create.rb
+++ b/app/services/statements/create.rb
@@ -11,7 +11,7 @@ module Statements
       statement.fee_type = FeeTypeForMonth.new(month: statement.month).call
 
       ActiveRecord::Base.transaction do
-        statement.save!(context: :service_create)
+        statement.save!
         Events::Record.record_statement_created_event!(author:, statement:)
       end
 

--- a/app/services/statements/create.rb
+++ b/app/services/statements/create.rb
@@ -11,7 +11,7 @@ module Statements
       statement.fee_type = FeeTypeForMonth.new(month: statement.month).call
 
       ActiveRecord::Base.transaction do
-        statement.save!
+        statement.save!(context: :service_create)
         Events::Record.record_statement_created_event!(author:, statement:)
       end
 

--- a/app/views/admin/finance/active_lead_providers/statements/show.html.erb
+++ b/app/views/admin/finance/active_lead_providers/statements/show.html.erb
@@ -9,7 +9,7 @@
 
 <%= render "statement", statement: @statement %>
 
-<% disabled = contract_period.started_on_or_before_today? %>
+<% disabled = !@active_lead_provider.editable? %>
 
 <div class="govuk-button-group">
   <%= govuk_button_link_to("Edit statement",

--- a/spec/factories/statement_factory.rb
+++ b/spec/factories/statement_factory.rb
@@ -21,6 +21,7 @@ FactoryBot.define do
       end
     end
 
+    allow_creation_with_past_deadline_date { true }
     contract { association(:contract, :for_ittecf_ectp, active_lead_provider:) }
     api_id { SecureRandom.uuid }
 

--- a/spec/models/active_lead_provider_spec.rb
+++ b/spec/models/active_lead_provider_spec.rb
@@ -20,6 +20,20 @@ describe ActiveLeadProvider do
     it { is_expected.to validate_uniqueness_of(:contract_period_year).scoped_to(:lead_provider_id).with_message("Contract period and lead provider must be unique") }
   end
 
+  describe "#editable?" do
+    subject { FactoryBot.create(:active_lead_provider, contract_period:) }
+
+    let(:contract_period) { FactoryBot.create(:contract_period) }
+
+    it { is_expected.to be_editable }
+
+    context "when the contract period is payments frozen" do
+      let(:contract_period) { FactoryBot.create(:contract_period, :with_payments_frozen) }
+
+      it { is_expected.not_to be_editable }
+    end
+  end
+
   describe "scopes" do
     let!(:rp_1) { FactoryBot.create(:contract_period) }
     let!(:rp_2) { FactoryBot.create(:contract_period) }

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -25,6 +25,7 @@ describe Statement do
     it { is_expected.to validate_inclusion_of(:fee_type).in_array(described_class.fee_types.keys).with_message("Fee type must be output or service") }
     it { is_expected.to validate_inclusion_of(:status).in_array(described_class.statuses.keys).with_message("Choose a valid status") }
     it { is_expected.to validate_comparison_of(:payment_date).is_greater_than(:deadline_date).with_message("Payment date must be later than the deadline date") }
+    it { is_expected.to validate_comparison_of(:deadline_date).is_greater_than(Date.current).on(:service_create).with_message("Deadline date must be in the future") }
 
     describe "uniqueness of month and year for the same active lead provider" do
       let(:active_lead_provider) { contract.active_lead_provider }
@@ -44,6 +45,22 @@ describe Statement do
         statement = described_class.new(contract: other_contract, month: 5, year: 2024, deadline_date: Date.new(2024, 5, 1).prev_day, payment_date: Date.new(2024, 5, 25))
 
         expect(statement).to be_valid
+      end
+    end
+
+    describe "deadline date remains in the future when updating" do
+      subject(:statement) { FactoryBot.create(:statement, deadline_date: 1.day.from_now.to_date) }
+
+      it "allows updates when the deadline_date remains in the future" do
+        statement.deadline_date = 2.days.from_now
+
+        expect(statement).to be_valid
+      end
+
+      it "prevents updates when the deadline_date is changed to a past date" do
+        statement.deadline_date = 1.day.ago
+
+        expect(statement).to have_error(:deadline_date, "Deadline date must remain in the future")
       end
     end
 

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -10,7 +10,7 @@ describe Statement do
   end
 
   describe "validations" do
-    subject { FactoryBot.create(:statement) }
+    subject { FactoryBot.create(:statement, allow_creation_with_past_deadline_date: false) }
 
     it { is_expected.to validate_presence_of(:contract).with_message("Contract is required") }
     it { is_expected.to validate_presence_of(:fee_type).with_message("Enter a fee type") }
@@ -25,7 +25,13 @@ describe Statement do
     it { is_expected.to validate_inclusion_of(:fee_type).in_array(described_class.fee_types.keys).with_message("Fee type must be output or service") }
     it { is_expected.to validate_inclusion_of(:status).in_array(described_class.statuses.keys).with_message("Choose a valid status") }
     it { is_expected.to validate_comparison_of(:payment_date).is_greater_than(:deadline_date).with_message("Payment date must be later than the deadline date") }
-    it { is_expected.to validate_comparison_of(:deadline_date).is_greater_than(Date.current).on(:service_create).with_message("Deadline date must be in the future") }
+    it { is_expected.to validate_comparison_of(:deadline_date).is_greater_than(Date.current).on(:create).with_message("Deadline date must be in the future") }
+
+    context "when allow_creation_with_past_deadline_date is true" do
+      subject { FactoryBot.build(:statement, allow_creation_with_past_deadline_date: true) }
+
+      it { is_expected.not_to validate_comparison_of(:deadline_date) }
+    end
 
     describe "uniqueness of month and year for the same active lead provider" do
       let(:active_lead_provider) { contract.active_lead_provider }
@@ -42,7 +48,7 @@ describe Statement do
       it "is valid to create another statement with the same month and year for a different active lead provider" do
         other_active_lead_provider = FactoryBot.create(:active_lead_provider)
         other_contract = FactoryBot.create(:contract, active_lead_provider: other_active_lead_provider)
-        statement = described_class.new(contract: other_contract, month: 5, year: 2024, deadline_date: Date.new(2024, 5, 1).prev_day, payment_date: Date.new(2024, 5, 25))
+        statement = FactoryBot.build(:statement, contract: other_contract, month: 5, year: 2024, deadline_date: Date.new(2024, 5, 1).prev_day, payment_date: Date.new(2024, 5, 25))
 
         expect(statement).to be_valid
       end

--- a/spec/requests/admin/finance/active_lead_providers/lead_provider_delivery_partnerships_spec.rb
+++ b/spec/requests/admin/finance/active_lead_providers/lead_provider_delivery_partnerships_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe "Admin finance active lead provider lead provider delivery partne
         expect(response).to have_http_status(:ok)
       end
 
-      context "when the contract period has started" do
-        let(:contract_period) { FactoryBot.create(:contract_period, :current) }
+      context "when the contract period is payments frozen" do
+        let(:contract_period) { FactoryBot.create(:contract_period, :with_payments_frozen) }
 
         it "renders the delivery partnerships index page" do
           get index_path
@@ -60,8 +60,8 @@ RSpec.describe "Admin finance active lead provider lead provider delivery partne
         expect(response).to have_http_status(:ok)
       end
 
-      context "when the contract period has started" do
-        let(:contract_period) { FactoryBot.create(:contract_period, :current) }
+      context "when the contract period is payments frozen" do
+        let(:contract_period) { FactoryBot.create(:contract_period, :with_payments_frozen) }
 
         it "blocks the new form, redirecting to the index" do
           get new_path
@@ -100,8 +100,8 @@ RSpec.describe "Admin finance active lead provider lead provider delivery partne
         end
       end
 
-      context "when the contract period has started" do
-        let(:contract_period) { FactoryBot.create(:contract_period, :current) }
+      context "when the contract period is payments frozen" do
+        let(:contract_period) { FactoryBot.create(:contract_period, :with_payments_frozen) }
 
         it "blocks the create, redirecting to the index" do
           expect {
@@ -143,8 +143,8 @@ RSpec.describe "Admin finance active lead provider lead provider delivery partne
         end
       end
 
-      context "when the contract period has started" do
-        let(:contract_period) { FactoryBot.create(:contract_period, :current) }
+      context "when the contract period is payments frozen" do
+        let(:contract_period) { FactoryBot.create(:contract_period, :with_payments_frozen) }
 
         it "blocks the delete page, redirecting to the index" do
           get delete_path
@@ -183,8 +183,8 @@ RSpec.describe "Admin finance active lead provider lead provider delivery partne
         end
       end
 
-      context "when the contract period has started" do
-        let(:contract_period) { FactoryBot.create(:contract_period, :current) }
+      context "when the contract period is payments frozen" do
+        let(:contract_period) { FactoryBot.create(:contract_period, :with_payments_frozen) }
 
         it "blocks the destroy, redirecting to the index" do
           lead_provider_delivery_partnership

--- a/spec/requests/admin/finance/active_lead_providers/statements_spec.rb
+++ b/spec/requests/admin/finance/active_lead_providers/statements_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Admin finance active lead provider statements", :enable_finance_
         expect(response).to have_http_status(:ok)
       end
 
-      context "when the contract period has started but is not frozen" do
+      context "when the contract period is not frozen" do
         let(:contract_period) { FactoryBot.create(:contract_period, :current) }
 
         it "allows the new form" do
@@ -130,7 +130,7 @@ RSpec.describe "Admin finance active lead provider statements", :enable_finance_
         end
       end
 
-      context "when the contract period has started but is not frozen" do
+      context "when the contract period is not frozen" do
         let(:contract_period) { FactoryBot.create(:contract_period, :current) }
 
         it "allows the create" do
@@ -195,8 +195,8 @@ RSpec.describe "Admin finance active lead provider statements", :enable_finance_
         expect(response).to have_http_status(:ok)
       end
 
-      context "when the contract period has started" do
-        let(:contract_period) { FactoryBot.create(:contract_period, :current) }
+      context "when the contract period is frozen" do
+        let(:contract_period) { FactoryBot.create(:contract_period, :current, :with_payments_frozen) }
 
         it "blocks the edit form, redirecting to the index" do
           get edit_path
@@ -251,8 +251,8 @@ RSpec.describe "Admin finance active lead provider statements", :enable_finance_
         end
       end
 
-      context "when the contract period has started" do
-        let(:contract_period) { FactoryBot.create(:contract_period, :current) }
+      context "when the contract period is frozen" do
+        let(:contract_period) { FactoryBot.create(:contract_period, :current, :with_payments_frozen) }
 
         it "blocks the update, redirecting to the index" do
           original_payment_date = statement.payment_date
@@ -286,8 +286,8 @@ RSpec.describe "Admin finance active lead provider statements", :enable_finance_
         expect(response).to have_http_status(:ok)
       end
 
-      context "when the contract period has started" do
-        let(:contract_period) { FactoryBot.create(:contract_period, :current) }
+      context "when the contract period is frozen" do
+        let(:contract_period) { FactoryBot.create(:contract_period, :current, :with_payments_frozen) }
 
         it "blocks the delete confirmation, redirecting to the index" do
           get delete_path
@@ -332,8 +332,8 @@ RSpec.describe "Admin finance active lead provider statements", :enable_finance_
         end
       end
 
-      context "when the contract period has started" do
-        let(:contract_period) { FactoryBot.create(:contract_period, :current) }
+      context "when the contract period is frozen" do
+        let(:contract_period) { FactoryBot.create(:contract_period, :current, :with_payments_frozen) }
 
         it "blocks the destroy, redirecting to the index" do
           expect {

--- a/spec/services/declarations/clawback_spec.rb
+++ b/spec/services/declarations/clawback_spec.rb
@@ -23,8 +23,9 @@ RSpec.describe Declarations::Clawback do
   end
 
   before do
-    # make payment statement precede clawback statement
-    declaration.payment_statement.update!(deadline_date: Date.yesterday, payment_date: Date.current)
+    # make payment statement precede clawback statement, avoiding
+    # validation rules around deadline_date.
+    declaration.payment_statement.update_columns(deadline_date: Date.yesterday, payment_date: Date.current)
   end
 
   describe "#clawback" do

--- a/spec/services/statements/create_spec.rb
+++ b/spec/services/statements/create_spec.rb
@@ -14,8 +14,8 @@ describe Statements::Create do
       contract_id: contract.id,
       month: 11,
       year: contract_period.year,
-      deadline_date: Date.new(contract_period.year, 11, 1),
-      payment_date: Date.new(contract_period.year, 12, 25)
+      deadline_date: Date.new(contract_period.year + 1, 11, 1),
+      payment_date: Date.new(contract_period.year + 1, 12, 25)
     }
   end
 
@@ -49,6 +49,15 @@ describe Statements::Create do
 
   context "when the statement is invalid" do
     let(:params) { super().merge(month: 99) }
+
+    it "raises ActiveRecord::RecordInvalid and does not create a statement" do
+      expect { subject.call }.to raise_error(ActiveRecord::RecordInvalid)
+      expect(Statement.count).to eq(0)
+    end
+  end
+
+  context "when the deadline date is in the past" do
+    let(:params) { super().merge(deadline_date: Date.yesterday) }
 
     it "raises ActiveRecord::RecordInvalid and does not create a statement" do
       expect { subject.call }.to raise_error(ActiveRecord::RecordInvalid)

--- a/spec/services/statements/create_spec.rb
+++ b/spec/services/statements/create_spec.rb
@@ -55,13 +55,4 @@ describe Statements::Create do
       expect(Statement.count).to eq(0)
     end
   end
-
-  context "when the deadline date is in the past" do
-    let(:params) { super().merge(deadline_date: Date.yesterday) }
-
-    it "raises ActiveRecord::RecordInvalid and does not create a statement" do
-      expect { subject.call }.to raise_error(ActiveRecord::RecordInvalid)
-      expect(Statement.count).to eq(0)
-    end
-  end
 end

--- a/spec/views/admin/finance/active_lead_providers/contracts/index.html.erb_spec.rb
+++ b/spec/views/admin/finance/active_lead_providers/contracts/index.html.erb_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe "admin/finance/active_lead_providers/contracts/index.html.erb" do
     end
   end
 
-  context "when the contract period is not editable" do
-    let(:contract_period) { FactoryBot.create(:contract_period, :current) }
+  context "when the contract period is payments frozen" do
+    let(:contract_period) { FactoryBot.create(:contract_period, :with_payments_frozen) }
 
     it "does not show delete buttons or an add contract link" do
       render

--- a/spec/views/admin/finance/active_lead_providers/contracts/show.html.erb_spec.rb
+++ b/spec/views/admin/finance/active_lead_providers/contracts/show.html.erb_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "admin/finance/active_lead_providers/contracts/show.html.erb" do
     end
   end
 
-  context "when the contract period is editable" do
+  context "when the contract period is not payments frozen" do
     it "shows edit and delete buttons" do
       render
 
@@ -53,8 +53,8 @@ RSpec.describe "admin/finance/active_lead_providers/contracts/show.html.erb" do
     end
   end
 
-  context "when the contract period is not editable" do
-    let(:contract_period) { FactoryBot.create(:contract_period, :current) }
+  context "when the contract period is payments frozen" do
+    let(:contract_period) { FactoryBot.create(:contract_period, :with_payments_frozen) }
 
     it "does not show edit or delete buttons" do
       render

--- a/spec/views/admin/finance/active_lead_providers/lead_provider_delivery_partnerships/index.html.erb_spec.rb
+++ b/spec/views/admin/finance/active_lead_providers/lead_provider_delivery_partnerships/index.html.erb_spec.rb
@@ -36,9 +36,9 @@ RSpec.describe "admin/finance/active_lead_providers/lead_provider_delivery_partn
     expect(rendered).not_to have_selector("a[aria-disabled='true']", text: "Add delivery partner")
   end
 
-  context "when the contract period has already started" do
+  context "when the contract period is payments frozen" do
     let(:contract_period) do
-      FactoryBot.create(:contract_period, year: 2020, started_on: Date.new(2020, 6, 1), finished_on: Date.new(2021, 5, 31))
+      FactoryBot.create(:contract_period, :with_payments_frozen)
     end
 
     it "hides remove buttons and renders the add button in a disabled state" do

--- a/spec/views/admin/finance/active_lead_providers/statements/show.html.erb_spec.rb
+++ b/spec/views/admin/finance/active_lead_providers/statements/show.html.erb_spec.rb
@@ -34,17 +34,27 @@ RSpec.describe "admin/finance/active_lead_providers/statements/show.html.erb" do
     expect(rendered).not_to have_selector("a[aria-disabled='true']")
   end
 
-  context "when the contract period has started" do
-    let(:contract_period) do
-      FactoryBot.create(:contract_period, year: 2020, started_on: Date.new(2020, 6, 1), finished_on: Date.new(2021, 5, 31))
-    end
-    let(:statement) { FactoryBot.create(:statement, :open, :output_fee, active_lead_provider:, month: 11, year: 2020) }
+  context "when the contract period is payments frozen" do
+    let(:contract_period) { FactoryBot.create(:contract_period, :with_payments_frozen) }
+    let(:statement) { FactoryBot.create(:statement, :open, :output_fee, active_lead_provider:) }
 
     it "renders the Edit and Delete buttons in a disabled state" do
       render
 
       expect(rendered).to have_selector("a[disabled], a[aria-disabled='true']", text: "Edit statement")
       expect(rendered).to have_selector("a[disabled], a[aria-disabled='true']", text: "Delete statement")
+    end
+  end
+
+  context "when the contract period is not payments frozen" do
+    let(:contract_period) { FactoryBot.create(:contract_period) }
+    let(:statement) { FactoryBot.create(:statement, :open, :output_fee, active_lead_provider:) }
+
+    it "renders the Edit and Delete buttons in an enabled state" do
+      render
+
+      expect(rendered).to have_selector("a:not([disabled])", text: "Edit statement")
+      expect(rendered).to have_selector("a:not([disabled])", text: "Delete statement")
     end
   end
 end


### PR DESCRIPTION
### Context

Initially we opted to block operations for statements, lead provider delivery partnerships and contracts in a contract period that has started. 

After reviewing this, we would like to relax the permissions so that we can create/update/delete these when in a
contract period as long as it is not payments frozen (and subject to other conditions for statements).

### Changes proposed in this pull request

- Relax permissions around statements

When creating or updating statements we should only be able to do so when the `deadline_date` has not yet passed.

When deleting a statement we should block if there are any associated declarations (which is the existing behaviour).

Update `Statement` model with additional validation rules; note I've used a `context` here for only allowing creation
of statements with a `deadline_date` in the past to avoid a large refactor, but we may want to try and tackle this
separately.

- Relax permissions around lead provider delivery partnerships

Currently we restrict the creation/deletion of lead provider delivery partnerships to only contract periods that have not yet started.

We want to relax this restriction to instead allow it for contract periods until they are payments frozen.

- Relax permissions around contracts

Allow adding/deleting contracts for contract periods as long as they are not payments frozen.

The behaviour change was already introduced with the change to `active_lead_provider.editable?`, this just updates the tests.

- Rework `Statement#deadline_date` validation rule

Moving to opt-out rather than opt-in.

### Guidance to review

We can pick up the remaining permission checks around contracts/bands as part of the tickets to add contracts/bands that are currently in-progress.

What do we think about the conditional validation rule around `deadline_date`? I also tried having it in the `Create` service but it felt awkward and disjointed.