### PR TITLE
[4142] Service to merge GIAS::School

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -30,6 +30,7 @@ class Event < ApplicationRecord
     school_opened
     school_closed
     school_changed
+    school_merged
     statement_adjustment_added
     statement_adjustment_deleted
     statement_adjustment_updated

--- a/app/models/gias/school.rb
+++ b/app/models/gias/school.rb
@@ -92,7 +92,18 @@ class GIAS::School < ApplicationRecord
       successor.open_status? &&
       successor.opened_on_or_before_today? &&
       successor.school_not_yet_opened? &&
-      school_replaced?
+      school_being_replaced?
+  end
+
+  def can_be_merged?
+    closed_status? &&
+      closed_on_or_before_today? &&
+      !school_merger_recorded? &&
+      successors.one? &&
+      successor.open_status? &&
+      successor.opened_on_or_before_today? &&
+      successor.school.present? &&
+      school_being_merged?
   end
 
   def school_not_yet_opened?
@@ -117,7 +128,15 @@ private
     Event.where(school:, event_type: :school_closed).exists?
   end
 
-  def school_replaced?
+  def school_merger_recorded?
+    Event.where(school:, event_type: :school_merged).exists?
+  end
+
+  def school_being_replaced?
     successor_links.where(link_type: GIAS::SchoolLink::SUCESSOR).exists?
+  end
+
+  def school_being_merged?
+    successor_links.where(link_type: GIAS::SchoolLink::SUCCESSOR_MERGED).exists?
   end
 end

--- a/app/models/gias/school.rb
+++ b/app/models/gias/school.rb
@@ -98,7 +98,7 @@ class GIAS::School < ApplicationRecord
   def can_be_merged?
     closed_status? &&
       closed_on_or_before_today? &&
-      !school_merger_recorded? &&
+      no_school_merged_event_recorded? &&
       successors.one? &&
       successor.open_status? &&
       successor.opened_on_or_before_today? &&
@@ -128,8 +128,8 @@ private
     Event.where(school:, event_type: :school_closed).exists?
   end
 
-  def school_merger_recorded?
-    Event.where(school:, event_type: :school_merged).exists?
+  def no_school_merged_event_recorded?
+    Event.where(school:, event_type: :school_merged).none?
   end
 
   def school_being_replaced?

--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -1398,6 +1398,23 @@ module Events
       new(event_type:, author:, heading:, school:, happened_at:, metadata:).record_event!
     end
 
+    def self.record_school_merged_event!(author:, school:, predecessor_gias_school:, successor_gias_school:, happened_at: Time.zone.now)
+      event_type = :school_merged
+
+      predecessor_gias_school_name = Schools::Name.new(predecessor_gias_school.school).name_and_urn
+      successor_gias_school_name = Schools::Name.new(successor_gias_school.school).name_and_urn
+
+      heading = "#{predecessor_gias_school_name} was merged into #{successor_gias_school_name} in GIAS"
+      metadata = {
+        predecessor_gias_school_urn: predecessor_gias_school.urn,
+        predecessor_gias_school_name: predecessor_gias_school.name,
+        successor_gias_school_urn: successor_gias_school.urn,
+        successor_gias_school_name: successor_gias_school.name,
+      }
+
+      new(event_type:, author:, heading:, school:, happened_at:, metadata:).record_event!
+    end
+
     ## band events
 
     def self.record_active_lead_provider_band_added_event!(author:, band:)

--- a/app/services/gias/schools/close.rb
+++ b/app/services/gias/schools/close.rb
@@ -1,7 +1,5 @@
 module GIAS::Schools
   class Close
-    attr_reader :gias_school
-
     def initialize(gias_school)
       @gias_school = gias_school
     end
@@ -15,6 +13,8 @@ module GIAS::Schools
     end
 
   private
+
+    attr_reader :gias_school
 
     def close_school!
       ActiveRecord::Base.transaction do
@@ -81,14 +81,12 @@ module GIAS::Schools
       )
     end
 
-    def author
-      Events::SystemAuthor.new
-    end
-
     def reported_by_school_id = school.id
 
     delegate :school, to: :gias_school
     delegate :closed_on, to: :gias_school
     delegate :ect_at_school_periods, :mentor_at_school_periods, to: :school
+
+    def author = Events::SystemAuthor.new
   end
 end

--- a/app/services/gias/schools/ect_at_school_periods/transfer.rb
+++ b/app/services/gias/schools/ect_at_school_periods/transfer.rb
@@ -1,73 +1,73 @@
-module GIAS
-  module Schools
-    module ECTAtSchoolPeriods
-      class Transfer
-        def self.call(...) = new(...).call
+module GIAS::Schools
+  module ECTAtSchoolPeriods
+    class Transfer
+      def self.call(...) = new(...).call
 
-        def initialize(ect_at_school_period:, predecessor_school:, successor_school:)
-          @ect_at_school_period = ect_at_school_period
-          @successor_school = successor_school
-          @predecessor_school = predecessor_school
-        end
-
-        def call
-          return unless predecessor_school == ect_at_school_period.school
-
-          ActiveRecord::Base.transaction do
-            update_ect_at_school_period!
-            update_training_periods!
-            update_events!
-
-            record_event!
-          end
-        end
-
-      private
-
-        attr_reader :ect_at_school_period, :predecessor_school, :successor_school
-
-        def update_ect_at_school_period!
-          ect_at_school_period.update!(school: successor_school)
-        end
-
-        def update_training_periods!
-          training_periods.where.associated(:school_partnership).each do |training_period|
-            new_partnership = successor_partnership(training_period.school_partnership)
-            training_period.update!(school_partnership: new_partnership)
-          end
-        end
-
-        def update_events!
-          events.where.associated(:school_partnership).each do |event|
-            new_partnership = successor_partnership(event.school_partnership)
-            event.update!(school_partnership: new_partnership)
-          end
-
-          events.where.associated(:school).each do |event|
-            event.update!(school: successor_school)
-          end
-        end
-
-        def successor_partnership(predecessor_school_partnership)
-          GIAS::Schools::SchoolPartnerships::Transfer.call(predecessor_school_partnership:, successor_school:)
-        end
-
-        def record_event!
-          Events::Record.record_teacher_ect_at_school_period_moved_school!(
-            teacher:,
-            ect_at_school_period:,
-            old_school_name_and_urn:,
-            new_school: successor_school,
-            happened_at: predecessor_gias_school.closed_on,
-            author: Events::SystemAuthor.new
-          )
-        end
-
-        def predecessor_gias_school = predecessor_school.gias_school
-        def old_school_name_and_urn = ::Schools::Name.new(predecessor_school).name_and_urn
-
-        delegate :mentorship_periods, :training_periods, :events, :teacher, to: :ect_at_school_period
+      def initialize(ect_at_school_period:, predecessor_school:, successor_school:)
+        @ect_at_school_period = ect_at_school_period
+        @successor_school = successor_school
+        @predecessor_school = predecessor_school
       end
+
+      def call
+        return unless predecessor_school == ect_at_school_period.school
+
+        ActiveRecord::Base.transaction do
+          update_ect_at_school_period!
+          update_training_periods!
+          update_events!
+
+          record_event!
+        end
+      end
+
+    private
+
+      attr_reader :ect_at_school_period, :predecessor_school, :successor_school
+
+      def update_ect_at_school_period!
+        ect_at_school_period.update!(school: successor_school)
+      end
+
+      def update_training_periods!
+        training_periods.where.associated(:school_partnership).each do |training_period|
+          new_partnership = successor_partnership(training_period.school_partnership)
+          training_period.update!(school_partnership: new_partnership)
+        end
+      end
+
+      def update_events!
+        events.where.associated(:school_partnership).each do |event|
+          new_partnership = successor_partnership(event.school_partnership)
+          event.update!(school_partnership: new_partnership)
+        end
+
+        events.where.associated(:school).each do |event|
+          event.update!(school: successor_school)
+        end
+      end
+
+      def successor_partnership(predecessor_school_partnership)
+        GIAS::Schools::SchoolPartnerships::Transfer.call(predecessor_school_partnership:, successor_school:)
+      end
+
+      def record_event!
+        Events::Record.record_teacher_ect_at_school_period_moved_school!(
+          teacher:,
+          ect_at_school_period:,
+          old_school_name_and_urn:,
+          new_school: successor_school,
+          happened_at: predecessor_gias_school.closed_on,
+          author:
+        )
+      end
+
+      def predecessor_gias_school = predecessor_school.gias_school
+      def old_school_name_and_urn = ::Schools::Name.new(predecessor_school).name_and_urn
+
+      delegate :mentorship_periods, :training_periods, :events, :teacher, to: :ect_at_school_period
+
+      def author = Events::SystemAuthor.new
     end
   end
 end

--- a/app/services/gias/schools/mentor_at_school_periods/merge.rb
+++ b/app/services/gias/schools/mentor_at_school_periods/merge.rb
@@ -1,119 +1,119 @@
-module GIAS
-  module Schools
-    module MentorAtSchoolPeriods
-      class Merge
-        attr_reader :periods, :predecessor_school, :successor_school
+module GIAS::Schools
+  module MentorAtSchoolPeriods
+    class Merge
+      def self.call(...) = new(...).call
 
-        def initialize(periods:, predecessor_school:, successor_school:)
-          @periods = periods
-          @predecessor_school = predecessor_school
-          @successor_school = successor_school
-        end
+      def initialize(periods:, predecessor_school:, successor_school:)
+        @periods = periods
+        @predecessor_school = predecessor_school
+        @successor_school = successor_school
+      end
 
-        def self.call(**args) = new(**args).call
+      def call
+        ActiveRecord::Base.transaction do
+          successor_period.assign_attributes(started_on:, finished_on:)
 
