### PR TITLE
Use rails time zone for school comms query dates

### DIFF
--- a/db/seeds/blazer_queries/school_comms.rb
+++ b/db/seeds/blazer_queries/school_comms.rb
@@ -30,6 +30,10 @@ module BlazerQueries
 
       delegate :quote, to: "ActiveRecord::Base.connection", private: true
 
+      def current_date_sql
+        "(CURRENT_TIMESTAMP AT TIME ZONE 'Europe/London')::date"
+      end
+
       def registrations_opening
         {
           name: "Comms: Registrations opening (June)",
@@ -158,12 +162,12 @@ module BlazerQueries
 
       def not_opted_out_sql
         "(s.opted_out_of_reminder_emails_until IS NULL " \
-          "OR s.opted_out_of_reminder_emails_until < CURRENT_DATE)"
+          "OR s.opted_out_of_reminder_emails_until < #{current_date_sql})"
       end
 
       # Date range of the contract period that contains today.
       def current_contract_period_range_sql
-        "(SELECT cp.range FROM contract_periods cp WHERE cp.range @> CURRENT_DATE)"
+        "(SELECT cp.range FROM contract_periods cp WHERE cp.range @> #{current_date_sql})"
       end
 
       # School has at least one partnership in the current contract period.
@@ -175,7 +179,7 @@ module BlazerQueries
           "INNER JOIN active_lead_providers alp " \
           "ON alp.id = lpdp.active_lead_provider_id " \
           "INNER JOIN contract_periods cp ON cp.year = alp.contract_period_year " \
-          "WHERE sp.school_id = s.id AND cp.range @> CURRENT_DATE)"
+          "WHERE sp.school_id = s.id AND cp.range @> #{current_date_sql})"
       end
 
       # ...but no ECT or mentor was at the school during the current contract period.

--- a/spec/seeds/blazer_queries/school_comms_spec.rb
+++ b/spec/seeds/blazer_queries/school_comms_spec.rb
@@ -60,6 +60,15 @@ RSpec.describe BlazerQueries::SchoolComms do
       expect(statements).to all(satisfy { |statement| statement.exclude?("https://https://") })
     end
 
+    it "uses a time zone aware SQL current date" do
+      statement = definitions.find { |definition| definition[:name] == "Comms: Start of term reminder (September)" }
+                             .fetch(:statement)
+
+      expect(statement).to include("(CURRENT_TIMESTAMP AT TIME ZONE 'Europe/London')::date")
+      expect(statement).not_to include("CURRENT_DATE")
+      expect(statement).not_to include("'#{Date.current}'::date")
+    end
+
     it "excludes children's centres and their linked sites everywhere (#2501)" do
       definitions.each do |definition|
         expect(definition[:statement]).to include(


### PR DESCRIPTION
## Summary

Replace `CURRENT_DATE` with a time zone aware SQL expression so the queries evaluate dates in the rails application time zone.

This avoids a mismatch between postgres `CURRENT_DATE` (which uses UTC) and the rails application time zone around midnight. 

Postgre expects an IANA time zone name, so the configured rails time zone is converted before being used in the SQL expression.