### PR TITLE
DO NOT MERGE - RIAB api endpoint structure spike

### DIFF
--- a/app/controllers/api/v4/appropriate_body/base_controller.rb
+++ b/app/controllers/api/v4/appropriate_body/base_controller.rb
@@ -1,0 +1,32 @@
+module API
+  module V4
+    module AppropriateBody
+      # SPIKE: authentication is deferred to a separate PR. For now every request
+      # acts as the "Golden Leaf" appropriate body.
+      class BaseController < APIController
+        skip_before_action :authenticate # skip for spike
+
+        rescue_from AppropriateBodies::CloseInduction::TeacherHasNoOngoingInductionPeriod, with: :not_found_response
+
+        rescue_from ActiveModel::ValidationError do |exception|
+          render json: API::Errors::Response.from(exception.model), status: :unprocessable_content
+        end
+
+        rescue_from ActiveRecord::RecordInvalid do |exception|
+          render json: API::Errors::Response.from(exception.record), status: :unprocessable_content
+        end
+
+      private
+
+        # SPIKE: hardcoded default appropriate body
+        def appropriate_body_period
+          @appropriate_body_period ||= AppropriateBodyPeriod.find_by!(name: "Golden Leaf Teaching School Hub")
+        end
+
+        def author
+          @author ||= Events::AppropriateBodyAPIAuthor.new(appropriate_body_period:, email: "spike@example.com")
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v4/induction/claims_controller.rb
+++ b/app/controllers/api/v4/induction/claims_controller.rb
@@ -1,0 +1,65 @@
+module API
+  module V4
+    module Induction
+      class ClaimsController < AppropriateBody::BaseController
+        rescue_from TRS::Errors::TeacherNotFound,
+                    TRS::Errors::TeacherDeactivated,
+                    TRS::Errors::TeacherMerged,
+                    with: :not_found_response
+
+        rescue_from AppropriateBodies::ClaimAnECT::CheckECT::TeacherHasOngoingInductionPeriodWithAnotherAB,
+                    AppropriateBodies::ClaimAnECT::FindECT::TeacherHasOngoingInductionPeriodWithCurrentAB do |exception|
+          render json: { errors: API::Errors::Response.new(title: "Conflict", messages: exception.message).call }, status: :conflict
+        end
+
+        rescue_from TRS::Errors::ProhibitedFromTeaching,
+                    TRS::Errors::InductionAlreadyCompleted,
+                    TRS::Errors::QTSNotAwarded do |exception|
+          render json: { errors: API::Errors::Response.new(title: "Unprocessable", messages: exception.message).call }, status: :unprocessable_content
+        end
+
+        def create
+          return render_submission_errors unless find_ect.import_from_trs!
+
+          check_ect.begin_claim!
+
+          if register.register(**claim_params.to_h.symbolize_keys)
+            render json: API::V4::InductionPeriodSerializer.render(register.induction_period), status: :created
+          else
+            render_submission_errors
+          end
+        end
+
+      private
+
+        def submission
+          @submission ||= PendingInductionSubmission.new(
+            trn: params[:trn],
+            date_of_birth: claim_params[:date_of_birth],
+            appropriate_body_period_id: appropriate_body_period.id
+          )
+        end
+
+        def find_ect
+          AppropriateBodies::ClaimAnECT::FindECT.new(appropriate_body_period:, pending_induction_submission: submission)
+        end
+
+        def check_ect
+          AppropriateBodies::ClaimAnECT::CheckECT.new(appropriate_body_period:, pending_induction_submission: submission)
+        end
+
+        def register
+          @register ||= AppropriateBodies::ClaimAnECT::RegisterECT.new(appropriate_body_period:, pending_induction_submission: submission, author:)
+        end
+
+        def claim_params
+          params.expect(claim: %i[date_of_birth started_on training_programme])
+        end
+
+        def render_submission_errors
+          render json: API::Errors::Response.from(submission), status: :unprocessable_content
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v4/induction/fails_controller.rb
+++ b/app/controllers/api/v4/induction/fails_controller.rb
@@ -1,0 +1,31 @@
+module API
+  module V4
+    module Induction
+      class FailsController < AppropriateBody::BaseController
+        before_action :set_teacher
+        before_action :set_induction_period
+
+        def create
+          AppropriateBodies::RecordFail.new(teacher: @teacher, appropriate_body_period:, author:)
+            .call(**fail_params.to_h.symbolize_keys)
+
+          render json: API::V4::InductionPeriodSerializer.render(@induction_period), status: :ok
+        end
+
+      private
+
+        def set_teacher
+          @teacher = AppropriateBodies::ECTs.new(appropriate_body_period).current.find_by!(trn: params[:trn])
+        end
+
+        def set_induction_period
+          @induction_period = @teacher.ongoing_induction_period
+        end
+
+        def fail_params
+          params.expect(fail: %i[finished_on number_of_terms fail_confirmation_sent_on])
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v4/induction/passes_controller.rb
+++ b/app/controllers/api/v4/induction/passes_controller.rb
@@ -1,0 +1,31 @@
+module API
+  module V4
+    module Induction
+      class PassesController < AppropriateBody::BaseController
+        before_action :set_teacher
+        before_action :set_induction_period
+
+        def create
+          AppropriateBodies::RecordPass.new(teacher: @teacher, appropriate_body_period:, author:)
+            .call(**pass_params.to_h.symbolize_keys)
+
+          render json: API::V4::InductionPeriodSerializer.render(@induction_period), status: :ok
+        end
+
+      private
+
+        def set_teacher
+          @teacher = AppropriateBodies::ECTs.new(appropriate_body_period).current.find_by!(trn: params[:trn])
+        end
+
+        def set_induction_period
+          @induction_period = @teacher.ongoing_induction_period
+        end
+
+        def pass_params
+          params.expect(pass: %i[finished_on number_of_terms])
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v4/induction/releases_controller.rb
+++ b/app/controllers/api/v4/induction/releases_controller.rb
@@ -1,0 +1,31 @@
+module API
+  module V4
+    module Induction
+      class ReleasesController < AppropriateBody::BaseController
+        before_action :set_teacher
+        before_action :set_induction_period
+
+        def create
+          AppropriateBodies::RecordRelease.new(teacher: @teacher, appropriate_body_period:, author:)
+            .call(**release_params.to_h.symbolize_keys)
+
+          render json: API::V4::InductionPeriodSerializer.render(@induction_period), status: :ok
+        end
+
+      private
+
+        def set_teacher
+          @teacher = AppropriateBodies::ECTs.new(appropriate_body_period).current.find_by!(trn: params[:trn])
+        end
+
+        def set_induction_period
+          @induction_period = @teacher.ongoing_induction_period
+        end
+
+        def release_params
+          params.expect(release: %i[finished_on number_of_terms])
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/api/v4/induction_period_serializer.rb
+++ b/app/serializers/api/v4/induction_period_serializer.rb
@@ -1,0 +1,23 @@
+# Shared response shape for the v4 claim / close endpoints — the induction
+# period in its current state.
+class API::V4::InductionPeriodSerializer < Blueprinter::Base
+  field(:trn) { |induction_period| induction_period.teacher.trn }
+  field(:full_name) { |induction_period| ::Teachers::Name.new(induction_period.teacher).full_name }
+
+  # ongoing | pass | fail | release (released = finished with no pass/fail outcome)
+  field(:status) do |induction_period|
+    if induction_period.finished_on.nil?
+      "ongoing"
+    else
+      induction_period.outcome.presence || "release"
+    end
+  end
+
+  field(:started_on)
+  field(:finished_on)
+  field(:training_programme)
+  field(:number_of_terms)
+
+  field(:created_at)
+  field(:updated_at)
+end

