### PR TITLE
Enable migration fixes (son-of-patch) to update read-only attrs

### DIFF
--- a/app/services/migration_fixes/processor.rb
+++ b/app/services/migration_fixes/processor.rb
@@ -41,6 +41,7 @@ private
 
   def update!(target_object, attrs)
     return if attrs.blank?
+
     orig_readonly_attrs = []
 
     if update_readonly_attrs

--- a/app/services/migration_fixes/processor.rb
+++ b/app/services/migration_fixes/processor.rb
@@ -1,8 +1,9 @@
 class MigrationFixes::Processor
-  attr_reader :batch_refs
+  attr_reader :batch_refs, :update_readonly_attrs
 
-  def initialize
+  def initialize(update_readonly_attrs: false)
     @batch_refs = {}
+    @update_readonly_attrs = update_readonly_attrs
   end
 
   def process!(data_change: {})
@@ -40,8 +41,21 @@ private
 
   def update!(target_object, attrs)
     return if attrs.blank?
+    orig_readonly_attrs = []
+
+    if update_readonly_attrs
+      # hacky workaround as there doesn't seem to be another way to do this other
+      # than perhaps raw sql
+      orig_readonly_attrs = target_object.class._attr_readonly
+      target_object.class._attr_readonly = []
+    end
 
     target_object.update!(**attrs)
+
+    if orig_readonly_attrs.present?
+      # this reverts after the session anyway but belt and braces
+      target_object.class._attr_readonly = orig_readonly_attrs
+    end
   end
 
   def delete!(target_object)

--- a/app/services/migration_fixes/processor.rb
+++ b/app/services/migration_fixes/processor.rb
@@ -52,11 +52,9 @@ private
     end
 
     target_object.update!(**attrs)
-
-    if orig_readonly_attrs.present?
-      # this reverts after the session anyway but belt and braces
-      target_object.class._attr_readonly = orig_readonly_attrs
-    end
+  ensure
+    # this reverts after the session anyway but belt and braces
+    target_object.class._attr_readonly = orig_readonly_attrs if orig_readonly_attrs.present?
   end
 
   def delete!(target_object)

--- a/config/database.yml
+++ b/config/database.yml
@@ -27,7 +27,7 @@ production_default: &production_default
 
 development:
   <<: *default
-  database: ecf2_development
+  database: ecf2_snapshot
 
 test:
   primary:

--- a/config/database.yml
+++ b/config/database.yml
@@ -27,7 +27,7 @@ production_default: &production_default
 
 development:
   <<: *default
-  database: ecf2_snapshot
+  database: ecf2_development
 
 test:
   primary:

--- a/db/scripts/migration_data_fixes.rb
+++ b/db/scripts/migration_data_fixes.rb
@@ -12,6 +12,11 @@
 csv_log = nil
 
 begin
+  if ENV[IGNORE_ATTR_READONLY].present?
+    Rails.logger.warn("Ignoring attr_readonly attributes")
+    Rails.config.active_record.raise_on_attr_readonly = false
+  end
+
   csv_file = Rails.root.join("db/scripts/migration_data_fixes.csv")
   csv_log = CSV.open(Rails.root.join("tmp/migration_data_fixes_log-#{Time.zone.now.to_fs(:iso8601)}.csv"), "w")
   csv_log << %w[object_type object_id action attributes errors]

--- a/db/scripts/migration_data_fixes.rb
+++ b/db/scripts/migration_data_fixes.rb
@@ -12,15 +12,12 @@
 csv_log = nil
 
 begin
-  if ENV[IGNORE_ATTR_READONLY].present?
-    Rails.logger.warn("Ignoring attr_readonly attributes")
-    Rails.config.active_record.raise_on_attr_readonly = false
-  end
+  update_readonly_attrs = ENV["UPDATE_READONLY_ATTRS"].present?
 
   csv_file = Rails.root.join("db/scripts/migration_data_fixes.csv")
   csv_log = CSV.open(Rails.root.join("tmp/migration_data_fixes_log-#{Time.zone.now.to_fs(:iso8601)}.csv"), "w")
   csv_log << %w[object_type object_id action attributes errors]
-  processor = MigrationFixes::Processor.new
+  processor = MigrationFixes::Processor.new(update_readonly_attrs:)
 
   CSV.foreach(csv_file, headers: true, header_converters: :symbol) do |row|
     processor.process!(data_change: row.to_h)

--- a/spec/services/migration_fixes/processor_spec.rb
+++ b/spec/services/migration_fixes/processor_spec.rb
@@ -57,6 +57,29 @@ describe MigrationFixes::Processor do
         expect(result.withdrawn_at).to eq(withdrawn_at)
         expect(result.withdrawal_reason).to eq "moved_school"
       end
+
+      context "when it attempts to update a attr_readonly attribute" do
+        let!(:target_object) { FactoryBot.create(:declaration) }
+        let(:delivery_partner) { FactoryBot.create(:delivery_partner) }
+
+        let(:attributes) { "delivery_partner_when_created_id,#{delivery_partner.id}" }
+
+        it "raises an error" do
+          expect {
+            processor.process!(data_change:)
+          }.to raise_error ActiveRecord::ReadonlyAttributeError
+        end
+
+        context "when update_readonly_attrs is set" do
+          subject(:processor) { described_class.new(update_readonly_attrs: true) }
+
+          it "updates the attribute correctly" do
+            result = processor.process!(data_change:)
+
+            expect(result.delivery_partner_when_created_id).to eq(delivery_partner.id)
+          end
+        end
+      end
     end
 
     context "when the action is 'delete'" do


### PR DESCRIPTION
### Context

We have some migration data fixes (in a different PR) that need to update the value in `Declaration.delivery_partner_when_created_id`.  This is a `attr_readonly` attribute and as such Rails will not allow us to update the value and save it to the database.

This PR adds a workaround that temporarily drops the `attr_readonly` list on the target model so that the updates can be applied, then adds them back in again once the changes have been saved.

To enable this, the env var `UPDATE_READONLY_ATTRS` needs to be set.

### Changes proposed in this pull request

### Guidance to review
