### PR TITLE
Fix n+1 query on delivery partners index

### DIFF
--- a/app/components/admin/lead_provider_partnerships_table_component.html.erb
+++ b/app/components/admin/lead_provider_partnerships_table_component.html.erb
@@ -9,20 +9,17 @@
   end
 
   table.with_body do |body|
-    contract_period_partnerships.each do |item|
-      contract_period = item[:contract_period]
-      partnerships = item[:partnerships]
-
+    partnership_data.each do |contract_period_year, lead_provider_names|
       body.with_row do |row|
-        row.with_cell(text: contract_period.year)
+        row.with_cell(text: contract_period_year)
         row.with_cell do
-          lead_provider_names(partnerships)
+          display_lead_provider_names(lead_provider_names)
         end
         row.with_cell do
-          if partnerships.empty?
-            govuk_link_to("Add", change_link_path(contract_period))
+          if lead_provider_names.none?
+            govuk_link_to("Add", change_link_path(contract_period_year))
           else
-            govuk_link_to("Change", change_link_path(contract_period))
+            govuk_link_to("Change", change_link_path(contract_period_year))
           end
         end
       end

--- a/app/components/admin/lead_provider_partnerships_table_component.rb
+++ b/app/components/admin/lead_provider_partnerships_table_component.rb
@@ -1,33 +1,29 @@
 module Admin
   class LeadProviderPartnershipsTableComponent < ApplicationComponent
-    attr_reader :contract_period_partnerships, :delivery_partner, :page, :q
+    attr_reader :partnership_data, :delivery_partner, :page, :q
 
-    def initialize(contract_period_partnerships:, delivery_partner:, page: nil, q: nil)
-      @contract_period_partnerships = contract_period_partnerships
+    # Expects partnerhsip data in format { 2026 => ["Lead provider one name", "Lead provider two name"] }
+    def initialize(partnership_data:, delivery_partner:, page: nil, q: nil)
+      @partnership_data = partnership_data
       @delivery_partner = delivery_partner
       @page = page
       @q = q
     end
 
     def render?
-      contract_period_partnerships.any?
+      partnership_data.present?
     end
 
   private
 
-    def change_link_path(contract_period)
-      helpers.new_admin_delivery_partner_delivery_partnership_path(
-        delivery_partner,
-        contract_period.year,
-        page:,
-        q:
-      )
+    def change_link_path(year)
+      helpers.new_admin_delivery_partner_delivery_partnership_path(delivery_partner, year, page:, q:)
     end
 
-    def lead_provider_names(partnerships)
-      return "Not reported" if partnerships.empty?
+    def display_lead_provider_names(lead_provider_names)
+      return "Not reported" if lead_provider_names.empty?
 
-      partnerships.map(&:lead_provider).map(&:name).join(", ")
+      lead_provider_names.join(", ")
     end
   end
 end

--- a/app/controllers/admin/delivery_partners_controller.rb
+++ b/app/controllers/admin/delivery_partners_controller.rb
@@ -22,19 +22,7 @@ module Admin
         @delivery_partner.name => nil
       }
 
-      existing_partnerships = @delivery_partner
-        .lead_provider_delivery_partnerships
-        .includes(active_lead_provider: %i[lead_provider contract_period])
-
-      contract_periods_with_providers = ContractPeriod
-        .joins(:active_lead_providers)
-        .distinct
-        .most_recent_first
-
-      @contract_period_partnerships = contract_periods_with_providers.map do |contract_period|
-        partnerships = existing_partnerships.select { |p| p.contract_period.year == contract_period.year }
-        { contract_period:, partnerships: }
-      end
+      @partnership_data = ::DeliveryPartners::PartnershipData.new(@delivery_partner).partners_by_contract_period
     end
 
     def new

--- a/app/services/delivery_partners/partnership_data.rb
+++ b/app/services/delivery_partners/partnership_data.rb
@@ -1,0 +1,25 @@
+module DeliveryPartners
+  class PartnershipData
+    attr_reader :delivery_partner, :all_contract_periods
+
+    def initialize(delivery_partner)
+      @delivery_partner = delivery_partner
+      @all_contract_periods = ContractPeriod.all.latest_first.each_with_object({}) do |cp, h|
+        h[cp.year] = []
+      end
+    end
+
+    # returns a hash of contract_period years and lead provider names
+    # { 2021 => ["Lead provider 1", "Lead provider 2"] }
+    def partners_by_contract_period
+      present = ContractPeriod
+        .includes(active_lead_providers: [:lead_provider, { lead_provider_delivery_partnerships: :delivery_partner }])
+        .where(active_lead_providers: { lead_provider_delivery_partnerships: { delivery_partner: } })
+        .each_with_object({}) do |cp, h|
+          h[cp.year] = cp.active_lead_providers.map { |alp| alp.lead_provider.name }.sort
+        end
+
+      { **all_contract_periods, **present }
+    end
+  end
+end

