### PR TITLE
[4233] Touch teachers

### DIFF
--- a/app/services/gias/schools/replace.rb
+++ b/app/services/gias/schools/replace.rb
@@ -19,10 +19,10 @@ module GIAS::Schools
     def replace_school!
       ActiveRecord::Base.transaction do
         ect_at_school_periods_to_be_moved =
-          school.ect_at_school_periods.includes(:teacher).load
+          school.ect_at_school_periods.tap(&:touch_all).includes(:teacher).load
 
         mentor_at_school_periods_to_be_moved =
-          school.mentor_at_school_periods.includes(:teacher).load
+          school.mentor_at_school_periods.tap(&:touch_all).includes(:teacher).load
 
         old_school_name = Schools::Name.new(school).name_and_urn
 

--- a/spec/services/gias/schools/replace_spec.rb
+++ b/spec/services/gias/schools/replace_spec.rb
@@ -37,9 +37,16 @@ RSpec.describe GIAS::Schools::Replace do
 
       context "when there are ECTs at the school" do
         let!(:old_school_name) { Schools::Name.new(gias_school.school).name_and_urn }
+        let!(:ects) { FactoryBot.create_list(:ect_at_school_period, 2, school: gias_school.school) }
 
         before do
-          FactoryBot.create_list(:ect_at_school_period, 2, school: gias_school.school)
+          ects.each { |ect| ect.update!(updated_at: 1.day.ago) }
+        end
+
+        it "touches the ECT at school periods" do
+          subject
+
+          expect(ects.map { |ect| ect.reload.updated_at }).to all(be > 1.day.ago)
         end
 
         it "records an event for each ECT moved" do
@@ -62,9 +69,16 @@ RSpec.describe GIAS::Schools::Replace do
 
       context "when there are Mentors at the school" do
         let!(:old_school_name) { Schools::Name.new(gias_school.school).name_and_urn }
+        let!(:mentors) { FactoryBot.create_list(:mentor_at_school_period, 2, school: gias_school.school) }
 
         before do
-          FactoryBot.create_list(:mentor_at_school_period, 2, school: gias_school.school)
+          mentors.each { |mentor| mentor.update!(updated_at: 1.day.ago) }
+        end
+
+        it "touches the mentor at school periods" do
+          subject
+
+          expect(mentors.map { |mentor| mentor.reload.updated_at }).to all(be > 1.day.ago)
         end
 
         it "records an event for each Mentor moved" do
@@ -102,8 +116,14 @@ RSpec.describe GIAS::Schools::Replace do
       end
 
       context "when there are ECTs at the school" do
+        let!(:ects) { FactoryBot.create_list(:ect_at_school_period, 2, school: gias_school.school) }
+
         before do
-          FactoryBot.create_list(:ect_at_school_period, 2, school: gias_school.school)
+          ects.each { |ect| ect.update!(updated_at: 1.day.ago) }
+        end
+
+        it "touches the ECT at school periods" do
+          expect { subject }.not_to(change { ects.map { |ect| ect.reload.updated_at } })
         end
 
         it "does not record an event for each ECT moved" do
@@ -114,8 +134,14 @@ RSpec.describe GIAS::Schools::Replace do
       end
 
       context "when there are Mentors at the school" do
+        let!(:mentors) { FactoryBot.create_list(:mentor_at_school_period, 2, school: gias_school.school) }
+
         before do
-          FactoryBot.create_list(:mentor_at_school_period, 2, school: gias_school.school)
+          mentors.each { |mentor| mentor.update!(updated_at: 1.day.ago) }
+        end
+
+        it "does not touch the mentor at school periods" do
+          expect { subject }.not_to(change { mentors.map { |mentor| mentor.reload.updated_at } })
         end
 
         it "does not record an event for each Mentor moved" do


### PR DESCRIPTION
### Context

When a school is replaced in GIAS, we switch the urn our school record is linked to, and log events for each ect or mentor.  However we don't actually need to update anything in their record.  For administrative purposes though, we need to set the `updated_at` on each of those affected records, so it is served over the API.

### Changes proposed in this pull request

Simply add `touch_all` when loading the records.

### Guidance to review

On the review app run:
```
monsters_college = GIAS::School.find_by(urn:  9123500)
GIAS::Schools::Replace.new(monsters_college).replace!
```
Observe that each ect/mentor has been updated via the api or console.
