### PR TITLE
Add `finished_on` to metadata refresh trigger

### DIFF
--- a/app/models/induction_period.rb
+++ b/app/models/induction_period.rb
@@ -21,7 +21,7 @@ class InductionPeriod < ApplicationRecord
 
   refresh_metadata -> { teacher },
                    on_event: %i[create destroy update],
-                   when_changing: %i[outcome]
+                   when_changing: %i[outcome finished_on]
 
   # Validations
   validates :appropriate_body_period_id, presence: { message: "Select an appropriate body" }

--- a/spec/models/induction_period_spec.rb
+++ b/spec/models/induction_period_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe InductionPeriod do
 
         it_behaves_like "a declarative metadata model",
                         on_event: %i[create destroy update],
-                        when_changing: %i[outcome]
+                        when_changing: %i[outcome finished_on]
       end
 
       describe "#touch_teacher?" do


### PR DESCRIPTION
### Context

We are not refreshing the `teacher` metadata when the `finished_on` of an `InductionPeriod` is set. It's a long shot (because `finished_on` is likely set at the same time as `outcome`) but this may be contributing to a metadata refresh alert we're seeing that effects the transfer status of the `Teacher` (which is tied to induction completion).

### Changes proposed in this pull request

Ensure we refresh metadata when the `InductionPeriod` is finished.

### Guidance to review

Relevant Sentry errors:

https://dfe-teacher-services.sentry.io/issues/7444944076/?environment=production&project=4508369974788096&query=is%3Aunresolved&referrer=issue-stream
https://dfe-teacher-services.sentry.io/issues/7590280327/?environment=production&project=4508369974788096&query=is%3Aunresolved&referrer=issue-stream