### PR TITLE
Fix flaky dfe-analytics spec

### DIFF
--- a/spec/requests/dfe_analytics_spec.rb
+++ b/spec/requests/dfe_analytics_spec.rb
@@ -38,15 +38,25 @@ RSpec.describe "DfE Analytics", type: :request do
     end
 
     it "does not send a web request event for GET /healthcheck" do
-      expect { get "/healthcheck" }.not_to have_sent_analytics_event_types(:web_request)
+      allow(DfE::Analytics::SendEvents).to receive(:do)
+
+      get "/healthcheck"
+
+      expect(DfE::Analytics::SendEvents).not_to have_received(:do)
+        .with(array_including(hash_including({ "request_path" => /healthcheck/ })))
     end
 
     context "when logged in as admin" do
       include_context "sign in as DfE user"
 
       it "does not send a web request event for GET /admin" do
-        expect { get "/admin" }.not_to have_sent_analytics_event_types(:web_request)
-        expect { get "/admin/teachers" }.not_to have_sent_analytics_event_types(:web_request)
+        allow(DfE::Analytics::SendEvents).to receive(:do)
+
+        get "/admin"
+        get "/admin/teachers"
+
+        expect(DfE::Analytics::SendEvents).not_to have_received(:do)
+          .with(array_including(hash_including({ "request_path" => /admin/ })))
       end
     end
   end


### PR DESCRIPTION
We often get failures in CI where we expect **to not** receive any `web_request` analytics events for excluded paths (`/healthcheck` and `/admin/*`).

Digging into how the dfe-analytics matcher works it asserts on the jobs enqueued during the request, but it looks open to race conditions and I think that's what we're seeing (it determines the jobs implicitly by doing a snapshot before/after calling the block).

Switch to a more explicit matcher that mocks and asserts on the `SendEvents` class, looking for events with the specific request path instead of just any web request event.

[Example failure in CI](https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/28781048696/job/85336460033)