### PR TITLE
Disable ALP band lock down to allow a script to populate sandbox

### DIFF
--- a/app/models/active_lead_provider/band.rb
+++ b/app/models/active_lead_provider/band.rb
@@ -29,7 +29,7 @@ class ActiveLeadProvider::Band < ApplicationRecord
             }
 
   # Callbacks
-  before_update :abort_update, unless: :last?
+  # before_update :abort_update, unless: :last?
   before_destroy :abort_destruction, unless: :last?
   before_validation :assign_allocation_order,
                     on: :create,

--- a/spec/models/active_lead_provider/band_spec.rb
+++ b/spec/models/active_lead_provider/band_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe ActiveLeadProvider::Band, type: :model do
     context "with multiple bands" do
       let!(:last_band) { FactoryBot.create(:active_lead_provider_band, active_lead_provider:) }
 
-      it "prevents changing the capacity of a band that is not the last" do
+      it "prevents changing the capacity of a band that is not the last", skip: "whilst backfilling" do
         expect { first_band.update!(capacity: 999) }.to raise_error(ActiveRecord::RecordNotSaved)
         expect(first_band.errors[:base]).to include("Only the last band can be updated")
       end


### PR DESCRIPTION
### Context

Active Lead Provider Band remodelling. This was broken down into multiple PRs.

1. We needed to backfill a new table `active_lead_provider_bands`
2. Then change the name of another `contract_banded_fee_structure_bands` to `contract_banded_fee_structure_band_terms`
3. A deployment failed and as a result we needed to resort to backfilling via script. This was run on `production` successfully but `staging` and `sandbox` were missed.
4. The next stage was to prevent all but the last band from being editable and to enforce `NOT NULL` which raised an error when deploying to pre-prod environments.
5. The cause was the script not having been run, which once run on `staging` deployed correctly; however the script was now raising an error on `sandbox` due to the `ActiveRecord` callback.

### Changes proposed in this pull request

Temporarily disable `before_update :abort_update, unless: :last?` on `ActiveLeadProvider::Band`.

This should allow `db/scripts/populate_alp_bands_from_band_terms.rb` to complete on `sandbox`. 

After which this can be reverted.

### Guidance to review

