### PR TITLE
[4168] Lock OTP accounts after repeated failed verification attempts

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -41,6 +41,14 @@ module Admin
       end
     end
 
+    def unlock_otp_sign_in
+      user = User.find(params[:id])
+
+      Sessions::UnlockOTPAccount.new(author: current_user, user:).unlock
+
+      redirect_to admin_user_path(user), alert: "#{user.name} can now sign in with OTP"
+    end
+
   private
 
     def user_params

--- a/app/forms/sessions/otp_sign_in_form.rb
+++ b/app/forms/sessions/otp_sign_in_form.rb
@@ -28,7 +28,18 @@ module Sessions
 
       errors.add(:code, "Enter the 6-digit code from the email") and return unless /\A\d{6}\z/.match?(code)
 
-      errors.add(:code, "The code entered is invalid") unless user && otp.verify(code:)
+      if user&.otp_locked_at.present?
+        errors.add(:code, "Your account is locked, please contact support")
+        return
+      end
+
+      return if user && otp.verify(code:)
+
+      if user&.otp_locked_at.present?
+        errors.add(:code, "Your account is locked, please contact support")
+      else
+        errors.add(:code, "The code entered is invalid")
+      end
     end
 
     def otp

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -14,6 +14,8 @@ class Event < ApplicationRecord
     induction_period_opened
     induction_period_reopened
     induction_period_updated
+    otp_account_locked
+    otp_account_unlocked
     lead_provider_api_token_created
     lead_provider_api_token_revoked
     lead_provider_delivery_partnership_added

--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -1088,6 +1088,20 @@ module Events
       new(event_type:, author:, user:, heading:, modifications:, happened_at:).record_event!
     end
 
+    def self.record_otp_account_locked_event!(user:, modifications:, author: Events::SystemAuthor.new, happened_at: Time.zone.now)
+      event_type = :otp_account_locked
+      heading = "#{user.name}’s account was locked after too many failed OTP attempts"
+
+      new(event_type:, author:, user:, heading:, modifications:, happened_at:).record_event!
+    end
+
+    def self.record_otp_account_unlocked_event!(author:, user:, modifications:, happened_at: Time.zone.now)
+      event_type = :otp_account_unlocked
+      heading = "#{user.name}’s account was unlocked"
+
+      new(event_type:, author:, user:, heading:, modifications:, happened_at:).record_event!
+    end
+
     # Declarations events
 
     def self.record_declaration_created_event!(author:, teacher:, lead_provider:, declaration:)

--- a/app/services/sessions/one_time_password.rb
+++ b/app/services/sessions/one_time_password.rb
@@ -1,5 +1,7 @@
 module Sessions
   class OneTimePassword
+    MAX_FAILED_ATTEMPTS = 10
+
     attr_reader :user
 
     def initialize(user:)
@@ -22,16 +24,23 @@ module Sessions
     end
 
     def verify(code:)
-      params = {
-        drift_behind: 10.minutes.in_seconds, # give a 10 minute window to use the OTP code
-        after: user.otp_verified_at,         # prevents re-use of OTP code within the window
-      }.compact
+      user.with_lock do
+        return false if user.otp_locked_at.present?
 
-      tm = totp.verify(code, **params)
+        params = {
+          drift_behind: 10.minutes.in_seconds, # give a 10 minute window to use the OTP code
+          after: user.otp_verified_at,         # prevents re-use of OTP code within the window
+        }.compact
 
-      return false if tm.blank?
+        tm = totp.verify(code, **params)
 
-      user.update!(otp_verified_at: Time.zone.at(tm))
+        if tm.blank?
+          record_failed_attempt_and_lock_if_needed!
+          return false
+        end
+
+        user.update!(otp_verified_at: Time.zone.at(tm), otp_failed_attempts: 0)
+      end
     end
 
   private
@@ -42,6 +51,18 @@ module Sessions
 
     def generate_otp_secret!
       user.update!(otp_secret: ROTP::Base32.random(16))
+    end
+
+    def record_failed_attempt_and_lock_if_needed!
+      attributes = { otp_failed_attempts: user.otp_failed_attempts + 1 }.tap do |attrs|
+        attrs[:otp_locked_at] = Time.zone.now if attrs[:otp_failed_attempts] >= MAX_FAILED_ATTEMPTS
+      end
+
+      user.assign_attributes(attributes)
+      modifications = user.changes
+
+      user.save!
+      Events::Record.record_otp_account_locked_event!(user:, modifications:) if attributes.key?(:otp_locked_at)
     end
   end
 end

