### PR TITLE
Fix statement setup in teacher migration spec

### DIFF
--- a/spec/migration_fixes/real_examples/teacher_210915_spec.rb
+++ b/spec/migration_fixes/real_examples/teacher_210915_spec.rb
@@ -11,8 +11,8 @@ describe "Real data check for teacher 210915 (missing training period and declar
   let!(:school_partnership) { FactoryBot.create(:school_partnership, id: 47_614, school: school_1, lead_provider_delivery_partnership: lpdp) }
   let(:contract_period) { FactoryBot.create(:contract_period, year: 2023, mentor_funding_enabled: false) }
   let!(:schedule) { FactoryBot.create(:schedule, id: 54, identifier: "ecf-standard-september", contract_period:) }
-  let!(:statement_1) { FactoryBot.create(:statement, id: 628, contract_period:) }
-  let!(:statement_2) { FactoryBot.create(:statement, id: 220, contract_period:) }
+  let!(:statement_1) { FactoryBot.create(:statement, id: 628, active_lead_provider:) }
+  let!(:statement_2) { FactoryBot.create(:statement, id: 220, active_lead_provider:) }
 
   let(:migration_fixes) do
     [


### PR DESCRIPTION
## Summary

This spec hard codes the lead provider id to match the real migration data. When the statement factory was given only a contract period, it could create another lead provider and clash with that fixed id depending on the database sequence.

Pass the existing active lead provider to the statement factory so the statements use the provider setup already created by the spec.

Failed run: https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/28933456814/job/85837938418
