### PR TITLE
Fix bug in `TrainingProgramme` service

### DIFF
--- a/app/services/schools/training_programme.rb
+++ b/app/services/schools/training_programme.rb
@@ -50,13 +50,18 @@ module Schools
     end
 
     def ect_training_programme(contract_period_year:)
-      ect_at_school_period_id = (
+      ect_at_school_period_ids = (
         (ect_expressions_of_interest_ids_by_contract_period_year[contract_period_year] || []) +
         (ect_at_school_period_ids_by_contract_period_year[contract_period_year] || []) +
         (school_led_ect_at_school_period_ids_by_contract_period_year[contract_period_year] || [])
       ).compact
 
-      training_programmes_by_ect_at_school_period_id&.slice(*ect_at_school_period_id)&.values&.first
+      # Prioritises provider-led training programmes over
+      # school-led training programmes if a school has both for the same ECT.
+      training_programmes_by_ect_at_school_period_id
+        .select { |id, _| ect_at_school_period_ids.include?(id) }
+        .min_by { |_, programme| programme }
+        &.last
     end
 
     def training_programmes_by_ect_at_school_period_id
@@ -71,7 +76,6 @@ module Schools
           .where(ect_at_school_period_id:)
           .order(training_programme: :asc)
           .pluck(:ect_at_school_period_id, :training_programme)
-          .to_h
       end
     end
 

--- a/spec/services/schools/training_programme_spec.rb
+++ b/spec/services/schools/training_programme_spec.rb
@@ -166,6 +166,34 @@ describe Schools::TrainingProgramme do
 
           it { is_expected.to eq("provider_led") }
         end
+
+        context "when the same ect at school period has both provider-led and school-led training periods" do
+          let(:ect_at_school_period) do
+            FactoryBot.create(:ect_at_school_period,
+                              :ongoing,
+                              school:,
+                              started_on: "2021-01-01")
+          end
+          let!(:provider_led_training_period) do
+            FactoryBot.create(:training_period,
+                              :provider_led,
+                              ect_at_school_period:,
+                              school_partnership:,
+                              started_on: contract_period.started_on,
+                              finished_on: contract_period.started_on + 1.month)
+          end
+          let!(:school_led_training_period) do
+            FactoryBot.create(:training_period,
+                              :school_led,
+                              ect_at_school_period:,
+                              started_on: contract_period.started_on + 2.months,
+                              finished_on: contract_period.started_on + 3.months)
+          end
+
+          it "prioritises provider-led training" do
+            expect(subject).to eq("provider_led")
+          end
+        end
       end
 
       context "when school has at least one expression of interest for training from an ect" do


### PR DESCRIPTION
### Context 

The `TrainingProgramme` service checks `TrainingPeriod` records against a given `ContractPeriod` for a `School` in order to determine the overall `induction_programme_choice` of the `School`.

It prioritises `provider-led` over `school-led`; if neither are present it will be `not-yet-known`.

Previously we were not accounting for multiple `TrainingPeriod` records with different `training_pgoramme` values against the same `AtSchoolPeriod`. For example:

```
TrainingPeriod
  .where(ect_at_school_period_id:)
  .order(training_programme: :asc)
  .pluck(:ect_at_school_period_id, :training_programme)

[[39, "provider_led"], [39, "school_led"]]
```

We would call `to_h` on the above result to get a mapping of `AtSchoolPeriod#id` -> `programme_choice`; with the way `to_h` works if there are multiple values with the same key we are left with only the last one:

```
[[39, "provider_led"], [39, "school_led"]].to_h

{39 => "school_led"}
```

In this scenario the `School` would incorrectly be identified as `school-led`. Instead, we should take into account both of the programme choices, prioritising `provider-led`.

This bug manifests as schools going from `provider-led` to `school-led` in the metadata refresh.

### Changes 

- Fix bug in `TrainingProgramme` service

### Guidance to review

After testing in the migration environment there are **139 schools effected**, with 174 incorrect induction programme types against contract periods:

```
2021 -> 14
2022 -> 47
2023 -> 48
2024 -> 42
2025 -> 18
2026 -> 5
```
