### PR TITLE
Only allow user accounts with DfE email addresses

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  VALID_EMAIL_SUFFIX = "@education.gov.uk"
+
   ROLES = {
     admin: "Admin",
     user_manager: "User manager",
@@ -16,6 +18,8 @@ class User < ApplicationRecord
             presence: { message: "Enter an email address" },
             uniqueness: { message: "Email address already used, enter another" },
             notify_email: true
+  validate :ensure_email_belongs_to_dfe, if: -> { email.present? }
+
   validates :otp_school_urn,
             reference_number_format: {
               allow_blank: true,
@@ -41,5 +45,13 @@ class User < ApplicationRecord
 
   def finance_access?
     finance?
+  end
+
+private
+
+  def ensure_email_belongs_to_dfe
+    return if email.downcase.ends_with?(VALID_EMAIL_SUFFIX)
+
+    errors.add(:email, %(Enter an '@education.gov.uk' email address))
   end
 end

--- a/config/personas.yml
+++ b/config/personas.yml
@@ -1,6 +1,6 @@
 ---
 - name: Velma Dinkley
-  email: velma@example.com
+  email: velma.dinkley@education.gov.uk
   appropriate_body_name: Golden Leaf Teaching School Hub
   school_name: Null
   dfe_staff: No
@@ -9,7 +9,7 @@
   type: Appropriate body user
 
 - name: Fred Jones
-  email: freddy@example.com
+  email: freddy.jones@education.gov.uk
   appropriate_body_name: Umber Teaching School Hub
   school_name: Null
   dfe_staff: No
@@ -18,7 +18,7 @@
   type: Appropriate body user
 
 - name: Daphne Blake
-  email: daphne@example.com
+  email: daphne.blake@education.gov.uk
   appropriate_body_name: Null
   dfe_staff: Yes
   school_name: Null
@@ -28,7 +28,7 @@
   role: user_manager
 
 - name: Norville Rogers
-  email: shaggy@example.com
+  email: shaggy.rogers@education.gov.uk
   appropriate_body_name: Null
   dfe_staff: Yes
   school_name: Null
@@ -38,7 +38,7 @@
   role: admin
 
 - name: Scrooge McDuck
-  email: scrooge@example.com
+  email: scrooge.mcduck@education.gov.uk
   appropriate_body_name: Null
   dfe_staff: Yes
   school_name: Null
@@ -48,7 +48,7 @@
   role: finance
 
 - name: Bob Belcher
-  email: bob@example.com
+  email: bob.belcher@education.gov.uk
   appropriate_body_name: Null
   dfe_staff: No
   school_name: Abbey Grove School
@@ -58,7 +58,7 @@
   type: School user
 
 - name: Serena Moon
-  email: serena@example.com
+  email: serena.moon@education.gov.uk
   appropriate_body_name: Null
   dfe_staff: No
   school_name: Brookfield School
@@ -68,7 +68,7 @@
   type: School user
 
 - name: Felix Starling
-  email: felix@example.com
+  email: felix.starling@education.gov.uk
   appropriate_body_name: Null
   dfe_staff: No
   school_name: Greyfriars School

--- a/spec/components/debug_session_component_spec.rb
+++ b/spec/components/debug_session_component_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe DebugSessionComponent, type: :component do
         expect(rendered_content).to have_text("Type")
         expect(rendered_content).to have_text("Sessions::Users::DfEUser")
         expect(rendered_content).to have_text("Email")
-        expect(rendered_content).to have_text("@example.com")
+        expect(rendered_content).to have_text(current_user.email)
         expect(rendered_content).to have_text("Last active at")
         expect(rendered_content).to have_text("1999-01-01 00:00:01 +0100")
         expect(rendered_content).to have_text("Role")

--- a/spec/factories/sessions/dfe_user_factory.rb
+++ b/spec/factories/sessions/dfe_user_factory.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
       new(email:)
     end
 
-    sequence(:email) { |n| "admin.user.#{n}@example.com" }
+    sequence(:email) { |n| "admin.user.#{n}@education.gov.uk" }
     sequence(:name) { |n| "Admin User #{n}" }
 
     role { User::ROLES.keys.sample.to_s }

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :user do
-    sequence(:email) { |n| "john.doe#{n}@example.com" }
+    sequence(:email) { |n| "john.doe#{n}@education.gov.uk" }
     sequence(:name) { |n| "John Doe #{n}" }
 
     admin

--- a/spec/features/admin/users/otp_sign_in_for_school_users_spec.rb
+++ b/spec/features/admin/users/otp_sign_in_for_school_users_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "OTP sign in for school users" do
+RSpec.describe "OTP sign in for school users", skip: "Blocked by new '@education.gov.uk' validation of email addresses" do
   scenario "create a user with a school URN and sign in via OTP" do
     given_otp_school_sign_in_is_enabled
     and_a_matching_school_exists

--- a/spec/forms/sessions/otp_sign_in_form_spec.rb
+++ b/spec/forms/sessions/otp_sign_in_form_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Sessions::OTPSignInForm, type: :model do
   describe "#code_is_verified" do
     subject(:form) { Sessions::OTPSignInForm.new(email:, code:) }
 
-    let(:email) { "bob@example.com" }
+    let(:email) { "bob@education.gov.uk" }
     let(:code) { "123456" }
     let(:result) { 987_654 }
     let!(:user) { FactoryBot.create(:user, email:) }

--- a/spec/jobs/appropriate_bodies/process_batch/action_job_spec.rb
+++ b/spec/jobs/appropriate_bodies/process_batch/action_job_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::ActionJob, type: :job do
 
   include_context "test TRS API returns a teacher"
 
-  let(:author) { FactoryBot.create(:user, name: "Barry Cryer", email: "barry@not-a-clue.co.uk") }
+  let(:author) { FactoryBot.create(:user, name: "Barry Cryer", email: "barry.cryer@education.gov.uk") }
 
   let(:appropriate_body_period) { FactoryBot.create(:appropriate_body_period) }
 

--- a/spec/jobs/appropriate_bodies/process_batch/claim_job_spec.rb
+++ b/spec/jobs/appropriate_bodies/process_batch/claim_job_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::ClaimJob, type: :job do
 
   include_context "test TRS API returns a teacher"
 
-  let(:author) { FactoryBot.create(:user, name: "Barry Cryer", email: "barry@not-a-clue.co.uk") }
+  let(:author) { FactoryBot.create(:user, name: "Barry Cryer", email: "barry.cryer@education.gov.uk") }
 
   let(:appropriate_body_period) { FactoryBot.create(:appropriate_body_period) }
   let(:pending_induction_submission_batch) do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -17,6 +17,25 @@ describe User do
     [1_234, 1_234_567, "abc123", -12_345].each do |urn|
       it { is_expected.not_to allow_value(urn).for(:otp_school_urn).with_message("URN must be 5 or 6 numbers") }
     end
+
+    describe "email addresses must end with @education.gov.uk" do
+      [
+        "julius.hibbert@education.gov.uk",
+        "MARVIN.MONROE@EDUCATION.GOV.UK",
+      ].each do |valid_email_address|
+        it { is_expected.to allow_value(valid_email_address).for(:email) }
+      end
+
+      let(:validation_message) { %(Enter an '@education.gov.uk' email address) }
+
+      [
+        "julius.hibbert@justice.gov.uk",
+        "nick.riviera@hotmail.com",
+        "marvin.monroe@fakeeducation.gov.uk",
+      ].each do |invalid_email_address|
+        it { is_expected.not_to allow_value(invalid_email_address).for(:email).with_message(validation_message) }
+      end
+    end
   end
 
   describe "associations" do

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -46,13 +46,13 @@ RSpec.describe "Admin::Users" do
     it "returns unauthorised for PATCH /admin/users/:id and does not update the user" do
       user_record = FactoryBot.create(:user)
 
-      patch admin_user_path(user_record), params: { user: { email: "hacked@example.com" } }
+      patch admin_user_path(user_record), params: { user: { email: "hacked@education.gov.uk" } }
 
       aggregate_failures do
         expect(response).to have_http_status(:unauthorized)
         expect(response.body).to include("You are not authorised to access this page")
         expect(response.body).to include(error_message)
-        expect(user_record.reload.email).not_to eq("hacked@example.com")
+        expect(user_record.reload.email).not_to eq("hacked@education.gov.uk")
       end
     end
   end
@@ -177,7 +177,7 @@ RSpec.describe "Admin::Users" do
 
     describe "PATCH /admin/users" do
       let(:user_record) { FactoryBot.create(:user) }
-      let(:new_email_address) { "joey@example.com" }
+      let(:new_email_address) { "joey@education.gov.uk" }
       let(:update_user_params) { { email: new_email_address } }
 
       it "updates the user record and records an event" do

--- a/spec/requests/otp_sessions_spec.rb
+++ b/spec/requests/otp_sessions_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "OTP sessions", type: :request do
+RSpec.describe "OTP sessions", skip: "Blocked by new '@education.gov.uk' validation of email addresses", type: :request do
   include ActionView::Helpers::SanitizeHelper
 
   let(:otp_school_sign_in_enabled) { true }

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -33,10 +33,10 @@ RSpec.describe "Sessions", type: :request do
   end
 
   describe "POST /auth/:provider/callback" do
-    let(:email) { Faker::Internet.email }
     let(:first_name) { Faker::Name.first_name }
     let(:last_name) { Faker::Name.last_name }
     let(:name) { [first_name, last_name].join(" ").strip }
+    let(:email) { "#{name.parameterize}@education.gov.uk" }
     let(:dfe_sign_in_organisation_name) { Faker::Company.name }
     let(:dfe_sign_in_organisation_id) { Faker::Internet.uuid }
     let(:dfe_sign_in_user_id) { Faker::Internet.uuid }

--- a/spec/services/sessions/user_spec.rb
+++ b/spec/services/sessions/user_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Sessions::User do
       let(:fake_user_session) do
         {
           "type" => "Sessions::Users::AppropriateBodyUser",
-          "email" => "ab_user@example.com",
+          "email" => "ab_user@education.gov.uk",
           "name" => "Christopher Lee",
           "last_active_at" => last_active_at,
           "dfe_sign_in_organisation_id" => dfe_sign_in_organisation_id,
@@ -32,7 +32,7 @@ RSpec.describe Sessions::User do
       it "instantiates a Sessions::Users::AppropriateBodyUser" do
         expect(session_user).to be_a(Sessions::Users::AppropriateBodyUser)
         expect(session_user.name).to eql("Christopher Lee")
-        expect(session_user.email).to eql("ab_user@example.com")
+        expect(session_user.email).to eql("ab_user@education.gov.uk")
         expect(session_user.last_active_at).to eql(last_active_at)
         expect(session_user.appropriate_body_period_id).to be(appropriate_body_period.id)
       end
@@ -43,7 +43,7 @@ RSpec.describe Sessions::User do
       let(:fake_user_session) do
         {
           "type" => "Sessions::Users::AppropriateBodyPersona",
-          "email" => "ab_persona@example.com",
+          "email" => "ab_persona@education.gov.uk",
           "name" => "Christopher Lee",
           "last_active_at" => last_active_at,
           "appropriate_body_period_id" => appropriate_body_period.id
@@ -53,18 +53,18 @@ RSpec.describe Sessions::User do
       it "instantiates a Sessions::Users::AppropriateBodyPersona" do
         expect(session_user).to be_a(Sessions::Users::AppropriateBodyPersona)
         expect(session_user.name).to eql("Christopher Lee")
-        expect(session_user.email).to eql("ab_persona@example.com")
+        expect(session_user.email).to eql("ab_persona@education.gov.uk")
         expect(session_user.last_active_at).to eql(last_active_at)
         expect(session_user.appropriate_body_period_id).to be(appropriate_body_period.id)
       end
     end
 
     context "when user session stores an existing db dfe user" do
-      let!(:dfe_user) { FactoryBot.create(:user, :admin, name: "Christopher Lee", email: "dfe_user@example.com") }
+      let!(:dfe_user) { FactoryBot.create(:user, :admin, name: "Christopher Lee", email: "dfe_user@education.gov.uk") }
       let(:fake_user_session) do
         {
           "type" => "Sessions::Users::DfEUser",
-          "email" => "dfe_user@example.com",
+          "email" => "dfe_user@education.gov.uk",
           "last_active_at" => last_active_at
         }
       end
@@ -72,17 +72,17 @@ RSpec.describe Sessions::User do
       it "instantiates a Sessions::Users::DfEUser" do
         expect(session_user).to be_a(Sessions::Users::DfEUser)
         expect(session_user.name).to eql("Christopher Lee")
-        expect(session_user.email).to eql("dfe_user@example.com")
+        expect(session_user.email).to eql("dfe_user@education.gov.uk")
         expect(session_user.last_active_at).to eql(last_active_at)
       end
     end
 
     context "when user session stores a dfe persona" do
-      let!(:dfe_user) { FactoryBot.create(:user, :admin, name: "Christopher Lee", email: "dfe_persona@example.com") }
+      let!(:dfe_user) { FactoryBot.create(:user, :admin, name: "Christopher Lee", email: "dfe_persona@education.gov.uk") }
       let(:fake_user_session) do
         {
           "type" => "Sessions::Users::DfEPersona",
-          "email" => "dfe_persona@example.com",
+          "email" => "dfe_persona@education.gov.uk",
           "last_active_at" => last_active_at
         }
       end
@@ -90,7 +90,7 @@ RSpec.describe Sessions::User do
       it "instantiates a Sessions::Users::DfEPersona" do
         expect(session_user).to be_a(Sessions::Users::DfEPersona)
         expect(session_user.name).to eql("Christopher Lee")
-        expect(session_user.email).to eql("dfe_persona@example.com")
+        expect(session_user.email).to eql("dfe_persona@education.gov.uk")
         expect(session_user.last_active_at).to eql(last_active_at)
       end
     end
@@ -102,7 +102,7 @@ RSpec.describe Sessions::User do
       let(:fake_user_session) do
         {
           "type" => "Sessions::Users::SchoolUser",
-          "email" => "school_user@example.com",
+          "email" => "school_user@education.gov.uk",
           "name" => "Christopher Lee",
           "last_active_at" => last_active_at,
           "school_urn" => school_urn,
@@ -114,7 +114,7 @@ RSpec.describe Sessions::User do
 
       it "instantiates a Sessions::Users::SchoolUser" do
         expect(session_user).to be_a(Sessions::Users::SchoolUser)
-        expect(session_user.email).to eql("school_user@example.com")
+        expect(session_user.email).to eql("school_user@education.gov.uk")
         expect(session_user.name).to eql("Christopher Lee")
         expect(session_user.last_active_at).to eql(last_active_at)
         expect(session_user.school_urn).to eql(school_urn)

--- a/spec/services/sessions/users/builder_spec.rb
+++ b/spec/services/sessions/users/builder_spec.rb
@@ -98,6 +98,7 @@ RSpec.describe Sessions::Users::Builder do
     end
 
     context "when the provider is a persona" do
+      let(:email) { "example.user@education.gov.uk" }
       let(:provider) { "persona" }
 
       context "and personas are not enabled" do
@@ -179,6 +180,7 @@ RSpec.describe Sessions::Users::Builder do
     end
 
     context "with an unknown provider" do
+      let(:email) { "example.user@education.gov.uk" }
       let(:provider) { "any_other_provider" }
       let(:uid) { email }
       let(:appropriate_body_period_id) { nil }

--- a/spec/services/sessions/users/dfe_user_impersonating_school_user_spec.rb
+++ b/spec/services/sessions/users/dfe_user_impersonating_school_user_spec.rb
@@ -1,7 +1,7 @@
 describe "Sessions::Users::DfEUserImpersonatingSchoolUser" do
   subject(:dfe_user_impersonating_school_user) { Sessions::Users::DfEUserImpersonatingSchoolUser.new(email: user.email, school_urn:, original_type:) }
 
-  let(:email) { "timothy.dalton@example.org" }
+  let(:email) { "timothy.dalton@education.gov.uk" }
   let(:user) { FactoryBot.create(:user, email:, name: "Timothy Dalton") }
   let(:school_urn) { 100_007 }
   let!(:school) { FactoryBot.create(:school, urn: school_urn) }

--- a/spec/services/statements/authorise_payment_spec.rb
+++ b/spec/services/statements/authorise_payment_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Statements::AuthorisePayment do
   subject { described_class.new(statement:, author:) }
 
-  let(:user)      { FactoryBot.create(:user, email: "test@example.com", name: "Test User") }
+  let(:user)      { FactoryBot.create(:user, :finance) }
   let(:author)    { Sessions::Users::DfEPersona.new(email: user.email) }
 
   let!(:statement) { FactoryBot.create(:statement, :payable, deadline_date: Date.yesterday) }

--- a/spec/validators/notify_email_validator_spec.rb
+++ b/spec/validators/notify_email_validator_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe NotifyEmailValidator, type: :model do
       email@double--hyphen.com
     ]
     valid_email_addresses.each do |email|
-      expect(User.new(name: "Geoff Capes", email:)).to be_valid
+      expect(NotifyEmailValidator.valid?(email)).to be(true)
     end
   end
 
@@ -61,7 +61,7 @@ RSpec.describe NotifyEmailValidator, type: :model do
       "incorrect-punycode@xn---something.com",
     ]
     invalid_email_addresses.each do |email|
-      expect(User.new(name: "Brian Jacks", email:)).not_to be_valid
+      expect(NotifyEmailValidator.valid?(email)).to be(false)
     end
   end
 end


### PR DESCRIPTION
### Context

We currently have two groups of users who get a user account (a record in the `users` table):

* DfE users
* School users who we give ad hoc access to in non-prod envs for UR purposes

### Changes proposed in this pull request

We want to limit all of our production users to being DfE staff for security purposes, and we want their access to stop once they've lost access to their DfE email address.

This PR adds a validation rule that ensures all user accounts have an email address that ends in `@education.gov.uk`.

### Notes

This will break the school signing-in via OTP functionality.

I think we need to either:

* formalise it and make it a fully-fledged `role` and feature
* remove it

Alternatively, if we were to add a new role we could adjust the validation so it only ensures DfE staff users need `@education.gov.uk` accounts.

> [!IMPORTANT]
> @avinhurry and I discussed this and decided that for now we'll go ahead and lock down accounts to `@education.gov.uk` ones, and I'll [raise a new issue](https://github.com/DFE-Digital/register-ects-project-board/issues/4164) to remove the functionality that supports schools logging in with an OTP