### PR TITLE
[4231] Fix lead provider shown on ECT index card

### DIFF
--- a/app/components/schools/teacher_profile_summary_list_component.rb
+++ b/app/components/schools/teacher_profile_summary_list_component.rb
@@ -3,12 +3,15 @@ module Schools
     include TeacherHelper
     include ECTHelper
 
-    def initialize(ect, current_school: nil)
+    def initialize(ect, training_period:, current_school: nil)
       @ect = ect
+      @training_period = training_period
       @current_school = current_school
     end
 
   private
+
+    attr_reader :training_period
 
     def show_school_start_date? = @ect.migrated_data_accurate?
     def show_working_pattern? = @ect.migrated_data_accurate?
@@ -43,13 +46,7 @@ module Schools
       end
     end
 
-    def training_period
-      @training_period ||= @ect.latest_training_period
-    end
-
-    def training_status
-      @training_status ||= @ect.latest_training_status
-    end
+    def training_status = training_period&.status
 
     def withdrawn?
       training_period&.provider_led_training_programme? && training_status == :withdrawn

--- a/app/controllers/schools/ects_controller.rb
+++ b/app/controllers/schools/ects_controller.rb
@@ -15,7 +15,16 @@ module Schools
         .includes(
           ect_at_school_periods: %i[latest_training_period mentorship_periods],
           current_or_next_ect_at_school_period: [
-            { latest_training_period: %i[lead_provider delivery_partner] },
+            { current_or_next_training_period: %i[
+              lead_provider
+              delivery_partner
+              expression_of_interest_lead_provider
+            ] },
+            { latest_training_period: %i[
+              lead_provider
+              delivery_partner
+              expression_of_interest_lead_provider
+            ] },
             { current_or_next_mentorship_period: { mentor: :teacher } }
           ]
         )
@@ -26,7 +35,7 @@ module Schools
 
     def show
       @ect_at_school_period = @school.ect_at_school_periods.find(params[:id])
-      @training_period = @ect_at_school_period.latest_training_period
+      @training_period = @ect_at_school_period.current_or_next_or_latest_training_period
       @teacher = @ect_at_school_period.teacher
     end
   end

--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -104,8 +104,8 @@ class ECTAtSchoolPeriod < ApplicationRecord
     teacher.ect_at_school_periods.excluding(self)
   end
 
-  def latest_training_status
-    latest_training_period&.status
+  def current_or_next_or_latest_training_period
+    current_or_next_training_period || latest_training_period
   end
 
   def latest_lead_provider_name

--- a/app/views/schools/ects/index.html.erb
+++ b/app/views/schools/ects/index.html.erb
@@ -30,10 +30,11 @@
         <p class="govuk-body">There are no ECTs that match your search.</p>
       <% else %>
         <% @teachers.each do |teacher| %>
+          <% ect_at_school_period = teacher.current_or_next_ect_at_school_period %>
           <%= render Schools::ECTs::ListingCardComponent.new(
             teacher: teacher,
-            ect_at_school_period: teacher.current_or_next_ect_at_school_period,
-            training_period: teacher.current_or_next_ect_at_school_period.latest_training_period,
+            ect_at_school_period:,
+            training_period: ect_at_school_period.current_or_next_or_latest_training_period,
             current_school: @school
           ) %>
         <% end %>

--- a/app/views/schools/ects/show.html.erb
+++ b/app/views/schools/ects/show.html.erb
@@ -10,7 +10,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-      <%= render Schools::TeacherProfileSummaryListComponent.new(@ect_at_school_period, current_school: @school) %>
+      <%= render Schools::TeacherProfileSummaryListComponent.new(
+        @ect_at_school_period,
+        training_period: @training_period,
+        current_school: @school
+      ) %>
 
       <%= render Schools::ECTInductionDetailsComponent.new(@ect_at_school_period) %>
 

--- a/spec/components/schools/teacher_profile_summary_list_component_spec.rb
+++ b/spec/components/schools/teacher_profile_summary_list_component_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe Schools::TeacherProfileSummaryListComponent, type: :component do
     FactoryBot.create(:ect_at_school_period, :ongoing, school:, teacher: mentee_teacher, started_on: Date.new(2021, 9, 1),
                                                        email: "foobarect@madeup.com", working_pattern: "full_time")
   end
