### PR TITLE
Ensure the relevant AB is displayed on the ECT card

### DIFF
--- a/app/components/schools/ect_induction_details_component.rb
+++ b/app/components/schools/ect_induction_details_component.rb
@@ -36,22 +36,39 @@ module Schools
       {
         text: "Change",
         visually_hidden_text: "appropriate body",
-        href: change_appropriate_body_path,
+        href: schools_ects_change_appropriate_body_wizard_edit_path(@ect),
         classes: "govuk-link--no-visited-state"
       }
     end
 
-    # The ongoing induction period that represents an AB claiming the ECT for
-    # *this* school placement (i.e. started within this placement's dates).
-    # Claims recorded before the school registered the ECT, or carried over from
-    # a previous school, are excluded, so the school keeps seeing its reported
-    # appropriate body as provisional until it's confirmed for this placement.
-    def claiming_induction_period
-      @claiming_induction_period ||=
-        @ect.teacher.induction_periods.ongoing
-            .where(started_on: @ect.started_on..@ect.finished_on)
-            .latest_first
-            .first
+    def appropriate_body
+      @appropriate_body ||= ECTAtSchoolPeriods::AppropriateBody.new(@ect)
+    end
+
+    def appropriate_body_html
+      return claimed_appropriate_body_html if appropriate_body.from_induction?
+      return appropriate_body.name unless appropriate_body.from_school?
+
+      safe_join([
+        appropriate_body.name,
+        tag.br,
+        tag.span("Awaiting confirmation by the appropriate body", class: "govuk-hint")
+      ])
+    end
+
+    def claimed_appropriate_body_html
+      safe_join([
+        appropriate_body.name,
+        tag.br,
+        tag.span(
+          safe_join([
+            "This appropriate body has recorded the ECT’s induction.",
+            tag.br,
+            "Contact them if this is wrong or if you want to change the appropriate body."
+          ]),
+          class: "govuk-hint"
+        )
+      ])
     end
 
     def induction_start_date_row
@@ -76,43 +93,11 @@ module Schools
       ])
     end
 
-    def appropriate_body_html
-      return claimed_appropriate_body_html if claiming_induction_period
-
-      name = @ect.school_reported_appropriate_body_name.presence
-      return "Not reported" if name.nil?
-
-      safe_join([
-        name,
-        tag.br,
-        tag.span("Awaiting confirmation by the appropriate body", class: "govuk-hint")
-      ])
-    end
-
-    def claimed_appropriate_body_html
-      safe_join([
-        claiming_induction_period.appropriate_body_name,
-        tag.br,
-        tag.span(
-          safe_join([
-            "This appropriate body has recorded the ECT’s induction.",
-            tag.br,
-            "Contact them if this is wrong or if you want to change the appropriate body."
-          ]),
-          class: "govuk-hint"
-        )
-      ])
-    end
-
     def induction_start_date_not_reported_row
       {
         key: { text: "Induction start date" },
         value: { text: "Yet to be reported by the appropriate body" }
       }
-    end
-
-    def change_appropriate_body_path
-      schools_ects_change_appropriate_body_wizard_edit_path(ect_id: @ect.id)
     end
   end
 end

--- a/app/components/schools/ects/listing_card_component.rb
+++ b/app/components/schools/ects/listing_card_component.rb
@@ -77,12 +77,12 @@ module Schools
       def appropriate_body_row
         {
           key: { text: "Appropriate body" },
-          value: { text: appropriate_body_text }
+          value: { text: appropriate_body.name }
         }
       end
 
-      def appropriate_body_text
-        ect_at_school_period.school_reported_appropriate_body_name.presence || "Not reported"
+      def appropriate_body
+        @appropriate_body ||= ECTAtSchoolPeriods::AppropriateBody.new(ect_at_school_period)
       end
 
       def delivery_partner_row

