### PR TITLE
[4226] Use latest contract periods for change lead provider options

### DIFF
--- a/app/services/mentor_at_school_periods/latest_registration_choices.rb
+++ b/app/services/mentor_at_school_periods/latest_registration_choices.rb
@@ -18,6 +18,11 @@ module MentorAtSchoolPeriods
       school_partnership&.lead_provider || expression_of_interest&.lead_provider
     end
 
+    def contract_period
+      training_period&.contract_period ||
+        training_period&.expression_of_interest_contract_period
+    end
+
     def school
       school_partnership&.school || training_period&.mentor_at_school_period&.school
     end

--- a/app/wizards/schools/ects/change_lead_provider_wizard/edit_step.rb
+++ b/app/wizards/schools/ects/change_lead_provider_wizard/edit_step.rb
@@ -2,8 +2,6 @@ module Schools
   module ECTs
     module ChangeLeadProviderWizard
       class EditStep < Step
-        include Schedules::Reuse
-
         attribute :lead_provider_id, :string
 
         validates :lead_provider_id,
@@ -44,10 +42,20 @@ module Schools
             .call
         end
 
-        def period = ect_at_school_period
-        def reuse_existing_schedule? = false
-        def current_or_next_training_period_confirmed? = true
-        def date_of_transition = period.started_on
+        def contract_period
+          return contract_period_reassignment.successor_contract_period if contract_period_reassignment.required?
+
+          contract_period_reassignment.assigned_contract_period
+        end
+
+        def training_period
+          @training_period ||= ect_at_school_period.current_or_next_training_period ||
+            ect_at_school_period.latest_training_period
+        end
+
+        def contract_period_reassignment
+          @contract_period_reassignment ||= ContractPeriods::Reassignment.new(training_period:)
+        end
       end
     end
   end

--- a/app/wizards/schools/mentors/change_lead_provider_wizard/edit_step.rb
+++ b/app/wizards/schools/mentors/change_lead_provider_wizard/edit_step.rb
@@ -43,7 +43,7 @@ module Schools
         end
 
         def contract_period
-          @contract_period ||= ContractPeriod.containing_date(mentor_at_school_period.started_on)
+          @contract_period ||= wizard.latest_registration_choice.contract_period
         end
 
         def lead_provider_for_mentor_at_school_period

--- a/spec/wizards/schools/ects/change_lead_provider_wizard/edit_step_spec.rb
+++ b/spec/wizards/schools/ects/change_lead_provider_wizard/edit_step_spec.rb
@@ -101,53 +101,59 @@ describe Schools::ECTs::ChangeLeadProviderWizard::EditStep do
     let(:current_contract_period) do
       FactoryBot.create(:contract_period, :current)
     end
-    let(:upcoming_contract_period) do
-      FactoryBot.create(:contract_period, :next)
-    end
-    let!(:active_lead_provider) do
-      FactoryBot.create(:active_lead_provider, contract_period: current_contract_period)
-    end
-    let!(:other_lead_provider) do
-      FactoryBot.create(:active_lead_provider, contract_period: current_contract_period)
-    end
-    let!(:future_lead_provider) do
-      FactoryBot.create(:active_lead_provider, contract_period: upcoming_contract_period)
-    end
     let(:ect_at_school_period) do
       FactoryBot.create(:ect_at_school_period, :ongoing, school:, started_on:)
+    end
+    let!(:current_lead_provider) do
+      FactoryBot.create(:active_lead_provider, contract_period: current_contract_period)
     end
     let!(:training_period) do
       FactoryBot.create(
         :training_period,
         :for_ect,
         :ongoing,
-        :provider_led,
+        :with_active_lead_provider,
         ect_at_school_period:,
-        started_on: ect_at_school_period.started_on
+        started_on: training_period_started_on,
+        active_lead_provider: current_lead_provider
       )
     end
+    let(:training_period_started_on) { ect_at_school_period.started_on }
 
-    context "when there are no active lead providers in contract period containing the ect's start date" do
-      let(:started_on) { current_contract_period.started_on.prev_day }
+    context "when there are no other active lead providers in the current contract period" do
+      let(:started_on) { current_contract_period.started_on.next_month }
 
       it { is_expected.to be_empty }
     end
 
-    context "when there are active lead providers in contract period containing the ect's start date" do
+    context "when there are active lead providers in the current contract period" do
       let(:started_on) { current_contract_period.started_on.next_month }
+      let!(:active_lead_provider) do
+        FactoryBot.create(:active_lead_provider, contract_period: current_contract_period)
+      end
+      let!(:other_lead_provider) do
+        FactoryBot.create(:active_lead_provider, contract_period: current_contract_period)
+      end
 
       it { is_expected.to contain_exactly(active_lead_provider.lead_provider, other_lead_provider.lead_provider) }
+    end
 
-      context "when the ect starts on the last day of the contract period" do
-        let(:started_on) { current_contract_period.finished_on }
-
-        it { is_expected.to contain_exactly(active_lead_provider.lead_provider, other_lead_provider.lead_provider) }
+    context "when the latest training period is in a different contract period to the ects start date" do
+      let(:original_contract_period) { FactoryBot.create(:contract_period, year: 2021) }
+      let(:current_contract_period) { FactoryBot.create(:contract_period, year: 2024) }
+      let(:started_on) { original_contract_period.started_on.next_week }
+      let(:training_period_started_on) { current_contract_period.started_on.next_week }
+      let!(:original_contract_period_lead_provider) do
+        FactoryBot.create(:active_lead_provider, contract_period: original_contract_period)
       end
