### PR TITLE
Fix and validate swagger schema

### DIFF
--- a/.github/workflows/lead_provider_openapi_check.yml
+++ b/.github/workflows/lead_provider_openapi_check.yml
@@ -59,6 +59,12 @@ jobs:
           prepare-test-database: "true"
           prepare-assets: "true"
 
+      - name: Install Redocly CLI
+        run: npm install -g @redocly/cli@latest
+      
+      - name: Run linting
+        run: redocly lint public/api/docs/v3/swagger.yaml --format=github-actions
+
       - name: Generate API doc checksums (original)
         run: |
           find public/api/docs/ -type f -exec sed -i 's/[[:space:]]\+$//' {} \;

--- a/.redocly.lint-ignore.yaml
+++ b/.redocly.lint-ignore.yaml
@@ -1,0 +1,7 @@
+# This file instructs Redocly's linter to ignore the rules contained for specific parts of your API.
+# See https://redocly.com/docs/cli/ for more information.
+public/api/docs/v3/swagger.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  info-license:
+    - '#/info'

--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -16,6 +16,7 @@ paths:
       - Declarations
       security:
       - api_key: []
+      operationId: createDeclaration
       parameters: []
       responses:
         '200':
@@ -53,6 +54,7 @@ paths:
       - Declarations
       security:
       - api_key: []
+      operationId: getDeclarations
       parameters:
       - name: filter
         in: query
@@ -86,6 +88,7 @@ paths:
       - Declarations
       security:
       - api_key: []
+      operationId: getDeclaration
       parameters:
       - name: id
         in: path
@@ -118,6 +121,7 @@ paths:
       - Declarations
       security:
       - api_key: []
+      operationId: voidDeclaration
       parameters:
       - name: id
         in: path
@@ -156,6 +160,7 @@ paths:
       - Delivery Partners
       security:
       - api_key: []
+      operationId: getDeliveryPartners
       parameters:
       - name: filter
         in: query
@@ -194,6 +199,7 @@ paths:
       - Delivery Partners
       security:
       - api_key: []
+      operationId: getDeliveryPartner
       parameters:
       - name: id
         in: path
@@ -226,6 +232,7 @@ paths:
       - Participants
       security:
       - api_key: []
+      operationId: getParticipants
       parameters:
       - name: filter
         in: query
@@ -302,6 +309,7 @@ paths:
       - Participants
       security:
       - api_key: []
+      operationId: getParticipant
       parameters:
       - name: id
         in: path
@@ -372,6 +380,7 @@ paths:
       - Participants
       security:
       - api_key: []
+      operationId: withdrawParticipant
       parameters:
       - name: id
         in: path
@@ -408,7 +417,7 @@ paths:
                           schedule_identifier: ecf-standard-january
                           delivery_partner_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
                           withdrawal:
-                            reason: moved-school
+                            reason: left-teaching-profession
                             date: '2021-05-31T02:22:32.000Z'
                           deferral:
                           created_at: '2023-01-01T00:00:00Z'
@@ -461,6 +470,7 @@ paths:
       - Participants
       security:
       - api_key: []
+      operationId: deferParticipant
       parameters:
       - name: id
         in: path
@@ -498,7 +508,7 @@ paths:
                           delivery_partner_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
                           withdrawal:
                           deferral:
-                            reason: career-break
+                            reason: bereavement
                             date: '2021-05-31T02:22:32.000Z'
                           created_at: '2023-01-01T00:00:00Z'
                           induction_end_date: '2023-01-01'
@@ -550,6 +560,7 @@ paths:
       - Participants
       security:
       - api_key: []
+      operationId: resumeParticipant
       parameters:
       - name: id
         in: path
@@ -637,6 +648,7 @@ paths:
       - Participants
       security:
       - api_key: []
+      operationId: changeScheduleParticipant
       parameters:
       - name: id
         in: path
@@ -673,10 +685,10 @@ paths:
                           schedule_identifier: ecf-extended-september
                           delivery_partner_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
                           withdrawal:
-                            reason: moved-school
+                            reason: left-teaching-profession
                             date: '2021-05-31T02:22:32.000Z'
                           deferral:
-                            reason: career-break
+                            reason: bereavement
                             date: '2021-05-31T02:22:32.000Z'
                           created_at: '2023-01-01T00:00:00Z'
                           induction_end_date: '2023-01-01'
