### PR TITLE
Record metadata for name changes

### DIFF
--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -220,14 +220,17 @@ module Events
     def self.teacher_name_changed_in_trs_event!(old_name:, new_name:, author:, teacher:, appropriate_body_period: nil, happened_at: Time.zone.now)
       event_type = :teacher_name_updated_by_trs
       heading = TransitionDescription.for("name", from: old_name, to: new_name)
+      metadata = { old_name:, new_name: }
 
-      new(event_type:, author:, appropriate_body_period:, teacher:, heading:, happened_at:).record_event!
+      new(event_type:, author:, appropriate_body_period:, teacher:, heading:, happened_at:, metadata:).record_event!
     end
 
     def self.teacher_name_updated_by_user_event!(old_name:, new_name:, author:, teacher:, happened_at: Time.zone.now)
       event_type = :teacher_name_updated_by_user
       heading = TransitionDescription.for("name", from: old_name, to: new_name)
-      new(event_type:, author:, appropriate_body_period: nil, teacher:, heading:, happened_at:).record_event!
+      metadata = { old_name:, new_name: }
+
+      new(event_type:, author:, appropriate_body_period: nil, teacher:, heading:, happened_at:, metadata:).record_event!
     end
 
     def self.teacher_induction_status_changed_in_trs_event!(old_induction_status:, new_induction_status:, author:, teacher:, appropriate_body_period: nil, happened_at: Time.zone.now)

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -437,6 +437,7 @@ RSpec.describe Events::Record do
           heading: "Name changed from 'Wilfred Bramble' to 'Willy Brambs'",
           event_type: :teacher_name_updated_by_trs,
           happened_at: Time.zone.now,
+          metadata: { old_name:, new_name: },
           **author_params
         )
       end
@@ -455,6 +456,7 @@ RSpec.describe Events::Record do
           heading: "Name changed from 'Wilfred Bramble' to 'Willy Brambs'",
           event_type: :teacher_name_updated_by_user,
           happened_at: Time.zone.now,
+          metadata: { old_name:, new_name: },
           **author_params
         )
       end

--- a/spec/services/teachers/manage_spec.rb
+++ b/spec/services/teachers/manage_spec.rb
@@ -87,7 +87,8 @@ RSpec.describe Teachers::Manage do
             event_type: :teacher_name_updated_by_trs,
             happened_at: Time.zone.now,
             heading: "Name changed from 'Barry Allen' to 'John Doe'",
-            teacher:
+            teacher:,
+            metadata: { old_name: "Barry Allen", new_name: "John Doe" }
           )
         end
       end


### PR DESCRIPTION
When names are changes we record a string in the heading with the old and new data.

This is fine and shows up nicely in the timeline but if we want to dig a bit deeper to ensure the name change functionality isn't being misused, having the data in a structured fashion is useful too.

We're storing it in `metadata` rather than `modificaitons` here because the `corrected_name` value is either being set or overwritten, so the teacher's name actually could 'change' from the name in `trs_first_name`/`trs_last_name` to the name in corrected_name.
