### PR TITLE
Fix flaky declarations API seed spec

### DIFF
--- a/app/services/api_seed_data/declarations.rb
+++ b/app/services/api_seed_data/declarations.rb
@@ -51,13 +51,13 @@ module APISeedData
         next unless declaration_date.past?
 
         payment_status = Declaration.payment_statuses.keys.sample
-        unless payment_status == :no_payment
+        unless payment_status == "no_payment"
           payment_statement = find_random_statement(active_lead_provider)
           next unless payment_statement
         end
 
         clawback_status = clawback_status(payment_status)
-        unless clawback_status == :no_clawback
+        unless clawback_status == "no_clawback"
           clawback_statement = find_random_statement(active_lead_provider, (payment_statement.deadline_date + 1.day)..)
           next unless clawback_statement
         end
@@ -106,7 +106,7 @@ module APISeedData
     end
 
     def clawback_status(payment_status)
-      return :no_clawback unless payment_status == "paid"
+      return "no_clawback" unless payment_status == "paid"
 
       Declaration.clawback_statuses.keys.sample
     end

--- a/app/services/api_seed_data/declarations.rb
+++ b/app/services/api_seed_data/declarations.rb
@@ -150,7 +150,7 @@ module APISeedData
 
     def teacher_ids_with_declarations
       Declaration
-        .joins(training_period: %i[ect_at_school_period mentor_at_school_period])
+        .left_joins(training_period: %i[ect_at_school_period mentor_at_school_period])
         .pluck("ect_at_school_periods.teacher_id", "mentor_at_school_periods.teacher_id")
         .flatten
         .uniq


### PR DESCRIPTION
- Fix flaky declarations API seed spec

There is a mistake in the `teacher_ids_with_declarations` join; it will always return 0 results as we `join` instead of `left_join` on the school periods (and a training period never has both!).

This means `teacher_ids_without_declarations` can return a teacher with declarations; if on both iterations we pick the same teacher, and if on the first loop we created all declaration types - which can happen:

```
types = Declaration.declaration_types.keys
types.sample(rand(1..types.size))
```

This guard clause will prevent a declaration being created for the second lead provider:

```
if existing_declarations.billable_or_changeable.where(declaration_type:).exists?
```

Fixing the `teacher_ids_with_declarations` ensures a teacher without declarations will always be chosen for each iteration and declarations will be created.

- Fix bug in declaration status checks

We are mixing comparing strings with symbols here; when we take the `keys.sample` from the enum it will always be a string, but we compare it to an enum. The `clawback_status` method returns a mixture of both.

I don't think this is contributing to flakyness, but it wasn't behaving quite right.

Note: I've opted not to add tests to try and cover these as it got pretty awkward and these seeds are hopefully being binned/rewritten in the not too distant future anyway.