-        def call
-          ActiveRecord::Base.transaction do
-            successor_period.assign_attributes(started_on:, finished_on:)
+          update_mentorship_periods!
+          update_training_periods!
+          update_events!
 
-            update_mentorship_periods!
-            update_training_periods!
-            update_events!
-
-            redundant_periods.each do |period|
-              period.training_periods.reset
-              period.mentorship_periods.reset
-              period.events.reset
-              period.destroy!
-            end
-
-            successor_period.save!
-
-            record_event!
+          redundant_periods.each do |period|
+            period.training_periods.reset
+            period.mentorship_periods.reset
+            period.events.reset
+            period.destroy!
           end
-        end
 
-      private
+          successor_period.save!
 
-        def successor_period
-          @successor_period ||= periods
-            .select { |period| period.school == successor_school }
-            .max_by(&:started_on)
-        end
-
-        def redundant_periods
-          @redundant_periods ||= periods.excluding(successor_period)
-        end
-
-        def training_periods
-          @training_periods ||= redundant_periods.flat_map(&:training_periods).uniq
-        end
-
-        def mentorship_periods
-          @mentorship_periods ||= redundant_periods.flat_map(&:mentorship_periods).uniq
-        end
-
-        def events
-          @events ||= redundant_periods.flat_map(&:events).uniq
-        end
-
-        def update_training_periods!
-          training_periods.each do |training_period|
-            if training_period.school_partnership.present?
-              training_period.school_partnership = successor_partnership(training_period.school_partnership)
-            end
-            training_period.mentor_at_school_period = successor_period
-            training_period.save!
-          end
-        end
-
-        def update_mentorship_periods!
-          mentorship_periods.each do |mentorship_period|
-            GIAS::Schools::ECTAtSchoolPeriods::Transfer.call(ect_at_school_period: mentorship_period.mentee, predecessor_school:, successor_school:)
-            mentorship_period.mentor = successor_period
-            mentorship_period.save!
-          end
-        end
-
-        def update_events!
-          events.each do |event|
-            if event.school_partnership.present?
-              event.school_partnership = successor_partnership(event.school_partnership)
-            end
-            event.school = successor_school if event.school.present?
-            event.mentor_at_school_period = successor_period
-            event.save!
-          end
-        end
-
-        def successor_partnership(predecessor_school_partnership)
-          GIAS::Schools::SchoolPartnerships::Transfer.call(predecessor_school_partnership:, successor_school:)
-        end
-
-        def finished_on
-          @finished_on ||= calculate_finished_on
-        end
-
-        def calculate_finished_on
-          return nil if periods.any?(&:ongoing?)
-
-          periods.map(&:finished_on).compact.max
-        end
-
-        def started_on
-          @started_on ||= periods.map(&:started_on).min
-        end
-
-        def record_event!
-          Events::Record.record_teacher_mentor_at_school_periods_merged!(
-            author: Events::SystemAuthor.new,
-            teacher: successor_period.teacher,
-            successor_period:,
-            mentor_at_school_periods: periods,
-            happened_at: predecessor_school.gias_school.closed_on
-          )
+          record_event!
         end
       end
+
+    private
+
+      attr_reader :periods, :predecessor_school, :successor_school
+
+      def successor_period
+        @successor_period ||= periods
+          .select { |period| period.school == successor_school }
+          .max_by(&:started_on)
+      end
+
+      def redundant_periods
+        @redundant_periods ||= periods.excluding(successor_period)
+      end
+
+      def training_periods
+        @training_periods ||= redundant_periods.flat_map(&:training_periods).uniq
+      end
+
+      def mentorship_periods
+        @mentorship_periods ||= redundant_periods.flat_map(&:mentorship_periods).uniq
+      end
+
+      def events
+        @events ||= redundant_periods.flat_map(&:events).uniq
+      end
+
+      def update_training_periods!
+        training_periods.each do |training_period|
+          if training_period.school_partnership.present?
+            training_period.school_partnership = successor_partnership(training_period.school_partnership)
+          end
+          training_period.mentor_at_school_period = successor_period
+          training_period.save!
+        end
+      end
+
+      def update_mentorship_periods!
+        mentorship_periods.each do |mentorship_period|
+          GIAS::Schools::ECTAtSchoolPeriods::Transfer.call(ect_at_school_period: mentorship_period.mentee, predecessor_school:, successor_school:)
+          mentorship_period.mentor = successor_period
+          mentorship_period.save!
+        end
+      end
+
+      def update_events!
+        events.each do |event|
+          if event.school_partnership.present?
+            event.school_partnership = successor_partnership(event.school_partnership)
+          end
+          event.school = successor_school if event.school.present?
+          event.mentor_at_school_period = successor_period
+          event.save!
+        end
+      end
+
+      def successor_partnership(predecessor_school_partnership)
+        GIAS::Schools::SchoolPartnerships::Transfer.call(predecessor_school_partnership:, successor_school:)
+      end
+
+      def finished_on
+        @finished_on ||= calculate_finished_on
+      end
+
+      def calculate_finished_on
+        return nil if periods.any?(&:ongoing?)
+
+        periods.map(&:finished_on).compact.max
+      end
+
+      def started_on
+        @started_on ||= periods.map(&:started_on).min
+      end
+
+      def record_event!
+        Events::Record.record_teacher_mentor_at_school_periods_merged!(
+          teacher: successor_period.teacher,
+          successor_period:,
+          mentor_at_school_periods: periods,
+          happened_at: predecessor_school.gias_school.closed_on,
+          author:
+        )
+      end
+
+      def author = Events::SystemAuthor.new
     end
   end
 end

--- a/app/services/gias/schools/mentor_at_school_periods/overlapping.rb
+++ b/app/services/gias/schools/mentor_at_school_periods/overlapping.rb
@@ -1,57 +1,55 @@
-module GIAS
-  module Schools
-    module MentorAtSchoolPeriods
-      class Overlapping
-        attr_reader :teacher, :schools, :groups
+module GIAS::Schools
+  module MentorAtSchoolPeriods
+    class Overlapping
+      def self.find(...) = new(...).find
 
-        def initialize(teacher:, schools:)
-          @teacher = teacher
-          @schools = Array(schools).compact.uniq
-          @groups = []
-        end
+      def initialize(teacher:, schools:)
+        @teacher = teacher
+        @schools = Array(schools).compact.uniq
+        @groups = []
+      end
 
-        def self.find(...) = new(...).find
+      def find
+        return [] if only_one_school?
 
-        def find
-          return [] if only_one_school?
+        group_mentor_at_school_periods
 
-          group_mentor_at_school_periods
+        groups.select(&:many?)
+      end
 
-          groups.select(&:many?)
-        end
+    private
 
-      private
+      attr_reader :teacher, :schools, :groups
 
-        def ordered_mentor_at_school_periods
-          @ordered_mentor_at_school_periods ||= teacher
-            .mentor_at_school_periods
-            .where(school: schools)
-            .order(:started_on)
-        end
+      def ordered_mentor_at_school_periods
+        @ordered_mentor_at_school_periods ||= teacher
+          .mentor_at_school_periods
+          .where(school: schools)
+          .order(:started_on)
+      end
 
-        def only_one_school?
-          schools.uniq.one? || ordered_mentor_at_school_periods.map(&:school_id).uniq.one?
-        end
+      def only_one_school?
+        schools.uniq.one? || ordered_mentor_at_school_periods.map(&:school_id).uniq.one?
+      end
 
-        def group_mentor_at_school_periods
-          ordered_mentor_at_school_periods.each do |period|
-            if start_new_group?(groups.last, period)
-              groups << [period]
-            else
-              groups.last << period
-            end
+      def group_mentor_at_school_periods
+        ordered_mentor_at_school_periods.each do |period|
+          if start_new_group?(groups.last, period)
+            groups << [period]
+          else
+            groups.last << period
           end
         end
+      end
 
-        def start_new_group?(current_group, next_period)
-          current_group.nil? || gap_between?(current_group, next_period)
-        end
+      def start_new_group?(current_group, next_period)
+        current_group.nil? || gap_between?(current_group, next_period)
+      end
 
-        def gap_between?(group, period)
-          return false if group.any?(&:ongoing?)
+      def gap_between?(group, period)
+        return false if group.any?(&:ongoing?)
 
-          group.map(&:finished_on).max < period.started_on
-        end
+        group.map(&:finished_on).max < period.started_on
       end
     end
   end

--- a/app/services/gias/schools/mentor_at_school_periods/transfer.rb
+++ b/app/services/gias/schools/mentor_at_school_periods/transfer.rb
@@ -1,80 +1,80 @@
-module GIAS
-  module Schools
-    module MentorAtSchoolPeriods
-      class Transfer
-        def self.call(...) = new(...).call
+module GIAS::Schools
+  module MentorAtSchoolPeriods
+    class Transfer
+      def self.call(...) = new(...).call
 