@@ -728,6 +740,7 @@ paths:
       - Partnerships
       security:
       - api_key: []
+      operationId: getPartnerships
       parameters:
       - name: filter
         in: query
@@ -765,6 +778,7 @@ paths:
       - Partnerships
       security:
       - api_key: []
+      operationId: createPartnership
       parameters: []
       responses:
         '200':
@@ -803,6 +817,7 @@ paths:
       - Partnerships
       security:
       - api_key: []
+      operationId: getPartnership
       parameters:
       - name: id
         in: path
@@ -834,6 +849,7 @@ paths:
       - Partnerships
       security:
       - api_key: []
+      operationId: updatePartnership
       parameters:
       - name: id
         in: path
@@ -883,6 +899,7 @@ paths:
       - Schools
       security:
       - api_key: []
+      operationId: getSchools
       parameters:
       - name: filter
         in: query
@@ -921,6 +938,7 @@ paths:
       - Schools
       security:
       - api_key: []
+      operationId: getSchool
       parameters:
       - name: id
         in: path
@@ -959,6 +977,7 @@ paths:
       - Statements
       security:
       - api_key: []
+      operationId: getStatements
       parameters:
       - name: filter
         in: query
@@ -992,6 +1011,7 @@ paths:
       - Statements
       security:
       - api_key: []
+      operationId: getStatement
       parameters:
       - name: id
         in: path
@@ -1024,6 +1044,7 @@ paths:
       - Transfers
       security:
       - api_key: []
+      operationId: getTransfers
       parameters:
       - name: filter
         in: query
@@ -1062,6 +1083,7 @@ paths:
       - Transfers
       security:
       - api_key: []
+      operationId: getTransfer
       parameters:
       - name: id
         in: path
@@ -1091,9 +1113,10 @@ paths:
     get:
       summary: Retrieve multiple unfunded mentors
       tags:
-      - Unfunded mentors
+      - Unfunded Mentors
       security:
       - api_key: []
+      operationId: getUnfundedMentors
       parameters:
       - name: filter
         in: query
@@ -1129,9 +1152,10 @@ paths:
     get:
       summary: Retrieve a single unfunded mentor
       tags:
-      - Unfunded mentors
+      - Unfunded Mentors
       security:
       - api_key: []
+      operationId: getUnfundedMentor
       parameters:
       - name: id
         in: path
@@ -1554,7 +1578,7 @@ components:
               type: string
               format: uuid
               nullable: true
-              example: cd3a12347-7308-4879-942a-c4a70ced400a
+              example: 45146ec2-594a-495a-bb02-8b2280a3deaf
             clawback_statement_id:
               description: Unique ID of the statement to which the declaration will
                 be clawed back on, if any.
@@ -1692,7 +1716,7 @@ components:
               type: string
               format: uuid
               nullable: true
-              example: cd3a12347-7308-4879-942a-c4a70ced400a
+              example: 45146ec2-594a-495a-bb02-8b2280a3deaf
             clawback_statement_id:
               description: Unique ID of the statement to which the declaration will
                 be clawed back on, if any.
@@ -2390,7 +2414,7 @@ components:
             cohort:
               description: The cohort for which you are reporting the partnership
               type: string
-              example: 2021
+              example: '2021'
             urn:
               description: The Unique Reference Number (URN) of the school you are
                 partnered with
@@ -2400,13 +2424,13 @@ components:
               description: The unique ID of the school you are partnered with
               type: string
               format: uuid
-              example: dd4a11347-7308-4879-942a-c4a70ced400v
+              example: dd4a1134-7308-4879-942a-c4a70ced400f
             delivery_partner_id:
               description: The unique ID of the delivery partner you are working with
                 for this partnership
               type: string
               format: uuid
-              example: cd3a12347-7308-4879-942a-c4a70ced400a
+              example: 45146ec2-594a-495a-bb02-8b2280a3deaf
             delivery_partner_name:
               description: The name of the delivery partner you are working with for
                 this partnership
@@ -2702,7 +2726,7 @@ components:
                   - parental-leave
                   - career-break
                   - other
-                  example: left-teaching-profession
+                  example: bereavement
                 course_identifier:
                   description: The type of course the participant is enrolled in
                   type: string
@@ -2943,7 +2967,7 @@ components:
               - switched-to-school-led
               - changed-lead-provider
               - other
