### PR TITLE
[4142] Service to merge overlapping Mentor periods

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -50,6 +50,7 @@ class Event < ApplicationRecord
     teacher_mentor_at_school_period_deleted
     teacher_ect_at_school_period_moved_school
     teacher_mentor_at_school_period_moved_school
+    teacher_mentor_at_school_periods_merged
     teacher_registered_as_mentor
     teacher_left_school_as_mentor
     teacher_starts_being_mentored

--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -407,28 +407,30 @@ module Events
       new(event_type:, author:, heading:, teacher:, mentor_at_school_period:, school: new_school, metadata:, happened_at:).record_event!
     end
 
-    def self.record_teacher_mentor_at_school_periods_merged!(author:, teacher:, target_period:, mentor_at_school_periods:, happened_at: Time.zone.now)
+    def self.record_teacher_mentor_at_school_periods_merged!(author:, teacher:, successor_period:, mentor_at_school_periods:, happened_at: Time.zone.now)
       event_type = :teacher_mentor_at_school_periods_merged
       teacher_name = Teachers::Name.new(teacher).full_name
-      school_name = Schools::Name.new(target_period.school).name_and_urn
+      school_name = Schools::Name.new(successor_period.school).name_and_urn
 
       periods = mentor_at_school_periods.collect do |period|
         { school: period.school.name,
           started_on: period.started_on,
-          finished_on: period.finished_on }
+          finished_on: period.finished_on,
+          id: period.id,
+          urn: period.school.urn }
       end
 
-      time_period = if target_period.ongoing?
-                      "from #{target_period.started_on}"
+      time_period = if successor_period.ongoing?
+                      "from #{successor_period.started_on}"
                     else
-                      "between #{target_period.started_on} and #{target_period.finished_on}"
+                      "between #{successor_period.started_on} and #{successor_period.finished_on}"
                     end
 
       heading = "#{teacher_name}'s mentor at school periods #{time_period} were merged into a single period at #{school_name}"
 
       metadata = { periods: }
 
-      new(event_type:, author:, heading:, teacher:, mentor_at_school_period: target_period, metadata:, happened_at:).record_event!
+      new(event_type:, author:, heading:, teacher:, mentor_at_school_period: successor_period, metadata:, happened_at:).record_event!
     end
 
     def self.record_teacher_starts_training_period_event!(author:, training_period:, ect_at_school_period:, mentor_at_school_period:, teacher:, school:, happened_at:)

--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -407,6 +407,30 @@ module Events
       new(event_type:, author:, heading:, teacher:, mentor_at_school_period:, school: new_school, metadata:, happened_at:).record_event!
     end
 
+    def self.record_teacher_mentor_at_school_periods_merged!(author:, teacher:, target_period:, mentor_at_school_periods:, happened_at: Time.zone.now)
+      event_type = :teacher_mentor_at_school_periods_merged
+      teacher_name = Teachers::Name.new(teacher).full_name
+      school_name = Schools::Name.new(target_period.school).name_and_urn
+
+      periods = mentor_at_school_periods.collect do |period|
+        { school: period.school.name,
+          started_on: period.started_on,
+          finished_on: period.finished_on }
+      end
+
+      time_period = if target_period.ongoing?
+                      "from #{target_period.started_on}"
+                    else
+                      "between #{target_period.started_on} and #{target_period.finished_on}"
+                    end
+
+      heading = "#{teacher_name}'s mentor at school periods #{time_period} were merged into a single period at #{school_name}"
+
+      metadata = { periods: }
+
+      new(event_type:, author:, heading:, teacher:, mentor_at_school_period: target_period, metadata:, happened_at:).record_event!
+    end
+
     def self.record_teacher_starts_training_period_event!(author:, training_period:, ect_at_school_period:, mentor_at_school_period:, teacher:, school:, happened_at:)
       if ect_at_school_period.present? && mentor_at_school_period.present?
         fail(ArgumentError, "either ect_at_school_period or mentor_at_school_period permitted, not both")

--- a/app/services/gias/schools/mentor_at_school_periods/merge.rb
+++ b/app/services/gias/schools/mentor_at_school_periods/merge.rb
@@ -16,9 +16,9 @@ module GIAS
           ActiveRecord::Base.transaction do
             successor_period.assign_attributes(started_on:, finished_on:)
 
-            update_mentorship_periods
-            update_training_periods
-            update_events
+            update_mentorship_periods!
+            update_training_periods!
+            update_events!
 
             redundant_periods.each do |period|
               period.training_periods.reset
@@ -57,16 +57,17 @@ module GIAS
           @events ||= redundant_periods.flat_map(&:events).uniq
         end
 
-        def update_training_periods
+        def update_training_periods!
           training_periods.each do |training_period|
-            new_partnership = new_partnership_for(training_period)
-            training_period.school_partnership = new_partnership if new_partnership
+            if training_period.school_partnership.present?
+              training_period.school_partnership = successor_partnership(training_period.school_partnership)
+            end
             training_period.mentor_at_school_period = successor_period
             training_period.save!
           end
         end
 
-        def update_mentorship_periods
+        def update_mentorship_periods!
           mentorship_periods.each do |mentorship_period|
             GIAS::Schools::ECTAtSchoolPeriods::Transfer.call(ect_at_school_period: mentorship_period.mentee, predecessor_school:, successor_school:)
             mentorship_period.mentor = successor_period
@@ -74,18 +75,19 @@ module GIAS
           end
         end
 
-        def update_events
+        def update_events!
           events.each do |event|
-            new_partnership = new_partnership_for(event)
-            event.school_partnership = new_partnership if new_partnership
+            if event.school_partnership.present?
+              event.school_partnership = successor_partnership(event.school_partnership)
+            end
             event.school = successor_school if event.school.present?
             event.mentor_at_school_period = successor_period
             event.save!
           end
         end
 
-        def new_partnership_for(object)
-          GIAS::Schools::SchoolPartnerships::Transfer.call(object:, successor_school:)
+        def successor_partnership(predecessor_school_partnership)
+          GIAS::Schools::SchoolPartnerships::Transfer.call(predecessor_school_partnership:, successor_school:)
         end
 
         def finished_on

--- a/app/services/gias/schools/mentor_at_school_periods/merge.rb
+++ b/app/services/gias/schools/mentor_at_school_periods/merge.rb
@@ -26,15 +26,17 @@ module GIAS
             end
 
             successor_period.save!
+
+            record_event!
           end
         end
 
       private
 
         def successor_period
-          @successor_period ||= periods.reverse.find do |period|
-            period.school == successor_school
-          end
+          @successor_period ||= periods
+            .select { |period| period.school == successor_school }
+            .max_by(&:started_on)
         end
 
         def redundant_periods
@@ -64,7 +66,7 @@ module GIAS
 
         def update_mentorship_periods
           mentorship_periods.each do |mentorship_period|
-            GIAS::Schools::ECTAtSchoolPeriods::Transfer.call(period: mentorship_period.mentee, predecessor_school:, successor_school:)
+            GIAS::Schools::ECTAtSchoolPeriods::Transfer.call(ect_at_school_period: mentorship_period.mentee, predecessor_school:, successor_school:)
             mentorship_period.mentor = successor_period
             mentorship_period.save!
           end
@@ -96,6 +98,16 @@ module GIAS
 
         def started_on
           @started_on ||= periods.map(&:started_on).min
+        end
+
+        def record_event!
+          Events::Record.record_teacher_mentor_at_school_periods_merged!(
+            author: Events::SystemAuthor.new,
+            teacher: successor_period.teacher,
+            successor_period:,
+            mentor_at_school_periods: periods,
+            happened_at: predecessor_school.gias_school.closed_on
+          )
         end
       end
     end