+  let(:training_period) { mentee.current_or_next_or_latest_training_period }
+  let(:component) { described_class.new(mentee, training_period:, current_school: school) }
 
   context "when the ECT has a mentor assigned" do
     let(:mentor_row) { page.find(".govuk-summary-list__row", text: "Mentor") }
@@ -21,7 +23,7 @@ RSpec.describe Schools::TeacherProfileSummaryListComponent, type: :component do
       FactoryBot.create(:mentorship_period, :ongoing, mentee:, mentor: previous_mentor, started_on: 3.years.ago, finished_on: 2.years.ago - 1.day)
       FactoryBot.create(:mentorship_period, :ongoing, mentee:, mentor: current_mentor, started_on: 2.years.ago)
 
-      render_inline(described_class.new(mentee, current_school: school))
+      render_inline(component)
     end
 
     it "renders the summary list container" do
@@ -46,7 +48,7 @@ RSpec.describe Schools::TeacherProfileSummaryListComponent, type: :component do
     end
   end
 
-  context "when latest started training is deferred" do
+  context "when the supplied training period is deferred" do
     before do
       training_period = FactoryBot.create(
         :training_period,
@@ -70,7 +72,7 @@ RSpec.describe Schools::TeacherProfileSummaryListComponent, type: :component do
         expression_of_interest: active_lead_provider
       )
 
-      render_inline(described_class.new(mentee, current_school: school))
+      render_inline(component)
     end
 
     it "shows training paused status" do
@@ -83,7 +85,7 @@ RSpec.describe Schools::TeacherProfileSummaryListComponent, type: :component do
     end
   end
 
-  context "when training is withdrawn" do
+  context "when the supplied training period is withdrawn" do
     before do
       training_period = FactoryBot.create(
         :training_period,
@@ -107,7 +109,7 @@ RSpec.describe Schools::TeacherProfileSummaryListComponent, type: :component do
         expression_of_interest: active_lead_provider
       )
 
-      render_inline(described_class.new(mentee, current_school: school))
+      render_inline(component)
     end
 
     it "shows action required status" do
@@ -131,7 +133,7 @@ RSpec.describe Schools::TeacherProfileSummaryListComponent, type: :component do
         withdrawal_reason: TrainingPeriod.withdrawal_reasons.keys.first
       )
 
-      render_inline(described_class.new(mentee, current_school: school))
+      render_inline(component)
     end
 
     it "shows withdrawn status instead of mentor required" do
@@ -153,7 +155,7 @@ RSpec.describe Schools::TeacherProfileSummaryListComponent, type: :component do
         deferral_reason: TrainingPeriod.deferral_reasons.keys.first
       )
 
-      render_inline(described_class.new(mentee, current_school: school))
+      render_inline(component)
     end
 
     it "shows training paused instead of mentor required" do
@@ -175,7 +177,7 @@ RSpec.describe Schools::TeacherProfileSummaryListComponent, type: :component do
 
       mentee.update!(finished_on: 1.day.from_now.to_date, reported_leaving_by_school_id: school.id)
 
-      render_inline(described_class.new(mentee, current_school: school))
+      render_inline(component)
     end
 
     it "shows leaving school instead of action required" do
@@ -197,7 +199,7 @@ RSpec.describe Schools::TeacherProfileSummaryListComponent, type: :component do
 
       mentee.update!(finished_on: 1.day.from_now.to_date, reported_leaving_by_school_id: school.id)
 
-      render_inline(described_class.new(mentee, current_school: school))
+      render_inline(component)
     end
 
     it "shows leaving school instead of training paused" do
@@ -219,7 +221,7 @@ RSpec.describe Schools::TeacherProfileSummaryListComponent, type: :component do
 
       mentee_teacher.update!(trs_induction_status: "Exempt")
 
-      render_inline(described_class.new(mentee, current_school: school))
+      render_inline(component)
     end
 
     it "shows exempt status instead of action required" do
