### PR TITLE
Speed up `with_metadata` specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,6 +82,7 @@ group :test do
   gem "rspec"
   gem "rspec-rails"
   gem "shoulda-matchers"
+  gem "test-prof"
   gem "webmock"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -801,6 +801,7 @@ GEM
       attr_required (>= 0.0.5)
       faraday (~> 2.0)
       faraday-follow_redirects
+    test-prof (1.6.1)
     thor (1.5.0)
     timeout (0.6.1)
     traces (0.18.2)
@@ -940,6 +941,7 @@ DEPENDENCIES
   solid_queue
   stackprof
   state_machines-activerecord
+  test-prof
   turbo-rails
   tzinfo-data
   webmock

--- a/spec/requests/api/v3/declarations_spec.rb
+++ b/spec/requests/api/v3/declarations_spec.rb
@@ -1,9 +1,10 @@
 RSpec.describe "Declarations API", :with_metadata, :with_touches, type: :request do
   let(:serializer) { API::DeclarationSerializer }
+  let(:lead_provider) { active_lead_provider.lead_provider }
   let(:serializer_options) { { lead_provider_id: lead_provider.id } }
   let(:query) { API::Declarations::Query }
-  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
-  let(:lead_provider) { active_lead_provider.lead_provider }
+
+  let_it_be(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
 
   def create_resource(active_lead_provider:, teacher: nil, declaration_trait: :no_payment)
     lead_provider_delivery_partnership = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:)
@@ -38,7 +39,8 @@ RSpec.describe "Declarations API", :with_metadata, :with_touches, type: :request
   end
 
   describe "#show" do
-    let(:resource) { create_resource(active_lead_provider:) }
+    # refind: examples exercise the endpoint against a reloaded copy of the record
+    let_it_be(:resource, refind: true) { create_resource(active_lead_provider:) }
     let(:path_id) { resource.api_id }
     let(:path) { api_v3_declaration_path(path_id) }
 
@@ -53,18 +55,9 @@ RSpec.describe "Declarations API", :with_metadata, :with_touches, type: :request
 
   describe "#create" do
     let(:path) { api_v3_declarations_path }
-    let(:service) { API::Declarations::Create }
-    let(:resource_type) { Declaration }
-    let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, :for_year, year: 2024) }
-    let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
-    let(:school_partnership) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:) }
-    let(:teacher) { FactoryBot.create(:teacher) }
-    let(:schedule) { FactoryBot.create(:schedule, contract_period: school_partnership.contract_period) }
-    let(:milestone) { FactoryBot.create(:milestone, declaration_type: :started, schedule:) }
     let(:declaration_date) do
       Faker::Date.between(from: milestone.start_date, to: milestone.milestone_date)
     end
-
     let(:service_args) do
       {
         lead_provider_id: lead_provider.id,
@@ -75,7 +68,6 @@ RSpec.describe "Declarations API", :with_metadata, :with_touches, type: :request
         teacher_type:
       }
     end
-
     let(:params) do
       {
         data: {
@@ -91,16 +83,26 @@ RSpec.describe "Declarations API", :with_metadata, :with_touches, type: :request
       }
     end
     let(:declaration_type) { "started" }
+    let(:service) { API::Declarations::Create }
+    let(:resource_type) { Declaration }
+
+    let_it_be(:active_lead_provider) { FactoryBot.create(:active_lead_provider, :for_year, year: 2024) }
+    let_it_be(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
+    let_it_be(:school_partnership) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:) }
+    # refind: the create endpoint touches the teacher (e.g. api_updated_at); give each example a fresh instance
+    let_it_be(:teacher, refind: true) { FactoryBot.create(:teacher) }
+    let_it_be(:schedule) { FactoryBot.create(:schedule, contract_period: school_partnership.contract_period) }
+    let_it_be(:milestone) { FactoryBot.create(:milestone, declaration_type: :started, schedule:) }
 
     %i[ect mentor].each do |teacher_type|
       context "for #{teacher_type}" do
-        let(:at_school_period) do
+        let_it_be(:at_school_period) do
           FactoryBot.create(:"#{teacher_type}_at_school_period",
                             started_on: 6.months.ago,
                             finished_on: 2.weeks.from_now,
                             teacher:)
         end