-        def initialize(mentor_at_school_period:, predecessor_school:, successor_school:)
-          @mentor_at_school_period = mentor_at_school_period
-          @successor_school = successor_school
-          @predecessor_school = predecessor_school
-        end
-
-        def call
-          return unless predecessor_school == mentor_at_school_period.school
-
-          ActiveRecord::Base.transaction do
-            update_mentor_at_school_period!
-            update_training_periods!
-            update_events!
-            update_mentorship_periods!
-
-            record_event!
-          end
-        end
-
-      private
-
-        attr_reader :mentor_at_school_period, :predecessor_school, :successor_school
-
-        def update_mentor_at_school_period!
-          mentor_at_school_period.update!(school: successor_school)
-        end
-
-        def update_training_periods!
-          training_periods.where.associated(:school_partnership).each do |training_period|
-            new_partnership = successor_partnership(training_period.school_partnership)
-            training_period.update!(school_partnership: new_partnership)
-          end
-        end
-
-        def update_events!
-          events.where.associated(:school_partnership).each do |event|
-            new_partnership = successor_partnership(event.school_partnership)
-            event.update!(school_partnership: new_partnership)
-          end
-
-          events.where.associated(:school).each do |event|
-            event.update!(school: successor_school)
-          end
-        end
-
-        def update_mentorship_periods!
-          mentorship_periods.each do |mentorship_period|
-            GIAS::Schools::ECTAtSchoolPeriods::Transfer.call(ect_at_school_period: mentorship_period.mentee, predecessor_school:, successor_school:)
-          end
-        end
-
-        def successor_partnership(predecessor_school_partnership)
-          GIAS::Schools::SchoolPartnerships::Transfer.call(predecessor_school_partnership:, successor_school:)
-        end
-
-        def record_event!
-          Events::Record.record_teacher_mentor_at_school_period_moved_school!(
-            teacher:,
-            mentor_at_school_period:,
-            old_school_name_and_urn:,
-            new_school: successor_school,
-            happened_at: predecessor_gias_school.closed_on,
-            author: Events::SystemAuthor.new
-          )
-        end
-
-        def predecessor_gias_school = predecessor_school.gias_school
-        def old_school_name_and_urn = ::Schools::Name.new(predecessor_school).name_and_urn
-
-        delegate :mentorship_periods, :training_periods, :events, :teacher, to: :mentor_at_school_period
+      def initialize(mentor_at_school_period:, predecessor_school:, successor_school:)
+        @mentor_at_school_period = mentor_at_school_period
+        @successor_school = successor_school
+        @predecessor_school = predecessor_school
       end
+
+      def call
+        return unless predecessor_school == mentor_at_school_period.school
+
+        ActiveRecord::Base.transaction do
+          update_mentor_at_school_period!
+          update_training_periods!
+          update_events!
+          update_mentorship_periods!
+
+          record_event!
+        end
+      end
+
+    private
+
+      attr_reader :mentor_at_school_period, :predecessor_school, :successor_school
+
+      def update_mentor_at_school_period!
+        mentor_at_school_period.update!(school: successor_school)
+      end
+
+      def update_training_periods!
+        training_periods.where.associated(:school_partnership).each do |training_period|
+          new_partnership = successor_partnership(training_period.school_partnership)
+          training_period.update!(school_partnership: new_partnership)
+        end
+      end
+
+      def update_events!
+        events.where.associated(:school_partnership).each do |event|
+          new_partnership = successor_partnership(event.school_partnership)
+          event.update!(school_partnership: new_partnership)
+        end
+
+        events.where.associated(:school).each do |event|
+          event.update!(school: successor_school)
+        end
+      end
+
+      def update_mentorship_periods!
+        mentorship_periods.each do |mentorship_period|
+          GIAS::Schools::ECTAtSchoolPeriods::Transfer.call(ect_at_school_period: mentorship_period.mentee, predecessor_school:, successor_school:)
+        end
+      end
+
+      def successor_partnership(predecessor_school_partnership)
+        GIAS::Schools::SchoolPartnerships::Transfer.call(predecessor_school_partnership:, successor_school:)
+      end
+
+      def record_event!
+        Events::Record.record_teacher_mentor_at_school_period_moved_school!(
+          teacher:,
+          mentor_at_school_period:,
+          old_school_name_and_urn:,
+          new_school: successor_school,
+          happened_at: predecessor_gias_school.closed_on,
+          author:
+        )
+      end
+
+      def predecessor_gias_school = predecessor_school.gias_school
+      def old_school_name_and_urn = ::Schools::Name.new(predecessor_school).name_and_urn
+
+      delegate :mentorship_periods, :training_periods, :events, :teacher, to: :mentor_at_school_period
+
+      def author = Events::SystemAuthor.new
     end
   end
 end

--- a/app/services/gias/schools/merge.rb
+++ b/app/services/gias/schools/merge.rb
@@ -1,0 +1,71 @@
+module GIAS::Schools
+  class Merge
+    attr_reader :gias_school
+
+    def initialize(gias_school)
+      @gias_school = gias_school
+    end
+
+    def merge!
+      return false unless gias_school.can_be_merged?
+
+      merge_school!
+
+      true
+    end
+
+  private
+
+    def merge_school!
+      ActiveRecord::Base.transaction do
+        mentor_teachers.each do |teacher|
+          overlapping_mentor_at_school_periods(teacher).each do |periods|
+            GIAS::Schools::MentorAtSchoolPeriods::Merge.call(periods:, predecessor_school:, successor_school:)
+          end
+        end
+
+        remaining_mentor_periods = school.mentor_at_school_periods.reload
+
+        remaining_mentor_periods.each do |mentor_at_school_period|
+          GIAS::Schools::MentorAtSchoolPeriods::Transfer.call(mentor_at_school_period:, predecessor_school:, successor_school:)
+        end
+
+        remaining_ect_periods = school.ect_at_school_periods.reload
+
+        remaining_ect_periods.each do |ect_at_school_period|
+          GIAS::Schools::ECTAtSchoolPeriods::Transfer.call(ect_at_school_period:, predecessor_school:, successor_school:)
+        end
+
+        record_school_merged_event!
+      end
+    end
+
+    def overlapping_mentor_at_school_periods(teacher)
+      GIAS::Schools::MentorAtSchoolPeriods::Overlapping.find(teacher:, schools:)
+    end
+
+    def record_school_merged_event!
+      Events::Record.record_school_merged_event!(
+        school: successor_school,
+        successor_gias_school: successor,
+        predecessor_gias_school: gias_school,
+        happened_at: closed_on,
+        author:
+      )
+    end
+
+    def author
+      Events::SystemAuthor.new
+    end
+
+    def schools = [school, successor_school]
+    def predecessor_school = school
+
+    def successor_school
+      @successor_school ||= successor.school
+    end
+
+    delegate :school, :closed_on, :successor, to: :gias_school
+    delegate :mentor_teachers, to: :school, prefix: false
+  end
+end

--- a/app/services/gias/schools/merge.rb
+++ b/app/services/gias/schools/merge.rb
@@ -1,7 +1,5 @@
 module GIAS::Schools
   class Merge
-    attr_reader :gias_school
-
     def initialize(gias_school)
       @gias_school = gias_school
     end
@@ -15,6 +13,8 @@ module GIAS::Schools
     end
 
   private
+
+    attr_reader :gias_school
 
     def merge_school!
       ActiveRecord::Base.transaction do
@@ -41,7 +41,10 @@ module GIAS::Schools
     end
 
     def overlapping_mentor_at_school_periods(teacher)
-      GIAS::Schools::MentorAtSchoolPeriods::Overlapping.find(teacher:, schools:)
+      GIAS::Schools::MentorAtSchoolPeriods::Overlapping.find(
+        teacher:,
+        schools: [predecessor_school, successor_school]
+      )
     end
 
     def record_school_merged_event!
@@ -54,18 +57,12 @@ module GIAS::Schools
       )
     end
 
-    def author
-      Events::SystemAuthor.new
-    end
-
-    def schools = [school, successor_school]
     def predecessor_school = school
-
-    def successor_school
-      @successor_school ||= successor.school
-    end
+    def successor_school = @successor_school ||= successor.school
 
     delegate :school, :closed_on, :successor, to: :gias_school
     delegate :mentor_teachers, to: :school, prefix: false
+
+    def author = Events::SystemAuthor.new
   end
 end

--- a/app/services/gias/schools/merge.rb
+++ b/app/services/gias/schools/merge.rb
@@ -24,13 +24,13 @@ module GIAS::Schools
           end
         end
 
-        remaining_mentor_periods = school.mentor_at_school_periods.reload
+        remaining_mentor_periods = predecessor_school.mentor_at_school_periods.reload
 
         remaining_mentor_periods.each do |mentor_at_school_period|
           GIAS::Schools::MentorAtSchoolPeriods::Transfer.call(mentor_at_school_period:, predecessor_school:, successor_school:)
         end
 
-        remaining_ect_periods = school.ect_at_school_periods.reload
+        remaining_ect_periods = predecessor_school.ect_at_school_periods.reload
 
         remaining_ect_periods.each do |ect_at_school_period|
           GIAS::Schools::ECTAtSchoolPeriods::Transfer.call(ect_at_school_period:, predecessor_school:, successor_school:)
@@ -49,7 +49,7 @@ module GIAS::Schools
 
     def record_school_merged_event!
       Events::Record.record_school_merged_event!(
-        school: successor_school,
+        school: predecessor_school,
         successor_gias_school: successor,
         predecessor_gias_school: gias_school,
         happened_at: closed_on,

--- a/app/services/gias/schools/open.rb
+++ b/app/services/gias/schools/open.rb
@@ -1,41 +1,37 @@
-module GIAS
-  module Schools
-    class Open
-      attr_reader :gias_school
+module GIAS::Schools
+  class Open
+    def initialize(gias_school)
+      @gias_school = gias_school
+    end
 
-      def initialize(gias_school)
-        @gias_school = gias_school
-      end
+    def open!
+      return false unless gias_school.can_be_opened?
 
-      def open!
-        return false unless gias_school.can_be_opened?
+      open_school!
 
-        open_school!
+      true
+    end
 
-        true
-      end
+  private
 
-    private
+    attr_reader :gias_school
 
-      def open_school!
-        ActiveRecord::Base.transaction do
-          gias_school.create_school!
-          record_school_opened_event!
-        end
-      end
-
-      def record_school_opened_event!
-        Events::Record.record_school_opened_event!(
-          school: gias_school.school,
-          gias_school:,
-          happened_at: gias_school.opened_on,
-          author:
-        )
-      end
-
-      def author
-        Events::SystemAuthor.new
+    def open_school!
+      ActiveRecord::Base.transaction do
+        gias_school.create_school!
+        record_school_opened_event!
       end
     end
+
+    def record_school_opened_event!
+      Events::Record.record_school_opened_event!(
+        school: gias_school.school,
+        gias_school:,
+        happened_at: gias_school.opened_on,
+        author:
+      )
+    end
+
+    def author = Events::SystemAuthor.new
   end
 end

--- a/app/services/gias/schools/replace.rb
+++ b/app/services/gias/schools/replace.rb
@@ -1,7 +1,5 @@
 module GIAS::Schools
   class Replace
-    attr_reader :gias_school
-
     def initialize(gias_school)
       @gias_school = gias_school
     end
@@ -15,6 +13,8 @@ module GIAS::Schools
     end
 
   private
+
+    attr_reader :gias_school
 
     def replace_school!
       ActiveRecord::Base.transaction do
@@ -70,13 +70,11 @@ module GIAS::Schools
       )
     end
 
