### PR TITLE
[3992] Show training period as withdrawn/deferred in the admin console

### DIFF
--- a/app/components/admin/teachers/training_summary_component.rb
+++ b/app/components/admin/teachers/training_summary_component.rb
@@ -14,18 +14,31 @@ module Admin
           if show_move_partnership_link?
             card.with_action { helpers.govuk_link_to("Move to a different partnership", move_partnership_path) }
           end
-          card.with_summary_list(actions: false) do |list|
-            rows.each do |row|
-              list.with_row do |r|
-                r.with_key(text: row[:key][:text]) if row[:key].present?
-                r.with_value(text: row[:value][:text])
+
+          helpers.safe_join([
+            status_inset_text,
+            helpers.govuk_summary_list(actions: false) do |list|
+              rows.each do |row|
+                list.with_row do |r|
+                  r.with_key(text: row.dig(:key, :text)) if row[:key].present?
+                  r.with_value(text: row.dig(:value, :text))
+                end
               end
             end
-          end
+          ].compact)
         end
       end
 
     private
+
+      def status_inset_text
+        case training_period.status
+        when :deferred
+          helpers.govuk_inset_text(text: "#{helpers.teacher_full_name(teacher)} has been deferred from this training period by the lead provider.")
+        when :withdrawn
+          helpers.govuk_inset_text(text: "#{helpers.teacher_full_name(teacher)} has been withdrawn from this training period by the lead provider.")
+        end
+      end
 
       def rows
         if training_period.provider_led_training_programme?

--- a/lib/tasks/product_review/3992.rake
+++ b/lib/tasks/product_review/3992.rake
@@ -1,0 +1,59 @@
+namespace :product_review do
+  desc "Set up deferred and withdrawn training periods at Abbey Grove for review (#3992)"
+  task "3992" => :environment do
+    if Teacher.exists?(trn: "0000060")
+      puts "Scenario already set up — Velma Dinkley (TRN 0000060) exists. Aborting."
+      next
+    end
+
+    abbey_grove = School.find_by!(urn: 1_759_427)
+    contract_period = ContractPeriod.find_by!(year: 2023)
+    ambition = LeadProvider.find_by!(name: "Ambition Institute")
+    active_lead_provider = ActiveLeadProvider.find_by!(lead_provider: ambition, contract_period:)
+    school_partnership = SchoolPartnership.find_by!(school: abbey_grove, lead_provider_delivery_partnership: LeadProviderDeliveryPartnership.find_by!(active_lead_provider:))
+    schedule = Schedule.find_by!(contract_period_year: 2023, identifier: "ecf-standard-september")
+
+    ApplicationRecord.transaction do
+      velma = Teacher.create!(trn: "0000060", trs_first_name: "Velma", trs_last_name: "Dinkley", trs_qts_awarded_on: Date.new(2022, 1, 1), trs_induction_status: "InProgress")
+      fred  = Teacher.create!(trn: "0000061", trs_first_name: "Fred",  trs_last_name: "Jones",   trs_qts_awarded_on: Date.new(2022, 1, 1), trs_induction_status: "InProgress")
+
+      velma_at_abbey_grove = ECTAtSchoolPeriod.create!(
+        teacher: velma,
+        school: abbey_grove,
+        started_on: Date.new(2023, 9, 1),
+        finished_on: nil
+      )
+
+      TrainingPeriod.create!(
+        ect_at_school_period: velma_at_abbey_grove,
+        school_partnership:,
+        schedule:,
+        training_programme: "provider_led",
+        started_on: Date.new(2023, 9, 1),
+        finished_on: Date.new(2024, 3, 1),
+        deferred_at: Date.new(2024, 3, 1),
+        deferral_reason: "long_term_sickness"
+      )
+
+      fred_at_abbey_grove = ECTAtSchoolPeriod.create!(
+        teacher: fred,
+        school: abbey_grove,
+        started_on: Date.new(2023, 9, 1),
+        finished_on: nil
+      )
+
+      TrainingPeriod.create!(
+        ect_at_school_period: fred_at_abbey_grove,
+        school_partnership:,
+        schedule:,
+        training_programme: "provider_led",
+        started_on: Date.new(2023, 9, 1),
+        finished_on: Date.new(2024, 3, 1),
+        withdrawn_at: Date.new(2024, 3, 1),
+        withdrawal_reason: "moved_school"
+      )
+    end
+
+    puts "All done 🎉"
+  end
+end

--- a/spec/components/admin/teachers/training_summary_component_spec.rb
+++ b/spec/components/admin/teachers/training_summary_component_spec.rb
@@ -193,6 +193,33 @@ RSpec.describe Admin::Teachers::TrainingSummaryComponent, type: :component do
       end
     end
 
+    describe "training period status inset text" do
+      subject { page }
+
+      let(:teacher) { training_period.teacher }
+      let(:teacher_name) { Teachers::Name.new(teacher).full_name }
+
+      before { rendered }
+
+      context "when the training period is active" do
+        let(:training_period) { FactoryBot.create(:training_period, :provider_led, :for_ect) }
+
+        it { is_expected.not_to have_css(".govuk-inset-text") }
+      end
+
+      context "when the training period is deferred" do
+        let(:training_period) { FactoryBot.create(:training_period, :provider_led, :for_ect, :deferred) }
+
+        it { is_expected.to have_css(".govuk-inset-text", text: "#{teacher_name} has been deferred from this training period by the lead provider.") }
+      end
+
+      context "when the training period is withdrawn" do
+        let(:training_period) { FactoryBot.create(:training_period, :provider_led, :for_ect, :withdrawn) }
+
+        it { is_expected.to have_css(".govuk-inset-text", text: "#{teacher_name} has been withdrawn from this training period by the lead provider.") }
+      end
+    end
+
     context "when the component is rendering a subsequent row" do
       subject(:rendered) { render_inline(described_class.new(training_period:, show_api_row: false)) }
 


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/3992

### Changes proposed in this pull request

Add inset text showing the deferred or withdrawn status in the admin console training summary