-        let!(:training_period) do
+        let_it_be(:training_period) do
           FactoryBot.create(:training_period, :"for_#{teacher_type}", :active,
                             "#{teacher_type}_at_school_period": at_school_period,
                             started_on: at_school_period.started_on.tomorrow,
@@ -146,7 +148,8 @@ RSpec.describe "Declarations API", :with_metadata, :with_touches, type: :request
 
     Declaration::VOIDABLE_PAYMENT_STATUSES.each do |status|
       context "when the declaration is in a `voidable` status: #{status}" do
-        let(:resource) { travel_to(3.days.from_now) { create_resource(active_lead_provider:, declaration_trait: status.to_sym) } }
+        # refind: the void endpoint mutates the declaration; give each example a fresh instance
+        let_it_be(:resource, refind: true) { travel_to(3.days.from_now) { create_resource(active_lead_provider:, declaration_trait: status.to_sym) } }
         let(:service) { API::Declarations::Void }
 
         it_behaves_like "a token authenticated endpoint", :put
@@ -157,7 +160,12 @@ RSpec.describe "Declarations API", :with_metadata, :with_touches, type: :request
     end
 
     context "when the declaration is in `paid` status" do
-      let(:resource) { travel_to(3.days.from_now) { create_resource(active_lead_provider:, declaration_trait: :paid) } }
+      # Pin the contract period to the next year so the paid statement's
+      # deadline (capped at 31 Oct of the contract year) resolves to the
+      # travelled date and stays in the future.
+      let_it_be(:active_lead_provider) { FactoryBot.create(:active_lead_provider, contract_period: FactoryBot.create(:contract_period, :next)) }
+      # refind: the clawback endpoint mutates the declaration
+      let_it_be(:resource, refind: true) { travel_to(3.days.from_now) { create_resource(active_lead_provider:, declaration_trait: :paid) } }
       let(:service) { API::Declarations::Clawback }
 
       it_behaves_like "a token authenticated endpoint", :put
@@ -167,7 +175,7 @@ RSpec.describe "Declarations API", :with_metadata, :with_touches, type: :request
     end
 
     context "when the declaration is in `voided` status" do
-      let(:resource) { travel_to(3.days.from_now) { create_resource(active_lead_provider:, declaration_trait: :voided) } }
+      let_it_be(:resource, refind: true) { travel_to(3.days.from_now) { create_resource(active_lead_provider:, declaration_trait: :voided) } }
 
       it "returns a 422 response" do
         authenticated_api_put(path, params:)
@@ -179,7 +187,8 @@ RSpec.describe "Declarations API", :with_metadata, :with_touches, type: :request
     end
 
     context "when the declaration is a previous declaration for a different lead provider" do
-      let(:resource) { travel_to(3.days.from_now) { create_resource(active_lead_provider: FactoryBot.create(:active_lead_provider)) } }
+      # refind: the before block mutates the resource's associated records
+      let_it_be(:resource, refind: true) { travel_to(3.days.from_now) { create_resource(active_lead_provider: FactoryBot.create(:active_lead_provider)) } }
 
       before do
         # Close training periods for other lead providers.

--- a/spec/requests/api/v3/schools_spec.rb
+++ b/spec/requests/api/v3/schools_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "Schools API", :with_metadata, type: :request do
-  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
+  let_it_be(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
   let(:lead_provider) { active_lead_provider.lead_provider }
   let(:contract_period) { active_lead_provider.contract_period }
   let(:serializer) { API::SchoolSerializer }
@@ -49,7 +49,7 @@ RSpec.describe "Schools API", :with_metadata, type: :request do
   end
 
   describe "#show" do
-    let(:resource) { create_resource(active_lead_provider:) }
+    let_it_be(:resource) { create_resource(active_lead_provider:) }
     let(:path_id) { resource.api_id }
     let(:path) { api_v3_school_path(path_id, filter: { cohort: contract_period.id }) }
 

--- a/spec/serializers/api/teacher_serializer_spec.rb
+++ b/spec/serializers/api/teacher_serializer_spec.rb
@@ -4,9 +4,10 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
     JSON.parse(described_class.render(teacher, **options))
   end
 
-  let!(:lead_provider) { FactoryBot.create(:lead_provider) }
-  let(:api_updated_at) { Time.utc(2023, 7, 2, 12, 0, 0) }
-  let(:teacher) do
+  let_it_be(:lead_provider) { FactoryBot.create(:lead_provider) }
+  let_it_be(:api_updated_at) { Time.utc(2023, 7, 2, 12, 0, 0) }
+  # refind: some examples mutate the teacher via update!
+  let_it_be(:teacher, refind: true) do
     FactoryBot.create(
       :teacher,
       :ineligible_for_mentor_funding,
@@ -103,22 +104,13 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
       it { is_expected.to be_empty }
 
       context "when there are ECT/mentor training periods for the lead provider" do
-        let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, lead_provider:) }
-        let(:school_partnership) do
+        let_it_be(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, lead_provider:) }
+        # refind: the before block mutates the associated contract period each example
+        let_it_be(:school_partnership, refind: true) do
           FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:)
         end
-        let(:school) { school_partnership.school }
+        let_it_be(:school) { school_partnership.school }
         let!(:school_funding_eligibility) { FactoryBot.create(:school_funding_eligibility, gias_school: school.gias_school, contract_period: school_partnership.contract_period) }
-
-        let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher:, school:, started_on: 2.months.ago, finished_on: nil) }
-        let!(:ect_training_period) { FactoryBot.create(:training_period, :for_ect, started_on: 1.month.ago, ect_at_school_period:, school_partnership:) }
-
-        let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, school:, teacher:, started_on: 2.months.ago, finished_on: nil) }
-        let!(:mentor_training_period) { FactoryBot.create(:training_period, :for_mentor, started_on: 1.month.ago, mentor_at_school_period:, school_partnership:) }
-
-        let(:other_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, school:, started_on: 2.months.ago, finished_on: nil) }
-        let!(:other_mentor_training_period) { FactoryBot.create(:training_period, :for_mentor, started_on: 1.month.ago, mentor_at_school_period: other_mentor_at_school_period, school_partnership:) }
-
         let!(:latest_mentorship_period) do
           FactoryBot.create(
             :mentorship_period,
@@ -128,6 +120,16 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
             finished_on: nil
           )
         end
+
+        # refind: some examples mutate these records via update!
+        let_it_be(:ect_at_school_period, refind: true) { FactoryBot.create(:ect_at_school_period, teacher:, school:, started_on: 2.months.ago, finished_on: nil) }
+        let_it_be(:ect_training_period, refind: true) { FactoryBot.create(:training_period, :for_ect, started_on: 1.month.ago, ect_at_school_period:, school_partnership:) }
+
+        let_it_be(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, school:, teacher:, started_on: 2.months.ago, finished_on: nil) }
+        let_it_be(:mentor_training_period, refind: true) { FactoryBot.create(:training_period, :for_mentor, started_on: 1.month.ago, mentor_at_school_period:, school_partnership:) }
+
+        let_it_be(:other_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, school:, started_on: 2.months.ago, finished_on: nil) }
+        let_it_be(:other_mentor_training_period) { FactoryBot.create(:training_period, :for_mentor, started_on: 1.month.ago, mentor_at_school_period: other_mentor_at_school_period, school_partnership:) }
 
         before do
           school_partnership.contract_period.update!(uplift_fees_enabled: true)