--- a/app/views/admin/delivery_partners/show.html.erb
+++ b/app/views/admin/delivery_partners/show.html.erb
@@ -9,13 +9,13 @@
 </p>
 
 <%= render(Admin::LeadProviderPartnershipsTableComponent.new(
-  contract_period_partnerships: @contract_period_partnerships,
+  partnership_data: @partnership_data,
   delivery_partner: @delivery_partner,
   page: @page,
   q: @q
 )) %>
 
-<% unless @contract_period_partnerships.any? %>
+<% if @partnership_data.blank? %>
   <p class="govuk-body">
     No contract periods with available lead providers found for this delivery partner.
   </p>

--- a/spec/components/admin/lead_provider_partnerships_table_component_spec.rb
+++ b/spec/components/admin/lead_provider_partnerships_table_component_spec.rb
@@ -24,16 +24,16 @@ RSpec.describe Admin::LeadProviderPartnershipsTableComponent, type: :component d
     ]
   end
 
-  let(:contract_period_partnerships) do
-    [
-      { contract_period: contract_period_2024, partnerships: partnerships_2024 },
-      { contract_period: contract_period_2025, partnerships: partnerships_2025 }
-    ]
+  let(:partnership_data) do
+    {
+      contract_period_2024.year => partnerships_2024.map { it.lead_provider.name },
+      contract_period_2025.year => partnerships_2025.map { it.lead_provider.name }
+    }
   end
 
   let(:component) do
     described_class.new(
-      contract_period_partnerships:,
+      partnership_data:,
       delivery_partner:,
       page: "2",
       q: "search"
@@ -77,11 +77,11 @@ RSpec.describe Admin::LeadProviderPartnershipsTableComponent, type: :component d
     end
 
     context "when some contract periods have no partnerships" do
-      let(:contract_period_partnerships) do
-        [
-          { contract_period: contract_period_2024, partnerships: partnerships_2024 },
-          { contract_period: contract_period_2025, partnerships: [] }
-        ]
+      let(:partnership_data) do
+        {
+          contract_period_2024.year => partnerships_2024.map { it.lead_provider.name },
+          contract_period_2025.year => []
+        }
       end
 
       before { render_inline(component) }
@@ -105,7 +105,7 @@ RSpec.describe Admin::LeadProviderPartnershipsTableComponent, type: :component d
     context "when page and q are nil" do
       let(:component) do
         described_class.new(
-          contract_period_partnerships:,
+          partnership_data:,
           delivery_partner:
         )
       end
@@ -131,7 +131,7 @@ RSpec.describe Admin::LeadProviderPartnershipsTableComponent, type: :component d
     context "when there are no contract periods" do
       let(:component) do
         described_class.new(
-          contract_period_partnerships: [],
+          partnership_data: {},
           delivery_partner:
         )
       end
@@ -145,12 +145,12 @@ RSpec.describe Admin::LeadProviderPartnershipsTableComponent, type: :component d
   describe "private methods" do
     describe "#lead_provider_names" do
       it "joins lead provider names with commas when partnerships exist" do
-        names = component.send(:lead_provider_names, partnerships_2024)
+        names = component.send(:display_lead_provider_names, partnerships_2024.map { it.lead_provider.name })
         expect(names).to eq("Lead Provider One, Lead Provider Two")
       end
 
       it "returns 'Not reported' when no partnerships exist" do
-        names = component.send(:lead_provider_names, [])
+        names = component.send(:display_lead_provider_names, [])
         expect(names).to eq("Not reported")
       end
     end

--- a/spec/services/delivery_partners/partnership_data_spec.rb
+++ b/spec/services/delivery_partners/partnership_data_spec.rb
@@ -1,0 +1,54 @@
+describe DeliveryPartners::PartnershipData do
+  subject { DeliveryPartners::PartnershipData.new(delivery_partner_1) }
+
+  let(:lead_provider_1) { FactoryBot.create(:lead_provider, name: "ZZZ") }
+  let(:lead_provider_2) { FactoryBot.create(:lead_provider, name: "AAA") }
+
+  let!(:contract_period_2027) { FactoryBot.create(:contract_period, year: 2027) } # unused but should be present in output
+  let(:contract_period_2026) { FactoryBot.create(:contract_period, year: 2026) }
+  let(:contract_period_2025) { FactoryBot.create(:contract_period, year: 2025) }
+
+  let(:delivery_partner_1) { FactoryBot.create(:delivery_partner) }
+  let(:delivery_partner_2) { FactoryBot.create(:delivery_partner) }
+  let(:delivery_partner_3) { FactoryBot.create(:delivery_partner) }
+
+  before do
+    active_lead_provider_1 = FactoryBot.create(:active_lead_provider, lead_provider: lead_provider_1, contract_period: contract_period_2025)
+    active_lead_provider_2 = FactoryBot.create(:active_lead_provider, lead_provider: lead_provider_1, contract_period: contract_period_2026)
+    active_lead_provider_3 = FactoryBot.create(:active_lead_provider, lead_provider: lead_provider_2, contract_period: contract_period_2025)
+    active_lead_provider_4 = FactoryBot.create(:active_lead_provider, lead_provider: lead_provider_2, contract_period: contract_period_2026)
+
+    # not included
+    FactoryBot.create(:lead_provider_delivery_partnership, delivery_partner: delivery_partner_2, active_lead_provider: active_lead_provider_4)
+    FactoryBot.create(:lead_provider_delivery_partnership, delivery_partner: delivery_partner_2, active_lead_provider: active_lead_provider_2)
+
+    # 2025, lead_provider_1
+    FactoryBot.create(:lead_provider_delivery_partnership, delivery_partner: delivery_partner_1, active_lead_provider: active_lead_provider_1)
+
+    # 2025, lead_provider_2
+    FactoryBot.create(:lead_provider_delivery_partnership, delivery_partner: delivery_partner_1, active_lead_provider: active_lead_provider_3)
+
+    # 2026, lead_provider 2
+    FactoryBot.create(:lead_provider_delivery_partnership, delivery_partner: delivery_partner_1, active_lead_provider: active_lead_provider_4)
+  end
+
+  describe "#partners_by_contract_period" do
+    it "includes all contract periods (even ones with no partnership data) order chronologically" do
+      expect(subject.partners_by_contract_period.keys).to eql([2027, 2026, 2025])
+    end
+
+    it "returns the lead providers partnered with the given delivery partner by registration period year" do
+      expect(subject.partners_by_contract_period).to eq(
+        {
+          contract_period_2027.year => [],
+          contract_period_2026.year => [lead_provider_2.name],
+          contract_period_2025.year => [lead_provider_2.name, lead_provider_1.name],
+        }
+      )
+    end
+
+    it "orders the lead provider names alphabetically" do
+      expect(subject.partners_by_contract_period.fetch(contract_period_2025.year)).to eql([lead_provider_2.name, lead_provider_1.name])
+    end
+  end
+end

--- a/spec/views/admin/delivery_partners/show.html.erb_spec.rb
+++ b/spec/views/admin/delivery_partners/show.html.erb_spec.rb
@@ -13,9 +13,7 @@ RSpec.describe "admin/delivery_partners/show.html.erb" do
     assign(:delivery_partner, delivery_partner)
     assign(:page, "2")
     assign(:q, "search term")
-    assign(:contract_period_partnerships, [
-      { contract_period: partnership.contract_period, partnerships: [partnership] }
-    ])
+    assign(:partnership_data, { partnership.contract_period.year => [active_lead_provider.lead_provider.name] })
   end
 
   it %(sets the page title to the delivery partner name) do
@@ -106,6 +104,13 @@ RSpec.describe "admin/delivery_partners/show.html.erb" do
         { contract_period: new_contract_period, partnerships: [new_partnership] },
         { contract_period: old_contract_period, partnerships: [old_partnership] }
       ])
