### PR TITLE
Fix paragraph rendering on mentor confirmation pages

### DIFF
--- a/app/views/schools/assign_existing_mentor_wizard/confirmation.md.erb
+++ b/app/views/schools/assign_existing_mentor_wizard/confirmation.md.erb
@@ -9,6 +9,7 @@ for
 <strong><%= @wizard.context.ect_teacher_full_name %></strong>
 <% end %>
 
+
 This completes <%= @wizard.context.ect_teacher_full_name %>’s registration for ECT training at your school.
 
 You do not need to give us any more information.

--- a/app/views/schools/mentorships/confirmation.md.erb
+++ b/app/views/schools/mentorships/confirmation.md.erb
@@ -9,6 +9,7 @@ for
 <strong><%= @ect_name %></strong>
 <% end %>
 
+
 This completes <%= @ect_name %>’s registration as an ECT at your school.
 
 You do not need to give us any more information.

--- a/app/views/schools/register_mentor_wizard/confirmation.md.erb
+++ b/app/views/schools/register_mentor_wizard/confirmation.md.erb
@@ -9,6 +9,7 @@ for
 <strong><%= @ect_name %></strong>
 <% end %>
 
+
 This completes <%= @ect_name %>’s registration for ECT training at your school.
 
 You do not need to give us any more information.


### PR DESCRIPTION
We're using the markdown renderer for these pages, but for some reason it doesn't render the paragraph immediately after the panel in a `<p>` tag.

This adds an extra newline to ensure it does.

<details>
<summary>Before</summary>
<img width="648" height="481" alt="image" src="https://github.com/user-attachments/assets/cb4d422c-6762-4fe9-b40a-4c2ccd9722fe" />

</details>

<details>
<summary>After</summary>
<img width="649" height="468" alt="image" src="https://github.com/user-attachments/assets/08e9e8c2-9048-4923-9662-8191b630bd30" />

</details>