--- a/app/services/appropriate_bodies/claim_an_ect/register_ect.rb
+++ b/app/services/appropriate_bodies/claim_an_ect/register_ect.rb
@@ -5,7 +5,8 @@ module AppropriateBodies
 
       attr_reader :appropriate_body_period,
                   :pending_induction_submission,
-                  :author
+                  :author,
+                  :induction_period
 
       def initialize(appropriate_body_period:, pending_induction_submission:, author:)
         @appropriate_body_period = appropriate_body_period
@@ -61,7 +62,7 @@ module AppropriateBodies
 
       # @return [Boolean]
       def create_induction_period
-        InductionPeriods::CreateInductionPeriod.new(
+        @induction_period = InductionPeriods::CreateInductionPeriod.new(
           author:,
           teacher:,
           params: {

--- a/app/services/events/appropriate_body_api_author.rb
+++ b/app/services/events/appropriate_body_api_author.rb
@@ -1,0 +1,21 @@
+class Events::AppropriateBodyAPIAuthor
+  attr_reader :appropriate_body_period_id, :email, :name
+
+  def initialize(appropriate_body_period:, email:)
+    @appropriate_body_period_id = appropriate_body_period.id
+    @email = email
+    @name = appropriate_body_period.name
+  end
+
+  def event_author_params
+    {
+      author_type: :appropriate_body_user,
+      author_name: name,
+      author_email: email,
+      appropriate_body_period_id:,
+    }
+  end
+
+  def dfe_user? = false
+  def appropriate_body_user? = true
+end

--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -1335,6 +1335,8 @@ module Events
         author.lead_provider_api_author_params
       when Events::AppropriateBodyBatchAuthor
         author.event_author_params
+      when Events::AppropriateBodyAPIAuthor
+        author.event_author_params
       else
         fail(InvalidAuthor, author.class)
       end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -30,4 +30,13 @@ namespace :api do
     resources :schools, only: %i[index show], param: :api_id
     resources :unfunded_mentors, only: %i[index show], path: "unfunded-mentors", param: :api_id
   end
+
+  namespace :v4 do
+    scope path: "appropriate-body/teachers/:trn", module: :induction do
+      resource :claim, only: :create
+      resource :pass, only: :create
+      resource :fail, only: :create
+      resource :release, only: :create
+    end
+  end
 end

--- a/spec/requests/api/v4/induction/claims_spec.rb
+++ b/spec/requests/api/v4/induction/claims_spec.rb
@@ -1,0 +1,75 @@
+RSpec.describe "API::V4::Induction::Claims", type: :request do
+  let!(:golden_leaf) { FactoryBot.create(:appropriate_body_period, name: "Golden Leaf Teaching School Hub") }
+  let(:trn) { "3002586" }
+
+  context "when the teacher can be claimed" do
+    include_context "test TRS API returns a teacher"
+
+    it "creates an ongoing induction period and returns 201" do
+      expect {
+        post api_v4_claim_path(trn:), params: {
+          date_of_birth: "1990-01-01",
+          started_on: 6.months.ago.to_date.iso8601,
+          training_programme: "school_led"
+        }, as: :json
+      }.to change(InductionPeriod, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      body = response.parsed_body
+      expect(body["trn"]).to eq(trn)
+      expect(body["status"]).to eq("ongoing")
+      expect(body["training_programme"]).to eq("school_led")
+    end
+  end
+
+  context "when no teacher is found in TRS" do
+    include_context "test TRS API returns nothing"
+
+    it "returns 404" do
+      post api_v4_claim_path(trn:), params: {
+        date_of_birth: "1990-01-01",
+        started_on: 6.months.ago.to_date.iso8601,
+        training_programme: "school_led"
+      }, as: :json
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  context "when the teacher is already claimed by another appropriate body" do
+    include_context "test TRS API returns a teacher"
+
+    let(:other_ab) { FactoryBot.create(:appropriate_body_period) }
+    let(:teacher) { FactoryBot.create(:teacher, trn:) }
+
+    before do
+      FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period: other_ab, started_on: Date.parse("2 October 2022"))
+    end
+
+    it "returns 409 and does not create a period" do
+      expect {
+        post api_v4_claim_path(trn:), params: {
+          date_of_birth: "1990-01-01",
+          started_on: 6.months.ago.to_date.iso8601,
+          training_programme: "school_led"
+        }, as: :json
+      }.not_to change(InductionPeriod, :count)
+
+      expect(response).to have_http_status(:conflict)
+    end
+  end
+
+  context "when the induction start date is before the QTS award date" do
+    include_context "test TRS API returns a teacher"
+
+    it "returns 422" do
+      post api_v4_claim_path(trn:), params: {
+        date_of_birth: "1990-01-01",
+        started_on: "2021-10-01",
+        training_programme: "school_led"
+      }, as: :json
+
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+  end
+end

--- a/spec/requests/api/v4/induction/fails_spec.rb
+++ b/spec/requests/api/v4/induction/fails_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe "API::V4::Induction::Fails", type: :request do
+  let!(:golden_leaf) { FactoryBot.create(:appropriate_body_period, name: "Golden Leaf Teaching School Hub") }
+  let(:teacher) { FactoryBot.create(:teacher) }
+
+  before do
+    FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period: golden_leaf, started_on: 1.year.ago.to_date)
+  end
+
+  it "closes the period with a fail outcome and returns 200" do
+    post api_v4_fail_path(trn: teacher.trn), params: {
+      finished_on: 1.day.ago.to_date.iso8601,
+      number_of_terms: 6,
+      fail_confirmation_sent_on: 1.day.ago.to_date.iso8601
+    }, as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body["status"]).to eq("fail")
+    expect(teacher.reload.induction_periods.last).to have_attributes(outcome: "fail", number_of_terms: 6)
+  end
+
+  it "requires the written confirmation date" do
+    post(api_v4_fail_path(trn: teacher.trn), params: { finished_on: 1.day.ago.to_date.iso8601, number_of_terms: 6 }, as: :json)
+
+    expect(response).to have_http_status(:unprocessable_content)
+  end
+end

--- a/spec/requests/api/v4/induction/passes_spec.rb
+++ b/spec/requests/api/v4/induction/passes_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe "API::V4::Induction::Passes", type: :request do
+  let!(:golden_leaf) { FactoryBot.create(:appropriate_body_period, name: "Golden Leaf Teaching School Hub") }
+  let(:teacher) { FactoryBot.create(:teacher) }
+
+  before do
+    FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period: golden_leaf, started_on: 1.year.ago.to_date)
+  end
+
+  it "closes the period with a pass outcome and returns 200" do
+    post(api_v4_pass_path(trn: teacher.trn), params: { finished_on: 1.day.ago.to_date.iso8601, number_of_terms: 6 }, as: :json)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body["status"]).to eq("pass")
+    expect(teacher.reload.induction_periods.last).to have_attributes(outcome: "pass", number_of_terms: 6)
+  end
+end