--- a/spec/services/api/declarations/query_spec.rb
+++ b/spec/services/api/declarations/query_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe API::Declarations::Query, :with_metadata do
     end
 
     let(:instance) { described_class.new }
-    let!(:declaration) { FactoryBot.create(:declaration) }
+
+    let_it_be(:declaration) { FactoryBot.create(:declaration) }
 
     describe "#declarations" do
       subject(:result) { instance.declarations.first }
@@ -122,27 +123,28 @@ RSpec.describe API::Declarations::Query, :with_metadata do
         end
 
         context "when there are declarations from previous lead provider" do
-          let(:contract_period) { FactoryBot.create(:contract_period) }
+          let_it_be(:contract_period) { FactoryBot.create(:contract_period) }
 
           # Previous training period with `lead_provider1`
-          let(:training_period1) { create_training_period(contract_period:, trainee: :ect) }
+          let_it_be(:training_period1) { create_training_period(contract_period:, trainee: :ect) }
           let(:lead_provider1) { training_period1.lead_provider }
+          let(:lead_provider2) { training_period2.lead_provider }
+          let(:lead_provider3) { training_period3.lead_provider }
+          # Declaration for each training period
+          # no let_it_be for declatarion1; overridden in nested contexts and mutated in example
+          let!(:declaration1) { create_declaration(training_period: training_period1, declaration_type: "started") }
 
           # Current training period with `lead_provider2`
-          let(:training_period2) { create_training_period(contract_period:, trainee: :ect, following_on_from_training_period: training_period1) }
-          let(:lead_provider2) { training_period2.lead_provider }
+          let_it_be(:training_period2) { create_training_period(contract_period:, trainee: :ect, following_on_from_training_period: training_period1) }
 
           # New ongoing training period with `lead_provider3`
-          let(:training_period3) { create_training_period(contract_period:, trainee: :ect, following_on_from_training_period: training_period2) }
-          let(:lead_provider3) { training_period3.lead_provider }
+          let_it_be(:training_period3) { create_training_period(contract_period:, trainee: :ect, following_on_from_training_period: training_period2) }
 
-          # Declaration for each training period
-          let!(:declaration1) { create_declaration(training_period: training_period1, declaration_type: "started") }
-          let!(:declaration2) { create_declaration(training_period: training_period2, declaration_type: "retained-1") }
-          let!(:declaration3) { create_declaration(training_period: training_period3, declaration_type: "retained-3") }
+          let_it_be(:declaration2) { create_declaration(training_period: training_period2, declaration_type: "retained-1") }
+          let_it_be(:declaration3) { create_declaration(training_period: training_period3, declaration_type: "retained-3") }
 
           # Additional unrelated declaration
-          before { FactoryBot.create(:declaration) }
+          before_all { FactoryBot.create(:declaration) }
 
           context "when lead_provider2 has previous and direct declaration" do
             it "returns previous declarations and direct declarations for lead_provider2" do
@@ -207,13 +209,13 @@ RSpec.describe API::Declarations::Query, :with_metadata do
       end
 
       describe "by `contract_period_years`" do
-        let(:contract_period1) { FactoryBot.create(:contract_period) }
-        let(:contract_period2) { FactoryBot.create(:contract_period) }
-        let(:contract_period3) { FactoryBot.create(:contract_period) }
+        let_it_be(:contract_period1) { FactoryBot.create(:contract_period) }
+        let_it_be(:contract_period2) { FactoryBot.create(:contract_period) }
+        let_it_be(:contract_period3) { FactoryBot.create(:contract_period) }
 
-        let!(:declaration1) { create_declaration(contract_period: contract_period1) }
-        let!(:declaration2) { create_declaration(contract_period: contract_period2) }
-        let!(:declaration3) { create_declaration(contract_period: contract_period3) }
+        let_it_be(:declaration1) { create_declaration(contract_period: contract_period1) }
+        let_it_be(:declaration2) { create_declaration(contract_period: contract_period2) }
+        let_it_be(:declaration3) { create_declaration(contract_period: contract_period3) }
 
         context "when `contract_period_years` param is omitted" do
           it "returns all declarations" do
@@ -253,15 +255,15 @@ RSpec.describe API::Declarations::Query, :with_metadata do
       end
 
       describe "by `teacher_api_ids`" do
-        let(:teacher1) { FactoryBot.create(:teacher) }
-        let(:teacher2) { FactoryBot.create(:teacher) }
+        let_it_be(:teacher1) { FactoryBot.create(:teacher) }
+        let_it_be(:teacher2) { FactoryBot.create(:teacher) }
 
-        let(:training_period1) { create_training_period(trainee: :ect, teacher: teacher1) }
-        let(:training_period2) { create_training_period(trainee: :ect, teacher: teacher2) }
+        let_it_be(:training_period1) { create_training_period(trainee: :ect, teacher: teacher1) }
+        let_it_be(:training_period2) { create_training_period(trainee: :ect, teacher: teacher2) }
 
-        let!(:declaration1) { FactoryBot.create(:declaration, training_period: training_period1) }
-        let!(:declaration2) { FactoryBot.create(:declaration, training_period: training_period2) }
-        let!(:declaration3) { FactoryBot.create(:declaration) }
+        let_it_be(:declaration1) { FactoryBot.create(:declaration, training_period: training_period1) }
+        let_it_be(:declaration2) { FactoryBot.create(:declaration, training_period: training_period2) }
+        let_it_be(:declaration3) { FactoryBot.create(:declaration) }
 
         context "when `teacher_api_ids` param is omitted" do
           it "returns all declarations" do
@@ -319,15 +321,15 @@ RSpec.describe API::Declarations::Query, :with_metadata do
       end
 
       describe "by `delivery_partner_api_ids`" do
-        let(:delivery_partner1) { FactoryBot.create(:delivery_partner) }
-        let(:delivery_partner2) { FactoryBot.create(:delivery_partner) }
+        let_it_be(:delivery_partner1) { FactoryBot.create(:delivery_partner) }
+        let_it_be(:delivery_partner2) { FactoryBot.create(:delivery_partner) }
 
