### PR TITLE
2855 - Adds schedule check to delete after reconcile

### DIFF
--- a/.github/workflows/review-app-reconcile.yml
+++ b/.github/workflows/review-app-reconcile.yml
@@ -65,10 +65,14 @@ jobs:
      environment: review
 
      if: >
-       github.event.inputs.dry_run == 'false' &&
-       needs.display-review-apps-to-remove.outputs.stale_prs != '[]'
+        (
+          github.event_name == 'schedule' ||
+          github.event.inputs.dry_run == 'false'
+        ) &&
+        needs.display-review-apps-to-remove.outputs.stale_prs != '[]'
 
      strategy:
+       max-parallel: 1
        fail-fast: false
        matrix:
          pr_number: ${{ fromJson(needs.display-review-apps-to-remove.outputs.stale_prs) }}


### PR DESCRIPTION
## Context

Ticket: [Trello card](https://trello.com/c/ZWznDc8Y/2855-add-review-app-cleanup-workflow)

We get quite a few rogue review apps i.e. the PR has been merged or closed, but the review app wasn’t deleted.

There are various reasons this can occur, but we also now have a workflow that will check for rogue review apps and delete them: [Review app](https://github.com/DFE-Digital/register-early-career-teachers-public/blob/main/.github/workflows/review-app-reconcile.yml)

However, the workflow must be amended so that it runs on a schedule. We require it to be run every Sunday.

## Changes proposed in this pull request

Amends if statement in existing **Reconcile review apps on AKS** workflow to ensure it runs on a schedule GitHub event.

`if: >
        (
          github.event_name == 'schedule' ||
          github.event.inputs.dry_run == 'false'
        ) &&
        needs.display-review-apps-to-remove.outputs.stale_prs != '[]'`

## Guidance to review

Aside from waiting until it fails on Sunday, we can test the deletion of review apps by running the workflow manually and removing the dry run flag. I did not do this as it is during the day and the review apps may still be needed. However, I completed a dry run and this worked fine: [My dry run](https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/29506787879)

There will be no issue if it fails to delete the review apps on Sunday as this is what it is doing at the moment anyway. This will just need revisiting, if so.

## Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Applied DevOps label
- [ ] Tested by running locally