+      let!(:active_lead_provider) do
+        FactoryBot.create(:active_lead_provider, contract_period: current_contract_period)
+      end
+
+      it { is_expected.to contain_exactly(active_lead_provider.lead_provider) }
     end
 
     context "when the ECT started provider-led training in a frozen contract period" do
-      let(:started_on) { frozen_contract_period.started_on.next_week }
-
       let(:frozen_contract_period) do
         FactoryBot.create(
           :contract_period,
@@ -155,20 +161,11 @@ describe Schools::ECTs::ChangeLeadProviderWizard::EditStep do
           year: 2021
         )
       end
-      let(:school_partnership) do
-        FactoryBot.create(:school_partnership, :for_year, year: 2021, school:)
+      let(:started_on) { frozen_contract_period.started_on.next_week }
+      let(:training_period_started_on) { started_on }
+      let!(:current_lead_provider) do
+        FactoryBot.create(:active_lead_provider, contract_period: frozen_contract_period)
       end
-      let!(:training_period) do
-        FactoryBot.create(
-          :training_period,
-          :for_ect,
-          :provider_led,
-          ect_at_school_period:,
-          started_on: ect_at_school_period.started_on,
-          school_partnership:
-        )
-      end
-
       let!(:replacement_active_lead_provider) do
         FactoryBot.create(:active_lead_provider, :for_year, year: 2024)
       end

--- a/spec/wizards/schools/mentors/change_lead_provider_wizard/edit_step_spec.rb
+++ b/spec/wizards/schools/mentors/change_lead_provider_wizard/edit_step_spec.rb
@@ -99,30 +99,39 @@ describe Schools::Mentors::ChangeLeadProviderWizard::EditStep, type: :model do
     let(:current_contract_period) do
       FactoryBot.create(:contract_period, :current)
     end
-    let(:upcoming_contract_period) do
-      FactoryBot.create(:contract_period, :next)
-    end
-    let!(:active_lead_provider) do
-      FactoryBot.create(:active_lead_provider, contract_period: current_contract_period)
-    end
-    let!(:other_lead_provider) do
-      FactoryBot.create(:active_lead_provider, contract_period: current_contract_period)
-    end
-    let!(:future_lead_provider) do
-      FactoryBot.create(:active_lead_provider, contract_period: upcoming_contract_period)
-    end
     let(:mentor_at_school_period) do
       FactoryBot.create(:mentor_at_school_period, :ongoing, school:, started_on:)
     end
+    let!(:current_lead_provider) do
+      FactoryBot.create(:active_lead_provider, contract_period: current_contract_period)
+    end
+    let!(:training_period) do
+      FactoryBot.create(
+        :training_period,
+        :for_mentor,
+        :ongoing,
+        :with_active_lead_provider,
+        mentor_at_school_period:,
+        started_on: training_started_on,
+        active_lead_provider: current_lead_provider
+      )
+    end
+    let(:training_started_on) { mentor_at_school_period.started_on }
 
-    context "when there are no active lead providers in contract period containing the mentor's start date" do
-      let(:started_on) { current_contract_period.started_on.prev_day }
+    context "when there are no other active lead providers in the current contract period" do
+      let(:started_on) { current_contract_period.started_on.next_month }
 
       it { is_expected.to be_empty }
     end
 
-    context "when there are active lead providers in contract period containing the mentor's start date" do
+    context "when there are active lead providers in the current contract period" do
       let(:started_on) { current_contract_period.started_on.next_month }
+      let!(:active_lead_provider) do
+        FactoryBot.create(:active_lead_provider, contract_period: current_contract_period)
+      end
+      let!(:other_lead_provider) do
+        FactoryBot.create(:active_lead_provider, contract_period: current_contract_period)
+      end
 
       it { is_expected.to contain_exactly(active_lead_provider.lead_provider, other_lead_provider.lead_provider) }
 
@@ -131,6 +140,21 @@ describe Schools::Mentors::ChangeLeadProviderWizard::EditStep, type: :model do
 
         it { is_expected.to contain_exactly(active_lead_provider.lead_provider, other_lead_provider.lead_provider) }
       end
+    end
+
+    context "when the latest training period is in a different contract period to the mentor's start date" do
+      let(:original_contract_period) { FactoryBot.create(:contract_period, year: 2021) }
+      let(:current_contract_period) { FactoryBot.create(:contract_period, year: 2024) }
+      let(:started_on) { original_contract_period.started_on.next_week }
+      let(:training_started_on) { current_contract_period.started_on.next_week }
+      let!(:original_contract_period_lead_provider) do
+        FactoryBot.create(:active_lead_provider, contract_period: original_contract_period)
+      end
+      let!(:active_lead_provider) do
+        FactoryBot.create(:active_lead_provider, contract_period: current_contract_period)
+      end
+
+      it { is_expected.to contain_exactly(active_lead_provider.lead_provider) }
     end
   end
 end


### PR DESCRIPTION
## Summary

The mentor and ECT "change lead provider" flows were using the participant start date to decide which lead providers to show. That meant participants who started in an older contract period but were later moved to a newer one could still see the old options.

Switch both flows to use the contract period from the participant's latest training period instead, so the options shown line up with their current contract period.