-        let(:training_period1) { create_training_period(trainee: :ect, delivery_partner: delivery_partner1) }
-        let(:training_period2) { create_training_period(trainee: :mentor, delivery_partner: delivery_partner2) }
+        let_it_be(:training_period1) { create_training_period(trainee: :ect, delivery_partner: delivery_partner1) }
+        let_it_be(:training_period2) { create_training_period(trainee: :mentor, delivery_partner: delivery_partner2) }
 
-        let!(:declaration1) { FactoryBot.create(:declaration, training_period: training_period1) }
-        let!(:declaration2) { FactoryBot.create(:declaration, training_period: training_period2) }
-        let!(:declaration3) { FactoryBot.create(:declaration) }
+        let_it_be(:declaration1) { FactoryBot.create(:declaration, training_period: training_period1) }
+        let_it_be(:declaration2) { FactoryBot.create(:declaration, training_period: training_period2) }
+        let_it_be(:declaration3) { FactoryBot.create(:declaration) }
 
         context "when `delivery_partner_api_ids` param is omitted" do
           it "returns all declarations" do

--- a/spec/services/api/teachers/query_spec.rb
+++ b/spec/services/api/teachers/query_spec.rb
@@ -39,11 +39,12 @@ RSpec.describe API::Teachers::Query, :with_metadata do
     end
 
     let(:instance) { described_class.new }
-    let(:teacher) { FactoryBot.create(:teacher) }
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher:, started_on: 1.year.ago, finished_on: nil) }
-    let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher:, started_on: 1.year.ago, finished_on: nil) }
-    let!(:latest_ect_training_period) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:, started_on: 1.month.ago, finished_on: nil) }
-    let!(:latest_mentor_training_period) { FactoryBot.create(:training_period, :for_mentor, mentor_at_school_period:, started_on: 1.month.ago, finished_on: nil) }
+
+    let_it_be(:teacher) { FactoryBot.create(:teacher) }
+    let_it_be(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher:, started_on: 1.year.ago, finished_on: nil) }
+    let_it_be(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher:, started_on: 1.year.ago, finished_on: nil) }
+    let_it_be(:latest_ect_training_period) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:, started_on: 1.month.ago, finished_on: nil) }
+    let_it_be(:latest_mentor_training_period) { FactoryBot.create(:training_period, :for_mentor, mentor_at_school_period:, started_on: 1.month.ago, finished_on: nil) }
 
     describe "#teachers" do
       subject(:result) do
@@ -86,10 +87,10 @@ RSpec.describe API::Teachers::Query, :with_metadata do
 
     describe "filtering" do
       describe "by `lead_provider`" do
-        let(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)) }
-        let!(:teacher1) { training_period.teacher }
-        let!(:teacher2) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)).teacher }
-        let!(:teacher3) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)).teacher }
+        let_it_be(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)) }
+        let_it_be(:teacher1) { training_period.teacher }
+        let_it_be(:teacher2) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)).teacher }
+        let_it_be(:teacher3) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)).teacher }
 
         context "when `lead_provider` param is omitted" do
           it "returns all teachers" do
@@ -118,18 +119,18 @@ RSpec.describe API::Teachers::Query, :with_metadata do
       end
 
       describe "by `contract_period_years`" do
-        let(:ect_at_school_period_1) { FactoryBot.create(:ect_at_school_period, :ongoing) }
-        let(:ect_at_school_period_2) { FactoryBot.create(:ect_at_school_period, :ongoing) }
-        let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing) }
-        let(:contract_period1) { FactoryBot.create(:contract_period) }
-        let(:contract_period2) { FactoryBot.create(:contract_period) }
-        let(:contract_period3) { FactoryBot.create(:contract_period) }
-        let(:school_partnership1) { FactoryBot.create(:school_partnership, active_lead_provider: FactoryBot.create(:active_lead_provider, contract_period: contract_period1)) }
-        let(:school_partnership2) { FactoryBot.create(:school_partnership, active_lead_provider: FactoryBot.create(:active_lead_provider, contract_period: contract_period2)) }
-        let(:school_partnership3) { FactoryBot.create(:school_partnership, active_lead_provider: FactoryBot.create(:active_lead_provider, contract_period: contract_period3)) }
-        let!(:teacher1) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: ect_at_school_period_1, school_partnership: school_partnership1).teacher }
-        let!(:teacher2) { FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period:, school_partnership: school_partnership2).teacher }
-        let!(:teacher3) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: ect_at_school_period_2, school_partnership: school_partnership3).teacher }
+        let_it_be(:ect_at_school_period_1) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+        let_it_be(:ect_at_school_period_2) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+        let_it_be(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing) }
+        let_it_be(:contract_period1) { FactoryBot.create(:contract_period) }
+        let_it_be(:contract_period2) { FactoryBot.create(:contract_period) }
+        let_it_be(:contract_period3) { FactoryBot.create(:contract_period) }
+        let_it_be(:school_partnership1) { FactoryBot.create(:school_partnership, active_lead_provider: FactoryBot.create(:active_lead_provider, contract_period: contract_period1)) }
+        let_it_be(:school_partnership2) { FactoryBot.create(:school_partnership, active_lead_provider: FactoryBot.create(:active_lead_provider, contract_period: contract_period2)) }
+        let_it_be(:school_partnership3) { FactoryBot.create(:school_partnership, active_lead_provider: FactoryBot.create(:active_lead_provider, contract_period: contract_period3)) }
+        let_it_be(:teacher1) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: ect_at_school_period_1, school_partnership: school_partnership1).teacher }
+        let_it_be(:teacher2) { FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period:, school_partnership: school_partnership2).teacher }
+        let_it_be(:teacher3) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: ect_at_school_period_2, school_partnership: school_partnership3).teacher }
 
         context "when `contract_period_years` param is omitted" do
           it "returns all teachers" do
