### PR TITLE
[3404] Skip partnership selection when only one option is available

### DIFF
--- a/app/views/admin/teachers/training_periods/change_contract_period_wizard/check_answers.html.erb
+++ b/app/views/admin/teachers/training_periods/change_contract_period_wizard/check_answers.html.erb
@@ -20,12 +20,7 @@
           <%= row.with_value { @wizard.selected_contract_period.year.to_s } %>
         <% end %>
 
-        <% if @wizard.partnership_details_required? %>
-          <%= list.with_row do |row| %>
-            <%= row.with_key { "Partnership" } %>
-            <%= row.with_value { @wizard.selected_partnership_name } %>
-          <% end %>
-        <% else %>
+        <% if @wizard.training_period_eoi_only? %>
           <%= list.with_row do |row| %>
             <%= row.with_key { "Lead provider" } %>
             <%= row.with_value { @wizard.selected_lead_provider_name } %>
@@ -34,6 +29,11 @@
           <%= list.with_row do |row| %>
             <%= row.with_key { "Delivery partner" } %>
             <%= row.with_value { "No delivery partner confirmed" } %>
+          <% end %>
+        <% else %>
+          <%= list.with_row do |row| %>
+            <%= row.with_key { "Partnership" } %>
+            <%= row.with_value { @wizard.selected_partnership_name } %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/admin/teachers/training_periods/change_contract_period_wizard/check_answers.html.erb
+++ b/app/views/admin/teachers/training_periods/change_contract_period_wizard/check_answers.html.erb
@@ -20,7 +20,7 @@
           <%= row.with_value { @wizard.selected_contract_period.year.to_s } %>
         <% end %>
 
-        <% if @wizard.partnership_selection_required? %>
+        <% if @wizard.partnership_details_required? %>
           <%= list.with_row do |row| %>
             <%= row.with_key { "Partnership" } %>
             <%= row.with_value { @wizard.selected_partnership_name } %>

--- a/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/check_answers_step.rb
+++ b/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/check_answers_step.rb
@@ -9,7 +9,7 @@ module Admin
           self.expected_store_keys = %i[contract_period_year]
 
           def previous_step
-            wizard.partnership_selection_required? ? :select_partnership : :select_contract_period
+            wizard.partnership_selection_step_required? ? :select_partnership : :select_contract_period
           end
 
           def save!

--- a/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/select_contract_period_step.rb
+++ b/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/select_contract_period_step.rb
@@ -11,9 +11,11 @@ module Admin
           def self.permitted_params = %i[contract_period_year]
 
           def next_step
-            return :check_answers unless wizard.partnership_selection_required?
+            return :check_answers unless wizard.partnership_details_required?
 
-            wizard.school_partnerships.exists? ? :select_partnership : :no_partnerships
+            return :no_partnerships unless wizard.school_partnerships.exists?
+
+            wizard.partnership_selection_step_required? ? :select_partnership : :check_answers
           end
 
         private

--- a/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/select_contract_period_step.rb
+++ b/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/select_contract_period_step.rb
@@ -11,7 +11,7 @@ module Admin
           def self.permitted_params = %i[contract_period_year]
 
           def next_step
-            return :check_answers unless wizard.partnership_details_required?
+            return :check_answers if wizard.training_period_eoi_only?
 
             return :no_partnerships unless wizard.school_partnerships.exists?
 

--- a/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard.rb
+++ b/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard.rb
@@ -24,7 +24,7 @@ module Admin
 
             return steps << :check_answers if training_period_eoi_only?
             return steps << :no_partnerships unless school_partnerships.exists?
-            return steps << :check_answers if single_school_partnership
+            return steps << :check_answers if only_school_partnership
 
             steps << :select_partnership
             return steps unless selected_school_partnership_allowed?
@@ -63,7 +63,7 @@ module Admin
           end
 
           def selected_school_partnership
-            return single_school_partnership if single_school_partnership
+            return only_school_partnership if only_school_partnership
             return if store.school_partnership_id.blank?
 
             @selected_school_partnership ||= school_partnerships.find_by(id: store.school_partnership_id)
@@ -152,7 +152,7 @@ module Admin
             @current_active_period ||= ::TrainingPeriods::RelatedPeriods.new(training_period:).current_active_period
           end
 
-          def single_school_partnership
+          def only_school_partnership
             partnerships = school_partnerships.limit(2).to_a
             partnerships.first if partnerships.one?
           end
@@ -163,7 +163,7 @@ module Admin
           end
 
           def selected_school_partnership_allowed?
-            return true if single_school_partnership.present?
+            return true if only_school_partnership.present?
 
             store.school_partnership_id.present? &&
               school_partnerships.where(id: store.school_partnership_id).exists?

