### PR TITLE
[3404] Broaden partnership options for current contract period changes

### DIFF
--- a/app/services/admin/teachers/training_periods/change_contract_period/future_period.rb
+++ b/app/services/admin/teachers/training_periods/change_contract_period/future_period.rb
@@ -59,8 +59,8 @@ module Admin
           def training_period_attributes
             {
               school_partnership: replacement_school_partnership,
+              expression_of_interest: replacement_expression_of_interest,
               schedule: equivalent_schedule,
-              **expression_of_interest_attributes
             }
           end
 
@@ -70,10 +70,10 @@ module Admin
             school_partnership
           end
 
-          def expression_of_interest_attributes
-            return {} unless training_period.only_expression_of_interest?
+          def replacement_expression_of_interest
+            return unless training_period.only_expression_of_interest?
 
-            { expression_of_interest: equivalent_active_lead_provider }
+            equivalent_active_lead_provider
           end
 
           def equivalent_active_lead_provider

--- a/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard.rb
+++ b/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard.rb
@@ -70,14 +70,16 @@ module Admin
           def school_partnerships
             return SchoolPartnership.none unless selected_contract_period
 
-            SchoolPartnerships::Search
-              .new(
-                school:,
-                contract_period: selected_contract_period,
-                lead_provider: training_period.lead_provider,
-                delivery_partner: training_period.delivery_partner
+            if future_period_with_current_active_period?
+              return SchoolPartnership.none unless same_partnership_as_current_active_period?
+
+              school_partnership_search(
+                lead_provider: current_active_period.lead_provider,
+                delivery_partner: current_active_period.delivery_partner
               )
-              .school_partnerships
+            else
+              school_partnership_search
+            end
           end
 
           def partnership_options
@@ -123,6 +125,29 @@ module Admin
 
           def eoi_only?
             training_period.only_expression_of_interest?
+          end
+
+          def school_partnership_search(lead_provider: :ignore, delivery_partner: :ignore)
+            SchoolPartnerships::Search
+              .new(
+                school:,
+                contract_period: selected_contract_period,
+                lead_provider:,
+                delivery_partner:
+              )
+              .school_partnerships
+          end
+
+          def same_partnership_as_current_active_period?
+            current_active_period.lead_provider_delivery_partnership == training_period.lead_provider_delivery_partnership
+          end
+
+          def future_period_with_current_active_period?
+            current_active_period.present? && training_period.started_on > Time.zone.today
+          end
+
+          def current_active_period
+            @current_active_period ||= ::TrainingPeriods::RelatedPeriods.new(training_period:).current_active_period
           end
 
           def selected_contract_period_allowed?

--- a/spec/requests/admin/teachers/training_periods/change_contract_period_wizard_spec.rb
+++ b/spec/requests/admin/teachers/training_periods/change_contract_period_wizard_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardCont
       expect(response).to redirect_to(path_for_step("select-partnership"))
     end
 
-    context "when there are no partnerships for the current lead provider and delivery partner" do
+    context "when there are no partnerships for the school" do
       let(:target_school_partnership) { nil }
 
       it "redirects to the no partnerships page" do
@@ -280,7 +280,7 @@ RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardCont
       expect(response).to redirect_to(path_for_step("check-answers"))
     end
 
-    it "validates the selected partnership uses the current lead provider and delivery partner" do
+    it "accepts a selected partnership with a different lead provider and delivery partner" do
       post(
         path_for_step("select-contract-period"),
         params: { select_contract_period: { contract_period_year: target_contract_period.year } }
@@ -291,11 +291,50 @@ RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardCont
         params: { select_partnership: { school_partnership_id: different_school_partnership.id } }
       )
 
-      page = Capybara.string(response.body)
+      expect(response).to redirect_to(path_for_step("check-answers"))
+    end
 
-      expect(response).to have_http_status(:unprocessable_content)
-      expect(page).to have_text("There is a problem")
-      expect(page).to have_text("Select a partnership")
+    context "when the selected training period starts in the future and has a current active period" do
+      let(:future_started_on) { today.next_month }
+      let!(:current_training_period) do
+        FactoryBot.create(
+          :training_period,
+          :provider_led,
+          ect_at_school_period:,
+          school_partnership:,
+          schedule:,
+          started_on: today.prev_month,
+          finished_on: future_started_on.yesterday
+        )
+      end
+      let(:training_period) do
+        FactoryBot.create(
+          :training_period,
+          :provider_led,
+          ect_at_school_period:,
+          school_partnership:,
+          schedule:,
+          started_on: future_started_on
+        )
+      end
+
+      it "validates the selected partnership uses the current active lead provider and delivery partner" do
+        post(
+          path_for_step("select-contract-period"),
+          params: { select_contract_period: { contract_period_year: target_contract_period.year } }
+        )
+
+        post(
+          path_for_step("select-partnership"),
+          params: { select_partnership: { school_partnership_id: different_school_partnership.id } }
+        )
+
+        page = Capybara.string(response.body)
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(page).to have_text("There is a problem")
+        expect(page).to have_text("Select a partnership")
+      end
     end
   end
 

--- a/spec/services/admin/teachers/training_periods/change_contract_period/future_period_spec.rb
+++ b/spec/services/admin/teachers/training_periods/change_contract_period/future_period_spec.rb
@@ -122,6 +122,32 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriod::FuturePer
     end
   end
 
+  context "when the future training period has a school partnership and stale expression of interest" do
+    let!(:training_period) do
+      FactoryBot.create(
+        :training_period,
+        ect_at_school_period: future_ect_at_school_period,
+        expression_of_interest: school_partnership.active_lead_provider,
+        school_partnership:,
+        schedule:,
+        started_on: future_started_on,
+        finished_on: future_finished_on
+      )
+    end
+
+    it "clears the expression of interest when updating the partnership" do
+      expect {
+        service_call
+      }.to change { training_period.reload.expression_of_interest_id }
+        .from(school_partnership.active_lead_provider.id)
+        .to(nil)
+
+      expect(training_period.school_partnership).to eq(target_school_partnership)
+      expect(training_period.contract_period).to eq(target_contract_period)
+      expect(training_period.schedule).to eq(target_schedule)
+    end
+  end
+
   context "when the future training period only has an expression of interest" do
     let(:target_school_partnership) { nil }
     let(:current_active_lead_provider) do

--- a/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard_spec.rb
+++ b/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard_spec.rb
@@ -1,4 +1,5 @@
 RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Wizard do
+  let(:today) { Date.new(2026, 2, 1) }
   let(:store) { FactoryBot.build(:session_repository) }
   let(:teacher) { FactoryBot.create(:teacher) }
   let(:school) { FactoryBot.create(:school) }
@@ -48,6 +49,10 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Wiz
     )
   end
 