@@ -177,12 +178,12 @@ RSpec.describe API::Teachers::Query, :with_metadata do
       end
 
       describe "by `api_from_teacher_id`" do
-        let(:teacher1) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)).teacher }
-        let(:teacher2) { FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period: FactoryBot.create(:mentor_at_school_period, :ongoing)).teacher }
-        let(:teacher3) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)).teacher }
-        let!(:teacher_id_change1) { FactoryBot.create(:teacher_id_change, teacher: teacher1, api_from_teacher_id: teacher2.api_id) }
-        let!(:teacher_id_change2) { FactoryBot.create(:teacher_id_change, teacher: teacher2, api_from_teacher_id: teacher3.api_id) }
-        let!(:teacher_id_change3) { FactoryBot.create(:teacher_id_change, teacher: teacher3, api_from_teacher_id: teacher1.api_id) }
+        let_it_be(:teacher1) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)).teacher }
+        let_it_be(:teacher2) { FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period: FactoryBot.create(:mentor_at_school_period, :ongoing)).teacher }
+        let_it_be(:teacher3) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)).teacher }
+        let_it_be(:teacher_id_change1) { FactoryBot.create(:teacher_id_change, teacher: teacher1, api_from_teacher_id: teacher2.api_id) }
+        let_it_be(:teacher_id_change2) { FactoryBot.create(:teacher_id_change, teacher: teacher2, api_from_teacher_id: teacher3.api_id) }
+        let_it_be(:teacher_id_change3) { FactoryBot.create(:teacher_id_change, teacher: teacher3, api_from_teacher_id: teacher1.api_id) }
 
         context "when `api_from_teacher_id` param is omitted" do
           it "returns all teachers" do
@@ -211,14 +212,14 @@ RSpec.describe API::Teachers::Query, :with_metadata do
       end
 
       describe "by `training_status`" do
-        let(:ect_at_school_period_1) { FactoryBot.create(:ect_at_school_period, :ongoing) }
-        let(:ect_at_school_period_2) { FactoryBot.create(:ect_at_school_period, :ongoing) }
-        let(:mentor_at_school_period_1) { FactoryBot.create(:mentor_at_school_period, :ongoing) }
+        let_it_be(:ect_at_school_period_1) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+        let_it_be(:ect_at_school_period_2) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+        let_it_be(:mentor_at_school_period_1) { FactoryBot.create(:mentor_at_school_period, :ongoing) }
 
-        let(:school_partnership) { FactoryBot.create(:school_partnership) }
-        let!(:deferred_teacher) { FactoryBot.create(:training_period, :for_ect, :ongoing, :deferred, ect_at_school_period: ect_at_school_period_1, school_partnership:).teacher }
-        let!(:withdrawn_teacher) { FactoryBot.create(:training_period, :for_mentor, :ongoing, :withdrawn, mentor_at_school_period: mentor_at_school_period_1, school_partnership:).teacher }
-        let!(:active_teacher) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: ect_at_school_period_2, school_partnership:).teacher }
+        let_it_be(:school_partnership) { FactoryBot.create(:school_partnership) }
+        let_it_be(:deferred_teacher) { FactoryBot.create(:training_period, :for_ect, :ongoing, :deferred, ect_at_school_period: ect_at_school_period_1, school_partnership:).teacher }
+        let_it_be(:withdrawn_teacher) { FactoryBot.create(:training_period, :for_mentor, :ongoing, :withdrawn, mentor_at_school_period: mentor_at_school_period_1, school_partnership:).teacher }
+        let_it_be(:active_teacher) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: ect_at_school_period_2, school_partnership:).teacher }
 
         context "when `training_status` param is omitted" do
           it "returns all teachers" do
@@ -260,12 +261,12 @@ RSpec.describe API::Teachers::Query, :with_metadata do
       end
 
       describe "by `training_status` when a teacher has multiple training periods" do
-        let(:teacher) { FactoryBot.create(:teacher) }
-        let(:school_partnership) { FactoryBot.create(:school_partnership) }
-        let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher:, school: school_partnership.school) }
-        let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher:, school: school_partnership.school) }
-        let!(:deferred_training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, :deferred, school_partnership:, ect_at_school_period:) }
-        let!(:withdrawn_training_period) { FactoryBot.create(:training_period, :for_mentor, :ongoing, :withdrawn, school_partnership:, mentor_at_school_period:) }
+        let_it_be(:teacher) { FactoryBot.create(:teacher) }
+        let_it_be(:school_partnership) { FactoryBot.create(:school_partnership) }
+        let_it_be(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher:, school: school_partnership.school) }
+        let_it_be(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher:, school: school_partnership.school) }
+        let_it_be(:deferred_training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, :deferred, school_partnership:, ect_at_school_period:) }
+        let_it_be(:withdrawn_training_period) { FactoryBot.create(:training_period, :for_mentor, :ongoing, :withdrawn, school_partnership:, mentor_at_school_period:) }
 
         it "returns the teacher if any of the latest training periods match the filter" do
           query = described_class.new(training_status: :deferred)
@@ -313,8 +314,9 @@ RSpec.describe API::Teachers::Query, :with_metadata do
     end
 
     describe "ordering" do
-      let!(:teacher1) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)).teacher }
-      let!(:teacher2) { travel_to(1.day.ago) { FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period: FactoryBot.create(:mentor_at_school_period, :ongoing)).teacher } }
+      # refind: an example mutates teacher2; give each example a fresh instance
+      let_it_be(:teacher1, refind: true) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)).teacher }
+      let_it_be(:teacher2, refind: true) { travel_to(1.day.ago) { FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period: FactoryBot.create(:mentor_at_school_period, :ongoing)).teacher } }
 
       describe "default order" do
         it "returns teachers ordered by created_at, in ascending order" do