--- a/app/services/gias/schools/mentor_at_school_periods/merge.rb
+++ b/app/services/gias/schools/mentor_at_school_periods/merge.rb
@@ -1,0 +1,103 @@
+module GIAS
+  module Schools
+    module MentorAtSchoolPeriods
+      class Merge
+        attr_reader :periods, :predecessor_school, :successor_school
+
+        def initialize(periods:, predecessor_school:, successor_school:)
+          @periods = periods
+          @predecessor_school = predecessor_school
+          @successor_school = successor_school
+        end
+
+        def self.call(**args) = new(**args).call
+
+        def call
+          ActiveRecord::Base.transaction do
+            successor_period.assign_attributes(started_on:, finished_on:)
+
+            update_mentorship_periods
+            update_training_periods
+            update_events
+
+            redundant_periods.each do |period|
+              period.training_periods.reset
+              period.destroy!
+            end
+
+            successor_period.save!
+          end
+        end
+
+      private
+
+        def successor_period
+          @successor_period ||= periods.reverse.find do |period|
+            period.school == successor_school
+          end
+        end
+
+        def redundant_periods
+          @redundant_periods ||= periods.excluding(successor_period)
+        end
+
+        def training_periods
+          @training_periods ||= redundant_periods.flat_map(&:training_periods).uniq
+        end
+
+        def mentorship_periods
+          @mentorship_periods ||= redundant_periods.flat_map(&:mentorship_periods).uniq
+        end
+
+        def events
+          @events ||= redundant_periods.flat_map(&:events).uniq
+        end
+
+        def update_training_periods
+          training_periods.each do |training_period|
+            new_partnership = new_partnership_for(training_period)
+            training_period.school_partnership = new_partnership if new_partnership
+            training_period.mentor_at_school_period = successor_period
+            training_period.save!
+          end
+        end
+
+        def update_mentorship_periods
+          mentorship_periods.each do |mentorship_period|
+            GIAS::Schools::ECTAtSchoolPeriods::Transfer.call(period: mentorship_period.mentee, predecessor_school:, successor_school:)
+            mentorship_period.mentor = successor_period
+            mentorship_period.save!
+          end
+        end
+
+        def update_events
+          events.each do |event|
+            new_partnership = new_partnership_for(event)
+            event.school_partnership = new_partnership if new_partnership
+            event.school = successor_school if event.school.present?
+            event.mentor_at_school_period = successor_period
+            event.save!
+          end
+        end
+
+        def new_partnership_for(object)
+          GIAS::Schools::SchoolPartnerships::Transfer.call(object:, successor_school:)
+        end
+
+        def finished_on
+          @finished_on ||= calculate_finished_on
+        end
+
+        def calculate_finished_on
+          return nil if periods.any?(&:ongoing?)
+
+          periods.map(&:finished_on).compact.max
+        end
+
+        def started_on
+          @started_on ||= periods.map(&:started_on).min
+        end
+      end
+    end
+  end
+end

--- a/app/services/gias/schools/mentor_at_school_periods/merge.rb
+++ b/app/services/gias/schools/mentor_at_school_periods/merge.rb
@@ -22,6 +22,8 @@ module GIAS
 
             redundant_periods.each do |period|
               period.training_periods.reset
+              period.mentorship_periods.reset
+              period.events.reset
               period.destroy!
             end
 

--- a/app/services/gias/schools/mentor_at_school_periods/overlapping.rb
+++ b/app/services/gias/schools/mentor_at_school_periods/overlapping.rb
@@ -1,0 +1,58 @@
+module GIAS
+  module Schools
+    module MentorAtSchoolPeriods
+      class Overlapping
+        attr_reader :teacher, :schools, :groups
+
+        def initialize(teacher:, schools:)
+          @teacher = teacher
+          @schools = Array(schools).compact.uniq
+          @groups = []
+        end
+
+        def self.find(...) = new(...).find
+
+        def find
+          return [] if only_one_school?
+
+          group_mentor_at_school_periods
+
+          groups.select(&:many?)
+        end
+
+      private
+
+        def ordered_mentor_at_school_periods
+          @ordered_mentor_at_school_periods ||= teacher
+            .mentor_at_school_periods
+            .where(school: schools)
+            .order(:started_on)
+        end
+
+        def only_one_school?
+          schools.uniq.one? || ordered_mentor_at_school_periods.map(&:school_id).uniq.one?
+        end
+
+        def group_mentor_at_school_periods
+          ordered_mentor_at_school_periods.each do |period|
+            if start_new_group?(groups.last, period)
+              groups << [period]
+            else
+              groups.last << period
+            end
+          end
+        end
+
+        def start_new_group?(current_group, next_period)
+          current_group.nil? || gap_between?(current_group, next_period)
+        end
+
+        def gap_between?(group, period)
+          return false if group.any?(&:ongoing?)
+
+          group.map(&:finished_on).max < period.started_on
+        end
+      end
+    end
+  end
+end

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -941,7 +941,7 @@ RSpec.describe Events::Record do
       )
     end
 
-    let(:target_period) do
+    let(:successor_period) do
       FactoryBot.create(
         :mentor_at_school_period,
         teacher:,
@@ -964,18 +964,22 @@ RSpec.describe Events::Record do
           periods = [
             { finished_on: Date.new(2025, 6, 30),
               school: "Monsters College",
-              started_on: Date.new(2025, 1, 1) },
+              started_on: Date.new(2025, 1, 1),
+              id: first_period.id,
+              urn: 1_234_567 },
             { finished_on: nil,
               school: "Monsters College",
-              started_on: Date.new(2025, 7, 1) }
+              started_on: Date.new(2025, 7, 1),
+              id: second_period.id,
+              urn: 1_234_567 }
           ]
 
