### PR TITLE
Fix flaky transfers spec

### DIFF
--- a/spec/serializers/api/teachers/school_transfer_serializer_spec.rb
+++ b/spec/serializers/api/teachers/school_transfer_serializer_spec.rb
@@ -9,18 +9,12 @@ RSpec.describe API::Teachers::SchoolTransferSerializer, type: :serializer do
   let(:lead_provider) { FactoryBot.create(:lead_provider) }
   let(:other_lead_provider) { FactoryBot.create(:lead_provider) }
   let(:teacher) { FactoryBot.create(:teacher) }
-  let(:leaving_training_period) do
-    teacher.ect_at_school_periods.first.latest_training_period
-  end
-  let(:leaving_school) do
-    teacher.ect_at_school_periods.first.school
-  end
-  let(:joining_training_period) do
-    teacher.ect_at_school_periods.second.earliest_training_period
-  end
-  let(:joining_school) do
-    teacher.ect_at_school_periods.second.school
-  end
+  let(:leaving_school_period) { teacher.ect_at_school_periods.order(:started_on).first }
+  let(:leaving_training_period) { leaving_school_period.latest_training_period }
+  let(:leaving_school) { leaving_school_period.school }
+  let(:joining_school_period) { teacher.ect_at_school_periods.order(:started_on).last }
+  let(:joining_training_period) { joining_school_period.earliest_training_period }
+  let(:joining_school) { joining_school_period.school }
 
   describe "core attributes" do
     before do


### PR DESCRIPTION
We're getting flaky failures in CI for asserting on the leaving school URN; I think the issue comes from the way the `leaving_training_period` and `joining_training_period` are non-deterministic as we don't apply any explicit ordering.

Order `leaving` and `joining` training periods by `started_on` to match the `TransferHistory` service and remove ambiguity.

https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/29487514875/job/87585419997

```
Failures:

  1) API::Teachers::SchoolTransferSerializer nested attributes when there is a transfer with a school-led joining training period serializes correctly
     Failure/Error: expect(leaving["school_urn"]).to eq(leaving_school.urn.to_s)

       expected: #<Encoding:US-ASCII> "961255"
            got: #<Encoding:UTF-8> "857950"

       (compared using ==)
     # ./spec/serializers/api/teachers/school_transfer_serializer_spec.rb:95:in 'block (4 levels) in <main>'
     # ./spec/rails_helper.rb:63:in 'block (3 levels) in <top (required)>'
     # ./app/models/concerns/declarative_updates.rb:63:in 'DeclarativeUpdates.skip'
     # ./spec/rails_helper.rb:63:in 'block (2 levels) in <top (required)>'
     # ./spec/support/rack_attack.rb:15:in 'block (2 levels) in <main>'
```