@@ -241,7 +243,7 @@ RSpec.describe Schools::TeacherProfileSummaryListComponent, type: :component do
 
       mentee_teacher.update!(trs_induction_status: "Exempt")
 
-      render_inline(described_class.new(mentee, current_school: school))
+      render_inline(component)
     end
 
     it "shows exempt status instead of training paused" do
@@ -252,7 +254,7 @@ RSpec.describe Schools::TeacherProfileSummaryListComponent, type: :component do
 
   context "when the ECT has no mentor assigned" do
     before do
-      render_inline(described_class.new(mentee, current_school: school))
+      render_inline(component)
     end
 
     it "shows action required with mentor assignment message" do
@@ -269,7 +271,7 @@ RSpec.describe Schools::TeacherProfileSummaryListComponent, type: :component do
   context "when the ECT's migrated data is not accurate" do
     before do
       allow(mentee).to receive(:migrated_data_accurate?).and_return(false)
-      render_inline(described_class.new(mentee))
+      render_inline(component)
     end
 
     it "does not show the school start date" do
@@ -284,7 +286,7 @@ RSpec.describe Schools::TeacherProfileSummaryListComponent, type: :component do
   context "when the ECT's migrated data is accurate" do
     before do
       allow(mentee).to receive(:migrated_data_accurate?).and_return(true)
-      render_inline(described_class.new(mentee))
+      render_inline(component)
     end
 
     it "shows the school start date" do

--- a/spec/models/ect_at_school_period_spec.rb
+++ b/spec/models/ect_at_school_period_spec.rb
@@ -55,6 +55,77 @@ describe ECTAtSchoolPeriod do
       end
     end
 
+    describe "#current_or_next_or_latest_training_period" do
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 1.year.ago) }
+
+      context "when there is a current period and a future period" do
+        let!(:current_training_period) do
+          FactoryBot.create(
+            :training_period,
+            :provider_led,
+            ect_at_school_period:,
+            started_on: Date.current,
+            finished_on: Date.current.next_month
+          )
+        end
+        let!(:future_training_period) do
+          FactoryBot.create(
+            :training_period,
+            :ongoing,
+            :provider_led,
+            ect_at_school_period:,
+            started_on: current_training_period.finished_on.next_day
+          )
+        end
+
+        it "returns the current period" do
+          expect(ect_at_school_period.current_or_next_or_latest_training_period).to eq(current_training_period)
+        end
+      end
+
+      context "when there is a next period and a later future period" do
+        let!(:next_training_period) do
+          FactoryBot.create(
+            :training_period,
+            :provider_led,
+            ect_at_school_period:,
+            started_on: Date.tomorrow,
+            finished_on: Date.current.next_month
+          )
+        end
+        let!(:future_training_period) do
+          FactoryBot.create(
+            :training_period,
+            :ongoing,
+            :provider_led,
+            ect_at_school_period:,
+            started_on: next_training_period.finished_on.next_day
+          )
+        end
+
+        it "returns the next period" do
+          expect(ect_at_school_period.current_or_next_or_latest_training_period).to eq(next_training_period)
+        end
+      end
+
+      context "when there is no current or future period" do
+        let!(:latest_training_period) do
+          FactoryBot.create(
+            :training_period,
+            :finished,
+            :provider_led,
+            ect_at_school_period:,
+            started_on: 1.year.ago,
+            finished_on: 1.month.ago
+          )
+        end
+
+        it "returns the latest period" do
+          expect(ect_at_school_period.current_or_next_or_latest_training_period).to eq(latest_training_period)
+        end
+      end
+    end
+
     describe "leaving/joining training periods" do
       let(:ect_at_school_period) do
         FactoryBot.create(


### PR DESCRIPTION
## Summary

The ECT index card could show a different lead provider from the ECT details page when the latest training period was different to the current or next training period.

This PR fixes that by:

-  deriving the ECTs lead provider, delivery partner and status from the current or next training period
-  falling back to the latest training period when no current or next training period exists
-  using the same selected training period on both the index card and the ECT details page