### PR TITLE
Use standard ApplicationService pattern for simpler calls

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -101,6 +101,9 @@ Style/HashSyntax:
 Style/Lambda:
   EnforcedStyle: literal
 
+Style/LambdaCall:
+  Enabled: false
+
 Rails/UnknownEnv:
   Environments:
     - production

--- a/app/controllers/admin/finance/active_lead_providers_controller.rb
+++ b/app/controllers/admin/finance/active_lead_providers_controller.rb
@@ -1,8 +1,11 @@
 module Admin::Finance
   class ActiveLeadProvidersController < Admin::Finance::BaseController
+    include ::ActiveLeadProviders
+
     layout "full"
 
     before_action :set_contract_period
+    before_action :set_active_lead_provider, only: %i[destroy]
     before_action :redirect_unless_contract_period_editable, only: %i[new create destroy]
 
     def index
@@ -24,11 +27,11 @@ module Admin::Finance
     end
 
     def create
-      @active_lead_provider = ::ActiveLeadProviders::Create.new(
+      @active_lead_provider = Create.(
         author: current_user,
         contract_period: @contract_period,
         lead_provider_id: active_lead_provider_params[:lead_provider_id]
-      ).call
+      )
 
       if @active_lead_provider.persisted?
         flash[:notice] = "#{@active_lead_provider.lead_provider.name} added"
@@ -37,19 +40,19 @@ module Admin::Finance
         @available_lead_providers = available_lead_providers
         render :new, status: :unprocessable_entity
       end
-    rescue ::ActiveLeadProviders::SeedFromPrevious::PreviousActiveLeadProviderError,
-           ::ActiveLeadProviders::SeedFromPrevious::AlreadyPopulatedError => e
+    rescue SeedFromPrevious::PreviousActiveLeadProviderError,
+           SeedFromPrevious::AlreadyPopulatedError => e
       flash[:error] = "Cannot seed: #{e.message}"
       redirect_to admin_contract_period_active_lead_providers_path(@contract_period)
     end
 
     def destroy
-      active_lead_provider = @contract_period.active_lead_providers.find(params[:id])
-      lead_provider_name = active_lead_provider.lead_provider.name
-      ::ActiveLeadProviders::CascadeDelete.new(active_lead_provider:, author: current_user).call
+      lead_provider_name = @active_lead_provider.lead_provider_name
+
+      CascadeDelete.(active_lead_provider: @active_lead_provider, author: current_user)
       flash[:notice] = "#{lead_provider_name} removed"
       redirect_to admin_contract_period_active_lead_providers_path(@contract_period)
-    rescue ::ActiveLeadProviders::CascadeDelete::CascadeDeleteError => e
+    rescue CascadeDelete::CascadeDeleteError => e
       flash[:error] = "Cannot remove #{lead_provider_name}: #{e.message}"
       redirect_to admin_contract_period_active_lead_providers_path(@contract_period)
     end
@@ -58,6 +61,10 @@ module Admin::Finance
 
     def set_contract_period
       @contract_period = ContractPeriod.find(params[:contract_period_id])
+    end
+
+    def set_active_lead_provider
+      @active_lead_provider = @contract_period.active_lead_providers.find(params[:id])
     end
 
     def redirect_unless_contract_period_editable

--- a/app/services/active_lead_providers/cascade_delete.rb
+++ b/app/services/active_lead_providers/cascade_delete.rb
@@ -1,5 +1,5 @@
 module ActiveLeadProviders
-  class CascadeDelete
+  class CascadeDelete < ApplicationService
     # Active lead providers should only be deleted before their contract period
     # has started, i.e. while still unused. If any usage data references this
     # active lead provider we refuse to delete it and raise CascadeDeleteError for
@@ -8,14 +8,10 @@ module ActiveLeadProviders
 
     class CascadeDeleteError < StandardError; end
 
-    attr_reader :active_lead_provider, :author
+    attribute :active_lead_provider
+    attribute :author
 
     delegate :lead_provider, :contract_period, to: :active_lead_provider
