### PR TITLE
GOV.UK frontend 6.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,8 +20,8 @@ gem "redis"
 gem "redis-session-store"
 gem "tzinfo-data", platforms: %i[windows jruby]
 
-gem "govuk-components", "6.4.0"
-gem "govuk_design_system_formbuilder", "6.3.1"
+gem "govuk-components", "6.4.1"
+gem "govuk_design_system_formbuilder", "6.4.0"
 gem "govuk_markdown"
 
 gem "mail-notify"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -300,11 +300,11 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
-    govuk-components (6.4.0)
+    govuk-components (6.4.1)
       html-attributes-utils (~> 1.0.0, >= 1.0.0)
       pagy (>= 6, < 10)
       view_component (>= 4.9, < 4.13)
-    govuk_design_system_formbuilder (6.3.1)
+    govuk_design_system_formbuilder (6.4.0)
       actionview (>= 7.2)
       activemodel (>= 7.2)
       activesupport (>= 7.2)
@@ -900,8 +900,8 @@ DEPENDENCIES
   factory_bot_rails
   faker
   faraday
-  govuk-components (= 6.4.0)
-  govuk_design_system_formbuilder (= 6.3.1)
+  govuk-components (= 6.4.1)
+  govuk_design_system_formbuilder (= 6.4.0)
   govuk_markdown
   herb
   hotwire-rails

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "@hotwired/turbo-rails": "^8.0.23",
         "accessible-autocomplete": "^3.0.1",
         "esbuild": "^0.28.1",
-        "govuk-frontend": "6.3.0",
+        "govuk-frontend": "6.4.0",
         "sass": "^1.101.0",
         "swagger-ui-dist": "^5.32.8"
       },
@@ -2959,9 +2959,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-6.3.0.tgz",
-      "integrity": "sha512-cXIQxm5PHCsbic47GXZrVBZhAeeshTLRL6ZBKilLsR6rMCjJuWb7Fruq0VUNMBJFlJk/srsRj/q8d5bM9cgKoA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-6.4.0.tgz",
+      "integrity": "sha512-jU3oaVFXqK1yDVIdZs1YZ6JD7YDB4PFUHF3rFMWJye9ArImp42F9wCsFzzB1+udjuzGCryJGcHHbBQ5HY+8rqQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@hotwired/turbo-rails": "^8.0.23",
     "accessible-autocomplete": "^3.0.1",
     "esbuild": "^0.28.1",
-    "govuk-frontend": "6.3.0",
+    "govuk-frontend": "6.4.0",
     "sass": "^1.101.0",
     "swagger-ui-dist": "^5.32.8"
   },


### PR DESCRIPTION
### Context

GOV.UK frontend 6.4.0 was released earlier today along with new versions of the govuk components and form builder gems.

The main addition is the interruption panel variant cc @jsjohal

### Changes proposed in this pull request

- **Upgrade to govuk-frontend 6.4.0**
- **Upgrade govuk components and form builder gems**
