### PR TITLE
Ignore ended TRS prohibition alerts during registration

### DIFF
--- a/lib/trs/teacher.rb
+++ b/lib/trs/teacher.rb
@@ -45,7 +45,9 @@ module TRS
       @trs_last_name = data["lastName"]
       @trs_email_address = data["emailAddress"]
       @trs_national_insurance_number = data["nationalInsuranceNumber"]
-      @trs_alerts = data.fetch("alerts", []).map { |a| a.dig(*%w[alertType alertCategory alertCategoryId]) }
+      alerts = data.fetch("alerts", [])
+      @trs_alerts = alerts.map { |alert| alert.dig(*%w[alertType alertCategory alertCategoryId]) }
+      @trs_prohibited_from_teaching = alerts.any? { |alert| active_prohibition_alert?(alert) }
       @trs_qtls_status = data["qtlsStatus"]
       @trs_routes_to_professional_status = data["routesToProfessionalStatuses"]
       @trs_induction_start_date = data.dig("induction", "startDate")
@@ -63,7 +65,7 @@ module TRS
 
     # @return [Boolean]
     def prohibited_from_teaching?
-      PROHIBITED_FROM_TEACHING_CATEGORY_ID.in?(trs_alerts)
+      @trs_prohibited_from_teaching
     end
 
     alias_method :trs_prohibited_from_teaching, :prohibited_from_teaching?
@@ -110,6 +112,22 @@ module TRS
         trs_alerts:,
         trs_prohibited_from_teaching:,
       }
+    end
+
+  private
+
+    def active_prohibition_alert?(alert)
+      alert.dig(*%w[alertType alertCategory alertCategoryId]) == PROHIBITED_FROM_TEACHING_CATEGORY_ID &&
+        active_alert?(alert)
+    end
+
+    def active_alert?(alert)
+      end_date = alert["endDate"]
+      return true if end_date.blank?
+
+      Date.iso8601(end_date).future?
+    rescue Date::Error
+      true
     end
   end
 end

--- a/spec/lib/trs/teacher_spec.rb
+++ b/spec/lib/trs/teacher_spec.rb
@@ -228,6 +228,36 @@ RSpec.describe TRS::Teacher do
       it { is_expected.to be_prohibited_from_teaching }
     end
 
+    context "when teacher has a prohibition alert with an end date" do
+      let(:data) do
+        {
+          "alerts" => [
+            {
+              "alertType" => { "alertCategory" => { "alertCategoryId" => "b2b19019-b165-47a3-8745-3297ff152581" } },
+              "endDate" => "2024-09-18"
+            }
+          ]
+        }
+      end
+
+      it { is_expected.not_to be_prohibited_from_teaching }
+    end
+
+    context "when teacher has a prohibition alert with a future end date" do
+      let(:data) do
+        {
+          "alerts" => [
+            {
+              "alertType" => { "alertCategory" => { "alertCategoryId" => "b2b19019-b165-47a3-8745-3297ff152581" } },
+              "endDate" => "9999-09-18"
+            }
+          ]
+        }
+      end
+
+      it { is_expected.to be_prohibited_from_teaching }
+    end
+
     context "when teacher has no alerts" do
       let(:data) { { "alerts" => [] } }
 

--- a/spec/wizards/schools/register_mentor_wizard/find_mentor_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/find_mentor_step_spec.rb
@@ -191,6 +191,40 @@ describe Schools::RegisterMentorWizard::FindMentorStep, type: :model do
       end
     end
 
+    context "when the mentor had a prohibition alert that has ended" do
+      let(:school) { FactoryBot.create(:school) }
+
+      before do
+        test_client = TRS::TestAPIClient.new
+
+        allow(test_client).to receive(:find_teacher).and_return(
+          TRS::Teacher.new(
+            "trn" => "1234568",
+            "firstName" => "Jane",
+            "lastName" => "Smith",
+            "dateOfBirth" => "1977-02-03",
+            "qts" => { "holdsFrom" => "2024-09-18" },
+            "alerts" => [
+              {
+                "alertType" => {
+                  "alertCategory" => {
+                    "alertCategoryId" => TRS::Teacher::PROHIBITED_FROM_TEACHING_CATEGORY_ID
+                  }
+                },
+                "endDate" => "2024-09-18"
+              }
+            ]
+          )
+        )
+        allow(::TRS::APIClient).to receive(:new).and_return(test_client)
+        subject.save!
+      end
+
+      it "returns :review_mentor_details" do
+        expect(subject.next_step).to eq(:review_mentor_details)
+      end
+    end
+
     context "otherwise" do
       let(:school) { FactoryBot.create(:school) }
 


### PR DESCRIPTION
## Context

Updating TRS prohibition handling so RECT only treats a teacher as prohibited from teaching when the prohibition alert is still active.

Previously, any TRS alert in the "Prohibition from teaching" category caused `trs_prohibited_from_teaching` to be `true`, even when the alert had an `endDate` in the past.

## Changes proposed

- Use the full TRS alert payload while building `TRS::Teacher` to check the alert `endDate`
- Treat prohibition alerts as active when:
  - `endDate` is blank or missing
  - `endDate` is in the future
  - `endDate` cannot be parsed
- Treat prohibition alerts as ended when `endDate` is in the past.
- Continue storing only:
  - `trs_alerts`: alert category ids
  - `trs_prohibited_from_teaching`: the calculated boolean

The end date is only used while building `TRS::Teacher` and the existing `trs_alerts` output hasn't changed and still only exposes the alert category ids.