--- a/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard.rb
+++ b/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard.rb
@@ -24,6 +24,7 @@ module Admin
 
             return steps << :check_answers if eoi_only?
             return steps << :no_partnerships unless school_partnerships.exists?
+            return steps << :check_answers if single_school_partnership
 
             steps << :select_partnership
             return steps unless selected_school_partnership_allowed?
@@ -62,6 +63,7 @@ module Admin
           end
 
           def selected_school_partnership
+            return single_school_partnership if single_school_partnership
             return if store.school_partnership_id.blank?
 
             @selected_school_partnership ||= school_partnerships.find_by(id: store.school_partnership_id)
@@ -117,8 +119,12 @@ module Admin
             training_period.expression_of_interest_lead_provider.name
           end
 
-          def partnership_selection_required?
+          def partnership_details_required?
             !eoi_only?
+          end
+
+          def partnership_selection_step_required?
+            partnership_details_required? && school_partnerships.many?
           end
 
         private
@@ -150,12 +156,19 @@ module Admin
             @current_active_period ||= ::TrainingPeriods::RelatedPeriods.new(training_period:).current_active_period
           end
 
+          def single_school_partnership
+            partnerships = school_partnerships.limit(2).to_a
+            partnerships.first if partnerships.one?
+          end
+
           def selected_contract_period_allowed?
             store.contract_period_year.present? &&
               contract_periods.where(year: store.contract_period_year).exists?
           end
 
           def selected_school_partnership_allowed?
+            return true if single_school_partnership.present?
+
             store.school_partnership_id.present? &&
               school_partnerships.where(id: store.school_partnership_id).exists?
           end

--- a/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard.rb
+++ b/app/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard.rb
@@ -22,7 +22,7 @@ module Admin
             steps = [:select_contract_period]
             return steps unless selected_contract_period_allowed?
 
-            return steps << :check_answers if eoi_only?
+            return steps << :check_answers if training_period_eoi_only?
             return steps << :no_partnerships unless school_partnerships.exists?
             return steps << :check_answers if single_school_partnership
 
@@ -119,19 +119,15 @@ module Admin
             training_period.expression_of_interest_lead_provider.name
           end
 
-          def partnership_details_required?
-            !eoi_only?
+          def training_period_eoi_only?
+            training_period.only_expression_of_interest?
           end
 
           def partnership_selection_step_required?
-            partnership_details_required? && school_partnerships.many?
+            !training_period_eoi_only? && school_partnerships.many?
           end
 
         private
-
-          def eoi_only?
-            training_period.only_expression_of_interest?
-          end
 
           def school_partnership_search(lead_provider: :ignore, delivery_partner: :ignore)
             SchoolPartnerships::Search

--- a/spec/features/admin/teachers/change_contract_period_spec.rb
+++ b/spec/features/admin/teachers/change_contract_period_spec.rb
@@ -97,6 +97,12 @@ private
       lead_provider:,
       delivery_partner:
     )
+    FactoryBot.create(
+      :school_partnership,
+      :for_year,
+      year: @target_contract_period.year,
+      school: @school
+    )
     @target_partnership_name = "#{lead_provider.name} & #{delivery_partner.name}"
     @training_period = FactoryBot.create(
       :training_period,

--- a/spec/requests/admin/teachers/training_periods/change_contract_period_wizard_spec.rb
+++ b/spec/requests/admin/teachers/training_periods/change_contract_period_wizard_spec.rb
@@ -198,13 +198,26 @@ RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardCont
       expect(response.body).to include("Select a new contract period")
     end
 
-    it "redirects to select partnership when the selection is valid" do
+    it "redirects to check answers when there is only one partnership for the selected contract period" do
       post(
         path_for_step("select-contract-period"),
         params: { select_contract_period: { contract_period_year: target_contract_period.year } }
       )
 
-      expect(response).to redirect_to(path_for_step("select-partnership"))
+      expect(response).to redirect_to(path_for_step("check-answers"))
+    end
+
+    context "when there are multiple partnerships for the selected contract period" do
+      before { different_school_partnership }
+
+      it "redirects to select partnership when the selection is valid" do
+        post(
+          path_for_step("select-contract-period"),
+          params: { select_contract_period: { contract_period_year: target_contract_period.year } }
+        )
+
+        expect(response).to redirect_to(path_for_step("select-partnership"))
+      end
     end
 
     context "when there are no partnerships for the school" do
@@ -255,6 +268,7 @@ RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardCont
     end
 
     it "renders the partnership selection page after a contract period has been selected" do
+      different_school_partnership
       target_school_partnership
       partnership_name =
         "#{target_school_partnership.lead_provider.name} & #{target_school_partnership.delivery_partner.name}"
@@ -318,22 +332,13 @@ RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardCont
         )
       end
 