--- a/app/services/sessions/unlock_otp_account.rb
+++ b/app/services/sessions/unlock_otp_account.rb
@@ -1,0 +1,20 @@
+module Sessions
+  class UnlockOTPAccount
+    attr_reader :author, :user
+
+    def initialize(author:, user:)
+      @author = author
+      @user = user
+    end
+
+    def unlock
+      ::User.transaction do
+        user.assign_attributes(otp_failed_attempts: 0, otp_locked_at: nil)
+        modifications = user.changes
+
+        user.save!
+        Events::Record.record_otp_account_unlocked_event!(author:, user:, modifications:) if modifications.any?
+      end
+    end
+  end
+end

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -36,8 +36,17 @@
       row.with_key(text: 'Role')
       row.with_value { role_name(@user.role) }
     end
+
+    component.with_row do |row|
+      row.with_key(text: "Account locked")
+      row.with_value(text: @user.otp_locked_at.present? ? "Yes" : "No")
+    end
   end
 %>
+
+<% if @user.otp_locked_at.present? %>
+  <%= govuk_button_to "Unlock OTP sign-in", unlock_otp_sign_in_admin_user_path(@user), method: :patch, secondary: true %>
+<% end %>
 
 <p class="govuk-body">
   <%= govuk_button_link_to 'Edit', edit_admin_user_path(@user), visually_hidden_suffix: @user.name, secondary: true %>

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -176,6 +176,8 @@
   - otp_verified_at
   - role
   - otp_school_urn
+  - otp_failed_attempts
+  - otp_locked_at
   :teachers:
   - migration_mode
   :metadata_teachers_lead_providers:

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -10,7 +10,11 @@ namespace :admin do
   # Background jobs dashboard
   mount MissionControl::Jobs::Engine, at: "jobs"
 
-  resources :users
+  resources :users do
+    member do
+      patch :unlock_otp_sign_in, path: "unlock-otp-sign-in"
+    end
+  end
   resources :batches, only: %i[index], path: "bulk" # all activity
 
   resources :organisations, only: %i[index] do

--- a/db/migrate/20260702065431_add_otp_locking_to_users.rb
+++ b/db/migrate/20260702065431_add_otp_locking_to_users.rb
@@ -1,0 +1,8 @@
+class AddOTPLockingToUsers < ActiveRecord::Migration[8.1]
+  def change
+    change_table :users, bulk: true do |t|
+      t.integer :otp_failed_attempts, default: 0, null: false
+      t.datetime :otp_locked_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_29_150700) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_02_065431) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -938,6 +938,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_29_150700) do
     t.datetime "created_at", null: false
     t.citext "email", null: false
     t.string "name", null: false
+    t.integer "otp_failed_attempts", default: 0, null: false
+    t.datetime "otp_locked_at"
     t.integer "otp_school_urn"
     t.string "otp_secret"
     t.datetime "otp_verified_at"

--- a/documentation/domain-model.md
+++ b/documentation/domain-model.md
@@ -53,6 +53,8 @@ erDiagram
     datetime otp_verified_at
     enum role
     datetime updated_at