--- a/app/controllers/schools/ects_controller.rb
+++ b/app/controllers/schools/ects_controller.rb
@@ -13,6 +13,7 @@ module Schools
         )
         .search
         .includes(
+          ongoing_induction_period: :appropriate_body_period,
           ect_at_school_periods: %i[latest_training_period mentorship_periods],
           current_or_next_ect_at_school_period: [
             { latest_training_period: %i[lead_provider delivery_partner] },

--- a/app/services/ect_at_school_periods/appropriate_body.rb
+++ b/app/services/ect_at_school_periods/appropriate_body.rb
@@ -6,7 +6,7 @@ module ECTAtSchoolPeriods
 
     delegate :name, to: :appropriate_body
 
-    def from_induction? = induction_periods_reported_during_placement.any?
+    def from_induction? = claimed_by_appropriate_body.present?
 
     def from_school?
       return false if from_induction?
@@ -22,25 +22,25 @@ module ECTAtSchoolPeriods
         NullAppropriateBody.new
     end
 
-    def claimed_by_appropriate_body
-      induction_periods_reported_during_placement.first&.appropriate_body_period
-    end
-
     # The ongoing induction period that represents an AB claiming the ECT for
     # *this* school placement (i.e. started within this placement's dates).
     # Claims recorded before the school registered the ECT, or carried over from
     # a previous school, are excluded, so the school keeps seeing its reported
     # appropriate body as provisional until it's confirmed for this placement.
-    def induction_periods_reported_during_placement
-      @ect_at_school_period
-        .teacher
-        .induction_periods
-        .ongoing
-        .where(started_on: @ect_at_school_period.started_on..@ect_at_school_period.finished_on)
-        .latest_first
+    def claimed_by_appropriate_body
+      if ongoing_induction_period&.started_on.in?(@ect_at_school_period.range)
+        ongoing_induction_period.appropriate_body_period
+      else
+        NullAppropriateBody.new
+      end
+    end
+
+    def ongoing_induction_period
+      @ect_at_school_period.teacher.ongoing_induction_period
     end
 
     NullAppropriateBody = Data.define do
+      def present? = false
       def name = "Not reported"
     end
   end

--- a/app/services/ect_at_school_periods/appropriate_body.rb
+++ b/app/services/ect_at_school_periods/appropriate_body.rb
@@ -1,0 +1,47 @@
+module ECTAtSchoolPeriods
+  class AppropriateBody
+    def initialize(ect_at_school_period)
+      @ect_at_school_period = ect_at_school_period
+    end
+
+    delegate :name, to: :appropriate_body
+
+    def from_induction? = induction_periods_reported_during_placement.any?
+
+    def from_school?
+      return false if from_induction?
+
+      @ect_at_school_period.school_reported_appropriate_body.present?
+    end
+
+  private
+
+    def appropriate_body
+      claimed_by_appropriate_body.presence ||
+        @ect_at_school_period.school_reported_appropriate_body.presence ||
+        NullAppropriateBody.new
+    end
+
+    def claimed_by_appropriate_body
+      induction_periods_reported_during_placement.first&.appropriate_body_period
+    end
+
+    # The ongoing induction period that represents an AB claiming the ECT for
+    # *this* school placement (i.e. started within this placement's dates).
+    # Claims recorded before the school registered the ECT, or carried over from
+    # a previous school, are excluded, so the school keeps seeing its reported
+    # appropriate body as provisional until it's confirmed for this placement.
+    def induction_periods_reported_during_placement
+      @ect_at_school_period
+        .teacher
+        .induction_periods
+        .ongoing
+        .where(started_on: @ect_at_school_period.started_on..@ect_at_school_period.finished_on)
+        .latest_first
+    end
+
+    NullAppropriateBody = Data.define do
+      def name = "Not reported"
+    end
+  end
+end

--- a/spec/components/schools/ects/listing_card_component_spec.rb
+++ b/spec/components/schools/ects/listing_card_component_spec.rb
@@ -87,6 +87,26 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
     end
   end
 
+  context "when the ECT has been claimed by an appropriate body" do
+    let!(:induction_period) do
+      FactoryBot.create(
+        :induction_period,
+        :ongoing,
+        teacher: ect_at_school_period.teacher,
+        started_on: ect_at_school_period.started_on
+      )
+    end
+
+    it "renders the claimed by appropriate body name" do
+      render_inline(described_class.new(teacher:, ect_at_school_period:, training_period:))
+
+      expect(rendered_content).to have_selector(".govuk-summary-list__row", text: "Appropriate body")
+      expect(rendered_content).to have_text(induction_period.appropriate_body_period.name)
+      expect(rendered_content).not_to have_text(ect_at_school_period.school_reported_appropriate_body_name)
+      expect(rendered_content).not_to have_text("Not reported")
+    end
+  end
+
   context "when provider led chosen" do
     let!(:training_period) { FactoryBot.create(:training_period, :ongoing, :provider_led, ect_at_school_period:, started_on:) }
 

--- a/spec/services/ect_at_school_periods/appropriate_body_spec.rb
+++ b/spec/services/ect_at_school_periods/appropriate_body_spec.rb
@@ -1,0 +1,347 @@
+RSpec.describe ECTAtSchoolPeriods::AppropriateBody do
+  subject(:service) { described_class.new(ect_at_school_period) }
+
+  let(:ect_at_school_period) do
+    FactoryBot.create(
+      :ect_at_school_period,
+      school_reported_appropriate_body:,
+      started_on: 1.year.ago,
+      finished_on: 1.month.ago
+    )
+  end
+
+  describe "#name" do
+    subject(:name) { service.name }
+
+    context "when there is a school reported appropriate body" do
+      let(:school_reported_appropriate_body) do
+        FactoryBot.create(:appropriate_body_period)
+      end
+
+      context "and there is no induction period" do
+        let!(:induction_period) { nil }
+
+        it { is_expected.to eq(school_reported_appropriate_body.name) }
+      end
+
+      context "and there is an induction period but it is not ongoing" do
+        let!(:induction_period) do
+          FactoryBot.create(
+            :induction_period,
+            teacher: ect_at_school_period.teacher,
+            started_on: ect_at_school_period.started_on,
+            finished_on: ect_at_school_period.started_on + 3.months
+          )
+        end
+
+        it { is_expected.to eq(school_reported_appropriate_body.name) }
+      end
+
+      context "and there is an ongoing induction period but it started " \
+              "before the ECT joined the school" do
+        let!(:induction_period) do
+          FactoryBot.create(
+            :induction_period,
+            :ongoing,
+            teacher: ect_at_school_period.teacher,
+            started_on: ect_at_school_period.started_on.prev_day
+          )
+        end
+
+        it { is_expected.to eq(school_reported_appropriate_body.name) }
+      end
+
+      context "and there is an ongoing induction period but it started " \
+              "after the ECT left the school" do
+        let!(:induction_period) do
+          FactoryBot.create(
+            :induction_period,
+            :ongoing,
+            teacher: ect_at_school_period.teacher,
+            started_on: ect_at_school_period.finished_on.next_day
+          )
+        end
+
+        it { is_expected.to eq(school_reported_appropriate_body.name) }
+      end
+
+      context "and there is an ongoing induction period that started " \
+              "while the ECT was at the school" do
+        let!(:induction_period) do
+          FactoryBot.create(
+            :induction_period,
+            :ongoing,
+            teacher: ect_at_school_period.teacher,
+            started_on: ect_at_school_period.started_on
+          )
+        end
+
+        it { is_expected.to eq(induction_period.appropriate_body_period.name) }
+      end
+    end
+
+    context "when there is not a school reported appropriate body" do
+      let(:school_reported_appropriate_body) { nil }
+
+      context "and there is no induction period" do
+        let!(:induction_period) { nil }
+
+        it { is_expected.to eq("Not reported") }
+      end
+
+      context "and there is an induction period but it is not ongoing" do
+        let!(:induction_period) do
+          FactoryBot.create(
+            :induction_period,
+            teacher: ect_at_school_period.teacher,
+            started_on: ect_at_school_period.started_on,
+            finished_on: ect_at_school_period.started_on + 3.months
+          )
+        end
+
+        it { is_expected.to eq("Not reported") }
+      end
+
+      context "and there is an ongoing induction period but it started " \
+              "before the ECT joined the school" do
+        let!(:induction_period) do
+          FactoryBot.create(
+            :induction_period,
+            :ongoing,
+            teacher: ect_at_school_period.teacher,
+            started_on: ect_at_school_period.started_on.prev_day
+          )
+        end
+
+        it { is_expected.to eq("Not reported") }
+      end
+
+      context "and there is an ongoing induction period but it started " \
+              "after the ECT left the school" do
+        let!(:induction_period) do
+          FactoryBot.create(
+            :induction_period,
+            :ongoing,
+            teacher: ect_at_school_period.teacher,
+            started_on: ect_at_school_period.finished_on.next_day
+          )
+        end
+
+        it { is_expected.to eq("Not reported") }
+      end
+
+      context "and there is an ongoing induction period that started " \
+              "while the ECT was at the school" do
+        let!(:induction_period) do
+          FactoryBot.create(
+            :induction_period,
+            :ongoing,
+            teacher: ect_at_school_period.teacher,
+            started_on: ect_at_school_period.started_on
+          )
+        end
+
+        it { is_expected.to eq(induction_period.appropriate_body_period.name) }
+      end
+    end
+  end
+
+  describe "#from_induction?" do
+    let(:school_reported_appropriate_body) { nil }
+
+    context "where there is no induction period" do
+      let!(:induction_period) { nil }
+
+      it { is_expected.not_to be_from_induction }
+    end
+
+    context "where there is an induction period but it is not ongoing" do
+      let!(:induction_period) do
+        FactoryBot.create(
+          :induction_period,
+          teacher: ect_at_school_period.teacher,
+          started_on: ect_at_school_period.started_on,
+          finished_on: ect_at_school_period.started_on + 3.months
+        )
+      end
+
+      it { is_expected.not_to be_from_induction }
+    end
+
+    context "and there is an ongoing induction period but it started " \
+            "before the ECT joined the school" do
+      let!(:induction_period) do
+        FactoryBot.create(
+          :induction_period,
+          :ongoing,
+          teacher: ect_at_school_period.teacher,
+          started_on: ect_at_school_period.started_on.prev_day
+        )
+      end
+
+      it { is_expected.not_to be_from_induction }
+    end
+
+    context "and there is an ongoing induction period but it started " \
+            "after the ECT left the school" do
+      let!(:induction_period) do
+        FactoryBot.create(
+          :induction_period,
+          :ongoing,
+          teacher: ect_at_school_period.teacher,
+          started_on: ect_at_school_period.finished_on.next_day
+        )
+      end
+
+      it { is_expected.not_to be_from_induction }
+    end
+
+    context "and there is an ongoing induction period that started " \
+            "while the ECT was at the school" do
+      let!(:induction_period) do
+        FactoryBot.create(
+          :induction_period,
+          :ongoing,
+          teacher: ect_at_school_period.teacher,
+          started_on: ect_at_school_period.started_on
+        )
+      end
+
+      it { is_expected.to be_from_induction }
+    end
+  end
+
+  describe "#from_school?" do
+    context "when there is a school reported appropriate body" do
+      let(:school_reported_appropriate_body) do
+        FactoryBot.create(:appropriate_body_period)
+      end
+
+      context "and there is no induction period" do
+        let!(:induction_period) { nil }
+
+        it { is_expected.to be_from_school }
+      end
+
+      context "and there is an induction period but it is not ongoing" do
+        let!(:induction_period) do
+          FactoryBot.create(
+            :induction_period,
+            teacher: ect_at_school_period.teacher,
+            started_on: ect_at_school_period.started_on,
+            finished_on: ect_at_school_period.started_on + 3.months
+          )
+        end
+
+        it { is_expected.to be_from_school }
+      end
+
+      context "and there is an ongoing induction period but it started " \
+              "before the ECT joined the school" do
+        let!(:induction_period) do
+          FactoryBot.create(
+            :induction_period,
+            :ongoing,
+            teacher: ect_at_school_period.teacher,
+            started_on: ect_at_school_period.started_on.prev_day
+          )
+        end
+
+        it { is_expected.to be_from_school }
+      end
+
+      context "and there is an ongoing induction period but it started " \
+              "after the ECT left the school" do
+        let!(:induction_period) do
+          FactoryBot.create(
+            :induction_period,
+            :ongoing,
+            teacher: ect_at_school_period.teacher,
+            started_on: ect_at_school_period.finished_on.next_day
+          )
+        end
+
+        it { is_expected.to be_from_school }
+      end
+
+      context "and there is an ongoing induction period that started " \
+              "while the ECT was at the school" do
+        let!(:induction_period) do
+          FactoryBot.create(
+            :induction_period,
+            :ongoing,
+            teacher: ect_at_school_period.teacher,
+            started_on: ect_at_school_period.started_on
+          )
+        end
+
+        it { is_expected.not_to be_from_school }
+      end
+    end
+
+    context "when there is not a school reported appropriate body" do
+      let(:school_reported_appropriate_body) { nil }
+
+      context "and there is no induction period" do
+        let!(:induction_period) { nil }
+
+        it { is_expected.not_to be_from_school }
+      end
+
+      context "and there is an induction period but it is not ongoing" do
+        let!(:induction_period) do
+          FactoryBot.create(
+            :induction_period,
+            teacher: ect_at_school_period.teacher,
+            started_on: ect_at_school_period.started_on,
+            finished_on: ect_at_school_period.started_on + 3.months
+          )
+        end
+
+        it { is_expected.not_to be_from_school }
+      end
+
+      context "and there is an ongoing induction period but it started " \
+              "before the ECT joined the school" do
+        let!(:induction_period) do
+          FactoryBot.create(
+            :induction_period,
+            :ongoing,
+            teacher: ect_at_school_period.teacher,
+            started_on: ect_at_school_period.started_on.prev_day
+          )
+        end
+
+        it { is_expected.not_to be_from_school }
+      end
+
+      context "and there is an ongoing induction period but it started " \
+              "after the ECT left the school" do
+        let!(:induction_period) do
+          FactoryBot.create(
+            :induction_period,
+            :ongoing,
+            teacher: ect_at_school_period.teacher,
+            started_on: ect_at_school_period.finished_on.next_day
+          )
+        end
+
+        it { is_expected.not_to be_from_school }
+      end
+
+      context "and there is an ongoing induction period that started " \
+              "while the ECT was at the school" do
+        let!(:induction_period) do
+          FactoryBot.create(
+            :induction_period,
+            :ongoing,
+            teacher: ect_at_school_period.teacher,
+            started_on: ect_at_school_period.started_on
+          )
+        end
+
+        it { is_expected.not_to be_from_school }
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/4184

### Changes proposed in this pull request

In #3171 we reworked the `Schools::ECTInductionDetailsComponent` so it displayed the details of the appropriate body that claimed an ECT if it was relevant.

We didn't do this work for the `Schools::ECTs::ListingCardComponent`, though.

This extracts a small service for determining the relevant appropriate body for a given ECT, then uses that service to display the relevant name in both contexts.

### Guidance to review

- [ ] Register an ECT and choose an appropriate body
- [ ] See the school reported appropriate body name on the teachers index page
- [ ] See the school reported appropriate body name on the teachers show page
- [ ] Claim an ECT at a different appropriate body
- [ ] See the claimed by appropriate body name on the teachers index page
- [ ] See the claimed by appropriate body name on the teachers show page (✨ the fix)