### PR TITLE
Align admin teacher pagination with display name sorting

### DIFF
--- a/app/services/admin/teachers/search.rb
+++ b/app/services/admin/teachers/search.rb
@@ -211,12 +211,12 @@ module Admin
         <<~SQL.squish
           LOWER(
             COALESCE(
-              NULLIF(teachers.corrected_name, ''),
+              NULLIF(TRIM(teachers.corrected_name), ''),
               NULLIF(
                 CONCAT_WS(
                   ' ',
-                  NULLIF(teachers.trs_first_name, '.'),
-                  NULLIF(teachers.trs_last_name, '.')
+                  NULLIF(NULLIF(TRIM(teachers.trs_first_name), ''), '.'),
+                  NULLIF(NULLIF(TRIM(teachers.trs_last_name), ''), '.')
                 ),
                 ''
               ),

--- a/app/services/admin/teachers/search.rb
+++ b/app/services/admin/teachers/search.rb
@@ -13,7 +13,7 @@ module Admin
 
       def teacher_scope
         preload_associations(filtered_teacher_scope)
-          .reorder(:trs_first_name, :trs_last_name, :id)
+          .reorder(Arel.sql(display_name_order_sql), :id)
       end
 
     private
@@ -203,6 +203,25 @@ module Admin
         {
           latest_training_period: :schedule
         }
+      end
+
+      def display_name_order_sql
+        <<~SQL.squish
+          LOWER(
+            COALESCE(
+              NULLIF(teachers.corrected_name, ''),
+              NULLIF(
+                CONCAT_WS(
+                  ' ',
+                  NULLIF(teachers.trs_first_name, '.'),
+                  NULLIF(teachers.trs_last_name, '.')
+                ),
+                ''
+              ),
+              'Unknown'
+            )
+          )
+        SQL
       end
     end
   end

--- a/app/services/admin/teachers/search.rb
+++ b/app/services/admin/teachers/search.rb
@@ -206,6 +206,8 @@ module Admin
       end
 
       def display_name_order_sql
+        # Mirrors Teachers::Name in SQL so ordering and pagination use the same
+        # display name logic used by the UI.
         <<~SQL.squish
           LOWER(
             COALESCE(

--- a/spec/services/admin/teachers/search_spec.rb
+++ b/spec/services/admin/teachers/search_spec.rb
@@ -15,6 +15,22 @@ RSpec.describe Admin::Teachers::Search do
       it { is_expected.to contain_exactly(teacher, other_teacher) }
     end
 
+    context "when a corrected name changes alphabetical ordering" do
+      let!(:teacher_with_corrected_name) do
+        FactoryBot.create(
+          :teacher,
+          trs_first_name: "Zelda",
+          trs_last_name: "Zimmer",
+          corrected_name: "Aaron Aardvark"
+        )
+      end
+      let!(:other_teacher) { FactoryBot.create(:teacher, trs_first_name: "Bob", trs_last_name: "Builder") }
+
+      it "orders teachers by the displayed full name" do
+        expect(teacher_scope).to eq([teacher_with_corrected_name, other_teacher])
+      end
+    end
+
     context "when it is an exact 7 digit TRN" do
       let(:query_string) { "1234567" }
       let!(:teacher) { FactoryBot.create(:teacher, trn: "1234567") }

--- a/spec/services/admin/teachers/search_spec.rb
+++ b/spec/services/admin/teachers/search_spec.rb
@@ -31,6 +31,28 @@ RSpec.describe Admin::Teachers::Search do
       end
     end
 
+    context "when TRS name parts are blank or placeholder values" do
+      let!(:teacher_with_blank_first_name) do
+        FactoryBot.create(:teacher, trs_first_name: "", trs_last_name: "Smith")
+      end
+
+      let!(:teacher_with_placeholder_first_name) do
+        FactoryBot.create(:teacher, trs_first_name: ".", trs_last_name: "Taylor")
+      end
+
+      let!(:teacher_with_no_name) do
+        FactoryBot.create(:teacher, trs_first_name: "", trs_last_name: "")
+      end
+
+      it "orders teachers by the displayed full name fallbacks" do
+        expect(teacher_scope).to eq([
+          teacher_with_blank_first_name,
+          teacher_with_placeholder_first_name,
+          teacher_with_no_name
+        ])
+      end
+    end
+
     context "when it is an exact 7 digit TRN" do
       let(:query_string) { "1234567" }
       let!(:teacher) { FactoryBot.create(:teacher, trn: "1234567") }


### PR DESCRIPTION
## Summary

Order the admin teacher search scope using the same display name logic used when rendering teacher rows.

Previously, teachers were ordered by their trs names in SQL, but the UI displayed corrected names (in Ruby). Because the ordering and rendering used different name logic, the visible ordering and pagination could become inconsistent making the alphabetical ordering appear incorrect on the UI.

The search scope now mirrors `Teachers::Name` in SQL by preferring `corrected_name`, falling back to the TRS full name, and using "Unknown" when neither name is present.