+    integer otp_failed_attempts
+    datetime otp_locked_at
   }
   TrainingPeriod {
     integer id

--- a/spec/forms/sessions/otp_sign_in_form_spec.rb
+++ b/spec/forms/sessions/otp_sign_in_form_spec.rb
@@ -40,6 +40,36 @@ RSpec.describe Sessions::OTPSignInForm, type: :model do
       end
     end
 
+    context "when the account is locked" do
+      before { user.update!(otp_locked_at: Time.zone.now) }
+
+      it "does not verify the code" do
+        expect(mock_otp_service).not_to receive(:verify)
+        form.valid?(:verify)
+      end
+
+      it "adds a locked error" do
+        expect(form.valid?(:verify)).to be false
+        expect(form.errors.messages[:code]).to include "Your account is locked, please contact support"
+      end
+    end
+
+    context "when the account is locked by this verification attempt" do
+      let(:result) { nil }
+
+      before do
+        allow(mock_otp_service).to receive(:verify).with(code:) do
+          form.user.update!(otp_locked_at: Time.zone.now)
+          result
+        end
+      end
+
+      it "adds a locked error" do
+        expect(form.valid?(:verify)).to be false
+        expect(form.errors.messages[:code]).to include "Your account is locked, please contact support"
+      end
+    end
+
     context "when there is no matching user" do
       let!(:user) { nil }
 

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -55,6 +55,20 @@ RSpec.describe "Admin::Users" do
         expect(user_record.reload.email).not_to eq("hacked@education.gov.uk")
       end
     end
+
+    it "returns unauthorised for PATCH /admin/users/:id/unlock-otp-sign-in and does not unlock the user" do
+      user_record = FactoryBot.create(:user, otp_failed_attempts: 10, otp_locked_at: Time.zone.now)
+
+      patch unlock_otp_sign_in_admin_user_path(user_record)
+
+      aggregate_failures do
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.body).to include("You are not authorised to access this page")
+        expect(response.body).to include(error_message)
+        expect(user_record.reload.otp_locked_at).to be_present
+        expect(user_record.otp_failed_attempts).to eq(10)
+      end
+    end
   end
 
   context "when signed in as a user manager" do
@@ -172,6 +186,26 @@ RSpec.describe "Admin::Users" do
       it "shows the user details on the page" do
         get admin_user_path(user_record)
         expect(response.body).to include(user_record.name)
+      end
+    end
+
+    describe "PATCH /admin/users/:id/unlock-otp-sign-in" do
+      let(:user_record) { FactoryBot.create(:user, otp_failed_attempts: 10, otp_locked_at: Time.zone.now) }
+      let(:service) { instance_double(Sessions::UnlockOTPAccount, unlock: true) }
+
+      before do
+        allow(Sessions::UnlockOTPAccount).to receive(:new).and_return(service)
+      end
+
+      it "uses the unlock service and redirects back to the user page" do
+        patch unlock_otp_sign_in_admin_user_path(user_record)
+
+        aggregate_failures do
+          expect(Sessions::UnlockOTPAccount).to have_received(:new).with(author: an_instance_of(Sessions::Users::DfEPersona), user: user_record)
+          expect(service).to have_received(:unlock)
+          expect(response).to redirect_to(admin_user_path(user_record))
+          expect(flash[:alert]).to eq("#{user_record.name} can now sign in with OTP")
+        end
       end
     end
 

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -2295,6 +2295,58 @@ RSpec.describe Events::Record do
     end
   end
 
+  describe ".record_otp_account_locked_event!" do
+    let(:author_params) { { author_type: "system" } }
+
+    it "queues a RecordEventJob with the correct values" do
+      freeze_time do
+        raw_modifications = {
+          "otp_failed_attempts" => [9, 10],
+          "otp_locked_at" => [nil, Time.zone.now],
+        }
+
+        Events::Record.record_otp_account_locked_event!(user: another_dfe_user, modifications: raw_modifications)
+
+        expect(RecordEventJob).to have_received(:perform_later).with(
+          hash_including(
+            user: another_dfe_user,
+            modifications: anything,
+            metadata: raw_modifications,
+            heading: "Ian Richardson’s account was locked after too many failed OTP attempts",
+            happened_at: Time.zone.now,
+            event_type: :otp_account_locked,
+            **author_params
+          )
+        )
+      end
+    end
+  end
+
+  describe ".record_otp_account_unlocked_event!" do
+    it "queues a RecordEventJob with the correct values" do
+      freeze_time do
+        raw_modifications = {
+          "otp_failed_attempts" => [10, 0],
+          "otp_locked_at" => [1.hour.ago, nil],
+        }
+
+        Events::Record.record_otp_account_unlocked_event!(author:, user: another_dfe_user, modifications: raw_modifications)
+
+        expect(RecordEventJob).to have_received(:perform_later).with(
+          hash_including(
+            user: another_dfe_user,
+            modifications: anything,
+            metadata: raw_modifications,
+            heading: "Ian Richardson’s account was unlocked",
+            happened_at: Time.zone.now,
+            event_type: :otp_account_unlocked,
+            **author_params
+          )
+        )
+      end
+    end
+  end
+
   describe ".record_teacher_set_funding_eligibility_event!" do
     it "queues a RecordEventJob with the correct values" do
       freeze_time do

