### PR TITLE
Disable `actions` column to stop API IDs from wrapping

### DIFF
--- a/app/components/admin/schools/partnerships_summary_component.html.erb
+++ b/app/components/admin/schools/partnerships_summary_component.html.erb
@@ -4,7 +4,7 @@
 
     <% school_partnerships_by_year[year].each do |school_partnership| %>
       <%= govuk_summary_card(title: school_partnership_title(school_partnership)) do |card| %>
-        <%= card.with_summary_list do |list| %>
+        <%= card.with_summary_list(actions: false) do |list| %>
           <% list.with_row do |row| %>
             <% row.with_key(text: "Lead provider") %>
             <% row.with_value(text: school_partnership.lead_provider.name) %>


### PR DESCRIPTION
The actions column, unless suppressed, limits the width the 'value' column can take.

This causes long strings, like UUIDs, to wrap, which makes them even harder to read than they already are.

| Before | After |
| ------ | ----- |
| <img width="1010" height="423" alt="Screenshot From 2026-06-30 14-26-26" src="https://github.com/user-attachments/assets/439f402b-487b-49fd-b851-dbd1ae102b8f" /> |<img width="1001" height="407" alt="Screenshot From 2026-06-30 14-26-37" src="https://github.com/user-attachments/assets/454d66d5-63a9-4f9b-9e67-20c9fc0cf43e" /> |