+      assign(
+        :partnership_data,
+        {
+          new_contract_period.year => [new_partnership.lead_provider.name],
+          old_contract_period.year => [old_partnership.lead_provider.name]
+        }
+      )
     end
 
     it "displays multiple partnerships" do
@@ -143,6 +148,15 @@ RSpec.describe "admin/delivery_partners/show.html.erb" do
       assign(:contract_period_partnerships, [
         { contract_period:, partnerships: [partnership_1, partnership_2] }
       ])
+      assign(
+        :partnership_data,
+        {
+          contract_period.year => [
+            partnership_1.lead_provider.name,
+            partnership_2.lead_provider.name,
+          ]
+        }
+      )
     end
 
     it "groups partnerships by year and displays lead providers in the same row" do
@@ -169,7 +183,7 @@ RSpec.describe "admin/delivery_partners/show.html.erb" do
 
   context "when there are no contract periods with available lead providers" do
     before do
-      assign(:contract_period_partnerships, [])
+      assign(:partnership_data, {})
     end
 
     it "shows empty state message" do


### PR DESCRIPTION
This PR fixes an n+1 query on the delivery partners show page by querying more efficiently.

It now uses two queries, one to retrieve the contract periods and the other to retrieve the list of appropriate bodies partnered per contract period. This is necessary so 'empty' contract periods are included in the list.

The page is really low traffic and not really a problem, but the fewer pages that trigger warnings the easier the real problem pages are to spot.

### Context

- **Add service object that returns partnership data**
- **Make delivery partner show page use new query service**