--- a/spec/services/sessions/one_time_password_spec.rb
+++ b/spec/services/sessions/one_time_password_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe Sessions::OneTimePassword do
         code = service.generate
         user.update!(otp_failed_attempts: 10, otp_locked_at: Time.zone.now)
 
-        expect { service.verify(code:) }.not_to change { user.reload.otp_failed_attempts }
+        expect { service.verify(code:) }.not_to(change { user.reload.otp_failed_attempts })
       end
     end
   end

--- a/spec/services/sessions/one_time_password_spec.rb
+++ b/spec/services/sessions/one_time_password_spec.rb
@@ -11,6 +11,18 @@ RSpec.describe Sessions::OneTimePassword do
     it "sets a secret on the user" do
       expect { service.generate }.to(change { user.otp_secret })
     end
+
+    it "does not reset failed attempts" do
+      user.update!(otp_failed_attempts: 4)
+
+      expect { service.generate }.not_to(change { user.reload.otp_failed_attempts })
+    end
+
+    it "does not unlock the account" do
+      user.update!(otp_locked_at: Time.zone.now)
+
+      expect { service.generate }.not_to(change { user.reload.otp_locked_at })
+    end
   end
 
   describe "#generate_and_send_code" do
@@ -41,6 +53,13 @@ RSpec.describe Sessions::OneTimePassword do
       it "updates the otp_verified_at timestamp" do
         code = service.generate
         expect { service.verify(code:) }.to(change { user.otp_verified_at })
+      end
+
+      it "resets failed attempts" do
+        user.update!(otp_failed_attempts: 3)
+        code = service.generate
+
+        expect { service.verify(code:) }.to change { user.reload.otp_failed_attempts }.from(3).to(0)
       end
     end
 
@@ -74,6 +93,77 @@ RSpec.describe Sessions::OneTimePassword do
         travel_to 11.minutes.from_now do
           expect { service.verify(code:) }.not_to(change { user.otp_verified_at })
         end
+      end
+    end
+
+    context "when the code is invalid" do
+      let(:code) { service.generate }
+      let(:invalid_code) { ((code.to_i + 1) % 1_000_000).to_s.rjust(6, "0") }
+
+      before do
+        allow(Events::Record).to receive(:record_otp_account_locked_event!)
+      end
+
+      it "increments failed attempts" do
+        expect { service.verify(code: invalid_code) }.to change { user.reload.otp_failed_attempts }.from(0).to(1)
+      end
+
+      it "does not record a locked event before the 10th failed attempt" do
+        service.verify(code: invalid_code)
+
+        expect(Events::Record).not_to have_received(:record_otp_account_locked_event!)
+      end
+
+      it "locks the account on the 10th failed attempt" do
+        user.update!(otp_failed_attempts: 9)
+
+        freeze_time do
+          expect { service.verify(code: invalid_code) }
+            .to change { user.reload.otp_locked_at }
+            .from(nil)
+            .to(Time.zone.now)
+
+          expect(user.otp_failed_attempts).to eq(10)
+        end
+      end
+
+      it "records a locked event on the 10th failed attempt" do
+        user.update!(otp_failed_attempts: 9)
+
+        freeze_time do
+          service.verify(code: invalid_code)
+
+          expect(Events::Record).to have_received(:record_otp_account_locked_event!).with(
+            user:,
+            modifications: {
+              "otp_failed_attempts" => [9, 10],
+              "otp_locked_at" => [nil, Time.zone.now],
+            }
+          )
+        end
+      end
+    end
+
+    context "when the account is locked" do
+      it "returns false" do
+        code = service.generate
+        user.update!(otp_locked_at: Time.zone.now)
+
+        expect(service.verify(code:)).to be false
+      end
+
+      it "does not update the otp_verified_at timestamp" do
+        code = service.generate
+        user.update!(otp_locked_at: Time.zone.now)
+
+        expect { service.verify(code:) }.not_to(change { user.reload.otp_verified_at })
+      end
+
+      it "does not increment failed attempts when the account is locked" do
+        code = service.generate
+        user.update!(otp_failed_attempts: 10, otp_locked_at: Time.zone.now)
+        
+        expect { service.verify(code:) }.not_to change { user.reload.otp_failed_attempts }
       end
     end
   end

