### PR TITLE
Fix flaky spec/services/api/declarations/clawback_spec.rb

### DIFF
--- a/spec/services/api/declarations/clawback_spec.rb
+++ b/spec/services/api/declarations/clawback_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe API::Declarations::Clawback, type: :model do
 
     before do
       payment_statement = declaration.payment_statement
-      payment_statement.update!(deadline_date: Date.yesterday)
+      payment_statement.update!(deadline_date: Date.yesterday, payment_date: Date.tomorrow)
       Statement.where("deadline_date > ?", payment_statement.deadline_date).destroy_all
     end
 
@@ -81,7 +81,7 @@ RSpec.describe API::Declarations::Clawback, type: :model do
   context "when the declaration's payment statement deadline date is in the past" do
     let(:declaration) { FactoryBot.create(:declaration, :paid) }
 
-    before { declaration.payment_statement.update!(deadline_date: Date.yesterday) }
+    before { declaration.payment_statement.update!(deadline_date: Date.yesterday, payment_date: Date.tomorrow) }
 
     it { is_expected.to have_one_error_only }
 


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/28666457963/job/85019283544?pr=3195

The above job failed due to a flaky (unrelated) spec, where randomness could cause the statement's `payment_date` not to fall after the `deadline_date`. 

### Changes proposed in this pull request

By fixing `payment_date` to Date.tomorrow the validation can't fail.