### PR TITLE
Fixing n+1 queries on the school ECTs index

### DIFF
--- a/app/controllers/schools/ects_controller.rb
+++ b/app/controllers/schools/ects_controller.rb
@@ -5,7 +5,20 @@ module Schools
     include Schools::InductionRedirectable
 
     def index
-      search = Teachers::Search.new(ect_at_school: school, in_progress: true, query_string: params[:q]).search
+      search = Teachers::Search
+        .new(
+          ect_at_school: school,
+          in_progress: true,
+          query_string: params[:q]
+        )
+        .search
+        .includes(
+          ect_at_school_periods: %i[latest_training_period mentorship_periods],
+          current_or_next_ect_at_school_period: [
+            { latest_training_period: %i[lead_provider delivery_partner] },
+            { current_or_next_mentorship_period: { mentor: :teacher } }
+          ]
+        )
       @pagy, @teachers = pagy(search)
 
       @number_of_teachers = Teachers::Search.new(ect_at_school: school, in_progress: true).count

--- a/app/services/ect_at_school_periods/mentorship.rb
+++ b/app/services/ect_at_school_periods/mentorship.rb
@@ -11,9 +11,7 @@ module ECTAtSchoolPeriods
     end
 
     def latest_mentorship_period
-      @latest_mentorship_period ||= ect_at_school_period.mentorship_periods
-                                                        .latest_first
-                                                        .first
+      @latest_mentorship_period ||= ect_at_school_period.latest_mentorship_period
     end
 
     # current_mentor

--- a/app/views/schools/ects/index.html.erb
+++ b/app/views/schools/ects/index.html.erb
@@ -16,15 +16,15 @@
   <%= govuk_button_link_to("Register an ECT starting at your school", schools_register_ect_wizard_start_path) %>
 <% end %>
 
-<hr class="govuk-section-break--m"/>
+<hr class="govuk-section-break--m">
 
 <div class="govuk-grid-row">
   <% if @number_of_teachers.zero? %>
-    <div class='govuk-grid-column-two-thirds'>
+    <div class="govuk-grid-column-two-thirds">
       <p class="govuk-body">Your school currently has no registered early career teachers.</p>
     </div>
   <% else %>
-    <div class='govuk-grid-column-full'>
+    <div class="govuk-grid-column-full">
       <%= render Shared::TopSearchComponent.new %>
       <% if @teachers.count.zero? %>
         <p class="govuk-body">There are no ECTs that match your search.</p>


### PR DESCRIPTION
### Context

There are lots of N+1 queries on the schools index page.

The main reason is that the view components are doing too much heavy lifting, we probably want to move to a model where we pass collections of structs/objects in and the view component logic uses it directly, rather than the component issuing its own queries. Rewriting can wait though, this solves most of the problem for now.

### Final task

There's one remaining n+1 that's trickier to fix. It's the eligible mentors one, the scope excludes the current teacher - so it's run every time. This will be fixed by getting a list of eligible for the school up front, and then excluding the current teacher in Ruby rather than SQL.

### Changes proposed in this pull request

- **Fix some linting errors**
- **Fix most n+1 queries on the school ECT index page**