-    def author
-      Events::SystemAuthor.new
-    end
-
     def new_school = successor.school
 
     delegate :successor, to: :gias_school
     delegate :school, to: :gias_school
+
+    def author = Events::SystemAuthor.new
   end
 end

--- a/app/services/gias/schools/school_partnerships/transfer.rb
+++ b/app/services/gias/schools/school_partnerships/transfer.rb
@@ -3,9 +3,8 @@ module GIAS::Schools
     class Transfer
       def self.call(...) = new(...).call
 
-      def initialize(predecessor_school_partnership:, successor_school:, author: Events::SystemAuthor.new)
+      def initialize(predecessor_school_partnership:, successor_school:)
         @successor_school = successor_school
-        @author = author
         @predecessor_school_partnership = predecessor_school_partnership
       end
 
@@ -17,7 +16,7 @@ module GIAS::Schools
 
     private
 
-      attr_reader :predecessor_school_partnership, :successor_school, :author
+      attr_reader :predecessor_school_partnership, :successor_school
 
       def reassignment_required?
         return false if successor_school.blank?
@@ -35,9 +34,9 @@ module GIAS::Schools
 
           if successor_school_partnership.previously_new_record?
             Events::Record.record_school_partnership_recreated_event!(
-              author:,
               old_school_partnership: predecessor_school_partnership,
-              new_school_partnership: successor_school_partnership
+              new_school_partnership: successor_school_partnership,
+              author:
             )
           end
 
@@ -48,6 +47,8 @@ module GIAS::Schools
       def predecessor_school = predecessor_school_partnership.school
 
       delegate :lead_provider_delivery_partnership, to: :predecessor_school_partnership
+
+      def author = Events::SystemAuthor.new
     end
   end
 end

--- a/db/seeds/gias_data.rb
+++ b/db/seeds/gias_data.rb
@@ -14,14 +14,171 @@ end
 
 def teacher(...) = TeacherHistories::TeacherBuilder.teacher(...)
 
-def populate_school(gias_school, counter = 0)
+SCENARIOS = [
+  {
+    name: "Overlap",
+    periods: [
+      {
+        school: :predecessor,
+        started_on: "2026-01-01",
+        finished_on: "2026-03-31"
+      },
+      {
+        school: :successor,
+        started_on: "2026-03-01",
+        finished_on: "2026-06-30"
+      }
+    ]
+  },
+  {
+    name: "Adjacent",
+    periods: [
+      {
+        school: :predecessor,
+        started_on: "2026-01-01",
+        finished_on: "2026-03-31"
+      },
+      {
+        school: :successor,
+        started_on: "2026-04-01",
+        finished_on: "2026-06-30"
+      }
+    ]
+  },
+  {
+    name: "Gap",
+    periods: [
+      {
+        school: :predecessor,
+        started_on: "2026-01-01",
+        finished_on: "2026-03-31"
+      },
+      {
+        school: :successor,
+        started_on: "2026-04-02",
+        finished_on: "2026-06-30"
+      }
+    ]
+  },
+  {
+    name: "Transitive",
+    periods: [
+      {
+        school: :predecessor,
+        started_on: "2026-01-01",
+        finished_on: "2026-03-31"
+      },
+      {
+        school: :successor,
+        started_on: "2026-03-01",
+        finished_on: "2026-11-30"
+      },
+      {
+        school: :predecessor,
+        started_on: "2026-11-01",
+        finished_on: "2026-12-31"
+      }
+    ]
+  },
+  {
+    name: "Separate",
+    periods: [
+      {
+        school: :predecessor,
+        started_on: "2026-01-01",
+        finished_on: "2026-03-31"
+      },
+      {
+        school: :successor,
+        started_on: "2026-03-01",
+        finished_on: "2026-11-30"
+      },
+      {
+        school: :predecessor,
+        started_on: "2026-12-15",
+        finished_on: "2026-12-31"
+      }
+    ]
+  },
+  {
+    name: "TwoSeparate",
+    periods: [
+      {
+        school: :predecessor,
+        started_on: "2026-01-01",
+        finished_on: "2026-03-31"
+      },
+      {
+        school: :successor,
+        started_on: "2026-03-15",
+        finished_on: "2026-06-30"
+      },
+      {
+        school: :predecessor,
+        started_on: "2026-07-15",
+        finished_on: "2026-09-30"
+      },
+      {
+        school: :successor,
+        started_on: "2026-09-01",
+        finished_on: "2026-12-31"
+      }
+    ]
+  },
+  {
+    name: "Ongoing",
+    periods: [
+      {
+        school: :predecessor,
+        started_on: "2026-01-01",
+        finished_on: nil
+      },
+      {
+        school: :successor,
+        started_on: "2026-04-01",
+        finished_on: "2026-06-30"
+      }
+    ]
+  },
+  {
+    name: "Predecessor",
+    periods: [
+      {
+        school: :predecessor,
+        started_on: "2026-01-01",
+        finished_on: "2026-03-31"
+      },
+      {
+        school: :predecessor,
+        started_on: "2026-04-02",
+        finished_on: "2026-06-30"
+      }
+    ]
+  },
+  {
+    name: "Successor",
+    periods: [
+      {
+        school: :successor,
+        started_on: "2026-01-01",
+        finished_on: "2026-03-31"
+      },
+      {
+        school: :successor,
+        started_on: "2026-04-01",
+        finished_on: "2026-06-30"
+      }
+    ]
+  }
+].freeze
+
+def populate_school(gias_school, lead_provider, counter = 0)
   school = gias_school.school
   closed_on = gias_school.closed_on || Date.current
 
   rp2025 = ContractPeriod.find_by!(year: 2025)
   rp2026 = ContractPeriod.find_by!(year: 2026)
 
-  lead_provider = LeadProvider.find_by!(name: "Ambition Institute")
   delivery_partner = DeliveryPartner.find_by!(name: "Artisan Education Group")
 
   [rp2025, rp2026].each do |contract_period|
@@ -64,6 +221,65 @@ def populate_school(gias_school, counter = 0)
   counter
 end
 
+def overlap_scenarios(predecessor_school:, successor_school:, lead_provider:, counter:)
+  schools = {
+    predecessor: predecessor_school.school,
+    successor: successor_school.school
+  }
+
+  SCENARIOS.each do |scenario|
+    print_seed_info("🧪 #{Colourize.text(scenario[:name], :blue)}", indent: 2)
+
+    counter += 1
+    mentor_trn = 9_000_000 + counter
+    mentees_to_create = []
+    mentor_teacher = teacher(mentor_trn, "#{scenario[:name]} Mentor") do
+      scenario[:periods].each_with_index do |period, index|
+        school_key = period[:school]
+        school = schools[school_key]
+        started_on = period[:started_on]
+        finished_on = period[:finished_on]
+        date_range = finished_on.present? ? "#{started_on}->#{finished_on}" : started_on
+        valid_period_for_mentor_training = index.zero? && (school_key == :predecessor)
+
+        mentor_at_school_period(school, date_range) do
+          if valid_period_for_mentor_training
+            training_period(lead_provider, 2025, date_range)
+          end
+        end
+
+        next unless school_key == :predecessor
+
+        counter += 1
+        mentee = { trn: 9_000_000 + counter, name: "#{scenario[:name]}#{index} Mentee", school:, started_on:, date_range: }
+        mentees_to_create << mentee
+      end
+    end
+
+    mentees_to_create.each do |attributes|
+      mentee_teacher = teacher(attributes[:trn], attributes[:name]) do
+        ect_at_school_period(attributes[:school], attributes[:date_range]) do
+          training_period(lead_provider, 2025, attributes[:date_range])
+        end
+      end
+
+      mentee = mentee_teacher.ect_at_school_periods.find_by!(
+        school: attributes[:school],
+        started_on: attributes[:started_on]
+      )
+
+      mentor = mentor_teacher.mentor_at_school_periods.find_by!(
+        school: attributes[:school],
+        started_on: attributes[:started_on]
+      )
+
+      create_mentorship(mentee:, mentor:, finished_on: attributes[:finished_on])
+    end
+  end
+
+  counter
+end
+
 def create_mentorship(mentee:, mentor:, finished_on:)
   started_on = [mentee.started_on, mentor.started_on].max
 
@@ -78,15 +294,18 @@ print_seed_info("\n🌱 GIAS Updates:")
 
 print_seed_info("\n🐉 Creating Test Schools:")
 
+ambition = LeadProvider.find_by!(name: "Ambition Institute")
+teach_first = LeadProvider.find_by!(name: "Teach First")
+
 monsters_college = FactoryBot.create(:gias_school, :with_school, :closed, closed_on: Date.new(2026, 4, 30), urn: 9_123_500, name: "Monsters College").tap do |school|
   describe_school(school)
 end
 
