### PR TITLE
Spike mentorship periods API

### DIFF
--- a/app/controllers/api/v3/mentorship_periods_controller.rb
+++ b/app/controllers/api/v3/mentorship_periods_controller.rb
@@ -1,0 +1,27 @@
+module API
+  module V3
+    class MentorshipPeriodsController < APIController
+      def index
+        paginated_mentorship_periods = paginate(mentorship_periods_query.mentorship_periods)
+
+        render json: to_json(paginated_mentorship_periods)
+      end
+
+    private
+
+      def mentorship_periods_query
+        MentorshipPeriods::Query.new(**default_query_conditions)
+      end
+
+      def default_query_conditions
+        @default_query_conditions ||= {
+          lead_provider_id: current_lead_provider.id,
+        }
+      end
+
+      def to_json(obj)
+        API::MentorshipPeriodsSerializer.render(obj, root: "data")
+      end
+    end
+  end
+end

--- a/app/controllers/api/v3/participants/mentorship_periods_controller.rb
+++ b/app/controllers/api/v3/participants/mentorship_periods_controller.rb
@@ -1,0 +1,33 @@
+module API
+  module V3::Participants
+    class MentorshipPeriodsController < APIController
+      def index
+        paginated_mentorship_periods = paginate(mentorship_periods_query.mentorship_periods)
+
+        render json: to_json(paginated_mentorship_periods)
+      end
+
+    private
+
+      def mentorship_periods_query
+        Teachers::MentorshipPeriods::Query.new(**default_query_conditions)
+      end
+
+      def default_query_conditions
+        @default_query_conditions ||= {
+          lead_provider_id: current_lead_provider.id,
+        }
+      end
+
+      def serializer_options
+        @serializer_options ||= {
+          lead_provider_id: current_lead_provider.id
+        }
+      end
+
+      def to_json(obj)
+        API::Teachers::MentorshipPeriodsSerializer.render(obj, root: "data", **serializer_options)
+      end
+    end
+  end
+end

--- a/app/serializers/api/mentorship_periods_serializer.rb
+++ b/app/serializers/api/mentorship_periods_serializer.rb
@@ -1,0 +1,31 @@
+class API::MentorshipPeriodsSerializer < Blueprinter::Base
+  class AttributesSerializer < Blueprinter::Base
+    field(:started_on)
+    field(:finished_on)
+
+    field(:school_urn) do |mentorship_period|
+      mentorship_period.mentee.school.urn
+    end
+
+    field(:ect_participant_id) do |mentorship_period|
+      mentorship_period.mentee.teacher.api_ect_training_record_id
+    end
+
+    field(:mentor_participant_id) do |mentorship_period|
+      mentorship_period.mentor.teacher.api_ect_training_record_id
+    end
+
+    field(:mentor_email) do |mentorship_period|
+      mentorship_period.mentor.email
+    end
+
+    field(:mentor_full_name) { |mentorship_period| Teachers::Name.new(mentorship_period.mentor.teacher).full_name }
+  end
+
+  identifier :api_id, name: :id
+  field(:type) { "mentorship-periods" }
+
+  association :attributes, blueprint: AttributesSerializer do |mentorship_period|
+    mentorship_period
+  end
+end

--- a/app/serializers/api/teachers/mentorship_periods_serializer.rb
+++ b/app/serializers/api/teachers/mentorship_periods_serializer.rb
@@ -1,0 +1,42 @@
+class API::Teachers::MentorshipPeriodsSerializer < Blueprinter::Base
+  class MentorshipPeriodSerializer < Blueprinter::Base
+    field(:started_on)
+    field(:finished_on)
+
+    field(:mentor_email) do |mentorship_period|
+      mentorship_period.mentor.email
+    end
+
+    field(:mentor_full_name) { |mentorship_period| Teachers::Name.new(mentorship_period.mentor.teacher).full_name }
+  end
+
+  class AttributesSerializer < Blueprinter::Base
+    field(:training_record_id) do |data|
+      data[:teacher].api_ect_training_record_id
+    end
+
+    field(:school_urn) do |data|
+      data[:latest_ect_training_period].ect_at_school_period.school.urn
+    end
+
+    association :mentorship_periods, blueprint: MentorshipPeriodSerializer do |data|
+      data[:mentorship_periods]
+    end
+  end
+
+  identifier :api_id, name: :id
+  field(:type) { "mentorship-periods" }
+
+  association :attributes, blueprint: AttributesSerializer do |teacher, options|
+    latest_ect_training_period = lead_provider_metadata(teacher:, options:).latest_ect_training_period
+    mentorship_periods = latest_ect_training_period.ect_at_school_period.mentorship_periods.select(&:ongoing_today?)
+
+    { teacher:, latest_ect_training_period:, mentorship_periods: }
+  end
+
+  class << self
+    def lead_provider_metadata(teacher:, options:)
+      teacher.lead_provider_metadata.select { it.lead_provider_id == options[:lead_provider_id] }.sole
+    end
+  end
+end

