### PR TITLE
Reduce worker memory to 4Gi in prod

### DIFF
--- a/config/terraform/application/config/production.tfvars.json
+++ b/config/terraform/application/config/production.tfvars.json
@@ -13,7 +13,7 @@
     "deploy_snapshot_database": true,
     "postgres_enable_high_availability": true,
     "azure_enable_backup_storage": true,
-    "worker_memory_max": "6Gi",
+    "worker_memory_max": "4Gi",
     "webapp_memory_max": "4Gi",
     "webapp_replicas": 4,
     "worker_replicas": 2


### PR DESCRIPTION
We increased it to 6Gi for the data migration but it's overkill. This reduces it to 4Gi as a first step, we might go a bit further if everything remains smooth.
