### PR TITLE
[Spike] Rename ActiveLeadProvider to FrameworkAgreement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Early Career Framework Version 2
 
+
 ECF is a framework of standards to help early career teachers succeed at the start of their careers.
 
 ## Workflows


### PR DESCRIPTION
### Context

The name **ActiveLeadProvider** is confusing. It's naming indicates an _is a_ relationship rather than a has a relationship. It sounds like a kind of **LeadProvider**, an _"active"_ one, and that's not really what it is. This makes things read poorly, for example `lead_provider.active_lead_providers` is basically nonsense?!!

The most obvious rename would be to **ContractPeriodLeadProvider**. This is the standard. default Rails naming convention for joining tables. Because it's not a pure HABTM table, we can order this as we choose. So if **LeadProviderContractPeriod** reads better (I'm not sure it does) then that is also an option. But, as an entity rather than a pure HABTM table the first still indicates an "is a" relationship.

> [!Note]
> Fundamentally it is the _"being"_ relationship name that makes this confusion, renaming this to a _"having"_ relationship would improve understandability. 

Instead,this is more than just a joining table between a **LeadProvider** and a **ContractPeriod**. It has most of the important tables in the system hanging off of it. We want a name that reflects that importance?

Any **LeadProvider** _participates_ in a **ContractPeriod**, so calling this relationship a **Participation** after the abstract noun would be reasonable. However, this **Participation** requires context in the name I think, so we would either get **LeadProviderParticipation** or a **ContractPeriodParticipation**. I think that the **ContractPeriodParticipation** reads most intuitively, but we still have a problem.

> [!Warning]
> We have already inherited the use of the word **Participant** in our API. A **Participation** is probably too close to that.


So we can take Participation off of the table, and maybe that's a good thing because if we look at what the **ActiveLeadProvider** is really doing, it is acting as a **FrameworkAgreement** between **DfE** and the  **LeadProvider** (https://en.wikipedia.org/wiki/Framework_agreement),  concretely it defines the **Bands** that the specific **Contracts** must adhere to, it defines the relationship between **DeliveryPartners**. This would either be a **FrameworkContract** or **FrameworkAgreement**, to avoid naming collisions **FrameworkAgreement** is probably the more meaningful option.

So,

> [!Tip]
> Rename **ActiveLeadProvider** to **FrameworkAgreement**.

We can see how this reads:

```
class LeadProvider < ApplicationRecord
  has_many :framework_agreements..
  ..
```
✅ Sensible and adds value semantically.

```
class ContractPeriod < ApplicationRecord
  has_many :framework_agreements..
  ..
```
✅ Makes sense and adds value  semantically.

```
class Contract < ApplicationRecord
  belongs_to :framework_agreement
  has_one :contract_period, through: :framework_agreement  
  ..
```
✅ Makes sense and adds value semantically.

* `contact_period.framework_agreements` ✅ Makes sense and adds value semantically
* `lead_provider.framework_agreements` ✅  Makes sense and adds value semantically
* `contract.framework_agremeent.bands` ✅ Makes sense and adds value  semantically 


<img width="5250" height="3240" alt="framework-agreement" src="https://github.com/user-attachments/assets/a68b0ffb-0e9f-4e6f-853c-205f0f10676c" />

Note: This would encompass a rename of **ActiveLeadProvider::Band**, to **FrameworkAgreement::Band** which is again a semantically valuable rename. 


Hi @peteryates This would address https://github.com/DFE-Digital/register-early-career-teachers-public/issues/2921 quite nicely (in my view) does it seem reasonable to you?