### PR TITLE
Remove unused ECF contract version attributes

### DIFF
--- a/app/controllers/admin/finance/active_lead_providers/contracts_controller.rb
+++ b/app/controllers/admin/finance/active_lead_providers/contracts_controller.rb
@@ -111,8 +111,6 @@ module Admin::Finance::ActiveLeadProviders
       params.expect(
         contract: [
           :contract_type,
-          :ecf_contract_version,
-          :ecf_mentor_contract_version,
           :vat_rate,
           {
             banded_fee_structure_attributes: [

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -30,14 +30,11 @@ class Contract < ApplicationRecord
   with_options if: :ittecf_ectp_contract_type? do
     validates :flat_rate_fee_structure, presence: { message: "Flat rate fee structure must be provided for ITTECF_ECTP contracts" }
     validates :banded_fee_structure, presence: { message: "Banded fee structure must be provided for ITTECF_ECTP contracts" }
-    validates :ecf_contract_version, presence: { message: "ECF contract version must be provided for ITTECF_ECTP contracts" }
-    validates :ecf_mentor_contract_version, presence: { message: "ECF mentor contract version must be provided for ITTECF_ECTP contracts" }
   end
 
   with_options if: :ecf_contract_type? do
     validates :flat_rate_fee_structure, absence: { message: "Flat rate fee structure must be blank for ECF contracts" }
     validates :banded_fee_structure, presence: { message: "Banded fee structure must be provided for ECF contracts" }
-    validates :ecf_contract_version, presence: { message: "ECF contract version must be provided for ECF contracts" }
   end
 
   accepts_nested_attributes_for :banded_fee_structure

--- a/app/services/active_lead_providers/seed_from_previous.rb
+++ b/app/services/active_lead_providers/seed_from_previous.rb
@@ -81,8 +81,6 @@ private
 
     active_lead_provider.contracts.create!(
       contract_type: previous_contract.contract_type,
-      ecf_contract_version: previous_contract.ecf_contract_version,
-      ecf_mentor_contract_version: previous_contract.ecf_mentor_contract_version,
       banded_fee_structure: build_banded_fee_structure(previous_contract.banded_fee_structure),
       flat_rate_fee_structure: build_flat_rate_fee_structure(previous_contract.flat_rate_fee_structure),
       statements: build_new_statements,

--- a/app/views/admin/finance/active_lead_providers/contracts/_fields.html.erb
+++ b/app/views/admin/finance/active_lead_providers/contracts/_fields.html.erb
@@ -6,15 +6,6 @@
       ->(type) { type.humanize.upcase },
       legend: { text: "Contract type", size: "s" } %>
 
-<%= form.govuk_text_field :ecf_contract_version,
-      label: { text: "ECF contract version", size: "s" },
-      width: 10 %>
-
-<%= form.govuk_text_field :ecf_mentor_contract_version,
-      label: { text: "ECF mentor contract version", size: "s" },
-      hint: { text: "Required for ITTECF_ECTP contracts only" },
-      width: 10 %>
-
 <%= form.govuk_text_field :vat_rate,
       label: { text: "VAT rate (enter as a decimal, e.g. 0.2 for 20%)", size: "s" },
       width: 5,

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -346,8 +346,6 @@
   - vat_rate
   - flat_rate_fee_structure_id
   - banded_fee_structure_id
-  - ecf_contract_version
-  - ecf_mentor_contract_version
   - created_at
   - updated_at
   :induction_periods:

--- a/db/migrate/20260713075124_remove_ecf_contract_versions.rb
+++ b/db/migrate/20260713075124_remove_ecf_contract_versions.rb
@@ -1,0 +1,8 @@
+class RemoveECFContractVersions < ActiveRecord::Migration[8.1]
+  def change
+    change_table :contracts, bulk: true do |t|
+      t.remove :ecf_contract_version, type: :string
+      t.remove :ecf_mentor_contract_version, type: :string
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_02_065431) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_13_075124) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -211,8 +211,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_02_065431) do
     t.bigint "active_lead_provider_id", null: false
     t.enum "contract_type", null: false, enum_type: "contract_types"
     t.datetime "created_at", null: false
-    t.string "ecf_contract_version", default: "1.0.0", null: false
-    t.string "ecf_mentor_contract_version"
     t.datetime "updated_at", null: false
     t.decimal "vat_rate", precision: 3, scale: 2, default: "0.2", null: false
     t.index ["active_lead_provider_id"], name: "index_contracts_on_active_lead_provider_id"

--- a/documentation/domain-model.md
+++ b/documentation/domain-model.md
@@ -435,8 +435,6 @@ erDiagram
     integer active_lead_provider_id
     enum contract_type
     datetime created_at
-    string ecf_contract_version
-    string ecf_mentor_contract_version
     datetime updated_at
     decimal vat_rate
   }

--- a/spec/factories/contract_factory.rb
+++ b/spec/factories/contract_factory.rb
@@ -6,15 +6,12 @@ FactoryBot.define do
 
     trait(:for_ecf) do
       contract_type { "ecf" }
-      ecf_contract_version { "1" }
       association :banded_fee_structure, factory: :contract_banded_fee_structure, strategy: :build
       flat_rate_fee_structure { nil }
     end
 
     trait(:for_ittecf_ectp) do
       contract_type { "ittecf_ectp" }
-      ecf_contract_version { "1" }
-      ecf_mentor_contract_version { "2" }
       association :banded_fee_structure, factory: :contract_banded_fee_structure, strategy: :build
       association :flat_rate_fee_structure, factory: :contract_flat_rate_fee_structure, strategy: :build
     end

--- a/spec/models/contract_spec.rb
+++ b/spec/models/contract_spec.rb
@@ -61,8 +61,6 @@ describe Contract do
     context "when contract type is `ITTECF_ECTP`" do
       subject { FactoryBot.build(:contract, :for_ittecf_ectp) }
 
-      it { is_expected.to validate_presence_of(:ecf_contract_version).with_message("ECF contract version must be provided for ITTECF_ECTP contracts") }
-      it { is_expected.to validate_presence_of(:ecf_mentor_contract_version).with_message("ECF mentor contract version must be provided for ITTECF_ECTP contracts") }
       it { is_expected.to validate_presence_of(:flat_rate_fee_structure).with_message("Flat rate fee structure must be provided for ITTECF_ECTP contracts") }
       it { is_expected.to validate_presence_of(:banded_fee_structure).with_message("Banded fee structure must be provided for ITTECF_ECTP contracts") }
     end
@@ -70,7 +68,6 @@ describe Contract do
     context "when contract type is `ECF`" do
       subject { FactoryBot.build(:contract, :for_ecf) }
 
-      it { is_expected.to validate_presence_of(:ecf_contract_version).with_message("ECF contract version must be provided for ECF contracts") }
       it { is_expected.to validate_presence_of(:banded_fee_structure).with_message("Banded fee structure must be provided for ECF contracts") }
       it { is_expected.to validate_absence_of(:flat_rate_fee_structure).with_message("Flat rate fee structure must be blank for ECF contracts") }
 

--- a/spec/requests/admin/finance/active_lead_providers/contracts_spec.rb
+++ b/spec/requests/admin/finance/active_lead_providers/contracts_spec.rb
@@ -108,8 +108,6 @@ RSpec.describe "Admin finance active lead provider contracts", type: :request do
       {
         contract: {
           contract_type: "ittecf_ectp",
-          ecf_contract_version: "1",
-          ecf_mentor_contract_version: "2",
           vat_rate: "0.2",
           flat_rate_fee_structure_attributes:,
           banded_fee_structure_attributes:
@@ -205,7 +203,7 @@ RSpec.describe "Admin finance active lead provider contracts", type: :request do
     let(:update_params) do
       {
         contract: {
-          ecf_contract_version: "updated",
+          vat_rate: 0.1,
           banded_fee_structure_attributes: {
             id: contract.banded_fee_structure.id,
             band_terms_attributes: {
@@ -243,7 +241,7 @@ RSpec.describe "Admin finance active lead provider contracts", type: :request do
         patch contract_path, params: update_params
 
         expect(response).to redirect_to(contract_path)
-        expect(contract.reload.ecf_contract_version).to eq("updated")
+        expect(contract.reload.vat_rate).to eq(0.1)
         expect(band_term.reload.fee_per_declaration).to eq(999)
       end
     end

--- a/spec/services/contracts/create_spec.rb
+++ b/spec/services/contracts/create_spec.rb
@@ -9,8 +9,6 @@ describe Contracts::Create do
   let(:params) do
     {
       contract_type: "ittecf_ectp",
-      ecf_contract_version: "1",
-      ecf_mentor_contract_version: "2",
       banded_fee_structure_attributes: {
         **banded_fee_structure_attributes,
         band_terms_attributes: [

--- a/spec/services/contracts/update_spec.rb
+++ b/spec/services/contracts/update_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Contracts::Update do
 
   let(:params) do
     {
-      ecf_contract_version: "updated-version",
+      vat_rate: 0.1,
       banded_fee_structure_attributes: {
         id: banded_fee_structure.id,
         recruitment_target: 9_999,
@@ -52,11 +52,12 @@ RSpec.describe Contracts::Update do
     original_fee_per_declaration = band_term.fee_per_declaration
     original_output_fee_ratio = band_term.output_fee_ratio
     original_service_fee_ratio = band_term.service_fee_ratio
+    original_vat_rate = contract.vat_rate
 
     result = service.call
 
     expect(result).to eq(contract)
-    expect(result.ecf_contract_version).to eq("updated-version")
+    expect(result.vat_rate).to eq(0.1)
     expect(result.banded_fee_structure.recruitment_target).to eq(9_999)
     expect(band_term.reload.fee_per_declaration).to eq(9_999)
     expect(band_term.output_fee_ratio).to eq(0.80)
@@ -67,7 +68,7 @@ RSpec.describe Contracts::Update do
         author:,
         contract:,
         modifications: hash_including(
-          "ecf_contract_version" => %w[1 updated-version],
+          "vat_rate" => [original_vat_rate, 0.1],
           "banded_recruitment_target" => [original_recruitment_target, 9_999],
           "band_A_fee_per_declaration" => [original_fee_per_declaration, 9_999],
           "band_A_output_fee_ratio" => [original_output_fee_ratio, 0.80],
@@ -80,7 +81,7 @@ RSpec.describe Contracts::Update do
   context "when the band term is not changed" do
     let(:params) do
       {
-        ecf_contract_version: "updated-version",
+        vat_rate: 0.1,
         banded_fee_structure_attributes: {
           id: banded_fee_structure.id,
           recruitment_target: 9_999,
@@ -99,6 +100,7 @@ RSpec.describe Contracts::Update do
 
     it "only records modifications for changed attributes" do
       original_recruitment_target = banded_fee_structure.recruitment_target
+      original_vat_rate = contract.vat_rate
 
       service.call
 
@@ -107,7 +109,7 @@ RSpec.describe Contracts::Update do
           author:,
           contract:,
           modifications: hash_including(
-            "ecf_contract_version" => %w[1 updated-version],
+            "vat_rate" => [original_vat_rate, 0.1],
             "banded_recruitment_target" => [original_recruitment_target, 9_999]
           )
         )

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -3155,7 +3155,7 @@ RSpec.describe Events::Record do
     describe ".record_contract_updated_event!" do
       let(:modifications) do
         {
-          "ecf_contract_version" => %w[1 2],
+          "vat_rate" => [0.05, 0.1],
           "banded_recruitment_target" => [1000, 2000],
         }
       end
@@ -3171,7 +3171,7 @@ RSpec.describe Events::Record do
             event_type: :contract_updated,
             happened_at: Time.zone.now,
             modifications: [
-              "ECF contract version changed from '1' to '2'",
+              "VAT rate changed from '0.05' to '0.1'",
               "Banded recruitment target changed from '1000' to '2000'",
             ],
             metadata: modifications,


### PR DESCRIPTION
These attributes were added to keep track of which contracts had been migrated from ECF during the RECT go-live process. We no longer maintain a contract version explicitly in RECT; instead contracts are directly linked to the statements they are applicable to.

The attributes can be safely removed from production.