-          Events::Record.record_teacher_mentor_at_school_periods_merged!(author:, teacher:, mentor_at_school_periods:, target_period:)
+          Events::Record.record_teacher_mentor_at_school_periods_merged!(author:, teacher:, mentor_at_school_periods:, successor_period:)
 
           expect(RecordEventJob).to have_received(:perform_later).with(
             event_type: :teacher_mentor_at_school_periods_merged,
             teacher:,
-            mentor_at_school_period: target_period,
+            mentor_at_school_period: successor_period,
             metadata: { periods: },
             heading: "Rhys Ifans's mentor at school periods from 2025-01-01 were merged into a single period at Abigail Hardscrabble High School for Girls (7654321)",
             happened_at: Time.zone.now,
@@ -993,21 +997,25 @@ RSpec.describe Events::Record do
 
       it "queues a RecordEventJob with the correct values" do
         freeze_time do
-          Events::Record.record_teacher_mentor_at_school_periods_merged!(author:, teacher:, mentor_at_school_periods:, target_period:)
+          Events::Record.record_teacher_mentor_at_school_periods_merged!(author:, teacher:, mentor_at_school_periods:, successor_period:)
 
           periods = [
             { finished_on: Date.new(2025, 6, 30),
               school: "Monsters College",
-              started_on: Date.new(2025, 1, 1) },
+              started_on: Date.new(2025, 1, 1),
+              id: first_period.id,
+              urn: 1_234_567 },
             { finished_on: Date.new(2025, 12, 31),
               school: "Monsters College",
-              started_on: Date.new(2025, 7, 1) }
+              started_on: Date.new(2025, 7, 1),
+              id: second_period.id,
+              urn: 1_234_567 }
           ]
 
           expect(RecordEventJob).to have_received(:perform_later).with(
             event_type: :teacher_mentor_at_school_periods_merged,
             teacher:,
-            mentor_at_school_period: target_period,
+            mentor_at_school_period: successor_period,
             metadata: { periods: },
             heading: "Rhys Ifans's mentor at school periods between 2025-01-01 and 2025-12-31 were merged into a single period at Abigail Hardscrabble High School for Girls (7654321)",
             happened_at: Time.zone.now,

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -916,6 +916,108 @@ RSpec.describe Events::Record do
     end
   end
 
+  describe ".record_teacher_mentor_at_school_periods_merged!" do
+    let(:first_gias_school) { FactoryBot.create(:gias_school, :with_school, urn: "1234567", name: "Monsters College") }
+    let(:second_gias_school) { FactoryBot.create(:gias_school, :with_school, urn: "7654321", name: "Abigail Hardscrabble High School for Girls") }
+    let(:first_school) { first_gias_school.school }
+    let(:second_school) { second_gias_school.school }
+    let!(:first_period) do
+      FactoryBot.create(
+        :mentor_at_school_period,
+        teacher:,
+        school: first_school,
+        started_on: first_period_started_on,
+        finished_on: first_period_finished_on
+      )
+    end
+
+    let!(:second_period) do
+      FactoryBot.create(
+        :mentor_at_school_period,
+        teacher:,
+        school: first_school,
+        started_on: second_period_started_on,
+        finished_on: second_period_finished_on
+      )
+    end
+
+    let(:target_period) do
+      FactoryBot.create(
+        :mentor_at_school_period,
+        teacher:,
+        school: second_school,
+        started_on: first_period_started_on,
+        finished_on: second_period_finished_on
+      )
+    end
+
+    let(:mentor_at_school_periods) { [first_period, second_period] }
+
+    context "when the target period is ongoing" do
+      let(:first_period_started_on) { Date.new(2025, 1, 1) }
+      let(:first_period_finished_on) { Date.new(2025, 6, 30) }
+      let(:second_period_started_on) { Date.new(2025, 7, 1) }
+      let(:second_period_finished_on) { nil }
+
+      it "queues a RecordEventJob with the correct values" do
+        freeze_time do
+          periods = [
+            { finished_on: Date.new(2025, 6, 30),
+              school: "Monsters College",
+              started_on: Date.new(2025, 1, 1) },
+            { finished_on: nil,
+              school: "Monsters College",
+              started_on: Date.new(2025, 7, 1) }
+          ]
+
+          Events::Record.record_teacher_mentor_at_school_periods_merged!(author:, teacher:, mentor_at_school_periods:, target_period:)
+
+          expect(RecordEventJob).to have_received(:perform_later).with(
+            event_type: :teacher_mentor_at_school_periods_merged,
+            teacher:,
+            mentor_at_school_period: target_period,
+            metadata: { periods: },
+            heading: "Rhys Ifans's mentor at school periods from 2025-01-01 were merged into a single period at Abigail Hardscrabble High School for Girls (7654321)",
+            happened_at: Time.zone.now,
+            **author_params
+          )
+        end
+      end
+    end
+
+    context "when the target period is finished" do
+      let(:first_period_started_on) { Date.new(2025, 1, 1) }
+      let(:first_period_finished_on) { Date.new(2025, 6, 30) }
+      let(:second_period_started_on) { Date.new(2025, 7, 1) }
+      let(:second_period_finished_on) { Date.new(2025, 12, 31) }
+
+      it "queues a RecordEventJob with the correct values" do
+        freeze_time do
+          Events::Record.record_teacher_mentor_at_school_periods_merged!(author:, teacher:, mentor_at_school_periods:, target_period:)
+
+          periods = [
+            { finished_on: Date.new(2025, 6, 30),
+              school: "Monsters College",
+              started_on: Date.new(2025, 1, 1) },
+            { finished_on: Date.new(2025, 12, 31),
+              school: "Monsters College",
+              started_on: Date.new(2025, 7, 1) }
+          ]
+
+          expect(RecordEventJob).to have_received(:perform_later).with(
+            event_type: :teacher_mentor_at_school_periods_merged,
+            teacher:,
+            mentor_at_school_period: target_period,
+            metadata: { periods: },
+            heading: "Rhys Ifans's mentor at school periods between 2025-01-01 and 2025-12-31 were merged into a single period at Abigail Hardscrabble High School for Girls (7654321)",
+            happened_at: Time.zone.now,
+            **author_params
+          )
+        end
+      end
+    end
+  end
+
   describe ".record_teacher_starts_training_period_event" do
     let(:started_on) { Date.new(2023, 7, 20) }
     let(:started_on_param) { { started_on: } }

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -953,13 +953,13 @@ RSpec.describe Events::Record do
 
     let(:mentor_at_school_periods) { [first_period, second_period] }
 
-    context "when the target period is ongoing" do
+    context "when the successor period is ongoing" do
       let(:first_period_started_on) { Date.new(2025, 1, 1) }
       let(:first_period_finished_on) { Date.new(2025, 6, 30) }
       let(:second_period_started_on) { Date.new(2025, 7, 1) }
       let(:second_period_finished_on) { nil }
 
-      it "queues a RecordEventJob with the correct values" do
+      it "queues a RecordEventJob with ongoing period message" do
         freeze_time do
           periods = [
             { finished_on: Date.new(2025, 6, 30),
@@ -989,13 +989,13 @@ RSpec.describe Events::Record do
       end
     end
 
-    context "when the target period is finished" do
+    context "when the successor period is finished" do
       let(:first_period_started_on) { Date.new(2025, 1, 1) }
       let(:first_period_finished_on) { Date.new(2025, 6, 30) }
       let(:second_period_started_on) { Date.new(2025, 7, 1) }
       let(:second_period_finished_on) { Date.new(2025, 12, 31) }
 
-      it "queues a RecordEventJob with the correct values" do
+      it "queues a RecordEventJob with between two dates message" do
         freeze_time do
           Events::Record.record_teacher_mentor_at_school_periods_merged!(author:, teacher:, mentor_at_school_periods:, successor_period:)
 

--- a/spec/services/gias/schools/mentor_at_school_periods/merge_spec.rb
+++ b/spec/services/gias/schools/mentor_at_school_periods/merge_spec.rb
@@ -1,0 +1,521 @@
+RSpec.describe GIAS::Schools::MentorAtSchoolPeriods::Merge do
+  subject(:service) do
+    described_class.call(
+      periods:,
+      predecessor_school:,
+      successor_school:
+    )
+  end
+
+  let(:author) { Events::SystemAuthor.new }
+  let(:predecessor_gias_school) { FactoryBot.create(:gias_school, :with_school) }
+  let(:gias_school) { FactoryBot.create(:gias_school, :with_school) }
+  let(:predecessor_school) { predecessor_gias_school.school }
+  let(:successor_school) { gias_school.school }
+
+  let(:teacher) { FactoryBot.create(:teacher) }
+
+  let(:started_on) { Date.new(2025, 1, 1) }
+  let(:finished_on) { Date.new(2025, 12, 31) }
+
+  let(:first_period) { FactoryBot.create(:mentor_at_school_period,  teacher:, school: predecessor_school, started_on:, finished_on: Date.new(2025, 12, 31)) }
+  let(:second_period) { FactoryBot.create(:mentor_at_school_period, teacher:, school: successor_school, started_on: Date.new(2025, 4, 1), finished_on: Date.new(2025, 9, 30)) }
+
+  let(:successor_period) { second_period }
+
+  let(:periods) { [first_period, second_period] }
+
+  describe "#call" do
+    context "when no school partnerships need to be created at the destination school" do
+      let!(:first_training_period) { FactoryBot.create(:training_period, :for_mentor,  :with_only_expression_of_interest, mentor_at_school_period: first_period) }
+      let!(:second_training_period) { FactoryBot.create(:training_period, :for_mentor, :with_only_expression_of_interest, mentor_at_school_period: second_period) }
+
+      context "when there is one mentor_at_school_period at each school that overlaps" do
+        let(:training_periods) { [first_training_period, second_training_period] }
+
+        context "when neither period is ongoing" do
+          it "changes the start date" do
+            expect { service }.to change(successor_period, :started_on).to(started_on)
+          end
+
+          it "changes the end date" do
+            expect { service }.to change(successor_period, :finished_on).to(finished_on)
+          end
+
+          it "points training periods to the successor period" do
+            service
+
+            training_periods.each do |training_period|
+              expect(training_period.mentor_at_school_period).to eq(successor_period)
+            end
+          end
+
+          it "merges the periods" do
+            expect { service }.to change(MentorAtSchoolPeriod, :count).by(-1)
+
+            expect(MentorAtSchoolPeriod.exists?(first_period.id)).to be(false)
+            expect(MentorAtSchoolPeriod.exists?(successor_period.id)).to be(true)
+          end
+        end
+
+        context "when the period at the destination school is ongoing" do
+          let(:second_period) { FactoryBot.create(:mentor_at_school_period, teacher:, school: successor_school, started_on: Date.new(2025, 7, 1), finished_on: nil) }
+
+          it "changes the start date" do
+            expect { service }.to change(successor_period, :started_on).to(started_on)
+          end
+
+          it "points training periods to the successor period" do
+            service
+
+            training_periods.each do |training_period|
+              expect(training_period.mentor_at_school_period).to eq(successor_period)
+            end
+          end
+
+          it "merges the periods" do
+            expect { service }.to change(MentorAtSchoolPeriod, :count).by(-1)
+
+            expect(MentorAtSchoolPeriod.exists?(first_period.id)).to be(false)
+            expect(MentorAtSchoolPeriod.exists?(successor_period.id)).to be(true)
+          end
+        end
+
+        context "when the period at the original school is ongoing" do
+          let(:first_period) { FactoryBot.create(:mentor_at_school_period, teacher:, school: predecessor_school, started_on:, finished_on: nil) }
+
+          it "changes the start date" do
+            expect { service }.to change(successor_period, :started_on).to(started_on)
+          end
+
+          it "changes the end date" do
+            expect { service }.to change(successor_period, :finished_on).to(nil)
+          end
+
+          it "points training periods to the successor period" do
+            service
+
+            training_periods.each do |training_period|
+              expect(training_period.mentor_at_school_period).to eq(successor_period)
+            end
+          end
+
+          it "merges the periods" do
+            expect { service }.to change(MentorAtSchoolPeriod, :count).by(-1)
+
+            expect(MentorAtSchoolPeriod.exists?(first_period.id)).to be(false)
+            expect(MentorAtSchoolPeriod.exists?(successor_period.id)).to be(true)
+          end
+        end
+      end
+
+      context "when there are two mentor periods at the destination school" do
+        let(:first_period) { FactoryBot.create(:mentor_at_school_period,  teacher:, school: predecessor_school, started_on:, finished_on: Date.new(2025, 6, 30)) }
+        let(:second_period) { FactoryBot.create(:mentor_at_school_period, teacher:, school: successor_school, started_on: Date.new(2025, 4, 1), finished_on: Date.new(2025, 7, 31)) }
+        let(:third_period) { FactoryBot.create(:mentor_at_school_period, teacher:, school: successor_school, started_on: Date.new(2025, 9, 1), finished_on: Date.new(2025, 12, 31)) }
+        let!(:third_training_period) { FactoryBot.create(:training_period, :for_mentor, :with_only_expression_of_interest, mentor_at_school_period: third_period) }
+        let(:successor_period) { third_period }
+
+        let(:training_periods) { [first_training_period, second_training_period, third_training_period] }
+        let(:periods) { [first_period, second_period, third_period] }
+
+        context "when no periods are ongoing" do
+          it "changes the start date" do
+            expect { service }.to change(successor_period, :started_on).to(started_on)
+          end
+
+          it "changes the end date" do
+            expect { service }.not_to change(successor_period, :finished_on)
+          end
+
+          it "points training periods to the successor period" do
+            service
+
+            training_periods.each do |training_period|
+              expect(training_period.mentor_at_school_period).to eq(successor_period)
+            end
+          end
+
+          it "merges the periods" do
+            expect { service }.to change(MentorAtSchoolPeriod, :count).by(-2)
+
+            expect(MentorAtSchoolPeriod.exists?(first_period.id)).to be(false)
+            expect(MentorAtSchoolPeriod.exists?(second_period.id)).to be(false)
+            expect(MentorAtSchoolPeriod.exists?(successor_period.id)).to be(true)
+          end
+        end
+
+        context "when the period at the destination school is ongoing" do
+          let(:successor_period) { third_period }
+          let(:third_period) { FactoryBot.create(:mentor_at_school_period, teacher:, school: successor_school, started_on: Date.new(2025, 9, 1), finished_on: nil) }
+
+          it "changes the start date" do
+            expect { service }.to change(successor_period, :started_on).to(started_on)
+          end
+
+          it "changes the end date" do
+            expect { service }.not_to change(successor_period, :finished_on)
+          end
+
+          it "points training periods to the successor period" do
+            service
+
+            training_periods.each do |training_period|
+              expect(training_period.mentor_at_school_period).to eq(successor_period)
+            end
+          end
+
+          it "merges the periods" do
+            expect { service }.to change(MentorAtSchoolPeriod, :count).by(-2)
+
+            expect(MentorAtSchoolPeriod.exists?(first_period.id)).to be(false)
+            expect(MentorAtSchoolPeriod.exists?(successor_period.id)).to be(true)
+          end
+        end
+
+        context "when the period at the original school is ongoing" do
+          let(:first_period) { FactoryBot.create(:mentor_at_school_period, teacher:, school: predecessor_school, started_on:, finished_on: nil) }
+
+          it "changes the start date" do
+            expect { service }.to change(successor_period, :started_on).to(started_on)
+          end
+
+          it "changes the end date" do
+            expect { service }.to change(successor_period, :finished_on).to(nil)
+          end
+
+          it "points training periods to the successor period" do
+            service
+
+            training_periods.each do |training_period|
+              expect(training_period.mentor_at_school_period).to eq(successor_period)
+            end
+          end
+
+          it "merges the periods" do
+            expect { service }.to change(MentorAtSchoolPeriod, :count).by(-2)
+
+            expect(MentorAtSchoolPeriod.exists?(first_period.id)).to be(false)
+            expect(MentorAtSchoolPeriod.exists?(successor_period.id)).to be(true)
+          end
+        end
+      end
+
+      context "when there are two mentor periods at the original school" do
+        let(:first_period) { FactoryBot.create(:mentor_at_school_period,  teacher:, school: predecessor_school, started_on:, finished_on: Date.new(2025, 6, 30)) }
+        let(:second_period) { FactoryBot.create(:mentor_at_school_period, teacher:, school: successor_school, started_on: Date.new(2025, 4, 1), finished_on: Date.new(2025, 11, 30)) }
+        let(:third_period) { FactoryBot.create(:mentor_at_school_period, teacher:, school: predecessor_school, started_on: Date.new(2025, 9, 1), finished_on: Date.new(2025, 12, 31)) }
+        let!(:third_training_period) { FactoryBot.create(:training_period, :for_mentor, :with_only_expression_of_interest, mentor_at_school_period: third_period) }
+
+        let(:training_periods) { [first_training_period, second_training_period, third_training_period] }
+        let(:periods) { [first_period, second_period, third_period] }
+
+        context "when no periods are ongoing" do
+          it "changes the start date" do
+            expect { service }.to change(successor_period, :started_on).to(started_on)
+          end
+
+          it "changes the end date" do
+            expect { service }.to change(successor_period, :finished_on).to(finished_on)
+          end
+
+          it "points training periods to the successor period" do
+            service
+
+            training_periods.each do |training_period|
+              expect(training_period.mentor_at_school_period).to eq(successor_period)
+            end
+          end
+
+          it "merges the periods" do
+            expect { service }.to change(MentorAtSchoolPeriod, :count).by(-2)
+
+            expect(MentorAtSchoolPeriod.exists?(first_period.id)).to be(false)
+            expect(MentorAtSchoolPeriod.exists?(successor_period.id)).to be(true)
+          end
+        end
+
+        context "when the period at the destination school is ongoing" do
+          let(:second_period) { FactoryBot.create(:mentor_at_school_period, teacher:, school: successor_school, started_on: Date.new(2025, 4, 1), finished_on: nil) }
+
+          it "changes the start date" do
+            expect { service }.to change(successor_period, :started_on).to(started_on)
+          end
+
+          it "points training periods to the successor period" do
+            service
+
+            training_periods.each do |training_period|
+              expect(training_period.mentor_at_school_period).to eq(successor_period)
+            end
+          end
+
+          it "merges the periods" do
+            expect { service }.to change(MentorAtSchoolPeriod, :count).by(-2)
+
+            expect(MentorAtSchoolPeriod.exists?(first_period.id)).to be(false)
+            expect(MentorAtSchoolPeriod.exists?(successor_period.id)).to be(true)
+          end
+        end
+
+        context "when the period at the original school is ongoing" do
+          let(:third_period) { FactoryBot.create(:mentor_at_school_period, teacher:, school: predecessor_school, started_on: Date.new(2025, 9, 1), finished_on: nil) }
+
+          it "changes the start date" do
+            expect { service }.to change(successor_period, :started_on).to(started_on)
+          end
+
+          it "changes the end date" do
+            expect { service }.to change(successor_period, :finished_on).to(nil)
+          end
+
+          it "points training periods to the successor period" do
+            service
+
+            training_periods.each do |training_period|
+              expect(training_period.mentor_at_school_period).to eq(successor_period)
+            end
+          end
+
+          it "merges the periods" do
+            expect { service }.to change(MentorAtSchoolPeriod, :count).by(-2)
+
+            expect(MentorAtSchoolPeriod.exists?(first_period.id)).to be(false)
+            expect(MentorAtSchoolPeriod.exists?(successor_period.id)).to be(true)
+          end
+        end
+
+        context "when both periods are ongoing" do
+          let(:second_period) { FactoryBot.create(:mentor_at_school_period, teacher:, school: successor_school, started_on: Date.new(2025, 4, 1), finished_on: nil) }
+          let(:third_period) { FactoryBot.create(:mentor_at_school_period, teacher:, school: predecessor_school, started_on: Date.new(2025, 9, 1), finished_on: nil) }
+
+          it "changes the start date" do
+            expect { service }.to change(successor_period, :started_on).to(started_on)
+          end
+
+          it "points training periods to the successor period" do
+            service
+
+            training_periods.each do |training_period|
+              expect(training_period.mentor_at_school_period).to eq(successor_period)
+            end
+          end
+
+          it "merges the periods" do
+            expect { service }.to change(MentorAtSchoolPeriod, :count).by(-2)
+
+            expect(MentorAtSchoolPeriod.exists?(first_period.id)).to be(false)
+            expect(MentorAtSchoolPeriod.exists?(successor_period.id)).to be(true)
+          end
+        end
+      end
+    end
+
+    context "when a school partnership needs to be reassigned at the destination school" do
+      let!(:first_training_period) { FactoryBot.create(:training_period, :for_mentor, :with_school_partnership, mentor_at_school_period: first_period) }
+      let!(:second_training_period) { FactoryBot.create(:training_period, :for_mentor, :with_only_expression_of_interest, mentor_at_school_period: second_period) }
+
+      context "when the partnership exists at the destination school" do
+        let(:lead_provider_delivery_partnership) { first_training_period.school_partnership.lead_provider_delivery_partnership }
+        let!(:partnership_at_destination_school) { FactoryBot.create(:school_partnership, school: successor_school, lead_provider_delivery_partnership:) }
+
+        it "moves the school partnership to the destination school" do
+          service
+
+          expect(first_training_period.school_partnership).to eq(partnership_at_destination_school)
+        end
+      end
+
+      context "when the partnership does not exist at the destination school" do
+        let(:school_partnership) { FactoryBot.create(:school_partnership, school: predecessor_school) }
+        let!(:first_training_period) { FactoryBot.create(:training_period, :for_mentor, mentor_at_school_period: first_period, school_partnership:) }
+
+        it "creates a new school partnership at the destination school" do
+          expect { service }.to change(SchoolPartnership, :count).by(1)
+
+          expect(first_training_period.school_partnership.school).to eq(successor_school)
+          expect(first_training_period.school_partnership.lead_provider_delivery_partnership).to eq(school_partnership.lead_provider_delivery_partnership)
+        end
+      end
+
+      context "when there are two training periods using the same school partnership" do
+        let(:school_partnership) { FactoryBot.create(:school_partnership, school: predecessor_school) }
+        let(:first_period) { FactoryBot.create(:mentor_at_school_period,  teacher:, school: predecessor_school, started_on:, finished_on: Date.new(2025, 6, 30)) }
+        let(:third_period) { FactoryBot.create(:mentor_at_school_period, teacher:, school: predecessor_school, started_on: Date.new(2025, 9, 1), finished_on: Date.new(2025, 12, 31)) }
+        let!(:third_training_period) { FactoryBot.create(:training_period, :for_mentor, mentor_at_school_period: third_period, school_partnership:) }
+        let!(:first_training_period) { FactoryBot.create(:training_period, :for_mentor, mentor_at_school_period: first_period, school_partnership:) }
+
+        let(:periods) { [first_period, second_period, third_period] }
+
+        it "creates one new school partnership at the destination school" do
+          expect(third_training_period.reload.school_partnership).to eq(first_training_period.reload.school_partnership)
+
+          expect { service }.to change(SchoolPartnership, :count).by(1)
+
+          expect(third_training_period.reload.school_partnership).to eq(first_training_period.reload.school_partnership)
+          expect(third_training_period.school_partnership.school).to eq(successor_school)
+          expect(first_training_period.school_partnership.school).to eq(successor_school)
+        end
+      end
+
+      context "when there are two training periods using a different school partnership" do
+        let(:first_period) { FactoryBot.create(:mentor_at_school_period, teacher:, school: predecessor_school, started_on:, finished_on: Date.new(2025, 6, 30)) }
+        let(:third_period) { FactoryBot.create(:mentor_at_school_period, teacher:, school: predecessor_school, started_on: Date.new(2025, 9, 1), finished_on: Date.new(2025, 12, 31)) }
+        let!(:third_training_period) { FactoryBot.create(:training_period, :with_school_partnership, :for_mentor, mentor_at_school_period: third_period) }
+        let!(:first_training_period) { FactoryBot.create(:training_period, :with_school_partnership, :for_mentor, mentor_at_school_period: first_period) }
+
+        let(:periods) { [first_period, second_period, third_period] }
+
+        it "creates one new school partnership at the destination school" do
+          expect { service }.to change(SchoolPartnership, :count).by(2)
+
+          expect(third_training_period.school_partnership.school).to eq(successor_school)
+          expect(first_training_period.school_partnership.school).to eq(successor_school)
+        end
+      end
+    end
+
+    context "when there is a mentorship period that needs to be reassigned" do
+      let(:mentee) { FactoryBot.create(:ect_at_school_period, school: predecessor_school, started_on:, finished_on:) }
+      let!(:mentorship_period) { FactoryBot.create(:mentorship_period, mentor: first_period, mentee:, started_on:, finished_on: Date.new(2025, 6, 30)) }
+
+      it "changes the mentorship period to point to the successor period" do
+        service
+
+        expect(mentorship_period.mentor).to eq(successor_period)
+      end
+
+      context "when the mentee has training periods" do
+        let!(:training_period) { FactoryBot.create(:training_period, :with_school_partnership, :for_ect, ect_at_school_period: mentee, started_on:, finished_on: Date.new(2025, 6, 30)) }
+
+        context "when the mentee's training period has a school partnership that needs to be reassigned" do
+          it "changes the mentorship period to point to the successor period" do
+            service
+
+            expect(mentorship_period.mentor).to eq(successor_period)
+          end
+
+          it "recreates the mentee's school partnership at the destination school" do
+            expect { service }.to change(SchoolPartnership, :count).by(1)
+
+            expect(training_period.school_partnership.school).to eq(successor_school)
+          end
+
+          it "moves the mentee period to the new school" do
+            service
+
+            expect(mentee.reload.school).to eq(successor_school)
+          end
+        end
+
+        context "when the mentee's training period has a school partnership that already exists at the destination school" do
+          let!(:training_period) { FactoryBot.create(:training_period, :with_school_partnership, :for_ect, ect_at_school_period: mentee, started_on:, finished_on: Date.new(2025, 6, 30)) }
+          let!(:existing_partnership) { FactoryBot.create(:school_partnership, school: successor_school, lead_provider_delivery_partnership: training_period.school_partnership.lead_provider_delivery_partnership) }
+
+          it "changes the mentorship period to point to the successor period" do
+            service
+
+            expect(mentorship_period.mentor).to eq(successor_period)
+          end
+
+          it "uses the existing partnership" do
+            expect { service }.not_to change(SchoolPartnership, :count)
+
+            expect(training_period.school_partnership).to eq(existing_partnership)
+          end
+
+          it "moves the mentee period to the new school" do
+            service
+
+            expect(mentee.reload.school).to eq(successor_school)
+          end
+        end
+
+        context "when the mentee's training period only has an expression of interest" do
+          let(:expression_of_interest) { FactoryBot.create(:active_lead_provider, :for_year, year: 2025) }
+          let!(:training_period) { FactoryBot.create(:training_period, :with_no_school_partnership, :for_ect, expression_of_interest:, ect_at_school_period: mentee, started_on:, finished_on: Date.new(2025, 6, 30)) }
+
+          it "changes the mentorship period to point to the successor period" do
+            service
+
+            expect(mentorship_period.mentor).to eq(successor_period)
+          end
+
+          it "does not change the expression of interest" do
+            expect { service }.not_to change(training_period, :expression_of_interest)
+
+            expect(training_period.school_partnership).to be_nil
+          end
+
+          it "moves the mentee period to the new school" do
+            service
+
+            expect(mentee.reload.school).to eq(successor_school)
+          end
+        end
+      end
+
+      context "when the mentee has events" do
+        let!(:event) { FactoryBot.create(:event, mentor_at_school_period: first_period) }
+
+        it "changes the mentorship period to point to the successor period" do
+          service
+
+          expect(mentorship_period.mentor).to eq(successor_period)
+        end
+
+        context "when the mentee's event has a school partnership that needs to be reassigned" do
+          let(:school_partnership) { FactoryBot.create(:school_partnership, school: predecessor_school) }
+          let!(:event) { FactoryBot.create(:event, mentor_at_school_period: first_period, school_partnership:) }
+
+          it "recreates the school partnership at the destination school" do
+            expect { service }.to change(SchoolPartnership, :count).by(1)
+
+            expect(event.reload.school_partnership.school).to eq(successor_school)
+          end
+
+          it "moves the event to the new school" do
+            service
+
+            expect(event.reload.school).to eq(successor_school)
+          end
+        end
+
+        context "when the event is linked to the predecessor school" do
+          let!(:event) { FactoryBot.create(:event, mentor_at_school_period: first_period, school: predecessor_school) }
+
+          it "moves the event to the new school" do
+            service
+
+            expect(event.reload.school).to eq(successor_school)
+          end
+        end
+      end
+    end
+
+    context "when there is an event that needs to be reassigned" do
+      let!(:event) { FactoryBot.create(:event, mentor_at_school_period: first_period) }
+
+      it "changes the event to point to the successor period" do
+        expect { service }.to change { event.reload.mentor_at_school_period }.to(successor_period)
+      end
+
+      context "when the event is linked to the predecessor school" do
+        let!(:event) { FactoryBot.create(:event, mentor_at_school_period: first_period, school: predecessor_school) }
+
+        it "changes the event to point to the successor period" do
+          expect { service }.to change { event.reload.school }.to(successor_school)
+        end
+      end
+
+      context "when the event is linked to a school partnership" do
+        let!(:first_training_period) { FactoryBot.create(:training_period, :for_mentor, :with_school_partnership, mentor_at_school_period: first_period) }
+        let!(:event) { FactoryBot.create(:event, mentor_at_school_period: first_period, school_partnership: first_training_period.school_partnership) }
+
+        it "changes the event to point to the successor period" do
+          expect { service }.to change { event.reload.mentor_at_school_period }.to(successor_period)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/gias/schools/mentor_at_school_periods/merge_spec.rb
+++ b/spec/services/gias/schools/mentor_at_school_periods/merge_spec.rb
@@ -398,7 +398,7 @@ RSpec.describe GIAS::Schools::MentorAtSchoolPeriods::Merge do
           it "recreates the mentee's school partnership at the destination school" do
             expect { service }.to change(SchoolPartnership, :count).by(1)
 
-            expect(training_period.school_partnership.school).to eq(successor_school)
+            expect(training_period.reload.school_partnership.school).to eq(successor_school)
           end
 
           it "moves the mentee period to the new school" do
@@ -421,7 +421,7 @@ RSpec.describe GIAS::Schools::MentorAtSchoolPeriods::Merge do
           it "uses the existing partnership" do
             expect { service }.not_to change(SchoolPartnership, :count)
 
-            expect(training_period.school_partnership).to eq(existing_partnership)
+            expect(training_period.reload.school_partnership).to eq(existing_partnership)
           end
 
           it "moves the mentee period to the new school" do
@@ -472,12 +472,6 @@ RSpec.describe GIAS::Schools::MentorAtSchoolPeriods::Merge do
             expect { service }.to change(SchoolPartnership, :count).by(1)
 
             expect(event.reload.school_partnership.school).to eq(successor_school)
-          end
-
-          it "moves the event to the new school" do
-            service
-
-            expect(event.reload.school).to eq(successor_school)
           end
         end
 

--- a/spec/services/gias/schools/mentor_at_school_periods/merge_spec.rb
+++ b/spec/services/gias/schools/mentor_at_school_periods/merge_spec.rb
@@ -517,5 +517,17 @@ RSpec.describe GIAS::Schools::MentorAtSchoolPeriods::Merge do
         end
       end
     end
+
+    it "records an event for the periods being merged" do
+      expect(Events::Record).to receive(:record_teacher_mentor_at_school_periods_merged!).with(
+        author: an_instance_of(Events::SystemAuthor),
+        teacher: successor_period.teacher,
+        successor_period:,
+        mentor_at_school_periods: periods,
+        happened_at: predecessor_school.gias_school.closed_on
+      )
+
+      service
+    end
   end
 end

--- a/spec/services/gias/schools/mentor_at_school_periods/overlapping_spec.rb
+++ b/spec/services/gias/schools/mentor_at_school_periods/overlapping_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe GIAS::Schools::MentorAtSchoolPeriods::Overlapping do
     )
   end
 
-  describe "#call" do
+  describe "#find" do
     context "when two periods overlap" do
       let(:first_period_started_on) { Date.new(2025, 1, 1) }
       let(:first_period_finished_on) { Date.new(2025, 3, 31) }

--- a/spec/services/gias/schools/mentor_at_school_periods/overlapping_spec.rb
+++ b/spec/services/gias/schools/mentor_at_school_periods/overlapping_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe GIAS::Schools::MentorAtSchoolPeriods::Overlapping do
       it { is_expected.to eq([[first_period, second_period]]) }
     end
 
-    context "when periods are adjacent" do
+    context "when two periods are adjacent" do
       let(:first_period_started_on) { Date.new(2025, 1, 1) }
       let(:first_period_finished_on) { Date.new(2025, 3, 31) }
       let(:second_period_started_on) { Date.new(2025, 4, 1) }
@@ -46,7 +46,7 @@ RSpec.describe GIAS::Schools::MentorAtSchoolPeriods::Overlapping do
       it { is_expected.to be_empty }
     end
 
-    context "when periods have a gap" do
+    context "when two periods have a gap" do
       let(:first_period_started_on) { Date.new(2025, 1, 1) }
       let(:first_period_finished_on) { Date.new(2025, 3, 31) }
       let(:second_period_started_on) { Date.new(2025, 4, 2) }
@@ -55,7 +55,7 @@ RSpec.describe GIAS::Schools::MentorAtSchoolPeriods::Overlapping do
       it { is_expected.to be_empty }
     end
 
-    context "when periods overlap transitively" do
+    context "when three periods overlap transitively" do
       let(:first_period_started_on) { Date.new(2025, 1, 1) }
       let(:first_period_finished_on) { Date.new(2025, 3, 31) }
       let(:second_period_started_on) { Date.new(2025, 3, 1) }
@@ -111,7 +111,7 @@ RSpec.describe GIAS::Schools::MentorAtSchoolPeriods::Overlapping do
       end
     end
 
-    context "when the earliest periods is ongoing" do
+    context "when the earliest period is ongoing" do
       let(:first_period_started_on) { Date.new(2025, 1, 1) }
       let(:first_period_finished_on) { nil }
       let(:second_period_started_on) { Date.new(2025, 4, 1) }
@@ -195,7 +195,7 @@ RSpec.describe GIAS::Schools::MentorAtSchoolPeriods::Overlapping do
       it { is_expected.to be_empty }
     end
 
-    context "when there mentor periods belonging to other teachers at the schools" do
+    context "when there are mentor periods belonging to other teachers at the schools" do
       let(:other_teacher) { FactoryBot.create(:teacher) }
       let(:another_teacher) { FactoryBot.create(:teacher) }
 

--- a/spec/services/gias/schools/mentor_at_school_periods/overlapping_spec.rb
+++ b/spec/services/gias/schools/mentor_at_school_periods/overlapping_spec.rb
@@ -1,0 +1,222 @@
+RSpec.describe GIAS::Schools::MentorAtSchoolPeriods::Overlapping do
+  subject(:groups) { described_class.find(teacher:, schools:) }
+
+  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:first_school) { FactoryBot.create(:school) }
+  let(:second_school) { FactoryBot.create(:school) }
+
+  let(:schools) { [first_school, second_school] }
+
+  let!(:first_period) do
+    FactoryBot.create(
+      :mentor_at_school_period,
+      teacher:,
+      school: first_school,
+      started_on: first_period_started_on,
+      finished_on: first_period_finished_on
+    )
+  end
+
+  let!(:second_period) do
+    FactoryBot.create(
+      :mentor_at_school_period,
+      teacher:,
+      school: second_school,
+      started_on: second_period_started_on,
+      finished_on: second_period_finished_on
+    )
+  end
+
+  describe "#call" do
+    context "when two periods overlap" do
+      let(:first_period_started_on) { Date.new(2025, 1, 1) }
+      let(:first_period_finished_on) { Date.new(2025, 3, 31) }
+      let(:second_period_started_on) { Date.new(2025, 3, 1) }
+      let(:second_period_finished_on) { Date.new(2025, 6, 30) }
+
+      it { is_expected.to eq([[first_period, second_period]]) }
+    end
+
+    context "when periods are adjacent" do
+      let(:first_period_started_on) { Date.new(2025, 1, 1) }
+      let(:first_period_finished_on) { Date.new(2025, 3, 31) }
+      let(:second_period_started_on) { Date.new(2025, 4, 1) }
+      let(:second_period_finished_on) { Date.new(2025, 6, 30) }
+
+      it { is_expected.to be_empty }
+    end
+
+    context "when periods have a gap" do
+      let(:first_period_started_on) { Date.new(2025, 1, 1) }
+      let(:first_period_finished_on) { Date.new(2025, 3, 31) }
+      let(:second_period_started_on) { Date.new(2025, 4, 2) }
+      let(:second_period_finished_on) { Date.new(2025, 6, 30) }
+
+      it { is_expected.to be_empty }
+    end
+
+    context "when periods overlap transitively" do
+      let(:first_period_started_on) { Date.new(2025, 1, 1) }
+      let(:first_period_finished_on) { Date.new(2025, 3, 31) }
+      let(:second_period_started_on) { Date.new(2025, 3, 1) }
+      let(:second_period_finished_on) { Date.new(2025, 11, 30) }
+
+      let!(:third_period) { FactoryBot.create(:mentor_at_school_period, teacher:, school: first_school, started_on: Date.new(2025, 11, 1), finished_on: Date.new(2025, 12, 31)) }
+
+      it { is_expected.to eq([[first_period, second_period, third_period]]) }
+    end
+
+    context "when two periods overlap but a third period is separate" do
+      let(:first_period_started_on) { Date.new(2025, 1, 1) }
+      let(:first_period_finished_on) { Date.new(2025, 3, 31) }
+      let(:second_period_started_on) { Date.new(2025, 3, 1) }
+      let(:second_period_finished_on) { Date.new(2025, 11, 30) }
+
+      let!(:third_period) { FactoryBot.create(:mentor_at_school_period, teacher:, school: first_school, started_on: Date.new(2025, 12, 15), finished_on: Date.new(2025, 12, 31)) }
+
+      it { is_expected.to eq([[first_period, second_period]]) }
+    end
+
+    context "when there are two separate groups of overlapping periods" do
+      let(:first_period_started_on) { Date.new(2025, 1, 1) }
+      let(:first_period_finished_on) { Date.new(2025, 3, 31) }
+      let(:second_period_started_on) { Date.new(2025, 3, 15) }
+      let(:second_period_finished_on) { Date.new(2025, 6, 30) }
+
+      let!(:third_period) do
+        FactoryBot.create(
+          :mentor_at_school_period,
+          teacher:,
+          school: first_school,
+          started_on: Date.new(2025, 7, 15),
+          finished_on: Date.new(2025, 9, 30)
+        )
+      end
+
+      let!(:fourth_period) do
+        FactoryBot.create(
+          :mentor_at_school_period,
+          teacher:,
+          school: second_school,
+          started_on: Date.new(2025, 9, 1),
+          finished_on: Date.new(2025, 12, 31)
+        )
+      end
+
+      it "returns two separate merge groups" do
+        expect(groups).to eq([
+          [first_period, second_period],
+          [third_period, fourth_period]
+        ])
+      end
+    end
+
+    context "when the earliest periods is ongoing" do
+      let(:first_period_started_on) { Date.new(2025, 1, 1) }
+      let(:first_period_finished_on) { nil }
+      let(:second_period_started_on) { Date.new(2025, 4, 1) }
+      let(:second_period_finished_on) { Date.new(2025, 6, 30) }
+
+      it { is_expected.to eq([[first_period, second_period]]) }
+    end
+
+    context "when the teacher has periods at other schools" do
+      let(:other_school) { FactoryBot.create(:school) }
+
+      let(:first_period_started_on) { Date.new(2025, 1, 1) }
+      let(:first_period_finished_on) { Date.new(2025, 3, 31) }
+      let(:second_period_started_on) { Date.new(2025, 4, 1) }
+      let(:second_period_finished_on) { Date.new(2025, 6, 30) }
+
+      let!(:other_school_period) do
+        FactoryBot.create(
+          :mentor_at_school_period,
+          teacher:,
+          school: other_school,
+          started_on: Date.new(2025, 1, 1),
+          finished_on: Date.new(2025, 12, 31)
+        )
+      end
+
+      it "does not include the other school period in the calculation" do
+        expect(groups).to be_empty
+      end
+    end
+
+    context "when the teacher only has periods at one school" do
+      let(:first_period_started_on) { Date.new(2025, 1, 1) }
+      let(:first_period_finished_on) { Date.new(2025, 3, 31) }
+      let(:second_period_started_on) { Date.new(2025, 4, 1) }
+      let(:second_period_finished_on) { Date.new(2025, 6, 30) }
+
+      let!(:second_period) do
+        FactoryBot.create(
+          :mentor_at_school_period,
+          teacher:,
+          school: first_school,
+          started_on: second_period_started_on,
+          finished_on: second_period_finished_on
+        )
+      end
+
+      it { is_expected.to be_empty }
+    end
+
+    context "when one school is given" do
+      let(:schools) { [first_school] }
+
+      let(:first_period_started_on) { Date.new(2025, 1, 1) }
+      let(:first_period_finished_on) { Date.new(2025, 3, 31) }
+      let(:second_period_started_on) { Date.new(2025, 4, 1) }
+      let(:second_period_finished_on) { Date.new(2025, 6, 30) }
+
+      it { is_expected.to be_empty }
+    end
+
+    context "when no schools are given" do
+      let(:schools) { [] }
+
+      let(:first_period_started_on) { Date.new(2025, 1, 1) }
+      let(:first_period_finished_on) { Date.new(2025, 3, 31) }
+      let(:second_period_started_on) { Date.new(2025, 4, 1) }
+      let(:second_period_finished_on) { Date.new(2025, 6, 30) }
+
+      it { is_expected.to be_empty }
+    end
+
+    context "when schools is nil" do
+      let(:schools) { nil }
+
+      let(:first_period_started_on) { Date.new(2025, 1, 1) }
+      let(:first_period_finished_on) { Date.new(2025, 3, 31) }
+      let(:second_period_started_on) { Date.new(2025, 4, 1) }
+      let(:second_period_finished_on) { Date.new(2025, 6, 30) }
+
+      it { is_expected.to be_empty }
+    end
+
+    context "when there mentor periods belonging to other teachers at the schools" do
+      let(:other_teacher) { FactoryBot.create(:teacher) }
+      let(:another_teacher) { FactoryBot.create(:teacher) }
+
+      let(:first_period_started_on) { Date.new(2025, 1, 1) }
+      let(:first_period_finished_on) { Date.new(2025, 3, 31) }
+      let(:second_period_started_on) { Date.new(2025, 4, 1) }
+      let(:second_period_finished_on) { Date.new(2025, 6, 30) }
+
+      let!(:other_teacher_period) do
+        FactoryBot.create(
+          :mentor_at_school_period,
+          teacher: other_teacher,
+          school: first_school,
+          started_on: Date.new(2025, 1, 1),
+          finished_on: Date.new(2025, 5, 31)
+        )
+      end
+
+      it "does not include the other teachers' periods in the calculation" do
+        expect(groups).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
In order to merge two school records, when we've received notification from GIAS that the schools are merging, we need to move all the ect_at_school_periods and mentor_at_school_periods in the predecessor school to the successor school. Because a teacher can mentor at two different schools simultaneosly, we need to identify overlapping `mentor_at_school_periods` at the two schools, and then merge them into an existing period at the successor school.  This previous [PR](https://github.com/DFE-Digital/register-early-career-teachers-public/pull/3224) introduces services to move ECTs and mentors when there are no overlaps.  

This PR introduces two services to identify and then merge the periods.  The intention is that a service to merge schools will run this process first then run the services introduced elsewhere to move mentors and ECTs with no overlaps.

### Changes proposed in this pull request
I first considered leveraging some of the specific time range functionality of psql in order to identify overlapping `mentor_at_school_periods`.  After some investigation I realised there was a much more simple way to do this in Ruby.  First we order the periods at both schools by `started_on`.  Then we try to group them into overlapping sets.  So we put the first period into a group.  Then we take the next period.  If the first period is ongoing, then the next period must overlap it, and it goes in the group.  If the first period has a finished_on date, and the next periods starts after that date, then the periods don't overlap and we should start a new group.  If there's no gap the next period goes in the group.  Then we simply continue until all the periods are assigned to groups.  

It is also worth noting some features of the current validation on periods that help simplify this.  A mentor cannot have overlapping periods at the same school.  So if a mentor has two periods at the same school, the first one cannot be ongoing.  If a mentor has periods at both schools, and the earliest period is ongoing then this period will cover all the other periods.  

The tests also include scenarios where we have transitive overlaps.  Suppose we have two periods at the source school that are say 1st Jan to 31st March, then 1st May to 30th June, and a third period at the target school starting 1st March and ending 30th May.  The third period bridges the two non-overlapping periods so that we have to have a period starting 1st Jan and ending 30th June to cover it all.  If either of the later periods were ongoing then we'd need a period starting 1st Jan that is ongoing to cover all of them.

### Brief outline of expected merge schools service
```
def merge_school!
  ActiveRecord::Base.transaction do
     mentor_teachers.each do |teacher|
      overlapping_mentor_at_school_periods(teacher).each do |periods|
        GIAS::Schools::MentorAtSchoolPeriods::Merge.call(periods:, predecessor_school:, successor_school:)
      end
    end

    mentors_without_overlapping_periods.each do |period|
      GIAS::Schools::MentorAtSchoolPeriods::Transfer.call(period:, predecessor_school:, successor_school:)
    end

    ects_without_mentorship_periods.each do |period|
      GIAS::Schools::ECTAtSchoolPeriods::Transfer.call(period:, predecessor_school:, successor_school:)
    end

    record_school_merged_event!
  end
end
```