### PR TITLE
Fix Swagger label styling

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -205,7 +205,6 @@ code {
 }
 
 pre {
-  background: $govuk-template-background-colour;
   white-space: pre-wrap;
   @include govuk-font($size: 16);
 


### PR DESCRIPTION
The pre styles which target the example JSON snippets in the admin area also (unintentionally) set the background of the little 'labels' on the Swagger API docs to be white.

We don't have control over that markup so the easiest thing is to just leave it as default.


| Before | After |
| ------ | ------- |
| <img width="645" height="261" alt="Screenshot From 2026-07-06 18-10-29" src="https://github.com/user-attachments/assets/751d9b43-6d37-4767-ad9f-784f13299186" /> | <img width="516" height="105" alt="Screenshot From 2026-07-06 18-09-59" src="https://github.com/user-attachments/assets/45f7f428-9886-4e59-a664-d60c4d3b8c11" /> |
| <img width="1066" height="661" alt="Screenshot From 2026-07-06 18-10-21" src="https://github.com/user-attachments/assets/200e0498-8e57-4f2b-9d0e-3af94501f98a" /> | <img width="1066" height="661" alt="Screenshot From 2026-07-06 18-10-12" src="https://github.com/user-attachments/assets/2bf871a9-fb93-4f53-a039-19a2a6e3ea8b" /> |