-school_of_excellence = FactoryBot.create(:gias_school, status: :open, opened_on: Date.new(2026, 4, 30), urn: 9_123_501, name: "Michael Wazowski School of Excellence").tap do |school|
+school_of_excellence = FactoryBot.create(:gias_school, :with_school, status: :open, opened_on: Date.new(2026, 4, 30), urn: 9_123_501, name: "Michael Wazowski School of Excellence").tap do |school|
   describe_school(school)
 end
 
-girls_high_school = FactoryBot.create(:gias_school, status: :open, opened_on: Date.new(2026, 4, 30), urn: 9_123_502, name: "Abigail Hardscrabble High School for Girls").tap do |school|
+girls_high_school = FactoryBot.create(:gias_school, :with_school, status: :closed, closed_on: Date.new(2026, 4, 30), urn: 9_123_502, name: "Abigail Hardscrabble High School for Girls").tap do |school|
   describe_school(school)
 end
 
@@ -106,11 +325,21 @@ open_school = FactoryBot.create(:gias_school, status: :open, opened_on: Date.new
   describe_school(school)
 end
 
+monstropolis_academy = FactoryBot.create(:gias_school, :with_school, status: :open, opened_on: Date.new(2026, 1, 30), urn: 9_123_507, name: "Monstropolis Academy").tap do |school|
+  describe_school(school)
+end
+
 counter = 0
 
-counter = populate_school(closed_school, counter)
-counter = populate_school(monsters_college, counter)
-populate_school(primary_school, counter)
+counter = populate_school(monsters_college, ambition, counter)
+counter = populate_school(school_of_excellence, teach_first, counter)
+counter = populate_school(girls_high_school, teach_first, counter)
+counter = populate_school(primary_school, ambition, counter)
+counter = populate_school(closed_school, ambition, counter)
+counter = populate_school(monstropolis_academy, ambition, counter)
+
+counter = overlap_scenarios(predecessor_school: monsters_college, successor_school: school_of_excellence, lead_provider: ambition, counter:)
+overlap_scenarios(predecessor_school: girls_high_school, successor_school: monstropolis_academy, lead_provider: teach_first, counter:)
 
 print_seed_info("\n🌱 Closures:")
 print_seed_info("🔒 #{Colourize.text(closed_school.name, :yellow)} (URN: #{Colourize.text(closed_school.urn, :yellow)}) closed on #{Colourize.text(closed_school.closed_on, :yellow)}", indent: 2)
@@ -127,16 +356,18 @@ FactoryBot.create(:gias_school_link,
   describe_school_link(school_link)
 end
 
+print_seed_info("\n🌱 Mergers:")
+
 FactoryBot.create(:gias_school_link,
-                  :successor_split,
+                  :successor_merged,
                   from_gias_school: monsters_college,
                   to_gias_school: school_of_excellence).tap do |school_link|
   describe_school_link(school_link)
 end
 
 FactoryBot.create(:gias_school_link,
-                  :successor_split,
-                  from_gias_school: monsters_college,
-                  to_gias_school: girls_high_school).tap do |school_link|
+                  :successor_merged,
+                  from_gias_school: girls_high_school,
+                  to_gias_school: monstropolis_academy).tap do |school_link|
   describe_school_link(school_link)
 end

--- a/spec/models/gias/school_spec.rb
+++ b/spec/models/gias/school_spec.rb
@@ -375,6 +375,92 @@ describe GIAS::School do
       end
     end
 
+    describe "#can_be_merged?" do
+      subject { gias_school.can_be_merged? }
+
+      context "when the school is closed" do
+        let(:gias_school) { FactoryBot.create(:gias_school, status: :closed, closed_on:) }
+        let(:closed_on) { Date.current }
+
+        it { is_expected.to be_falsy }
+
+        context "when there is a unique successor" do
+          let(:successor) { FactoryBot.create(:gias_school, :with_school, status: :open, opened_on:) }
+          let(:opened_on) { Date.current }
+          let(:link_type) { :successor_merged }
+
+          before do
+            FactoryBot.create(:gias_school_link, link_type, from_gias_school: gias_school, to_gias_school: successor)
+          end
+
+          context "when the successor is open, linked and has a school record" do
+            it { is_expected.to be_truthy }
+          end
+
+          context "when the successor is not open" do
+            let(:successor) { FactoryBot.create(:gias_school, :with_school, status: :proposed_to_open, opened_on:) }
+
+            it { is_expected.to be_falsy }
+          end
+
+          context "when the successor does not have a school record" do
+            let(:successor) { FactoryBot.create(:gias_school, status: :open, opened_on:) }
+
+            it { is_expected.to be_falsy }
+          end
+
+          context "when the successor opens in the future" do
+            let(:opened_on) { Date.tomorrow }
+
+            it { is_expected.to be_falsy }
+          end
+
+          context "when the link between the schools is not a merger" do
+            let(:link_type) { :successor_amalgamated }
+
+            it { is_expected.to be_falsy }
+          end
+
+          context "when the school closes in the future" do
+            let(:closed_on) { Date.tomorrow }
+
+            it { is_expected.to be_falsy }
+          end
+
+          context "when the school has already been merged" do
+            before do
+              FactoryBot.create(:event, event_type: :school_merged, school: gias_school.school)
+            end
+
+            it { is_expected.to be_falsy }
+          end
+        end
+
+        context "when there are multiple successors" do
+          let(:successor) { FactoryBot.create(:gias_school, :with_school, status: :open, opened_on: Date.current) }
+          let(:other_successor) { FactoryBot.create(:gias_school, :with_school, status: :open, opened_on: Date.current) }
+
+          before do
+            FactoryBot.create(:gias_school_link, :successor_merged, from_gias_school: gias_school, to_gias_school: other_successor)
+            FactoryBot.create(:gias_school_link, :successor_merged, from_gias_school: gias_school, to_gias_school: successor)
+          end
+
+          it { is_expected.to be_falsy }
+        end
+      end
+
+      context "when the school is not closed" do
+        let(:gias_school) { FactoryBot.create(:gias_school, status: :proposed_to_close) }
+        let(:successor) { FactoryBot.create(:gias_school, :with_school, status: :open, opened_on: Date.current) }
+
+        before do
+          FactoryBot.create(:gias_school_link, :successor_merged, from_gias_school: gias_school, to_gias_school: successor)
+        end
+
+        it { is_expected.to be_falsy }
+      end
+    end
+
     describe "#school_not_yet_opened?" do
       subject { gias_school.school_not_yet_opened? }
 

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -3275,6 +3275,35 @@ RSpec.describe Events::Record do
     end
   end
 
+  describe ".record_school_merged_event!" do
+    let(:predecessor_gias_school) { FactoryBot.create(:gias_school, :with_school, name: "Monsters High School", urn: "123456") }
+    let(:successor_gias_school) { FactoryBot.create(:gias_school, :with_school, name: "Abigail Hardscrabble School For Girls", urn: "654321") }
+    let(:school) { successor_gias_school.school }
+
+    it "queues a RecordEventJob with the correct values" do
+      freeze_time do
+        metadata = {
+          predecessor_gias_school_name: "Monsters High School",
+          predecessor_gias_school_urn: 123_456,
+          successor_gias_school_name: "Abigail Hardscrabble School For Girls",
+          successor_gias_school_urn: 654_321
+
+        }
+
+        Events::Record.record_school_merged_event!(author:, school:, predecessor_gias_school:, successor_gias_school:)
+
+        expect(RecordEventJob).to have_received(:perform_later).with(
+          school:,
+          heading: "Monsters High School (123456) was merged into Abigail Hardscrabble School For Girls (654321) in GIAS",
+          event_type: :school_merged,
+          happened_at: Time.zone.now,
+          metadata:,
+          **author_params
+        )
+      end
+    end
+  end
+
   describe "contracts" do
     let(:lead_provider) do
       FactoryBot.create(:lead_provider,

--- a/spec/services/gias/schools/merge_spec.rb
+++ b/spec/services/gias/schools/merge_spec.rb
@@ -122,13 +122,16 @@ RSpec.describe GIAS::Schools::Merge do
           end
 
           it "records a school merged event" do
-            expect(Events::Record).to receive(:record_school_merged_event!)
+            expect(Events::Record)
+              .to receive(:record_school_merged_event!)
               .once
-              .with(school: successor_school,
-                    predecessor_gias_school: gias_school,
-                    successor_gias_school:,
-                    happened_at: gias_school.closed_on,
-                    author: an_instance_of(Events::SystemAuthor))
+              .with(
+                school: predecessor_school,
+                predecessor_gias_school: gias_school,
+                successor_gias_school:,
+                happened_at: gias_school.closed_on,
+                author: an_instance_of(Events::SystemAuthor)
+              )
 
             merge_school
           end
@@ -170,13 +173,16 @@ RSpec.describe GIAS::Schools::Merge do
           end
 
           it "records a school merged event" do
-            expect(Events::Record).to receive(:record_school_merged_event!)
+            expect(Events::Record)
+              .to receive(:record_school_merged_event!)
               .once
-              .with(school: successor_school,
-                    predecessor_gias_school: gias_school,
-                    successor_gias_school:,
-                    happened_at: gias_school.closed_on,
-                    author: an_instance_of(Events::SystemAuthor))
+              .with(
+                school: predecessor_school,
+                predecessor_gias_school: gias_school,
+                successor_gias_school:,
+                happened_at: gias_school.closed_on,
+                author: an_instance_of(Events::SystemAuthor)
+              )
 
             merge_school
           end
@@ -200,13 +206,16 @@ RSpec.describe GIAS::Schools::Merge do
           end
 
           it "records a school merged event" do
-            expect(Events::Record).to receive(:record_school_merged_event!)
+            expect(Events::Record)
+              .to receive(:record_school_merged_event!)
               .once
-              .with(school: successor_school,
-                    predecessor_gias_school: gias_school,
-                    successor_gias_school:,
-                    happened_at: gias_school.closed_on,
-                    author: an_instance_of(Events::SystemAuthor))
+              .with(
+                school: predecessor_school,
+                predecessor_gias_school: gias_school,
+                successor_gias_school:,
+                happened_at: gias_school.closed_on,
+                author: an_instance_of(Events::SystemAuthor)
+              )
 
             merge_school
           end
@@ -263,13 +272,16 @@ RSpec.describe GIAS::Schools::Merge do
         end
 
         it "records a school merged event" do
-          expect(Events::Record).to receive(:record_school_merged_event!)
+          expect(Events::Record)
+            .to receive(:record_school_merged_event!)
             .once
-            .with(school: successor_school,
-                  predecessor_gias_school: gias_school,
-                  successor_gias_school:,
-                  happened_at: gias_school.closed_on,
-                  author: an_instance_of(Events::SystemAuthor))
+            .with(
+              school: predecessor_school,
+              predecessor_gias_school: gias_school,
+              successor_gias_school:,
+              happened_at: gias_school.closed_on,
+              author: an_instance_of(Events::SystemAuthor)
+            )
 
           merge_school
         end

--- a/spec/services/gias/schools/merge_spec.rb
+++ b/spec/services/gias/schools/merge_spec.rb
@@ -1,290 +1,162 @@
 RSpec.describe GIAS::Schools::Merge do
+  subject(:service) { described_class.new(gias_school) }
+
+  let(:gias_school) { FactoryBot.create(:gias_school, :with_school, :closed) }
+  let(:successor_gias_school) { FactoryBot.create(:gias_school, :with_school, :open) }
+  let!(:school_link) do
+    FactoryBot.create(
+      :gias_school_link,
+      :successor_merged,
+      from_gias_school: gias_school,
+      to_gias_school: successor_gias_school
+    )
+  end
+
   describe "#merge!" do
-    subject(:merge_school) { described_class.new(gias_school).merge! }
+    subject(:merge!) { service.merge! }
 
     let(:predecessor_school) { gias_school.school }
     let(:successor_school) { successor_gias_school.school }
-    let(:teacher) { FactoryBot.create(:teacher) }
-
-    let(:gias_school) { FactoryBot.create(:gias_school, :with_school, :closed) }
-    let(:successor_gias_school) { FactoryBot.create(:gias_school, :with_school, :open) }
-
-    let!(:school_link) { FactoryBot.create(:gias_school_link, :successor_merged, from_gias_school: gias_school, to_gias_school: successor_gias_school) }
-
-    let(:can_be_merged) { true }
 
     before do
-      allow(gias_school).to receive(:can_be_merged?).and_return(can_be_merged)
+      allow(gias_school).to receive(:can_be_merged?).and_return(gias_school_can_be_merged?)
     end
 
-    context "when the school cannot be merged" do
-      let(:can_be_merged) { false }
+    context "when the GIAS school cannot be merged" do
+      let(:gias_school_can_be_merged?) { false }
 
-      let(:school_partnership) { FactoryBot.create(:school_partnership, school: predecessor_school) }
-      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, school: predecessor_school) }
-      let!(:training_period) { FactoryBot.create(:training_period, :for_ect, :with_school_partnership, ect_at_school_period:, school_partnership:) }
+      it { expect(merge!).to be_falsey }
 
