### PR TITLE
Reuse ECT contract period across schools

### DIFF
--- a/app/services/ect_at_school_periods/switch_training.rb
+++ b/app/services/ect_at_school_periods/switch_training.rb
@@ -66,7 +66,6 @@ module ECTAtSchoolPeriods
           .teacher
           .ect_training_periods
           .provider_led_training_programme
-          .where(ect_at_school_periods: { school_id: @ect_at_school_period.school_id })
           .where("training_periods.started_on < ?", date_of_transition)
           .latest_first
           .first

--- a/app/services/ect_at_school_periods/switch_training.rb
+++ b/app/services/ect_at_school_periods/switch_training.rb
@@ -66,7 +66,7 @@ module ECTAtSchoolPeriods
           .teacher
           .ect_training_periods
           .provider_led_training_programme
-          .where("training_periods.started_on < ?", date_of_transition)
+          .started_before(date_of_transition)
           .latest_first
           .first
     end

--- a/spec/services/ect_at_school_periods/switch_training_spec.rb
+++ b/spec/services/ect_at_school_periods/switch_training_spec.rb
@@ -676,6 +676,95 @@ module ECTAtSchoolPeriods
           end
         end
 
+        context "when the previous provider-led training period belongs to an earlier ECT-at-school period" do
+          let(:mentorship_period) { nil }
+          let(:started_on) { Date.new(2026, 9, 1) }
+          let(:previous_contract_period) do
+            FactoryBot.create(:contract_period, :with_schedules, year: 2025)
+          end
+
+          let(:previous_school) { ect_at_school_period.school }
+
+          let!(:previous_active_lead_provider) do
+            FactoryBot.create(
+              :active_lead_provider,
+              lead_provider:,
+              contract_period: previous_contract_period
+            )
+          end
+
+          let!(:previous_ect_at_school_period) do
+            FactoryBot.create(
+              :ect_at_school_period,
+              teacher: ect_at_school_period.teacher,
+              school: previous_school,
+              started_on: previous_contract_period.started_on,
+              finished_on: Date.new(2026, 5, 31)
+            )
+          end
+
+          let!(:previous_training_period) do
+            FactoryBot.create(
+              :training_period,
+              :for_ect,
+              :provider_led,
+              :with_only_expression_of_interest,
+              ect_at_school_period: previous_ect_at_school_period,
+              expression_of_interest: previous_active_lead_provider,
+              started_on: previous_ect_at_school_period.started_on,
+              finished_on: previous_ect_at_school_period.finished_on
+            )
+          end
+
+          let!(:training_period) do
+            FactoryBot.create(
+              :training_period,
+              :for_ect,
+              :ongoing,
+              :school_led,
+              ect_at_school_period:,
+              started_on:
+            )
+          end
+
+          shared_examples "retains the earlier provider-led contract period" do
+            it "retains the previous provider-led contract period" do
+              SwitchTraining.to_provider_led(
+                ect_at_school_period,
+                lead_provider:,
+                author:
+              )
+
+              new_training_period = ect_at_school_period
+                .reload
+                .training_periods
+                .provider_led_training_programme
+                .latest_first
+                .first
+
+              expect(new_training_period.schedule.contract_period)
+                .to eq(previous_contract_period)
+
+              association_contract_period =
+                new_training_period.contract_period ||
+                new_training_period.expression_of_interest_contract_period
+
+              expect(association_contract_period)
+                .to eq(previous_contract_period)
+            end
+          end
+
+          context "when it was at the same school" do
+            include_examples "retains the earlier provider-led contract period"
+          end
+
+          context "when it was at a different school" do
+            let(:previous_school) { FactoryBot.create(:school) }
+
+            include_examples "retains the earlier provider-led contract period"
+          end
+        end
+
         context "when there is no confirmed school partnership" do
           let!(:previous_training_period) do
             FactoryBot.create(

--- a/spec/services/ect_at_school_periods/switch_training_spec.rb
+++ b/spec/services/ect_at_school_periods/switch_training_spec.rb
@@ -613,72 +613,6 @@ module ECTAtSchoolPeriods
         context "when the previous provider-led training period belongs to an earlier ECT-at-school period" do
           let(:mentorship_period) { nil }
           let(:started_on) { Date.new(2026, 9, 1) }
-          let(:previous_contract_period) { FactoryBot.create(:contract_period, :with_schedules, year: 2025) }
-
-          let!(:previous_active_lead_provider) do
-            FactoryBot.create(
-              :active_lead_provider,
-              lead_provider:,
-              contract_period: previous_contract_period
-            )
-          end
-
-          let!(:previous_ect_at_school_period) do
-            FactoryBot.create(
-              :ect_at_school_period,
-              teacher: ect_at_school_period.teacher,
-              school: ect_at_school_period.school,
-              started_on: previous_contract_period.started_on,
-              finished_on: Date.new(2026, 5, 31)
-            )
-          end
-
-          let!(:previous_training_period) do
-            FactoryBot.create(
-              :training_period,
-              :for_ect,
-              :provider_led,
-              :with_only_expression_of_interest,
-              ect_at_school_period: previous_ect_at_school_period,
-              expression_of_interest: previous_active_lead_provider,
-              started_on: previous_ect_at_school_period.started_on,
-              finished_on: previous_ect_at_school_period.finished_on
-            )
-          end
-
-          let!(:training_period) do
-            FactoryBot.create(
-              :training_period,
-              :for_ect,
-              :ongoing,
-              :school_led,
-              ect_at_school_period:,
-              started_on:
-            )
-          end
-
-          it "retains the previous provider-led contract period" do
-            SwitchTraining.to_provider_led(ect_at_school_period, lead_provider:, author:)
-
-            new_training_period = ect_at_school_period
-              .reload
-              .training_periods
-              .provider_led_training_programme
-              .latest_first
-              .first
-
-            expect(new_training_period.schedule.contract_period).to eq(previous_contract_period)
-
-            association_contract_period =
-              new_training_period.contract_period ||
-              new_training_period.expression_of_interest_contract_period
-            expect(association_contract_period).to eq(previous_contract_period)
-          end
-        end
-
-        context "when the previous provider-led training period belongs to an earlier ECT-at-school period" do
-          let(:mentorship_period) { nil }
-          let(:started_on) { Date.new(2026, 9, 1) }
           let(:previous_contract_period) do
             FactoryBot.create(:contract_period, :with_schedules, year: 2025)
           end
@@ -762,6 +696,65 @@ module ECTAtSchoolPeriods
             let(:previous_school) { FactoryBot.create(:school) }
 
             include_examples "retains the earlier provider-led contract period"
+          end
+
+          context "when there are multiple previous provider-led periods at different schools" do
+            let(:previous_school) { FactoryBot.create(:school) }
+
+            let(:older_contract_period) do
+              FactoryBot.create(:contract_period, :with_schedules, year: 2024)
+            end
+
+            let(:older_active_lead_provider) do
+              FactoryBot.create(
+                :active_lead_provider,
+                lead_provider:,
+                contract_period: older_contract_period
+              )
+            end
+
+            let(:older_school) { FactoryBot.create(:school) }
+
+            let!(:older_ect_at_school_period) do
+              FactoryBot.create(
+                :ect_at_school_period,
+                teacher: ect_at_school_period.teacher,
+                school: older_school,
+                started_on: older_contract_period.started_on,
+                finished_on: Date.new(2025, 5, 31)
+              )
+            end
+
+            let!(:older_training_period) do
+              FactoryBot.create(
+                :training_period,
+                :for_ect,
+                :provider_led,
+                :with_only_expression_of_interest,
+                ect_at_school_period: older_ect_at_school_period,
+                expression_of_interest: older_active_lead_provider,
+                started_on: older_ect_at_school_period.started_on,
+                finished_on: older_ect_at_school_period.finished_on
+              )
+            end
+
+            it "retains the most recent previous provider-led contract period" do
+              SwitchTraining.to_provider_led(
+                ect_at_school_period,
+                lead_provider:,
+                author:
+              )
+
+              new_training_period = ect_at_school_period
+                .reload
+                .training_periods
+                .provider_led_training_programme
+                .latest_first
+                .first
+
+              expect(new_training_period.schedule.contract_period)
+                .to eq(previous_contract_period)
+            end
           end
         end
 


### PR DESCRIPTION
Relating to this [ticket](https://github.com/DFE-Digital/register-ects-project-board/issues/4131) - a further example was found

### Context
Updates ECTAtSchoolPeriods::SwitchTraining so that, when switching an ECT back to provider-led training, it looks across the teacher’s full previous provider-led training history rather than restricting the lookup to the same school

### Changes proposed in this pull request
The same-school filter has been removed from `most_recent_provider_led_period`

### Guidance to review
The main scenario is an ECT who:

1. previously had provider-led training on an earlier contract period;
2. later moved to school-led training;
3. then switches back to provider-led training at a different school.

In that case, we should reuse the most recent earlier provider-led contract period rather than assigning the current one.