-
-    def initialize(active_lead_provider:, author:)
-      @active_lead_provider = active_lead_provider
-      @author = author
-    end
 
     def call
       reject_if_in_use!

--- a/app/services/active_lead_providers/create.rb
+++ b/app/services/active_lead_providers/create.rb
@@ -1,28 +1,22 @@
-# Builds an active lead provider for a contract period and, once saved, seeds it
-# from the previous contract period (see SeedFromPrevious). Returns the active
-# lead provider so callers can inspect validation errors when it isn't persisted;
-# SeedFromPrevious errors are allowed to propagate.
-class ActiveLeadProviders::Create
-  attr_reader :active_lead_provider
+module ActiveLeadProviders
+  # Builds an active lead provider for a contract period and, once saved, seeds it
+  # from the previous contract period (see SeedFromPrevious). Returns the active
+  # lead provider so callers can inspect validation errors when it isn't persisted;
+  # SeedFromPrevious errors are allowed to propagate.
+  class Create < ApplicationService
+    attribute :author
+    attribute :contract_period
+    attribute :lead_provider_id
 
-  def initialize(author:, contract_period:, lead_provider_id:)
-    @author = author
-    @contract_period = contract_period
-    @lead_provider_id = lead_provider_id
-  end
+    def call
+      active_lead_provider = contract_period.active_lead_providers.build(lead_provider_id:)
 
-  def call
-    @active_lead_provider = contract_period.active_lead_providers.build(lead_provider_id:)
+      if active_lead_provider.save
+        Events::Record.record_active_lead_provider_created_event!(author:, active_lead_provider:)
+        SeedFromPrevious.(active_lead_provider:)
+      end
 
-    if active_lead_provider.save
-      Events::Record.record_active_lead_provider_created_event!(author:, active_lead_provider:)
-      ActiveLeadProviders::SeedFromPrevious.new(active_lead_provider:).call
+      active_lead_provider
     end
-
-    active_lead_provider
   end
-
-private
-
-  attr_reader :author, :contract_period, :lead_provider_id
 end

--- a/app/services/active_lead_providers/seed_from_previous.rb
+++ b/app/services/active_lead_providers/seed_from_previous.rb
@@ -5,11 +5,11 @@
 # rolled forward to the new period's year.
 #
 # It Errors if it cannot do this.
-class ActiveLeadProviders::SeedFromPrevious
+class ActiveLeadProviders::SeedFromPrevious < ApplicationService
   class PreviousActiveLeadProviderError < StandardError; end
   class AlreadyPopulatedError < StandardError; end
 
-  attr_reader :active_lead_provider
+  attribute :active_lead_provider
 
   delegate :lead_provider, to: :active_lead_provider
   delegate :name, to: :lead_provider, prefix: true
@@ -17,10 +17,9 @@ class ActiveLeadProviders::SeedFromPrevious
   delegate :lead_provider_delivery_partnerships, :contracts, :statements,
            to: :previous_activation, prefix: :previous
 
-  def initialize(active_lead_provider:)
+  def initialize(...)
+    super
     raise ArgumentError, "active_lead_provider is required" if active_lead_provider.blank?
-
-    @active_lead_provider = active_lead_provider
   end
 
   def call

--- a/app/services/application_service.rb
+++ b/app/services/application_service.rb
@@ -1,0 +1,6 @@
+class ApplicationService
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  def self.call(**kwargs) = new(**kwargs).call
+end

--- a/spec/services/active_lead_providers/create_spec.rb
+++ b/spec/services/active_lead_providers/create_spec.rb
@@ -1,14 +1,13 @@
 describe ActiveLeadProviders::Create do
-  subject(:service) { described_class.new(author:, contract_period:, lead_provider_id:) }
+  subject(:call_service) { described_class.(author:, contract_period:, lead_provider_id:) }
 
   let(:contract_period) { FactoryBot.create(:contract_period, :next) }
   let(:lead_provider) { FactoryBot.create(:lead_provider) }
   let(:user) { FactoryBot.create(:user, :admin) }
   let(:author) { Sessions::Users::DfEPersona.new(email: user.email) }