-      let!(:mentor_period_at_predecessor) do
-        FactoryBot.create(
-          :mentor_at_school_period,
-          teacher:,
-          school: predecessor_school,
-          started_on: Date.new(2025, 1, 1),
-          finished_on: Date.new(2025, 3, 31)
-        )
+      it "does not find any overlapping `MentorAtSchoolPeriod` records" do
+        expect(GIAS::Schools::MentorAtSchoolPeriods::Overlapping).not_to receive(:find)
+
+        merge!
       end
 
-      let!(:mentor_period_at_successor) do
-        FactoryBot.create(
-          :mentor_at_school_period,
-          teacher:,
-          school: successor_school,
-          started_on: Date.new(2025, 3, 1),
-          finished_on: Date.new(2025, 6, 30)
-        )
+      it "does not merge any `MentorAtSchoolPeriod` records" do
+        expect(GIAS::Schools::MentorAtSchoolPeriods::Merge).not_to receive(:call)
+
+        merge!
       end
 
-      it { expect(merge_school).to be_falsey }
+      it "does not transfer any `MentorAtSchoolPeriod` records" do
+        expect(GIAS::Schools::MentorAtSchoolPeriods::Transfer).not_to receive(:call)
 
-      it "does not merge any periods" do
-        allow(GIAS::Schools::MentorAtSchoolPeriods::Merge).to receive(:call)
-
-        expect { merge_school }.not_to change(MentorAtSchoolPeriod, :count)
-
-        expect(GIAS::Schools::MentorAtSchoolPeriods::Merge).not_to have_received(:call)
+        merge!
       end
 
-      it "does not move any periods" do
-        allow(GIAS::Schools::MentorAtSchoolPeriods::Transfer).to receive(:call)
-        allow(GIAS::Schools::ECTAtSchoolPeriods::Transfer).to receive(:call)
+      it "does not transfer any `ECTAtSchoolPeriod` records" do
+        expect(GIAS::Schools::ECTAtSchoolPeriods::Transfer).not_to receive(:call)
 
-        merge_school
-
-        expect(GIAS::Schools::MentorAtSchoolPeriods::Transfer).not_to have_received(:call)
-        expect(GIAS::Schools::ECTAtSchoolPeriods::Transfer).not_to have_received(:call)
-
-        expect(mentor_period_at_predecessor.reload.school).to eq(predecessor_school)
-        expect(mentor_period_at_successor.reload.school).to eq(successor_school)
-        expect(ect_at_school_period.reload.school).to eq(predecessor_school)
-      end
-
-      it "does not move any school partnerships" do
-        expect { merge_school }.not_to change(SchoolPartnership, :count)
-
-        expect(training_period.reload.school_partnership.school).to eq(predecessor_school)
+        merge!
       end
 
       it "does not record a school merged event" do
         expect(Events::Record).not_to receive(:record_school_merged_event!)
 
-        merge_school
+        merge!
       end
     end
 
-    context "when the school can be merged" do
-      context "when there are teachers with periods at the predecessor school" do
-        context "when there is a teacher mentoring at the predecessor school only" do
-          let(:mentor_without_overlapping_periods) do
-            FactoryBot.create(:mentor_at_school_period,
-                              school: predecessor_school,
-                              started_on: Date.new(2025, 7, 1),
-                              finished_on: Date.new(2025, 12, 31))
-          end
+    context "when the GIAS school can be merged" do
+      let(:gias_school_can_be_merged?) { true }
 
-          let(:mentees) do
-            FactoryBot.create_list(:ect_at_school_period, 2,
-                                   school: predecessor_school,
-                                   started_on: Date.new(2025, 7, 2),
-                                   finished_on: Date.new(2025, 12, 30))
-          end
-
-          before do
-            mentees.each do |mentee|
-              FactoryBot.create(:mentorship_period, mentor: mentor_without_overlapping_periods, mentee:)
-            end
-          end
-
-          it { expect(merge_school).to be_truthy }
-
-          it "moves mentor periods without overlaps to the successor school" do
-            allow(GIAS::Schools::MentorAtSchoolPeriods::Transfer).to receive(:call).and_call_original
-            allow(GIAS::Schools::ECTAtSchoolPeriods::Transfer).to receive(:call).and_call_original
-
-            merge_school
-
-            expect(GIAS::Schools::MentorAtSchoolPeriods::Transfer).to have_received(:call).once
-            expect(GIAS::Schools::ECTAtSchoolPeriods::Transfer).to have_received(:call).twice
-
-            expect(mentor_without_overlapping_periods.reload.school).to eq(successor_school)
-            mentees.each do |mentee|
-              expect(mentee.reload.school).to eq(successor_school)
-            end
-          end
-
-          it "records a school merged event" do
-            expect(Events::Record)
-              .to receive(:record_school_merged_event!)
-              .once
-              .with(
-                school: predecessor_school,
-                predecessor_gias_school: gias_school,
-                successor_gias_school:,
-                happened_at: gias_school.closed_on,
-                author: an_instance_of(Events::SystemAuthor)
-              )
-
-            merge_school
-          end
-        end
-
-        context "when there is a teacher who mentors at both schools and has overlapping periods" do
-          let!(:mentor_period_at_predecessor) do
-            FactoryBot.create(
-              :mentor_at_school_period,
-              teacher:,
-              school: predecessor_school,
-              started_on: Date.new(2025, 1, 1),
-              finished_on: Date.new(2025, 3, 31)
-            )
-          end
-
-          let!(:mentor_period_at_successor) do
-            FactoryBot.create(
-              :mentor_at_school_period,
-              teacher:,
-              school: successor_school,
-              started_on: Date.new(2025, 3, 1),
-              finished_on: Date.new(2025, 6, 30)
-            )
-          end
-
-          it { expect(merge_school).to be_truthy }
-
-          it "merges overlapping mentor periods and moves remaining periods to the successor school" do
-            expect { merge_school }.to change(MentorAtSchoolPeriod, :count).by(-1)
-
-            expect { mentor_period_at_predecessor.reload }.to raise_error(ActiveRecord::RecordNotFound)
-
-            expect(mentor_period_at_successor.reload).to have_attributes(
-              school: successor_school,
-              started_on: Date.new(2025, 1, 1),
-              finished_on: Date.new(2025, 6, 30)
-            )
-          end
-
-          it "records a school merged event" do
-            expect(Events::Record)
-              .to receive(:record_school_merged_event!)
-              .once
-              .with(
-                school: predecessor_school,
-                predecessor_gias_school: gias_school,
-                successor_gias_school:,
-                happened_at: gias_school.closed_on,
-                author: an_instance_of(Events::SystemAuthor)
-              )
-
-            merge_school
-          end
-        end
-
-        context "when there are ECT periods without mentors to move" do
-          let!(:ects_without_mentor) { FactoryBot.create_list(:ect_at_school_period, 2, school: predecessor_school) }
-
-          it { expect(merge_school).to be_truthy }
-
-          it "moves ECT periods without mentors to the successor school" do
-            allow(GIAS::Schools::ECTAtSchoolPeriods::Transfer).to receive(:call).and_call_original
-
-            merge_school
-
-            expect(GIAS::Schools::ECTAtSchoolPeriods::Transfer).to have_received(:call).twice
-
-            ects_without_mentor.each do |ect|
-              expect(ect.reload.school).to eq(successor_school)
-            end
-          end
-
-          it "records a school merged event" do
-            expect(Events::Record)
-              .to receive(:record_school_merged_event!)
-              .once
-              .with(
-                school: predecessor_school,
-                predecessor_gias_school: gias_school,
-                successor_gias_school:,
-                happened_at: gias_school.closed_on,
-                author: an_instance_of(Events::SystemAuthor)
-              )
-
-            merge_school
-          end
-
-          context "when both ECTs are training with the same partnership" do
-            let(:school_partnership) { FactoryBot.create(:school_partnership, school: predecessor_school, lead_provider_delivery_partnership:) }
-            let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership) }
-
-            before do
-              ects_without_mentor.each do |ect_at_school_period|
-                FactoryBot.create(:training_period, :for_ect, :with_school_partnership, ect_at_school_period:, school_partnership:)
-              end
-            end
-
-            it "moves ECT periods without mentors to the successor school and creates a new partnership for the successor school" do
-              allow(GIAS::Schools::ECTAtSchoolPeriods::Transfer).to receive(:call).and_call_original
-
-              expect { merge_school }.to change(SchoolPartnership, :count).by(1)
-
-              expect(GIAS::Schools::ECTAtSchoolPeriods::Transfer).to have_received(:call).twice
-
-              ects_without_mentor.each do |ect|
-                expect(ect.reload.school).to eq(successor_school)
-                new_school_partnership = ect.training_periods.first.school_partnership
-                expect(new_school_partnership.school).to eq(successor_school)
-                expect(new_school_partnership.lead_provider_delivery_partnership).to eq(lead_provider_delivery_partnership)
-              end
-            end
-          end
-        end
+      let(:predecessor_school) { FactoryBot.create(:school) }
+      let(:gias_school) do
+        FactoryBot.create(
+          :gias_school,
+          :with_school,
+          :closed,
+          school: predecessor_school
+        )
       end
 
