### PR TITLE
Return `422` instead of `200`

### DIFF
--- a/app/controllers/schools/register_ect_wizard_controller.rb
+++ b/app/controllers/schools/register_ect_wizard_controller.rb
@@ -23,7 +23,7 @@ module Schools
       if @wizard.save!
         redirect_to @wizard.next_step_path
       else
-        render current_step
+        render current_step, status: :unprocessable_content
       end
     end
 

--- a/app/controllers/schools/register_mentor_wizard_controller.rb
+++ b/app/controllers/schools/register_mentor_wizard_controller.rb
@@ -26,7 +26,7 @@ module Schools
       if @wizard.save!
         redirect_to @wizard.next_step_path
       else
-        render current_step
+        render current_step, status: :unprocessable_content
       end
     end
 


### PR DESCRIPTION
Before, we returned a `200` status whenever a user submitted a form in either the register ECT or register mentor journeys.

Typically a [200 OK][200] should mean "an action succeeded", but we were returning it even when the action definitely didn't succeeded and there were validation errors.

Now, we return a `422` instead in these scenarios. A [422 Unprocessable Content][422] indicates there was some sort of error that prevented the action succeeding.

This is more appropriate, plus it makes it easier to trawl the logs for validation errors!

[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/200
[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/422