### PR TITLE
Only allow reuse of AB if active

### DIFF
--- a/app/wizards/schools/register_ect_wizard/use_previous_ect_choices_step.rb
+++ b/app/wizards/schools/register_ect_wizard/use_previous_ect_choices_step.rb
@@ -34,17 +34,21 @@ module Schools
         provider_led_reusable? || school_led_reusable?
       end
 
+      def previous_appropriate_body_active?
+        school.last_chosen_appropriate_body&.active? == true
+      end
+
       def provider_led_reusable?
         return false unless school.provider_led_training_programme_chosen?
         return false if school.last_chosen_lead_provider.blank?
-        return false if school.last_chosen_appropriate_body_id.blank?
+        return false unless previous_appropriate_body_active?
 
         reusable_partnership_id.present? || reusable_expression_of_interest?
       end
 
       def school_led_reusable?
         school.school_led_training_programme_chosen? &&
-          school.last_chosen_appropriate_body_id.present?
+          previous_appropriate_body_active?
       end
 
       def reusable_partnership_id

--- a/app/wizards/schools/register_ect_wizard/use_previous_ect_choices_step.rb
+++ b/app/wizards/schools/register_ect_wizard/use_previous_ect_choices_step.rb
@@ -34,21 +34,17 @@ module Schools
         provider_led_reusable? || school_led_reusable?
       end
 
-      def previous_appropriate_body_active?
-        school.last_chosen_appropriate_body&.active? == true
-      end
-
       def provider_led_reusable?
         return false unless school.provider_led_training_programme_chosen?
         return false if school.last_chosen_lead_provider.blank?
-        return false unless previous_appropriate_body_active?
+        return false unless school.last_chosen_appropriate_body&.active?
 
         reusable_partnership_id.present? || reusable_expression_of_interest?
       end
 
       def school_led_reusable?
         school.school_led_training_programme_chosen? &&
-          previous_appropriate_body_active?
+          school.last_chosen_appropriate_body&.active?
       end
 
       def reusable_partnership_id

--- a/spec/wizards/schools/register_ect_wizard/use_previous_ect_choices_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/use_previous_ect_choices_step_spec.rb
@@ -31,11 +31,12 @@ RSpec.describe Schools::RegisterECTWizard::UsePreviousECTChoicesStep, type: :mod
     )
   end
 
-  def stub_school_led_school_choice(school:, appropriate_body_id:)
+  def stub_school_led_school_choice(school:, appropriate_body:)
     allow(school).to receive_messages(
       provider_led_training_programme_chosen?: false,
       school_led_training_programme_chosen?: true,
-      last_chosen_appropriate_body_id: appropriate_body_id
+      last_chosen_appropriate_body: appropriate_body,
+      last_chosen_appropriate_body_id: appropriate_body&.id
     )
   end
 
@@ -575,7 +576,7 @@ RSpec.describe Schools::RegisterECTWizard::UsePreviousECTChoicesStep, type: :mod
       let!(:appropriate_body_period) { FactoryBot.create(:appropriate_body_period, :national) }
 
       before do
-        stub_school_led_school_choice(school:, appropriate_body_id: appropriate_body_period.id)
+        stub_school_led_school_choice(school:, appropriate_body: appropriate_body_period)
       end
 
       it "is allowed (product expectation for school-led)" do
@@ -585,7 +586,7 @@ RSpec.describe Schools::RegisterECTWizard::UsePreviousECTChoicesStep, type: :mod
 
     context "when school-led is chosen but last chosen appropriate body is missing" do
       before do
-        stub_school_led_school_choice(school:, appropriate_body_id: nil)
+        stub_school_led_school_choice(school:, appropriate_body: nil)
       end
 
       it "is not allowed" do
@@ -868,7 +869,7 @@ RSpec.describe Schools::RegisterECTWizard::UsePreviousECTChoicesStep, type: :mod
 
       before do
         allow(step.ect).to receive(:update).and_return(true)
-        stub_school_led_school_choice(school:, appropriate_body_id: appropriate_body_period.id)
+        stub_school_led_school_choice(school:, appropriate_body: appropriate_body_period)
       end
 
       it "does not set school_partnership_to_reuse_id" do

--- a/spec/wizards/schools/register_ect_wizard/use_previous_ect_choices_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/use_previous_ect_choices_step_spec.rb
@@ -572,7 +572,7 @@ RSpec.describe Schools::RegisterECTWizard::UsePreviousECTChoicesStep, type: :mod
       end
     end
 