-              example: moved-school
+              example: left-teaching-profession
             date:
               description: The date and time the participant was withdrawn
               type: string
@@ -2966,7 +2990,7 @@ components:
               - parental-leave
               - career-break
               - other
-              example: career-break
+              example: bereavement
             date:
               description: The date and time the participant was deferred
               type: string
@@ -3163,7 +3187,7 @@ components:
           example: '2021-05-13T11:21:55Z'
     ParticipantTransfersResponse:
       description: Transfers for a given participant
-      tyoe: object
+      type: object
       required:
       - data
       properties:

--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -1332,7 +1332,6 @@ components:
           description: Return schools within the specified cohort.
           type: string
           example: '2021'
-          required: true
         urn:
           description: Return a school with the specified Unique Reference Number
             (URN).
@@ -2482,7 +2481,6 @@ components:
           properties:
             type:
               type: string
-              required: true
               enum:
               - partnership
               example: partnership
@@ -2496,20 +2494,17 @@ components:
               properties:
                 cohort:
                   description: The cohort for which you are reporting the partnership
-                  required: true
                   nullable: false
                   type: string
                   example: '2022'
                 school_id:
                   description: The Unique ID of the school you are partnering with
-                  required: true
                   nullable: false
                   type: string
                   example: 24b61d1c-ad95-4000-aee0-afbdd542294a
                 delivery_partner_id:
                   description: The unique ID of the delivery partner you will work
                     with for this school partnership
-                  required: true
                   nullable: false
                   type: string
                   example: db2fbf67-b7b7-454f-a1b7-0020411e2314
@@ -2528,7 +2523,6 @@ components:
           properties:
             type:
               type: string
-              required: true
               enum:
               - partnership
               example: partnership
@@ -2541,7 +2535,6 @@ components:
                 delivery_partner_id:
                   description: The unique ID of the delivery partner you will work
                     with for this school partnership
-                  required: true
                   nullable: false
                   type: string
                   example: db2fbf67-b7b7-454f-a1b7-0020411e2314
@@ -2647,7 +2640,6 @@ components:
           properties:
             type:
               type: string
-              required: true
               enum:
               - participant-withdraw
               example: participant-withdraw
@@ -2661,7 +2653,6 @@ components:
                 reason:
                   description: The reason for the withdrawal
                   type: string
-                  required: true
                   enum:
                   - left-teaching-profession
                   - moved-school
@@ -2673,7 +2664,6 @@ components:
                 course_identifier:
                   description: The type of course the participant is enrolled in
                   type: string
-                  required: true
                   enum:
                   - ecf-mentor
                   - ecf-induction
@@ -2693,7 +2683,6 @@ components:
           properties:
             type:
               type: string
-              required: true
               enum:
               - participant-defer
               example: participant-defer
@@ -2707,7 +2696,6 @@ components:
                 reason:
                   description: The reason for the deferral
                   type: string
-                  required: true
                   enum:
                   - bereavement
                   - long-term-sickness
@@ -2718,7 +2706,6 @@ components:
                 course_identifier:
                   description: The type of course the participant is enrolled in
                   type: string
-                  required: true
                   enum:
                   - ecf-mentor
                   - ecf-induction
@@ -2738,7 +2725,6 @@ components:
           properties:
             type:
               type: string
-              required: true
               enum:
               - participant-resume
               example: participant-resume
@@ -2751,7 +2737,6 @@ components:
                 course_identifier:
                   description: The type of course the participant is enrolled in
                   type: string
-                  required: true
                   enum:
                   - ecf-mentor
                   - ecf-induction
@@ -2771,7 +2756,6 @@ components:
           properties:
             type:
               type: string
-              required: true
               enum:
               - participant-change-schedule
               example: participant-change-schedule
@@ -2785,7 +2769,6 @@ components:
                 schedule_identifier:
                   description: The new schedule of the participant
                   type: string
-                  required: true
                   enum:
                   - ecf-standard-january
                   - ecf-standard-april
@@ -2803,7 +2786,6 @@ components:
                 course_identifier:
                   description: The type of course the participant is enrolled in
                   type: string
-                  required: true
                   enum:
                   - ecf-mentor
                   - ecf-induction
@@ -2814,7 +2796,6 @@ components:
                     training. 2021 indicates a participant that has started, or will
                     start, their training in the 2021/22 academic year.
                   type: string