-      context "when there are no mentors or ECTs at the predecessor school" do
-        it "does not merge any periods" do
-          allow(GIAS::Schools::MentorAtSchoolPeriods::Merge).to receive(:call)
+      let(:mentor_teacher) { FactoryBot.create(:teacher) }
+      let!(:mentor_at_school_period) do
+        FactoryBot.create(
+          :mentor_at_school_period,
+          teacher: mentor_teacher,
+          school: predecessor_school
+        )
+      end
+      let!(:ect_at_school_period) do
+        FactoryBot.create(
+          :ect_at_school_period,
+          school: predecessor_school
+        )
+      end
 
-          merge_school
+      before do
+        allow(GIAS::Schools::MentorAtSchoolPeriods::Overlapping)
+          .to receive(:find)
+          .and_return([[mentor_at_school_period]])
+        allow(GIAS::Schools::MentorAtSchoolPeriods::Merge).to receive(:call)
+        allow(GIAS::Schools::MentorAtSchoolPeriods::Transfer).to receive(:call)
+        allow(GIAS::Schools::ECTAtSchoolPeriods::Transfer).to receive(:call)
+        allow(Events::Record).to receive(:record_school_merged_event!)
+      end
 
-          expect(GIAS::Schools::MentorAtSchoolPeriods::Merge).not_to have_received(:call)
-        end
+      it { expect(merge!).to be_truthy }
 
-        it "does not move any periods" do
-          allow(GIAS::Schools::MentorAtSchoolPeriods::Transfer).to receive(:call)
-          allow(GIAS::Schools::ECTAtSchoolPeriods::Transfer).to receive(:call)
+      it "finds overlapping `MentorAtSchoolPeriod` records for each mentor teacher" do
+        merge!
 
-          merge_school
+        expect(GIAS::Schools::MentorAtSchoolPeriods::Overlapping)
+          .to have_received(:find)
+          .with(
+            teacher: mentor_teacher,
+            schools: [predecessor_school, successor_school]
+          )
+      end
 
-          expect(GIAS::Schools::MentorAtSchoolPeriods::Transfer).not_to have_received(:call)
-          expect(GIAS::Schools::ECTAtSchoolPeriods::Transfer).not_to have_received(:call)
-        end
+      it "merges overlapping `MentorAtSchoolPeriod` records" do
+        merge!
 
-        it "does not create any school partnerships" do
-          expect { merge_school }.not_to change(SchoolPartnership, :count)
-        end
+        expect(GIAS::Schools::MentorAtSchoolPeriods::Merge)
+          .to have_received(:call)
+          .with(
+            periods: [mentor_at_school_period],
+            predecessor_school:,
+            successor_school:
+          )
+      end
 
-        it "records a school merged event" do
-          expect(Events::Record)
-            .to receive(:record_school_merged_event!)
-            .once
-            .with(
-              school: predecessor_school,
-              predecessor_gias_school: gias_school,
-              successor_gias_school:,
-              happened_at: gias_school.closed_on,
-              author: an_instance_of(Events::SystemAuthor)
-            )
+      it "transfers remaining `MentorAtSchoolPeriod` records" do
+        merge!
 
-          merge_school
-        end
+        expect(GIAS::Schools::MentorAtSchoolPeriods::Transfer)
+          .to have_received(:call)
+          .with(
+            mentor_at_school_period:,
+            predecessor_school:,
+            successor_school:
+          )
+      end
+
+      it "transfers remaining `ECTAtSchoolPeriod` records" do
+        merge!
+
+        expect(GIAS::Schools::ECTAtSchoolPeriods::Transfer)
+          .to have_received(:call)
+          .with(
+            ect_at_school_period:,
+            predecessor_school:,
+            successor_school:
+          )
+      end
+
+      it "records a school merged event" do
+        merge!
+
+        expect(Events::Record)
+          .to have_received(:record_school_merged_event!)
+          .with(
+            school: predecessor_school,
+            successor_gias_school:,
+            predecessor_gias_school: gias_school,
+            happened_at: gias_school.closed_on,
+            author: an_instance_of(Events::SystemAuthor)
+          )
       end
     end
   end