+  around do |example|
+    travel_to(today) { example.run }
+  end
+
   describe "#allowed_steps" do
     subject { wizard.allowed_steps }
 
@@ -61,7 +66,7 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Wiz
       it { is_expected.to eq(%i[select_contract_period select_partnership]) }
     end
 
-    context "when an available contract period has no partnerships for the current lead provider and delivery partner" do
+    context "when an available contract period has no partnerships for the school" do
       let(:target_school_partnership) { nil }
 
       before { store.contract_period_year = target_contract_period.year }
@@ -139,6 +144,14 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Wiz
   describe "#school_partnerships" do
     let(:lead_provider) { FactoryBot.create(:lead_provider, name: "Target lead provider") }
     let(:delivery_partner) { FactoryBot.create(:delivery_partner, name: "Target delivery partner") }
+    let!(:different_school_partnership) do
+      FactoryBot.create(
+        :school_partnership,
+        :for_year,
+        year: target_contract_period.year,
+        school:
+      )
+    end
     let!(:target_school_partnership) do
       FactoryBot.create(
         :school_partnership,
@@ -164,8 +177,53 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Wiz
     context "when a contract period has been selected" do
       before { store.contract_period_year = target_contract_period.year }
 
-      it "returns school partnerships for the selected contract period, school, lead provider and delivery partner" do
-        expect(wizard.school_partnerships).to contain_exactly(target_school_partnership)
+      it "returns school partnerships for the selected contract period and school" do
+        expect(wizard.school_partnerships).to contain_exactly(target_school_partnership, different_school_partnership)
+      end
+
+      context "when the selected training period starts in the future and has a current active period" do
+        let(:future_started_on) { today.next_month }
+        let(:current_school_partnership) { school_partnership }
+        let!(:current_training_period) do
+          FactoryBot.create(
+            :training_period,
+            :provider_led,
+            ect_at_school_period:,
+            school_partnership: current_school_partnership,
+            schedule:,
+            started_on: today.prev_month,
+            finished_on: future_started_on.yesterday
+          )
+        end
+        let(:training_period) do
+          FactoryBot.create(
+            :training_period,
+            :provider_led,
+            ect_at_school_period:,
+            school_partnership:,
+            schedule:,
+            started_on: future_started_on
+          )
+        end
+
+        it "returns school partnerships for the selected contract period, school and current active LP/DP" do
+          expect(wizard.school_partnerships).to contain_exactly(target_school_partnership)
+        end
+
+        context "when the future period has a different LP/DP from the current active period" do
+          let(:current_school_partnership) do
+            FactoryBot.create(
+              :school_partnership,
+              :for_year,
+              year: current_contract_period.year,
+              school:
+            )
+          end
+
+          it "returns no school partnerships" do
+            expect(wizard.school_partnerships).to be_empty
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary

Updating the contract period change wizard so current active training periods show all partnerships for the selected school and contract period.

When moving contract period, the school may not be working with the same LP/DP in the target year, or that DP may no longer be working with that LP. This gives admins the flexibility to choose the correct partnership.

Future training period changes remain restricted to the current active LP/DP when the future period is eligible.