-      it "validates the selected partnership uses the current active lead provider and delivery partner" do
+      it "redirects to check answers when there is one available current active lead provider and delivery partner partnership" do
         post(
           path_for_step("select-contract-period"),
           params: { select_contract_period: { contract_period_year: target_contract_period.year } }
         )
 
-        post(
-          path_for_step("select-partnership"),
-          params: { select_partnership: { school_partnership_id: different_school_partnership.id } }
-        )
-
-        page = Capybara.string(response.body)
-
-        expect(response).to have_http_status(:unprocessable_content)
-        expect(page).to have_text("There is a problem")
-        expect(page).to have_text("Select a partnership")
+        expect(response).to redirect_to(path_for_step("check-answers"))
       end
     end
   end
@@ -357,6 +362,8 @@ RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardCont
 
   describe "GET check-answers" do
     it "redirects to select partnership when no partnership has been selected" do
+      different_school_partnership
+
       post(
         path_for_step("select-contract-period"),
         params: { select_contract_period: { contract_period_year: target_contract_period.year } }
@@ -365,6 +372,21 @@ RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardCont
       get path_for_step("check-answers")
 
       expect(response).to redirect_to(path_for_step("select-partnership"))
+    end
+
+    it "renders the CYA page after the contract period has been selected when there is only one partnership" do
+      post(
+        path_for_step("select-contract-period"),
+        params: { select_contract_period: { contract_period_year: target_contract_period.year } }
+      )
+
+      get path_for_step("check-answers")
+      page = Capybara.string(response.body)
+      partnership_name =
+        "#{target_school_partnership.lead_provider.name} & #{target_school_partnership.delivery_partner.name}"
+
+      expect(response).to have_http_status(:ok)
+      expect(page).to have_summary_list_row("Partnership", value: partnership_name)
     end
 
     it "renders the CYA page after the contract period and partnership have been selected" do
@@ -442,6 +464,22 @@ RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardCont
       follow_redirect!
 
       expect(response.body).to include("Contract period changed")
+    end
+
+    it "applies the contract period change after selecting only the contract period when there is one partnership" do
+      target_schedule
+
+      post(
+        path_for_step("select-contract-period"),
+        params: { select_contract_period: { contract_period_year: target_contract_period.year } }
+      )
+
+      expect {
+        post path_for_step("check-answers"), params: { check_answers: {} }
+      }.to change { TrainingPeriod.where(ect_at_school_period:).count }.by(1)
+
+      expect(response).to redirect_to(admin_teacher_training_path(teacher))
+      expect(replacement_training_period.school_partnership).to eq(target_school_partnership)
     end
 
     it "shows an error when the selected contract period has no matching schedule" do
@@ -593,6 +631,8 @@ private
   end
 
   def select_contract_period_and_partnership
+    different_school_partnership
+
     post(
       path_for_step("select-contract-period"),
       params: { select_contract_period: { contract_period_year: target_contract_period.year } }

--- a/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/check_answers_step_spec.rb
+++ b/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/check_answers_step_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Che
     instance_double(
       Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Wizard,
       store:,
-      partnership_selection_required?: partnership_selection_required,
+      partnership_selection_step_required?: partnership_selection_step_required,
       training_period:,
       selected_contract_period:,
       selected_school_partnership:,
@@ -13,7 +13,7 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Che
     )
   end
   let(:store) { FactoryBot.build(:session_repository) }
-  let(:partnership_selection_required) { true }
+  let(:partnership_selection_step_required) { true }
   let(:today) { Date.new(2026, 2, 1) }
   let(:started_on) { today.next_month }
   let(:training_period) { instance_double(TrainingPeriod, started_on:) }
@@ -27,7 +27,7 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Che
     end
 
     context "when the partnership selection is skipped" do
-      let(:partnership_selection_required) { false }
+      let(:partnership_selection_step_required) { false }
 
       it "returns select contract period" do
         expect(step.previous_step).to eq(:select_contract_period)

--- a/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/select_contract_period_step_spec.rb
+++ b/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/select_contract_period_step_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Sel
       store:,
       contract_periods:,
       school_partnerships:,
-      partnership_selection_required?: partnership_selection_required
+      partnership_details_required?: partnership_details_required,
+      partnership_selection_step_required?: partnership_selection_step_required
     )
   end
   let(:store) { FactoryBot.build(:session_repository) }
@@ -15,8 +16,10 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Sel
   let(:other_contract_period) { FactoryBot.create(:contract_period, year: 2027) }
   let(:contract_periods) { ContractPeriod.where(year: available_contract_period.year) }
   let(:available_school_partnership) { FactoryBot.create(:school_partnership) }
-  let(:school_partnerships) { SchoolPartnership.where(id: available_school_partnership.id) }
-  let(:partnership_selection_required) { true }
+  let(:other_school_partnership) { FactoryBot.create(:school_partnership) }
+  let(:school_partnerships) { SchoolPartnership.where(id: [available_school_partnership.id, other_school_partnership.id]) }
+  let(:partnership_details_required) { true }
+  let(:partnership_selection_step_required) { true }
   let(:contract_period_year) { available_contract_period.year }
 
   before do
@@ -81,16 +84,26 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Sel
       expect(step.next_step).to eq(:select_partnership)
     end
 
+    context "when only one school partnership is available" do
+      let(:school_partnerships) { SchoolPartnership.where(id: available_school_partnership.id) }
+      let(:partnership_selection_step_required) { false }
+
+      it "returns check answers" do
+        expect(step.next_step).to eq(:check_answers)
+      end
+    end
+
     context "when no school partnership is available" do
       let(:school_partnerships) { SchoolPartnership.none }
+      let(:partnership_selection_step_required) { false }
 
       it "returns no partnerships" do
         expect(step.next_step).to eq(:no_partnerships)
       end
     end
 
-    context "when partnership selection is not required" do
-      let(:partnership_selection_required) { false }
+    context "when partnership details are not required" do
+      let(:partnership_details_required) { false }
 
       it "returns check answers" do
         expect(step.next_step).to eq(:check_answers)

--- a/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/select_contract_period_step_spec.rb
+++ b/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/select_contract_period_step_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Sel
       store:,
       contract_periods:,
       school_partnerships:,
-      partnership_details_required?: partnership_details_required,
+      training_period_eoi_only?: training_period_eoi_only,
       partnership_selection_step_required?: partnership_selection_step_required
     )
   end