--- a/spec/services/gias/schools/merge_spec.rb
+++ b/spec/services/gias/schools/merge_spec.rb
@@ -1,0 +1,279 @@
+RSpec.describe GIAS::Schools::Merge do
+  describe "#merge!" do
+    subject(:merge_school) { described_class.new(gias_school).merge! }
+
+    let(:predecessor_school) { gias_school.school }
+    let(:successor_school) { successor_gias_school.school }
+    let(:teacher) { FactoryBot.create(:teacher) }
+
+    let(:gias_school) { FactoryBot.create(:gias_school, :with_school, :closed) }
+    let(:successor_gias_school) { FactoryBot.create(:gias_school, :with_school, :open) }
+
+    let!(:school_link) { FactoryBot.create(:gias_school_link, :successor_merged, from_gias_school: gias_school, to_gias_school: successor_gias_school) }
+
+    let(:can_be_merged) { true }
+
+    before do
+      allow(gias_school).to receive(:can_be_merged?).and_return(can_be_merged)
+    end
+
+    context "when the school cannot be merged" do
+      let(:can_be_merged) { false }
+
+      let(:school_partnership) { FactoryBot.create(:school_partnership, school: predecessor_school) }
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, school: predecessor_school) }
+      let!(:training_period) { FactoryBot.create(:training_period, :for_ect, :with_school_partnership, ect_at_school_period:, school_partnership:) }
+
+      let!(:mentor_period_at_predecessor) do
+        FactoryBot.create(
+          :mentor_at_school_period,
+          teacher:,
+          school: predecessor_school,
+          started_on: Date.new(2025, 1, 1),
+          finished_on: Date.new(2025, 3, 31)
+        )
+      end
+
+      let!(:mentor_period_at_successor) do
+        FactoryBot.create(
+          :mentor_at_school_period,
+          teacher:,
+          school: successor_school,
+          started_on: Date.new(2025, 3, 1),
+          finished_on: Date.new(2025, 6, 30)
+        )
+      end
+
+      it { expect(merge_school).to be_falsey }
+
+      it "does not merge any periods" do
+        allow(GIAS::Schools::MentorAtSchoolPeriods::Merge).to receive(:call)
+
+        expect { merge_school }.not_to change(MentorAtSchoolPeriod, :count)
+
+        expect(GIAS::Schools::MentorAtSchoolPeriods::Merge).not_to have_received(:call)
+      end
+
+      it "does not move any periods" do
+        allow(GIAS::Schools::MentorAtSchoolPeriods::Transfer).to receive(:call)
+        allow(GIAS::Schools::ECTAtSchoolPeriods::Transfer).to receive(:call)
+
+        merge_school
+
+        expect(GIAS::Schools::MentorAtSchoolPeriods::Transfer).not_to have_received(:call)
+        expect(GIAS::Schools::ECTAtSchoolPeriods::Transfer).not_to have_received(:call)
+
+        expect(mentor_period_at_predecessor.reload.school).to eq(predecessor_school)
+        expect(mentor_period_at_successor.reload.school).to eq(successor_school)
+        expect(ect_at_school_period.reload.school).to eq(predecessor_school)
+      end
+
+      it "does not move any school partnerships" do
+        expect { merge_school }.not_to change(SchoolPartnership, :count)
+
+        expect(training_period.reload.school_partnership.school).to eq(predecessor_school)
+      end
+
+      it "does not record a school merged event" do
+        expect(Events::Record).not_to receive(:record_school_merged_event!)
+
+        merge_school
+      end
+    end
+
+    context "when the school can be merged" do
+      context "when there are teachers with periods at the predecessor school" do
+        context "when there is a teacher mentoring at the predecessor school only" do
+          let(:mentor_without_overlapping_periods) do
+            FactoryBot.create(:mentor_at_school_period,
+                              school: predecessor_school,
+                              started_on: Date.new(2025, 7, 1),
+                              finished_on: Date.new(2025, 12, 31))
+          end
+
+          let(:mentees) do
+            FactoryBot.create_list(:ect_at_school_period, 2,
+                                   school: predecessor_school,
+                                   started_on: Date.new(2025, 7, 2),
+                                   finished_on: Date.new(2025, 12, 30))
+          end
+
+          before do
+            mentees.each do |mentee|
+              FactoryBot.create(:mentorship_period, mentor: mentor_without_overlapping_periods, mentee:)
+            end
+          end
+
+          it { expect(merge_school).to be_truthy }
+
+          it "moves mentor periods without overlaps to the successor school" do
+            allow(GIAS::Schools::MentorAtSchoolPeriods::Transfer).to receive(:call).and_call_original
+            allow(GIAS::Schools::ECTAtSchoolPeriods::Transfer).to receive(:call).and_call_original
+
+            merge_school
+
+            expect(GIAS::Schools::MentorAtSchoolPeriods::Transfer).to have_received(:call).once
+            expect(GIAS::Schools::ECTAtSchoolPeriods::Transfer).to have_received(:call).twice
+
+            expect(mentor_without_overlapping_periods.reload.school).to eq(successor_school)
+            mentees.each do |mentee|
+              expect(mentee.reload.school).to eq(successor_school)
+            end
+          end
+
+          it "records a school merged event" do
+            expect(Events::Record).to receive(:record_school_merged_event!)
+              .once
+              .with(school: successor_school,
+                    predecessor_gias_school: gias_school,
+                    successor_gias_school:,
+                    happened_at: gias_school.closed_on,
+                    author: an_instance_of(Events::SystemAuthor))
+
+            merge_school
+          end
+        end
+
+        context "when there is a teacher who mentors at both schools and has overlapping periods" do
+          let!(:mentor_period_at_predecessor) do
+            FactoryBot.create(
+              :mentor_at_school_period,
+              teacher:,
+              school: predecessor_school,
+              started_on: Date.new(2025, 1, 1),
+              finished_on: Date.new(2025, 3, 31)
+            )
+          end
+
+          let!(:mentor_period_at_successor) do
+            FactoryBot.create(
+              :mentor_at_school_period,
+              teacher:,
+              school: successor_school,
+              started_on: Date.new(2025, 3, 1),
+              finished_on: Date.new(2025, 6, 30)
+            )
+          end
+
+          it { expect(merge_school).to be_truthy }
+
+          it "merges overlapping mentor periods and moves remaining periods to the successor school" do
+            expect { merge_school }.to change(MentorAtSchoolPeriod, :count).by(-1)
+
+            expect { mentor_period_at_predecessor.reload }.to raise_error(ActiveRecord::RecordNotFound)
+
+            expect(mentor_period_at_successor.reload).to have_attributes(
+              school: successor_school,
+              started_on: Date.new(2025, 1, 1),
+              finished_on: Date.new(2025, 6, 30)
+            )
+          end
+
+          it "records a school merged event" do
+            expect(Events::Record).to receive(:record_school_merged_event!)
+              .once
+              .with(school: successor_school,
+                    predecessor_gias_school: gias_school,
+                    successor_gias_school:,
+                    happened_at: gias_school.closed_on,
+                    author: an_instance_of(Events::SystemAuthor))
+
+            merge_school
+          end
+        end
+
+        context "when there are ECT periods without mentors to move" do
+          let!(:ects_without_mentor) { FactoryBot.create_list(:ect_at_school_period, 2, school: predecessor_school) }
+
+          it { expect(merge_school).to be_truthy }
+
+          it "moves ECT periods without mentors to the successor school" do
+            allow(GIAS::Schools::ECTAtSchoolPeriods::Transfer).to receive(:call).and_call_original
+
+            merge_school
+
+            expect(GIAS::Schools::ECTAtSchoolPeriods::Transfer).to have_received(:call).twice
+
+            ects_without_mentor.each do |ect|
+              expect(ect.reload.school).to eq(successor_school)
+            end
+          end
+
+          it "records a school merged event" do
+            expect(Events::Record).to receive(:record_school_merged_event!)
+              .once
+              .with(school: successor_school,
+                    predecessor_gias_school: gias_school,
+                    successor_gias_school:,
+                    happened_at: gias_school.closed_on,
+                    author: an_instance_of(Events::SystemAuthor))
+
+            merge_school
+          end
+
+          context "when both ECTs are training with the same partnership" do
+            let(:school_partnership) { FactoryBot.create(:school_partnership, school: predecessor_school, lead_provider_delivery_partnership:) }
+            let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership) }
+
+            before do
+              ects_without_mentor.each do |ect_at_school_period|
+                FactoryBot.create(:training_period, :for_ect, :with_school_partnership, ect_at_school_period:, school_partnership:)
+              end
+            end
+
+            it "moves ECT periods without mentors to the successor school and creates a new partnership for the successor school" do
+              allow(GIAS::Schools::ECTAtSchoolPeriods::Transfer).to receive(:call).and_call_original
+
+              expect { merge_school }.to change(SchoolPartnership, :count).by(1)
+
+              expect(GIAS::Schools::ECTAtSchoolPeriods::Transfer).to have_received(:call).twice
+
+              ects_without_mentor.each do |ect|
+                expect(ect.reload.school).to eq(successor_school)
+                new_school_partnership = ect.training_periods.first.school_partnership
+                expect(new_school_partnership.school).to eq(successor_school)
+                expect(new_school_partnership.lead_provider_delivery_partnership).to eq(lead_provider_delivery_partnership)
+              end
+            end
+          end
+        end
+      end
+
+      context "when there are no mentors or ECTs at the predecessor school" do
+        it "does not merge any periods" do
+          allow(GIAS::Schools::MentorAtSchoolPeriods::Merge).to receive(:call)
+
+          merge_school
+
+          expect(GIAS::Schools::MentorAtSchoolPeriods::Merge).not_to have_received(:call)
+        end
+
+        it "does not move any periods" do
+          allow(GIAS::Schools::MentorAtSchoolPeriods::Transfer).to receive(:call)
+          allow(GIAS::Schools::ECTAtSchoolPeriods::Transfer).to receive(:call)
+
+          merge_school
+
+          expect(GIAS::Schools::MentorAtSchoolPeriods::Transfer).not_to have_received(:call)
+          expect(GIAS::Schools::ECTAtSchoolPeriods::Transfer).not_to have_received(:call)
+        end
+
+        it "does not create any school partnerships" do
+          expect { merge_school }.not_to change(SchoolPartnership, :count)
+        end
+
+        it "records a school merged event" do
+          expect(Events::Record).to receive(:record_school_merged_event!)
+            .once
+            .with(school: successor_school,
+                  predecessor_gias_school: gias_school,
+                  successor_gias_school:,
+                  happened_at: gias_school.closed_on,
+                  author: an_instance_of(Events::SystemAuthor))
+
+          merge_school
+        end
+      end
+    end
+  end
+end

--- a/spec/services/gias/schools/school_partnerships/transfer_spec.rb
+++ b/spec/services/gias/schools/school_partnerships/transfer_spec.rb
@@ -2,8 +2,7 @@ RSpec.describe GIAS::Schools::SchoolPartnerships::Transfer do
   subject(:service) do
     described_class.call(
       predecessor_school_partnership:,
-      successor_school:,
-      author:
+      successor_school:
     )
   end
 
@@ -46,9 +45,9 @@ RSpec.describe GIAS::Schools::SchoolPartnerships::Transfer do
       expect(Events::Record)
         .to have_received(:record_school_partnership_recreated_event!)
         .with(
-          author:,
           old_school_partnership: predecessor_school_partnership,
-          new_school_partnership:
+          new_school_partnership:,
+          author: an_instance_of(Events::SystemAuthor)
         )
     end
   end


### PR DESCRIPTION
### Context

The final orchestrator service which merges two school records, when their `GIAS::School` records are merged.

### Changes proposed in this pull request

This follows what has turned out to be a straightforward process.  Merge any `mentor_at_school_periods` at the two schools which overlap, and move their mentees and other associated records.  Then for the remaining `mentor_at_school_periods` move them and move their mentees and other associated records.  Finally move any remaining ect_at_school_periods.  

As with the three other services, this service only merges schools in the correct condition to be merged.  For purposes of override by a developer there is a private `merge_school!` method which can be run whilst we are testing the service.



### Guidance to review

For product review there are two sets of school merges we can look at.  Each school has a variety of mentors and ECTs which cover all scenarios.  Before merging we should observe the teachers at each school and what we expect.  The mentors are named according to the arrangement of their periods at both schools, eg "Overlapping Mentor", "Separate Mentor".  In order to product review, I will take the the reviewer through the scenarios, and then we can run the merge and observe the output to see if it worked.

```
monsters_college = GIAS::School.find(9123500)
GIAS::Schools::Merge.new(monsters_college).merge!
```
