### PR TITLE
Fix n+1 query on the personas page and refactor

### DIFF
--- a/app/controllers/personas_controller.rb
+++ b/app/controllers/personas_controller.rb
@@ -2,21 +2,6 @@ class PersonasController < ApplicationController
   layout "full"
 
   def index
-    persona_data = Struct.new(:name, :email, :school_name, :school_type, :image, :alt, :appropriate_body_name, :dfe_staff, :type, :role) do
-      def appropriate_body_period_id
-        AppropriateBodyPeriod.find_by!(name: appropriate_body_name).id if appropriate_body_name.present?
-      end
-
-      def school_urn
-        School.joins(:gias_school).find_by!(gias_school: { name: school_name }).urn if school_name.present?
-      end
-
-      def user_id
-        User.find_by!(name:).id if dfe_staff
-      end
-    end
-
-    @personas = YAML.load_file(Rails.root.join("config/personas.yml"))
-                    .map { |p| persona_data.new(**p.symbolize_keys) }
+    @personas = Sessions::PersonaLoader.new("config/personas.yml").personas
   end
 end

--- a/app/services/sessions/persona_loader.rb
+++ b/app/services/sessions/persona_loader.rb
@@ -1,0 +1,69 @@
+module Sessions
+  class PersonaLoader
+    attr_reader :filename
+
+    PersonaData = Struct.new(
+      :name,
+      :user_id,
+      :email,
+      :school_urn,
+      :school_name,
+      :school_type,
+      :image,
+      :alt,
+      :appropriate_body_period_id,
+      :appropriate_body_name,
+      :dfe_staff,
+      :type,
+      :role
+    )
+
+    def initialize(filename = "config/personas.yml")
+      @filename = filename
+    end
+
+    def personas
+      personas_yaml.map do |persona|
+        PersonaData.new(
+          **persona.symbolize_keys,
+          school_urn: schools[persona["school_name"]]&.urn,
+          appropriate_body_period_id: appropriate_bodies[persona["appropriate_body_name"]]&.id,
+          user_id: users[persona["name"]]&.id
+        )
+      end
+    end
+
+  private
+
+    def personas_yaml
+      @personas_yaml ||= YAML.load_file(Rails.root.join(@filename))
+    end
+
+    def schools
+      @schools ||= School.includes(:gias_school)
+                         .where(gias_school: { name: school_names })
+                         .index_by(&:name)
+    end
+
+    def school_names
+      personas_yaml.map { it["school_name"] }.compact
+    end
+
+    def appropriate_bodies
+      @appropriate_bodies ||= AppropriateBodyPeriod.where(name: appropriate_body_names)
+                                                   .index_by(&:name)
+    end
+
+    def appropriate_body_names
+      personas_yaml.map { it["appropriate_body_name"] }.compact
+    end
+
+    def users
+      @users ||= ::User.where(name: user_names).index_by(&:name)
+    end
+
+    def user_names
+      personas_yaml.select { it["dfe_staff"] }.map { it["name"] }.compact
+    end
+  end
+end

--- a/spec/services/sessions/persona_loader_spec.rb
+++ b/spec/services/sessions/persona_loader_spec.rb
@@ -1,0 +1,60 @@
+describe Sessions::PersonaLoader do
+  subject { Sessions::PersonaLoader.new }
+
+  it "loads the list of personas in config/personas.yml by default" do
+    expect(subject.filename).to eql("config/personas.yml")
+  end
+
+  describe "#personas" do
+    it "contains a list of personas" do
+      expect(subject.personas).to all(be_a(Sessions::PersonaLoader::PersonaData))
+    end
+
+    it "loads each YAML entry into a persona" do
+      yaml = YAML.load_file(Rails.root.join("config/personas.yml"))
+      expect(subject.personas.size).to eql(yaml.size)
+    end
+
+    describe "Appropriate body users" do
+      it "sets the right appropriate_body_period_id given a name" do
+        ab = FactoryBot.create(:appropriate_body_period, name: "Umber Teaching School Hub")
+
+        fred_jones = subject.personas.find { it.name == "Fred Jones" }
+
+        aggregate_failures do
+          expect(fred_jones.appropriate_body_period_id).to eql(ab.id)
+          expect(fred_jones.school_urn).to be_nil
+          expect(fred_jones.user_id).to be_nil
+        end
+      end
+    end
+
+    describe "School users" do
+      it "sets the right school_urn given a name" do
+        school = FactoryBot.create(:gias_school, :with_school, name: "Brookfield School").school
+
+        serena_moon = subject.personas.find { it.name == "Serena Moon" }
+
+        aggregate_failures do
+          expect(serena_moon.school_urn).to eql(school.urn)
+          expect(serena_moon.appropriate_body_period_id).to be_nil
+          expect(serena_moon.user_id).to be_nil
+        end
+      end
+    end
+
+    describe "DfE staff" do
+      it "sets the right user_id given a name" do
+        user = FactoryBot.create(:user, name: "Norville Rogers")
+
+        norville_rogers = subject.personas.find { it.name == "Norville Rogers" }
+
+        aggregate_failures do
+          expect(norville_rogers.user_id).to eql(user.id)
+          expect(norville_rogers.school_urn).to be_nil
+          expect(norville_rogers.appropriate_body_period_id).to be_nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This moves the logic from the `PersonasController` into a service class that does the same thing but now does all the querying at the start rather than n+1. And it has some specs.

I know this isn't a 'real' page and users won't actually see it, but the less noise we have the easier it will be to see real n+1 problems.