--- a/spec/services/sessions/one_time_password_spec.rb
+++ b/spec/services/sessions/one_time_password_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe Sessions::OneTimePassword do
       it "does not increment failed attempts when the account is locked" do
         code = service.generate
         user.update!(otp_failed_attempts: 10, otp_locked_at: Time.zone.now)
-        
+
         expect { service.verify(code:) }.not_to change { user.reload.otp_failed_attempts }
       end
     end

--- a/spec/services/sessions/unlock_otp_account_spec.rb
+++ b/spec/services/sessions/unlock_otp_account_spec.rb
@@ -1,0 +1,45 @@
+RSpec.describe Sessions::UnlockOTPAccount do
+  subject(:service) { described_class.new(author:, user: locked_user) }
+
+  let(:author_user) { FactoryBot.create(:user, email: "unlocker@education.gov.uk") }
+  let(:author) { Sessions::Users::DfEUser.new(email: author_user.email) }
+  let(:locked_user) { FactoryBot.create(:user, otp_failed_attempts: 10, otp_locked_at: Time.zone.now) }
+
+  before do
+    allow(Events::Record).to receive(:record_otp_account_unlocked_event!).with(any_args).and_call_original
+  end
+
+  describe "#unlock" do
+    it "resets failed attempts" do
+      expect { service.unlock }.to change { locked_user.reload.otp_failed_attempts }.from(10).to(0)
+    end
+
+    it "clears the locked timestamp" do
+      expect { service.unlock }.to change { locked_user.reload.otp_locked_at }.to(nil)
+    end
+
+    it "records an unlock event" do
+      freeze_time do
+        service.unlock
+
+        expect(Events::Record).to have_received(:record_otp_account_unlocked_event!).with(
+          author:,
+          user: locked_user,
+          modifications: {
+            "otp_failed_attempts" => [10, 0],
+            "otp_locked_at" => [Time.zone.now, nil],
+          }
+        )
+      end
+    end
+
+    it "restores access" do
+      otp = Sessions::OneTimePassword.new(user: locked_user)
+      code = otp.generate
+
+      service.unlock
+
+      expect(otp.verify(code:)).to be true
+    end
+  end
+end

--- a/spec/views/admin/users/show.html.erb_spec.rb
+++ b/spec/views/admin/users/show.html.erb_spec.rb
@@ -37,8 +37,30 @@ describe "admin/users/show.html.erb" do
     expect(rendered).to have_css("dd", text: "Admin")
   end
 
+  it "displays whether the account is locked for OTP sign-in" do
+    expect(rendered).to have_css("dt", text: "Account locked")
+    expect(rendered).to have_css("dd", text: "No")
+  end
+
+  it "does not display an unlock OTP sign-in button" do
+    expect(rendered).not_to have_button("Unlock OTP sign-in")
+  end
+
   it "does not display the otp school URN row when otp school sign-in flag is disabled" do
     expect(rendered).not_to have_css("dt", text: "School URN for OTP sign-in")
+  end
+
+  context "when the user is locked out of OTP sign-in" do
+    let(:user) { FactoryBot.create(:user, role, otp_locked_at: Time.zone.now) }
+
+    it "displays that the account is locked for OTP sign-in" do
+      expect(rendered).to have_css("dt", text: "Account locked")
+      expect(rendered).to have_css("dd", text: "Yes")
+    end
+
+    it "displays an unlock OTP sign-in button" do
+      expect(rendered).to have_button("Unlock OTP sign-in")
+    end
   end
 
   context "when the user is a user manager user" do


### PR DESCRIPTION
## Summary

This PR locks OTP accounts after 10 failed attempts to sign in, along with an admin journey for unlocking accounts.

## Changes

- Track failed OTP verification attempts on users
- Lock the ability to sign in via OTP after 10 unsuccessful verification attempts
- Prevent locked accounts from verifying OTP codes
- Reset failed attempts after successful OTP verification
- Add a service for unlocking locked OTP accounts
- Record audit events when OTP accounts are locked and unlocked
- Add "Account locked" status and unlock action to the DfE user admin UI

## Screenshots

| `admin/users/{:id}` |
|------------|
|<img width="1124" height="425" alt="image" src="https://github.com/user-attachments/assets/17f7e9f5-deee-4d36-af22-242725bc6753" />|