-  let(:seed) { instance_double(ActiveLeadProviders::SeedFromPrevious, call: true) }
 
   before do
-    allow(ActiveLeadProviders::SeedFromPrevious).to receive(:new).and_return(seed)
+    allow(ActiveLeadProviders::SeedFromPrevious).to receive(:call)
     allow(Events::Record).to receive(:record_active_lead_provider_created_event!)
   end
 
@@ -17,13 +16,12 @@ describe ActiveLeadProviders::Create do
 
     it "builds and saves the active lead provider, records the created event, then seeds it from the previous period" do
       result = nil
-      expect { result = service.call }.to change(ActiveLeadProvider, :count).by(1)
+      expect { result = call_service }.to change(ActiveLeadProvider, :count).by(1)
 
       expect(result).to be_persisted
       expect(result).to have_attributes(contract_period_year: contract_period.year, lead_provider_id: lead_provider.id)
       expect(Events::Record).to have_received(:record_active_lead_provider_created_event!).with(author:, active_lead_provider: result)
-      expect(ActiveLeadProviders::SeedFromPrevious).to have_received(:new).with(active_lead_provider: result)
-      expect(seed).to have_received(:call)
+      expect(ActiveLeadProviders::SeedFromPrevious).to have_received(:call).with(active_lead_provider: result)
     end
   end
 
@@ -32,12 +30,12 @@ describe ActiveLeadProviders::Create do
 
     it "does not save, record an event, or seed, and returns the unpersisted record carrying its errors" do
       result = nil
-      expect { result = service.call }.not_to change(ActiveLeadProvider, :count)
+      expect { result = call_service }.not_to change(ActiveLeadProvider, :count)
 
       expect(result).not_to be_persisted
       expect(result.errors[:lead_provider_id]).to include("Choose a lead provider")
       expect(Events::Record).not_to have_received(:record_active_lead_provider_created_event!)
-      expect(ActiveLeadProviders::SeedFromPrevious).not_to have_received(:new)
+      expect(ActiveLeadProviders::SeedFromPrevious).not_to have_received(:call)
     end
   end
 end


### PR DESCRIPTION
### Context

This project makes use of Service Objects extensively.  Our Service Objects are not sure of themselves. While they only a single public method, and are verb named (e.g. Create, Find, etc), they have custom execute names. This attempt to provide additional context actually ends up obfuscating and confusing the situation since:
* The Service Object name is already a verb, so we violate DRY.
* It makes it less obvious that this thing is actually a service object rather than a "real" domain centred PORO.

In Ruby, objects that encapsulate executable logic like **Proc**, **Method**, and **Lambda** are invoked using `.call`. By naming our service method `call` we follow Ruby's native design language.

This is a widely accepted standard, that improves predictability.

#### Why not dry-rb?

I don't think dry-rb is a great fit for a Rails application. It's built around a fundamentally different philosophy, and mixing that with Rails usually means carrying two sets of patterns and conventions. 

In our case, we can get the fundamental benefits with a simple **ApplicationService** superclass and one single-line method, without introducing another abstraction or dependency.

```
  def self.call(**kwargs) = new(**kwargs).call
```


### Changes proposed in this pull request

* Make service objects inherit from ApplicationService. This provides a class `call` for convenience method.
* Call service objects using their class method using the explicit dot-syntax. 

I.e.

Instead of:
```
# This is bad 
seed_from_previous = ActiveLeadProviders::SeedFromPrevious.new(active_lead_provider:)
seed_from_previous.seed!

# This is still bad
ActiveLeadProviders::SeedFromPrevious.new(active_lead_provider:).seed!

# This is still not good
ActiveLeadProviders::SeedFromPrevious.new(active_lead_provider:).call
```

Use: 
```
# This is okay
ActiveLeadProviders::SeedFromPrevious.(active_lead_provider:)

# This is best (IMO)
SeedFromPrevious.(active_lead_provider:)
```

This keeps them as close to methods in the caller as possible. The actual instance doing the work is never seen by the caller.

### Guidance to review

* Superclass ApplicationService.
* Class based invocation.
* includes namespace ~ this one might be controversial.