--- a/spec/requests/api/v4/induction/releases_spec.rb
+++ b/spec/requests/api/v4/induction/releases_spec.rb
@@ -1,0 +1,43 @@
+RSpec.describe "API::V4::Induction::Releases", type: :request do
+  let!(:golden_leaf) { FactoryBot.create(:appropriate_body_period, name: "Golden Leaf Teaching School Hub") }
+  let(:teacher) { FactoryBot.create(:teacher) }
+
+  context "with an ongoing induction period" do
+    before do
+      FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period: golden_leaf, started_on: 1.year.ago.to_date)
+    end
+
+    it "closes the period as released and returns 200" do
+      post(api_v4_release_path(trn: teacher.trn), params: { finished_on: 1.day.ago.to_date.iso8601, number_of_terms: 6 }, as: :json)
+
+      expect(response).to have_http_status(:ok)
+      body = response.parsed_body
+      expect(body["status"]).to eq("release")
+      expect(body["finished_on"]).to eq(1.day.ago.to_date.iso8601)
+      expect(teacher.reload.ongoing_induction_period).to be_nil
+    end
+  end
+
+  context "when there is no ongoing induction period" do
+    it "returns 404" do
+      post(api_v4_release_path(trn: teacher.trn), params: { finished_on: 1.day.ago.to_date.iso8601, number_of_terms: 6 }, as: :json)
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  context "when the ongoing induction period belongs to another appropriate body" do
+    let(:other_ab) { FactoryBot.create(:appropriate_body_period) }
+
+    before do
+      FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period: other_ab, started_on: 1.year.ago.to_date)
+    end
+
+    it "returns 404 and does not close it" do
+      post(api_v4_release_path(trn: teacher.trn), params: { finished_on: 1.day.ago.to_date.iso8601, number_of_terms: 6 }, as: :json)
+
+      expect(response).to have_http_status(:not_found)
+      expect(teacher.reload.ongoing_induction_period).to be_present
+    end
+  end
+end