@@ -18,7 +18,7 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Sel
   let(:available_school_partnership) { FactoryBot.create(:school_partnership) }
   let(:other_school_partnership) { FactoryBot.create(:school_partnership) }
   let(:school_partnerships) { SchoolPartnership.where(id: [available_school_partnership.id, other_school_partnership.id]) }
-  let(:partnership_details_required) { true }
+  let(:training_period_eoi_only) { false }
   let(:partnership_selection_step_required) { true }
   let(:contract_period_year) { available_contract_period.year }
 
@@ -102,8 +102,8 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Sel
       end
     end
 
-    context "when partnership details are not required" do
-      let(:partnership_details_required) { false }
+    context "when the training period is EOI only" do
+      let(:training_period_eoi_only) { true }
 
       it "returns check answers" do
         expect(step.next_step).to eq(:check_answers)

--- a/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard_spec.rb
+++ b/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard_spec.rb
@@ -63,7 +63,15 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Wiz
     context "when an available contract period has been selected" do
       before { store.contract_period_year = target_contract_period.year }
 
-      it { is_expected.to eq(%i[select_contract_period select_partnership]) }
+      it { is_expected.to eq(%i[select_contract_period check_answers]) }
+
+      context "when there are multiple partnerships for the school and contract period" do
+        before do
+          FactoryBot.create(:school_partnership, :for_year, year: target_contract_period.year, school:)
+        end
+
+        it { is_expected.to eq(%i[select_contract_period select_partnership]) }
+      end
     end
 
     context "when an available contract period has no partnerships for the school" do
@@ -76,6 +84,7 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Wiz
 
     context "when an available contract period and partnership have been selected" do
       before do
+        FactoryBot.create(:school_partnership, :for_year, year: target_contract_period.year, school:)
         store.contract_period_year = target_contract_period.year
         store.school_partnership_id = target_school_partnership.id
       end
@@ -112,6 +121,7 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Wiz
 
     context "when an unavailable partnership has been selected" do
       before do
+        FactoryBot.create(:school_partnership, :for_year, year: target_contract_period.year, school:)
         store.contract_period_year = target_contract_period.year
         store.school_partnership_id = school_partnership.id
       end
@@ -138,6 +148,24 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Wiz
       expect(Admin::Teachers::TrainingPeriods::ChangeContractPeriod::AvailableContractPeriods)
         .to have_received(:new)
         .with(training_period: wizard.training_period)
+    end
+  end
+
+  describe "#selected_school_partnership" do
+    before { store.contract_period_year = target_contract_period.year }
+
+    it "infers the selected partnership when there is only one available partnership" do
+      expect(wizard.selected_school_partnership).to eq(target_school_partnership)
+    end
+
+    context "when there are multiple partnerships" do
+      before do
+        FactoryBot.create(:school_partnership, :for_year, year: target_contract_period.year, school:)
+      end
+
+      it "returns nil without a stored partnership selection" do
+        expect(wizard.selected_school_partnership).to be_nil
+      end
     end
   end
 


### PR DESCRIPTION
### Summary

When there is only one school partnership available, it doesn't make sense to show the user a radio selection with a single option. This PR skips that page and uses the only available partnership for the check answers step.

<img width="1402" height="434" alt="image" src="https://github.com/user-attachments/assets/4faf7885-2d1e-42b4-b094-c1068e541976" />
