### PR TITLE
Fix Knapsack / test pollution in spec/services/api/request_spec.rb

### DIFF
--- a/spec/services/api/request_spec.rb
+++ b/spec/services/api/request_spec.rb
@@ -176,13 +176,11 @@ RSpec.describe API::Request do
           }
         end
 
-        let(:original_excluded_paths) { DfE::Analytics.config.excluded_paths }
-
-        before do
+        around do |example|
+          original_excluded_paths = DfE::Analytics.config.excluded_paths
           DfE::Analytics.config.excluded_paths = [%r{^/school/opt-out-of-reminder-emails(?:[/?].*)?$}]
-        end
-
-        after do
+          example.run
+        ensure
           DfE::Analytics.config.excluded_paths = original_excluded_paths
         end
 


### PR DESCRIPTION
I noticed recent Refresh Knapsack Manifest runs were failing due to `spec/services/api/request_spec.rb` failing.

This PR fixes by replacing the let/before/after with an around hook that captures the original value before mutating, with an ensure to restore it.