--- a/app/services/api/mentorship_periods/query.rb
+++ b/app/services/api/mentorship_periods/query.rb
@@ -1,0 +1,38 @@
+module API::MentorshipPeriods
+  class Query
+    include Queries::FilterIgnorable
+
+    attr_reader :scope
+
+    def initialize(lead_provider_id:)
+      @scope = MentorshipPeriod.current_or_future
+
+      where_lead_provider(lead_provider_id)
+    end
+
+    def mentorship_periods
+      preload_associations(block_given? ? yield(scope) : scope)
+    end
+
+  private
+
+    def preload_associations(results)
+      results
+        .strict_loading
+        .includes(
+          mentee: %i[teacher school],
+          mentor: :teacher
+        )
+    end
+
+    def where_lead_provider(lead_provider_id)
+      @scope = scope
+        .joins(mentee: { training_periods: :lead_provider })
+        .where(
+          lead_providers: {
+            id: lead_provider_id,
+          }
+        )
+    end
+  end
+end

--- a/app/services/api/teachers/mentorship_periods/query.rb
+++ b/app/services/api/teachers/mentorship_periods/query.rb
@@ -1,0 +1,58 @@
+module API::Teachers::MentorshipPeriods
+  class Query
+    include Queries::FilterIgnorable
+
+    attr_reader :scope
+
+    def initialize(lead_provider_id:)
+      @scope = Teacher.all
+
+      with_current_or_future_mentorship_periods
+      where_lead_provider(lead_provider_id)
+    end
+
+    def mentorship_periods
+      preload_associations(block_given? ? yield(scope) : scope)
+    end
+
+  private
+
+    def preload_associations(results)
+      results
+        .strict_loading
+        .includes(
+          lead_provider_metadata: {
+            latest_ect_training_period: {
+              ect_at_school_period: {
+                school: {},
+                mentorship_periods: {
+                  mentor: :teacher
+                }
+              },
+            }
+          }
+        )
+    end
+
+    def where_lead_provider(lead_provider_id)
+      @scope = scope
+        .joins(:lead_provider_metadata)
+        .where(
+          lead_provider_metadata: {
+            lead_provider_id:,
+          }
+        )
+    end
+
+    def with_current_or_future_mentorship_periods
+      @scope = scope.joins(
+        lead_provider_metadata: {
+          latest_ect_training_period: {
+            ect_at_school_period: :mentorship_periods,
+          }
+        }
+      )
+      .where("mentorship_periods.finished_on IS NULL OR mentorship_periods.finished_on >= ?", Time.zone.today)
+    end
+  end
+end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -356,6 +356,7 @@
   - ecf_start_induction_record_id
   - ecf_end_induction_record_id
   :mentorship_periods:
+  - api_id
   - range
   - ecf_start_induction_record_id
   - ecf_end_induction_record_id

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -17,6 +17,7 @@ namespace :api do
 
       collection do
         resources :transfers, only: %i[index]
+        resources :mentorship_periods, only: %i[index], path: "mentorship-periods", controller: "participants/mentorship_periods"
       end
     end
 

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -21,6 +21,8 @@ namespace :api do
       end
     end
 
+    resources :mentorship_periods, only: %i[index], path: "mentorship-periods"
+
     resources :declarations, only: %i[create show index], param: :api_id, path: "participant-declarations" do
       member { put :void, path: "void" }
     end

--- a/db/migrate/20260702090522_add_api_id_to_mentorship_periods.rb
+++ b/db/migrate/20260702090522_add_api_id_to_mentorship_periods.rb
@@ -1,0 +1,6 @@
+class AddAPIIdToMentorshipPeriods < ActiveRecord::Migration[8.1]
+  def change
+    add_column :mentorship_periods, :api_id, :uuid, null: false, default: "gen_random_uuid()"
+    add_index :mentorship_periods, :api_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_29_150700) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_02_090522) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -484,6 +484,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_29_150700) do
   end
 
   create_table "mentorship_periods", force: :cascade do |t|