--- a/spec/services/api/teachers/unfunded_mentors/query_spec.rb
+++ b/spec/services/api/teachers/unfunded_mentors/query_spec.rb
@@ -1,11 +1,12 @@
 RSpec.describe API::Teachers::UnfundedMentors::Query, :with_metadata do
   include MentorshipPeriodHelpers
 
-  let(:school_partnership) { FactoryBot.create(:school_partnership) }
+  let_it_be(:school_partnership) { FactoryBot.create(:school_partnership) }
   let(:lead_provider_id) { school_partnership.lead_provider.id }
   let(:query) { described_class.new(lead_provider_id:) }
 
-  let!(:unfunded_mentor) do
+  # refind: some examples mutate the record via update!
+  let_it_be(:unfunded_mentor, refind: true) do
     mentor_school_partnership = other_lp_school_partnership_for(school_partnership:)
 
     create_mentorship_period_for(
@@ -55,7 +56,7 @@ RSpec.describe API::Teachers::UnfundedMentors::Query, :with_metadata do
   describe "#unfunded_mentors" do
     describe "filtering" do
       describe "by `lead_provider`" do
-        let!(:other_unfunded_mentor) do
+        let_it_be(:other_unfunded_mentor) do
           mentor_school_partnership = other_lp_school_partnership_for(school_partnership:)
 
           create_mentorship_period_for(
@@ -108,7 +109,8 @@ RSpec.describe API::Teachers::UnfundedMentors::Query, :with_metadata do
       end
 
       describe "by `updated_since`" do
-        let!(:other_unfunded_mentor) do
+        # refind: the before block mutates the record via update!
+        let_it_be(:other_unfunded_mentor, refind: true) do
           mentor_school_partnership = other_lp_school_partnership_for(school_partnership:)
 
           create_mentorship_period_for(
@@ -142,7 +144,8 @@ RSpec.describe API::Teachers::UnfundedMentors::Query, :with_metadata do
     end
 
     describe "ordering" do
-      let!(:other_unfunded_mentor) do
+      # refind: the before block mutates the record via update!
+      let_it_be(:other_unfunded_mentor, refind: true) do
         mentor_school_partnership = other_lp_school_partnership_for(school_partnership:)
 
         create_mentorship_period_for(

--- a/spec/services/api_seed_data/ect_scenarios_spec.rb
+++ b/spec/services/api_seed_data/ect_scenarios_spec.rb
@@ -4,23 +4,29 @@ RSpec.describe APISeedData::ECTScenarios do
   let(:environment) { "sandbox" }
   let(:logger) { instance_double(Logger, info: nil, "formatter=" => nil, "level=" => nil) }
 
-  let(:contract_period_2023) { FactoryBot.create(:contract_period, year: 2023) }
-  let(:contract_period_2024) { FactoryBot.create(:contract_period, year: 2024) }
-  let(:contract_period_2025) { FactoryBot.create(:contract_period, year: 2025) }
+  let_it_be(:contract_period_2023) { FactoryBot.create(:contract_period, year: 2023) }
+  let_it_be(:contract_period_2024) { FactoryBot.create(:contract_period, year: 2024) }
+  let_it_be(:contract_period_2025) { FactoryBot.create(:contract_period, year: 2025) }
+
+  before_all do
+    DeclarativeUpdates.skip(:metadata, :touch) do
+      FactoryBot.create_list(:lead_provider, 2).each do |lead_provider|
+        FactoryBot.create_list(:lead_provider_delivery_partnership, 3, :for_year, lead_provider:, year: 2023)
+        FactoryBot.create_list(:lead_provider_delivery_partnership, 3, :for_year, lead_provider:, year: 2024)
+        FactoryBot.create_list(:lead_provider_delivery_partnership, 3, :for_year, lead_provider:, year: 2025)
+      end
+
+      plant_api_seed_support_data(
+        APISeedData::Schools,
+        APISeedData::SchoolPartnerships,
+        APISeedData::SchedulesAndMilestones
+      )
+    end
+  end
 
   before do
     allow(Logger).to receive(:new).with($stdout) { logger }
     allow(Rails).to receive(:env) { environment.inquiry }
-
-    # Create support data
-    FactoryBot.create_list(:lead_provider, 2).each do |lead_provider|
-      FactoryBot.create_list(:lead_provider_delivery_partnership, 3, :for_year, lead_provider:, year: contract_period_2023.year)
-      FactoryBot.create_list(:lead_provider_delivery_partnership, 3, :for_year, lead_provider:, year: contract_period_2024.year)
-      FactoryBot.create_list(:lead_provider_delivery_partnership, 3, :for_year, lead_provider:, year: contract_period_2025.year)
-    end
-    APISeedData::Schools.new.plant
-    APISeedData::SchoolPartnerships.new.plant
-    APISeedData::SchedulesAndMilestones.new.plant
   end
 
   describe "#plant" do

--- a/spec/services/api_seed_data/mentor_scenarios_spec.rb
+++ b/spec/services/api_seed_data/mentor_scenarios_spec.rb
@@ -4,20 +4,26 @@ RSpec.describe APISeedData::MentorScenarios do
   let(:environment) { "sandbox" }
   let(:logger) { instance_double(Logger, info: nil, "formatter=" => nil, "level=" => nil) }
 
-  let(:contract_period_2024) { FactoryBot.create(:contract_period, year: 2024) }
-  let(:contract_period_2025) { FactoryBot.create(:contract_period, year: 2025) }
+  let_it_be(:contract_period_2024) { FactoryBot.create(:contract_period, year: 2024) }
+  let_it_be(:contract_period_2025) { FactoryBot.create(:contract_period, year: 2025) }
+
+  before_all do
+    DeclarativeUpdates.skip(:metadata, :touch) do
+      FactoryBot.create_list(:lead_provider, 2).each do |lead_provider|
+        FactoryBot.create_list(:lead_provider_delivery_partnership, 2, :for_year, lead_provider:, year: 2024)
+        FactoryBot.create_list(:lead_provider_delivery_partnership, 2, :for_year, lead_provider:, year: 2025)
+      end
+
+      plant_api_seed_support_data(
+        APISeedData::Schools,
+        APISeedData::SchoolPartnerships
+      )
+    end
+  end
 
   before do
     allow(Logger).to receive(:new).with($stdout) { logger }
     allow(Rails).to receive(:env) { environment.inquiry }
-
-    # Create support data
-    FactoryBot.create_list(:lead_provider, 2).each do |lead_provider|
-      FactoryBot.create_list(:lead_provider_delivery_partnership, 2, :for_year, lead_provider:, year: contract_period_2024.year)
-      FactoryBot.create_list(:lead_provider_delivery_partnership, 2, :for_year, lead_provider:, year: contract_period_2025.year)
-    end
-    APISeedData::Schools.new.plant
-    APISeedData::SchoolPartnerships.new.plant
   end
 
   describe "#plant" do

--- a/spec/services/api_seed_data/participant_scenarios_spec.rb
+++ b/spec/services/api_seed_data/participant_scenarios_spec.rb
@@ -4,31 +4,32 @@ RSpec.describe APISeedData::ParticipantScenarios do
   let(:environment) { "sandbox" }
   let(:logger) { instance_double(Logger, info: nil, "formatter=" => nil, "level=" => nil) }
 
-  let(:contract_period_2024) { FactoryBot.create(:contract_period, year: 2024) }
-  let(:contract_period_2025) { FactoryBot.create(:contract_period, year: 2025) }
+  before_all do
+    DeclarativeUpdates.skip(:metadata, :touch) do
+      contract_period_2024 = FactoryBot.create(:contract_period, year: 2024)
+      contract_period_2025 = FactoryBot.create(:contract_period, year: 2025)
+
+      FactoryBot.create_list(:lead_provider, 2).each do |lead_provider|
+        FactoryBot.create_list(:lead_provider_delivery_partnership, 5, :for_year, lead_provider:, year: contract_period_2024.year)
+        FactoryBot.create_list(:lead_provider_delivery_partnership, 5, :for_year, lead_provider:, year: contract_period_2025.year)
+      end
+      FactoryBot.create_list(:appropriate_body, 5)
+
+      plant_api_seed_support_data(
+        APISeedData::Contracts,
+        APISeedData::Statements,
+        APISeedData::Schools,
+        APISeedData::SchoolPartnerships,
+        APISeedData::SchedulesAndMilestones
+      )
+    end
+  end
 
   before do
     stub_const("#{described_class}::NUMBER_OF_RECORDS_PER_SCENARIO", 1)
 
     allow(Logger).to receive(:new).with($stdout) { logger }
     allow(Rails).to receive(:env) { environment.inquiry }
-
-    ignored_logger = instance_double(Logger, info: nil, "formatter=" => nil, "level=" => nil)
-    allow(Logger).to receive(:new).with($stdout) { ignored_logger }
-
-    # Create support data
-    FactoryBot.create_list(:lead_provider, 2).each do |lead_provider|
-      FactoryBot.create_list(:lead_provider_delivery_partnership, 5, :for_year, lead_provider:, year: contract_period_2024.year)
-      FactoryBot.create_list(:lead_provider_delivery_partnership, 5, :for_year, lead_provider:, year: contract_period_2025.year)
-    end
-    FactoryBot.create_list(:appropriate_body, 5)
-    APISeedData::Contracts.new.plant
-    APISeedData::Statements.new.plant
-    APISeedData::Schools.new.plant
-    APISeedData::SchoolPartnerships.new.plant
-    APISeedData::SchedulesAndMilestones.new.plant
-
-    allow(Logger).to receive(:new).with($stdout) { logger }
   end
 
   describe "#plant" do

--- a/spec/services/api_seed_data/school_scenarios_spec.rb
+++ b/spec/services/api_seed_data/school_scenarios_spec.rb
@@ -1,27 +1,30 @@
 RSpec.describe APISeedData::SchoolScenarios do
   let(:verbose) { true }
+  let(:lead_provider_count) { LeadProvider.count }
+  let(:active_lead_provider_count) { ActiveLeadProvider.count }
   let(:instance) { described_class.new(verbose:) }
   let(:environment) { "sandbox" }
   let(:logger) { instance_double(Logger, info: nil, "formatter=" => nil, "level=" => nil) }
 
-  let(:contract_period_2024) { FactoryBot.create(:contract_period, year: 2024) }
-  let(:contract_period_2025) { FactoryBot.create(:contract_period, year: 2025) }
+  let_it_be(:contract_period_2024) { FactoryBot.create(:contract_period, year: 2024) }
+  let_it_be(:contract_period_2025) { FactoryBot.create(:contract_period, year: 2025) }
 
-  let(:lead_provider_count) { LeadProvider.count }
-  let(:active_lead_provider_count) { ActiveLeadProvider.count }
+  before_all do
+    DeclarativeUpdates.skip(:metadata, :touch) do
+      # Create lead providers with active lead providers for both contract periods
+      FactoryBot.create_list(:lead_provider, 2).each do |lead_provider|
+        FactoryBot.create(:active_lead_provider, lead_provider:, contract_period: contract_period_2024)
+        FactoryBot.create(:active_lead_provider, lead_provider:, contract_period: contract_period_2025)
+      end
+
+      # Create delivery partners
+      FactoryBot.create_list(:delivery_partner, 5)
+    end
+  end
 
   before do
     allow(Logger).to receive(:new).with($stdout) { logger }
     allow(Rails).to receive(:env) { environment.inquiry }
-
-    # Create lead providers with active lead providers for both contract periods
-    FactoryBot.create_list(:lead_provider, 2).each do |lead_provider|
-      FactoryBot.create(:active_lead_provider, lead_provider:, contract_period: contract_period_2024)
-      FactoryBot.create(:active_lead_provider, lead_provider:, contract_period: contract_period_2025)
-    end
-
-    # Create delivery partners
-    FactoryBot.create_list(:delivery_partner, 5)
   end
 
   describe "#plant" do

--- a/spec/services/api_seed_data/unfunded_mentors_spec.rb
+++ b/spec/services/api_seed_data/unfunded_mentors_spec.rb
@@ -4,23 +4,31 @@ RSpec.describe APISeedData::UnfundedMentors, :with_metadata do
   let(:environment) { "sandbox" }
   let(:logger) { instance_double(Logger, info: nil, "formatter=" => nil, "level=" => nil) }
 
-  let(:contract_period_2024) { FactoryBot.create(:contract_period, year: 2024) }
-  let(:contract_period_2025) { FactoryBot.create(:contract_period, year: 2025) }
+  let_it_be(:contract_period_2024) { FactoryBot.create(:contract_period, year: 2024) }
+  let_it_be(:contract_period_2025) { FactoryBot.create(:contract_period, year: 2025) }
+
+  # Metadata updates deliberately not skipped here: this group runs :with_metadata
+  # and its queries depend on the metadata rows.
+  before_all do
+    DeclarativeUpdates.skip(:touch) do
+      FactoryBot.create_list(:lead_provider, 2).each do |lead_provider|
+        FactoryBot.create_list(:lead_provider_delivery_partnership, 2, :for_year, lead_provider:, year: 2024)
+        FactoryBot.create_list(:lead_provider_delivery_partnership, 2, :for_year, lead_provider:, year: 2025)
+      end
+
+      plant_api_seed_support_data(
+        APISeedData::Schools,
+        APISeedData::SchoolPartnerships,
+        APISeedData::SchedulesAndMilestones
+      )
+    end
+  end
 
   before do
     allow(Logger).to receive(:new).with($stdout) { logger }
     allow(Rails).to receive(:env) { environment.inquiry }
 
     stub_const("#{described_class}::MIN_UNFUNDED_MENTORS_PER_LP", 2)
-
-    # Create support data
-    FactoryBot.create_list(:lead_provider, 2).each do |lead_provider|
-      FactoryBot.create_list(:lead_provider_delivery_partnership, 2, :for_year, lead_provider:, year: contract_period_2024.year)
-      FactoryBot.create_list(:lead_provider_delivery_partnership, 2, :for_year, lead_provider:, year: contract_period_2025.year)
-    end
-    APISeedData::Schools.new.plant
-    APISeedData::SchoolPartnerships.new.plant
-    APISeedData::SchedulesAndMilestones.new.plant
   end
 
   describe "#plant" do

--- a/spec/support/api_seed_data_helpers.rb
+++ b/spec/support/api_seed_data_helpers.rb
@@ -1,0 +1,23 @@
+module APISeedDataHelpers
+  # Runs API seed planters outside of per-example stubs, e.g. in `before_all`
+  # blocks: seed services only plant in certain environments (see
+  # APISeedData::Base#plantable?) and log to $stdout, and RSpec mocks are not
+  # available outside of examples, so we swap the real Rails.env and $stdout
+  # around the plant calls instead.
+  def plant_api_seed_support_data(*planter_classes)
+    original_env = Rails.env
+    original_stdout = $stdout
+
+    Rails.env = "sandbox"
+    $stdout = File.open(File::NULL, "w")
+
+    planter_classes.each { |planter_class| planter_class.new.plant }
+  ensure
+    $stdout = original_stdout
+    Rails.env = original_env
+  end
+end
+
+RSpec.configure do |config|
+  config.include APISeedDataHelpers
+end

--- a/spec/support/test_prof.rb
+++ b/spec/support/test_prof.rb
@@ -1,0 +1,2 @@
+require "test_prof/recipes/rspec/before_all"
+require "test_prof/recipes/rspec/let_it_be"


### PR DESCRIPTION
I started looking at https://github.com/DFE-Digital/register-early-career-teachers-public/issues/2925, but creating contract periods as fixtures actually made the suite _slower_, because the sum cost of refreshing metadata across all contract periods in `with_metadata` examples exceeds the savings from skipping factory creations.

[TestProf](https://test-prof.evilmartians.io/) and specifically the [`before_all`](https://test-prof.evilmartians.io/guide/recipes/before_all) / [`let_it_be`](https://test-prof.evilmartians.io/guide/recipes/let_it_be) helpers facilitate building the world once per example _group_ (instead of per example) and rolling back to it after each example, so kind of similar to transactional fixtures, but scoped to specs / example groups.

With these commits, profiling estimates just over 4 minutes off the serial run time, pushing ~60s off the wall time per CI run (after merging and Knapsack rebalancing), so about 20% reduction of CI time spent on RSpec. Seems like quite a good win, pruning CI time a little, and a nice step towards making local runs of the full suite more practical.

OTOH, not strictly necessary and does add a dependency and a little bit of extra complexity to some specs, so opening this up for consideration/conversation really... I won't be upset if this doesn't get merged 🙃 the changes should be quite minimal outside of swapping to these TestProf helpers, although I'm not super familiar with API spec seed stuff, so it'd be good to sanity check those.

Comments / discussion welcome!

[b2efbc1](https://github.com/DFE-Digital/register-early-career-teachers-public/pull/3199/commits/b2efbc169590f737e8d6fcaf650256f95343e334) - saves 80-120s of serial test time by focussing on API Seed specs, should shave at least 20s off total wall time once Knapsack is rebalanced
[ebe27b1](https://github.com/DFE-Digital/register-early-career-teachers-public/pull/3199/commits/ebe27b11ed68f2fee8d8f47e53cd894544c1f3c7) - the rest of the savings from tackling the main `with_metadata` specs