-    context "when school-led is chosen and last chosen appropriate body is present" do
+    context "when school-led is chosen and the last chosen appropriate body is active" do
       let!(:appropriate_body_period) { FactoryBot.create(:appropriate_body_period, :national) }
 
       before do
@@ -584,7 +584,25 @@ RSpec.describe Schools::RegisterECTWizard::UsePreviousECTChoicesStep, type: :mod
       end
     end
 
-    context "when school-led is chosen but last chosen appropriate body is missing" do
+    context "when school-led is chosen but the last chosen appropriate body is inactive" do
+      let(:inactive_appropriate_body) do
+        FactoryBot.create(
+          :appropriate_body_period,
+          :national,
+          dfe_sign_in_organisation_id: nil
+        )
+      end
+
+      before do
+        stub_school_led_school_choice(school:, appropriate_body: inactive_appropriate_body)
+      end
+
+      it "is not allowed" do
+        expect(step.allowed?).to be(false)
+      end
+    end
+
+    context "when school-led is chosen but the last chosen appropriate body is missing" do
       before do
         stub_school_led_school_choice(school:, appropriate_body: nil)
       end
@@ -638,6 +656,25 @@ RSpec.describe Schools::RegisterECTWizard::UsePreviousECTChoicesStep, type: :mod
 
       context "and the last chosen appropriate body is missing" do
         before { school.update(last_chosen_appropriate_body: nil) }
+
+        it { is_expected.not_to be_allowed }
+      end
+
+      context "and the last chosen appropriate body is inactive" do
+        let(:inactive_appropriate_body) do
+          FactoryBot.create(
+            :appropriate_body_period,
+            :teaching_school_hub,
+            dfe_sign_in_organisation_id: nil
+          )
+        end
+
+        before do
+          school.update!(
+            last_chosen_training_programme: "provider_led",
+            last_chosen_appropriate_body: inactive_appropriate_body
+          )
+        end
 
         it { is_expected.not_to be_allowed }
       end

--- a/spec/wizards/schools/register_ect_wizard/use_previous_ect_choices_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/use_previous_ect_choices_step_spec.rb
@@ -598,7 +598,7 @@ RSpec.describe Schools::RegisterECTWizard::UsePreviousECTChoicesStep, type: :mod
       end
 
       it "is not allowed" do
-        expect(step.allowed?).to be(false)
+        expect(step).not_to be_allowed
       end
     end
 
@@ -608,7 +608,7 @@ RSpec.describe Schools::RegisterECTWizard::UsePreviousECTChoicesStep, type: :mod
       end
 
       it "is not allowed" do
-        expect(step.allowed?).to be(false)
+        expect(step).not_to be_allowed
       end
     end
 

--- a/spec/wizards/schools/register_ect_wizard/wizard_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/wizard_spec.rb
@@ -361,8 +361,28 @@ RSpec.describe Schools::RegisterECTWizard::Wizard do
         expect(wizard.allowed_steps).to include(:use_previous_ect_choices)
       end
 
-      context "but the last_chosen_appropriate_body is missing" do
+      context "but the last chosen appropriate body is missing" do
         before { school.update(last_chosen_appropriate_body: nil) }
+
+        it "does not include use_previous_ect_choices step" do
+          expect(wizard.allowed_steps).not_to include(:use_previous_ect_choices)
+        end
+      end
+
+      context "but the last chosen appropriate body is inactive" do
+        let(:inactive_appropriate_body) do
+          FactoryBot.create(
+            :appropriate_body_period,
+            :teaching_school_hub,
+            dfe_sign_in_organisation_id: nil
+          )
+        end
+
+        before do
+          school.update!(
+            last_chosen_appropriate_body: inactive_appropriate_body
+          )
+        end
 
         it "does not include use_previous_ect_choices step" do
           expect(wizard.allowed_steps).not_to include(:use_previous_ect_choices)


### PR DESCRIPTION
Ticket [here](https://github.com/DFE-Digital/register-ects-project-board/issues/4135)
### Context

Currently, if the school’s previously chosen appropriate body is no longer active, the school is still directed to the previous choices step. 

This PR updates the register ECT previous choices eligibility check so that previous choices can only be reused when the school’s last chosen appropriate body is active.

### Changes proposed in this pull request
- Replaces the presence check with an active appropriate body check for both provider-led and school-led reuse paths, using `school.last_chosen_appropriate_body.active?`


### Guidance to review

The main behaviour to check is that UsePreviousECTChoicesStep is only allowed when school.last_chosen_appropriate_body is active.