+    t.uuid "api_id", default: -> { "gen_random_uuid()" }, null: false
     t.datetime "created_at", null: false
     t.uuid "ecf_end_induction_record_id"
     t.uuid "ecf_start_induction_record_id"
@@ -494,6 +495,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_29_150700) do
     t.date "started_on", null: false
     t.datetime "updated_at", null: false
     t.index "ect_at_school_period_id, ((finished_on IS NULL))", name: "idx_on_ect_at_school_period_id_finished_on_IS_NULL_afd5cf131d", unique: true, where: "(finished_on IS NULL)"
+    t.index ["api_id"], name: "index_mentorship_periods_on_api_id", unique: true
     t.index ["ect_at_school_period_id", "started_on"], name: "index_mentorship_periods_on_ect_at_school_period_id_started_on", unique: true
     t.index ["ect_at_school_period_id"], name: "index_mentorship_periods_on_ect_at_school_period_id"
     t.index ["mentor_at_school_period_id", "ect_at_school_period_id", "started_on"], name: "idx_on_mentor_at_school_period_id_ect_at_school_per_d69dffeecc", unique: true

--- a/documentation/domain-model.md
+++ b/documentation/domain-model.md
@@ -274,6 +274,7 @@ erDiagram
     daterange range
     date started_on
     datetime updated_at
+    uuid api_id
   }
   MentorshipPeriod }o--|| ECTAtSchoolPeriod : belongs_to
   MentorshipPeriod }o--|| MentorAtSchoolPeriod : belongs_to


### PR DESCRIPTION
> ⚠️ WIP

### Context

We want to explore different ways of exposing the mentorship periods for participants, to get around the current issues with unfunded mentors (we can't see all mentors and those that we see we only get the _latest_ details for the mentor, not the details relative to the ECT/school).

### Changes proposed in this pull request

- Add participants/mentorship-periods endpoint

Returns `Teacher` records for all ECTs that have at least one `MentorshipPeriod`. Lists the `mentorship_periods` in the response for each ECT.

- Add /mentorship-periods endpoint

Returns `MentorshipPeriod` records for all ECTs of a lead provider, linking back to the ECT/mentor participants in each

### Guidance to review

Examples for each approach are below (showing seed data).

#### `participants/mentorship-periods`

```
{
    "data": [
        {
            "id": "f960c7ea-de28-4004-a687-35c586b14f62",
            "type": "mentorship-periods",
            "attributes": {
                "training_record_id": "72d1ba66-08fd-49e9-b777-cc20f14a49ff",
                "school_urn": 1759427,
                "mentorship_periods": [
                    {
                        "started_on": "2024-07-31",
                        "finished_on": null,
                        "mentor_email": "hugh.grant@abbey-grove-school.org.uk",
                        "mentor_full_name": "Hugh Grant"
                    }
                ]
            }
        }
    ]
}
```

This approach requires metadata to find the latest ECT training period for each participant and we need to filter the mentorship periods to only those that are current/future in-memory during serialisation. We also need to preload a lot more tables to construct the response:

```
teacher -> metadata -> latest training period -> school period -> school
teacher -> metadata -> latest training period -> ECT school period -> mentorship period -> mentor school period -> teacher
```

The touch model/updated_at filtering will be more complicated with this approach as we'll need to add an `api_mentorship_periods_updated_at` to `Teacher` or aggregate the `updated_at` from current/future mentorship periods in the serializer.

#### `/mentorship-periods`

```
{
    "data": [
        {
            "id": "8e102906-15a6-4c4b-ab56-6e0f120a3fef",
            "type": "mentorship-periods",
            "attributes": {
                "started_on": "2024-07-31",
                "finished_on": null,
                "school_urn": 1759427,
                "ect_participant_id": "72d1ba66-08fd-49e9-b777-cc20f14a49ff",
                "mentor_participant_id": "c832fd6e-1eb0-4a9c-9424-f87dae7b2aac",
                "mentor_email": "hugh.grant@abbey-grove-school.org.uk",
                "mentor_full_name": "Hugh Grant"
            }
        }
    ]
}
```

This approach doesn't require any metadata as we return a response entry for each current/future mentorship period linked to the lead provider. The preloading is a lot lighter here as well, so it will be faster:

```
mentee -> teacher
mentee -> school
mentor -> teacher
```

As we are returning the `MentorshipPeriod`, which isn't something we have exposed in the API yet, we have to add an `api_id` attribute to generate a UUID for each record.

Filtering and displaying an `updated_at` using this approach would be simple and not require any workarounds.