-                  required: false
                   example: '2021'
     ParticipantsResponse:
       description: A list of participants.

--- a/spec/requests/api/docs/v3/declarations_spec.rb
+++ b/spec/requests/api/docs/v3/declarations_spec.rb
@@ -92,6 +92,7 @@ RSpec.describe "Declarations endpoint", :with_metadata, openapi_spec: "v3/swagge
                   {
                     url: "/api/v3/participant-declarations/{id}/void",
                     tag: "Declarations",
+                    operation_id: "voidDeclaration",
                     resource_description: "Void a declaration",
                     response_description: "The declaration being voided",
                     response_schema_ref: "#/components/schemas/DeclarationResponse",

--- a/spec/requests/api/docs/v3/participants_spec.rb
+++ b/spec/requests/api/docs/v3/participants_spec.rb
@@ -75,6 +75,7 @@ describe "Participants endpoint", :with_metadata, openapi_spec: "v3/swagger.yaml
                   {
                     url: "/api/v3/participants/{id}/withdraw",
                     tag: "Participants",
+                    operation_id: "withdrawParticipant",
                     resource_description: "Notify that a participant has withdrawn from their course",
                     response_description: "The participant being withdrawn",
                     request_schema_ref: "#/components/schemas/ParticipantWithdrawRequest",
@@ -116,6 +117,7 @@ describe "Participants endpoint", :with_metadata, openapi_spec: "v3/swagger.yaml
                   {
                     url: "/api/v3/participants/{id}/defer",
                     tag: "Participants",
+                    operation_id: "deferParticipant",
                     resource_description: "Notify that a participant is taking a break from their course",
                     response_description: "The participant being deferred",
                     request_schema_ref: "#/components/schemas/ParticipantDeferRequest",
@@ -157,6 +159,7 @@ describe "Participants endpoint", :with_metadata, openapi_spec: "v3/swagger.yaml
                   {
                     url: "/api/v3/participants/{id}/resume",
                     tag: "Participants",
+                    operation_id: "resumeParticipant",
                     resource_description: "Notify that a participant is resuming their course",
                     response_description: "The participant being resumed",
                     request_schema_ref: "#/components/schemas/ParticipantResumeRequest",
@@ -207,6 +210,7 @@ describe "Participants endpoint", :with_metadata, openapi_spec: "v3/swagger.yaml
                   {
                     url: "/api/v3/participants/{id}/change-schedule",
                     tag: "Participants",
+                    operation_id: "changeScheduleParticipant",
                     resource_description: "Notify that a participant is changing training schedule",
                     response_description: "The participant changing schedule",
                     request_schema_ref: "#/components/schemas/ParticipantChangeScheduleRequest",

--- a/spec/requests/api/docs/v3/unfunded_mentors_spec.rb
+++ b/spec/requests/api/docs/v3/unfunded_mentors_spec.rb
@@ -29,7 +29,7 @@ describe "Unfunded mentors endpoint", :with_metadata, openapi_spec: "v3/swagger.
   it_behaves_like "an API index endpoint documentation",
                   {
                     url: "/api/v3/unfunded-mentors",
-                    tag: "Unfunded mentors",
+                    tag: "Unfunded Mentors",
                     resource_description: "Retrieve multiple unfunded mentors",
                     response_description: "A list of unfunded mentors",
                     response_schema_ref: "#/components/schemas/UnfundedMentorsResponse",
@@ -40,7 +40,7 @@ describe "Unfunded mentors endpoint", :with_metadata, openapi_spec: "v3/swagger.
   it_behaves_like "an API show endpoint documentation",
                   {
                     url: "/api/v3/unfunded-mentors/{id}",
-                    tag: "Unfunded mentors",
+                    tag: "Unfunded Mentors",
                     resource_description: "Retrieve a single unfunded mentor",
                     response_description: "A single unfunded mentor",
                     response_schema_ref: "#/components/schemas/UnfundedMentorResponse",

--- a/spec/support/shared_contexts/api/docs/api_create_endpoint_documentation_support.rb
+++ b/spec/support/shared_contexts/api/docs/api_create_endpoint_documentation_support.rb
@@ -5,6 +5,7 @@ RSpec.shared_context "an API create endpoint documentation", :exceptions_app do 
       consumes "application/json"
       produces "application/json"
       security [{ api_key: [] }]
+      operationId params[:operation_id] || "create#{params[:tag].singularize.delete(' ')}"
 
       parameter name: :params,
                 in: :body,

--- a/spec/support/shared_contexts/api/docs/api_index_endpoint_documentation_support.rb
+++ b/spec/support/shared_contexts/api/docs/api_index_endpoint_documentation_support.rb
@@ -5,6 +5,7 @@ RSpec.shared_context "an API index endpoint documentation", :exceptions_app do |
       consumes "application/json"
       produces "application/json"
       security [{ api_key: [] }]
+      operationId params[:operation_id] || "get#{params[:tag].delete(' ')}"
 
       if params[:filter_schema_ref]
         parameter name: :filter,

--- a/spec/support/shared_contexts/api/docs/api_show_endpoint_documentation_support.rb
+++ b/spec/support/shared_contexts/api/docs/api_show_endpoint_documentation_support.rb
@@ -5,6 +5,7 @@ RSpec.shared_context "an API show endpoint documentation", :exceptions_app do |p
       consumes "application/json"
       produces "application/json"
       security [{ api_key: [] }]
+      operationId params[:operation_id] || "get#{params[:tag].singularize.delete(' ')}"
 
       parameter name: :id,
                 in: :path,

--- a/spec/support/shared_contexts/api/docs/api_update_endpoint_documentation_support.rb
+++ b/spec/support/shared_contexts/api/docs/api_update_endpoint_documentation_support.rb
@@ -5,6 +5,7 @@ RSpec.shared_context "an API update endpoint documentation", :exceptions_app do 
       consumes "application/json"
       produces "application/json"
       security [{ api_key: [] }]
+      operationId params[:operation_id] || "update#{params[:tag].singularize.delete(' ')}"
 
       parameter name: :id,
                 in: :path,

--- a/spec/swagger_schemas/filters/schools.rb
+++ b/spec/swagger_schemas/filters/schools.rb
@@ -9,7 +9,6 @@ SCHOOLS_FILTER = {
       description: "Return schools within the specified cohort.",
       type: "string",
       example: "2021",
-      required: true,
     },
     urn: {
       description: "Return a school with the specified Unique Reference Number (URN).",

--- a/spec/swagger_schemas/models/declaration.rb
+++ b/spec/swagger_schemas/models/declaration.rb
@@ -77,7 +77,7 @@ DECLARATION = {
           type: :string,
           format: :uuid,
           nullable: true,
-          example: "cd3a12347-7308-4879-942a-c4a70ced400a",
+          example: "45146ec2-594a-495a-bb02-8b2280a3deaf",
         },
         clawback_statement_id: {
           description: "Unique ID of the statement to which the declaration will be clawed back on, if any.",

--- a/spec/swagger_schemas/models/participants/ecf_enrolment.rb
+++ b/spec/swagger_schemas/models/participants/ecf_enrolment.rb
@@ -108,7 +108,7 @@ PARTICIPANT_ECF_ENROLMENT = {
           description: "The reason a participant was withdrawn",
           type: :string,
           enum: TrainingPeriod.withdrawal_reasons.keys.map(&:dasherize),
-          example: "moved-school"
+          example: TrainingPeriod.withdrawal_reasons.keys.map(&:dasherize).first
         },
         date: {
           description: "The date and time the participant was withdrawn",
@@ -128,7 +128,7 @@ PARTICIPANT_ECF_ENROLMENT = {
           description: "The reason a participant was deferred",
           type: :string,
           enum: TrainingPeriod.deferral_reasons.keys.map(&:dasherize),
-          example: "career-break"
+          example: TrainingPeriod.deferral_reasons.keys.map(&:dasherize).first
         },
         date: {
           description: "The date and time the participant was deferred",

--- a/spec/swagger_schemas/models/partnership.rb
+++ b/spec/swagger_schemas/models/partnership.rb
@@ -19,7 +19,7 @@ PARTNERSHIP = {
         cohort: {
           description: "The cohort for which you are reporting the partnership",
           type: "string",
-          example: 2021
+          example: "2021"
         },
         urn: {
           description: "The Unique Reference Number (URN) of the school you are partnered with",
@@ -30,13 +30,13 @@ PARTNERSHIP = {
           description: "The unique ID of the school you are partnered with",
           type: "string",
           format: "uuid",
-          example: "dd4a11347-7308-4879-942a-c4a70ced400v"
+          example: "dd4a1134-7308-4879-942a-c4a70ced400f"
         },
         delivery_partner_id: {
           description: "The unique ID of the delivery partner you are working with for this partnership",
           type: "string",
           format: "uuid",
-          example: "cd3a12347-7308-4879-942a-c4a70ced400a"
+          example: "45146ec2-594a-495a-bb02-8b2280a3deaf"
         },
         delivery_partner_name: {
           description: "The name of the delivery partner you are working with for this partnership",

--- a/spec/swagger_schemas/requests/participant_change_schedule.rb
+++ b/spec/swagger_schemas/requests/participant_change_schedule.rb
@@ -10,7 +10,6 @@ PARTICIPANT_CHANGE_SCHEDULE_REQUEST = {
       properties: {
         type: {
           type: :string,
-          required: true,
           enum: %w[participant-change-schedule],
           example: "participant-change-schedule",
         },
@@ -22,14 +21,12 @@ PARTICIPANT_CHANGE_SCHEDULE_REQUEST = {
             schedule_identifier: {
               description: "The new schedule of the participant",
               type: :string,
-              required: true,
               enum: Schedule.identifiers.keys,
               example: "ecf-extended-september",
             },
             course_identifier: {
               description: "The type of course the participant is enrolled in",
               type: :string,
-              required: true,
               enum: %w[ecf-mentor ecf-induction],
               example: "ecf-mentor"
             },
@@ -38,7 +35,6 @@ PARTICIPANT_CHANGE_SCHEDULE_REQUEST = {
               "Indicates which call-off contract funds this participant’s training. "\
               "2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year.",
               type: :string,
-              required: false,
               example: "2021"
             }
           }

--- a/spec/swagger_schemas/requests/participant_defer.rb
+++ b/spec/swagger_schemas/requests/participant_defer.rb
@@ -22,7 +22,7 @@ PARTICIPANT_DEFER_REQUEST = {
               description: "The reason for the deferral",
               type: :string,
               enum: TrainingPeriod.deferral_reasons.keys.map(&:dasherize),
-              example: "left-teaching-profession",
+              example: TrainingPeriod.deferral_reasons.keys.map(&:dasherize).first,
             },
             course_identifier: {
               description: "The type of course the participant is enrolled in",

--- a/spec/swagger_schemas/requests/participant_defer.rb
+++ b/spec/swagger_schemas/requests/participant_defer.rb
@@ -10,7 +10,6 @@ PARTICIPANT_DEFER_REQUEST = {
       properties: {
         type: {
           type: :string,
-          required: true,
           enum: %w[participant-defer],
           example: "participant-defer",
         },
@@ -22,14 +21,12 @@ PARTICIPANT_DEFER_REQUEST = {
             reason: {
               description: "The reason for the deferral",
               type: :string,
-              required: true,
               enum: TrainingPeriod.deferral_reasons.keys.map(&:dasherize),
               example: "left-teaching-profession",
             },
             course_identifier: {
               description: "The type of course the participant is enrolled in",
               type: :string,
-              required: true,
               enum: %w[ecf-mentor ecf-induction],
               example: "ecf-mentor"
             }

--- a/spec/swagger_schemas/requests/participant_resume.rb
+++ b/spec/swagger_schemas/requests/participant_resume.rb
@@ -10,7 +10,6 @@ PARTICIPANT_RESUME_REQUEST = {
       properties: {
         type: {
           type: :string,
-          required: true,
           enum: %w[participant-resume],
           example: "participant-resume",
         },
@@ -22,7 +21,6 @@ PARTICIPANT_RESUME_REQUEST = {
             course_identifier: {
               description: "The type of course the participant is enrolled in",
               type: :string,
-              required: true,
               enum: %w[ecf-mentor ecf-induction],
               example: "ecf-mentor"
             }

--- a/spec/swagger_schemas/requests/participant_withdraw.rb
+++ b/spec/swagger_schemas/requests/participant_withdraw.rb
@@ -22,7 +22,7 @@ PARTICIPANT_WITHDRAW_REQUEST = {
               description: "The reason for the withdrawal",
               type: :string,
               enum: TrainingPeriod.withdrawal_reasons.keys.map(&:dasherize),
-              example: "left-teaching-profession",
+              example: TrainingPeriod.withdrawal_reasons.keys.map(&:dasherize).first,
             },
             course_identifier: {
               description: "The type of course the participant is enrolled in",

--- a/spec/swagger_schemas/requests/participant_withdraw.rb
+++ b/spec/swagger_schemas/requests/participant_withdraw.rb
@@ -10,7 +10,6 @@ PARTICIPANT_WITHDRAW_REQUEST = {
       properties: {
         type: {
           type: :string,
-          required: true,
           enum: %w[participant-withdraw],
           example: "participant-withdraw",
         },
@@ -22,14 +21,12 @@ PARTICIPANT_WITHDRAW_REQUEST = {
             reason: {
               description: "The reason for the withdrawal",
               type: :string,
-              required: true,
               enum: TrainingPeriod.withdrawal_reasons.keys.map(&:dasherize),
               example: "left-teaching-profession",
             },
             course_identifier: {
               description: "The type of course the participant is enrolled in",
               type: :string,
-              required: true,
               enum: %w[ecf-mentor ecf-induction],
               example: "ecf-mentor"
             }

--- a/spec/swagger_schemas/requests/partnership_create.rb
+++ b/spec/swagger_schemas/requests/partnership_create.rb
@@ -10,7 +10,6 @@ PARTNERSHIP_CREATE_REQUEST = {
       properties: {
         type: {
           type: :string,
-          required: true,
           enum: %w[
             partnership
           ],
@@ -23,21 +22,18 @@ PARTNERSHIP_CREATE_REQUEST = {
           properties: {
             cohort: {
               description: "The cohort for which you are reporting the partnership",
-              required: true,
               nullable: false,
               type: :string,
               example: "2022",
             },
             school_id: {
               description: "The Unique ID of the school you are partnering with",
-              required: true,
               nullable: false,
               type: :string,
               example: "24b61d1c-ad95-4000-aee0-afbdd542294a",
             },
             delivery_partner_id: {
               description: "The unique ID of the delivery partner you will work with for this school partnership",
-              required: true,
               nullable: false,
               type: :string,
               example: "db2fbf67-b7b7-454f-a1b7-0020411e2314",

--- a/spec/swagger_schemas/requests/partnership_update.rb
+++ b/spec/swagger_schemas/requests/partnership_update.rb
@@ -10,7 +10,6 @@ PARTNERSHIP_UPDATE_REQUEST = {
       properties: {
         type: {
           type: :string,
-          required: true,
           enum: %w[
             partnership
           ],
@@ -23,7 +22,6 @@ PARTNERSHIP_UPDATE_REQUEST = {
           properties: {
             delivery_partner_id: {
               description: "The unique ID of the delivery partner you will work with for this school partnership",
-              required: true,
               nullable: false,
               type: :string,
               example: "db2fbf67-b7b7-454f-a1b7-0020411e2314",

--- a/spec/swagger_schemas/responses/particpant_transfers.rb
+++ b/spec/swagger_schemas/responses/particpant_transfers.rb
@@ -1,6 +1,6 @@
 PARTICIPANT_TRANSFERS_RESPONSE = {
   description: "Transfers for a given participant",
-  tyoe: :object,
+  type: :object,
   required: %i[data],
   properties: {
     data: { "$ref": "#/components/schemas/ParticipantTransfer" },


### PR DESCRIPTION
### Context

As part of setting up the API in the Find and Use an API service we ran into errors uploading our swagger schema as it is falling foul of the OpenAPI v3 spec.

### Changes proposed in this pull request

- Fix `required` notation in swagger schemas

The OpenAPI spec only wants you to specify `required` attributes as an array before defining the `properties`. Having `required: true/false` on the property itself results in a validation error.

I think we did this originally because swagger-ui wasn't putting a required asterisk next to the attribute name without it, but I checked after this change and it appears to now, so it isn't an issue any longer.

- Validate OpenAPI schema in GitHub action

Extends the existing action to also run the swagger.yaml through Redocly CLI which will validate it against the OpenAPI spec v3.

- Fix swagger schema issues

There were a number of minor issues in our swagger schema that resulted in validation errors:

- Typos
- Examples that don't match the attribute type
- Examples that don't match the enum options
- Examples with invalid UUID values
- Missing operation IDs

### Guidance to review

This prevents issues when we later upload the generated schema file to the Find and Use an API service.