### PR TITLE
Reduce number of webapp replicas to 2 in prod

### DIFF
--- a/config/terraform/application/config/production.tfvars.json
+++ b/config/terraform/application/config/production.tfvars.json
@@ -15,6 +15,6 @@
     "azure_enable_backup_storage": true,
     "worker_memory_max": "4Gi",
     "webapp_memory_max": "4Gi",
-    "webapp_replicas": 4,
+    "webapp_replicas": 2,
     "worker_replicas": 2
 }


### PR DESCRIPTION
We currently have 4 each with 4Gi RAM and they aren't being fully utilised, so reducing the number makes sense. We can _probably_ reduce the memory to 2Gi too but that will be done in a later PR once we're sure this won't cause any problems.
