### PR TITLE
Remove redundant spec tag

### DIFF
--- a/spec/features/admin/finance/active_lead_providers/contracts/update_contract_band_percentages_spec.rb
+++ b/spec/features/admin/finance/active_lead_providers/contracts/update_contract_band_percentages_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Update contract band percentages", :enable_finance_contract_periods, :js do
+RSpec.describe "Update contract band percentages", :js do
   before { sign_in_as_dfe_user(role: :finance) }
 
   scenario "Output fee percentage drives service fee percentage" do

--- a/spec/requests/admin/finance/active_lead_providers/bands_spec.rb
+++ b/spec/requests/admin/finance/active_lead_providers/bands_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Admin finance active lead provider bands", :enable_finance_contract_periods, type: :request do
+RSpec.describe "Admin finance active lead provider bands", type: :request do
   let(:contract_period) { FactoryBot.create(:contract_period, :current) }
   let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, contract_period:) }
 


### PR DESCRIPTION
These aren't used anymore since #3223, so we can remove them.