### PR DESCRIPTION
### Context

resolves https://github.com/DFE-Digital/register-ects-project-board/issues/4143

### Changes proposed in this pull request

Details in https://github.com/DFE-Digital/register-ects-project-board/issues/4143

Spike implementation additional decisions:
* Follow `/appropriate-body/teachers/:trn/claim` pattern.
* Short-circuit appropriate body - as that is out of scope of this spike.
* Using `training_programme` rather than `induction_programme` for ease of implementation.

### Guidance to review

#### Claim
cURL:

```
 curl http://localhost:3000/api/v4/appropriate-body/teachers/4000300/claim \
    -H 'Content-Type: application/json' \
    -d '{"date_of_birth":"1990-01-01","started_on":"2025-05-02","training_programme":"school_led"}'
```

We have short-circuited authorization, so the real implementation would obviously also have an authorization token.

#### Pass

```
curl http://localhost:3000/api/v4/appropriate-body/teachers/4000300/pass \
    -H 'Content-Type: application/json' \
    -d '{"finished_on":"2026-05-02","number_of_terms":6}'
```

#### Fail

```
curl http://localhost:3000/api/v4/appropriate-body/teachers/4000300/fail \
    -H 'Content-Type: application/json' \
    -d '{"finished_on":"2026-05-02","number_of_terms":6,"fail_confirmation_sent_on":"2026-05-01"}'
```

#### Release

````
curl http://localhost:3000/api/v4/appropriate-body/teachers/4000300/release \
    -H 'Content-Type: application/json' \
    -d '{"finished_on":"2026-05-02","number_of_terms":6}'
````    

These all return a success response like:  
```
{
  "trn":"4000300",
  "full_name":"Kate Ashfield",
  "status":"ongoing",
  "started_on":"2025-05-02",
  "finished_on":null,
  "training_programme":"school_led",
  "number_of_terms":null,
  "created_at":"2026-07-14T11:28:48Z",
  "updated_at":"2026-07-14T11:28:48Z"
 }
```

And a failure responses like:

```
{"errors":[{"title":"Resource not found","detail":"Nothing could be found for the provided details"}]}
```

```
{"errors":[{"title":"Bad request","detail":"Correct json data structure required. See API docs for reference."}]}
```
`
