### PR TITLE
Move service nav and phase banner inside the `<header>`

### DIFF
--- a/app/assets/stylesheets/api_guidance.scss
+++ b/app/assets/stylesheets/api_guidance.scss
@@ -5,6 +5,9 @@ $x-govuk-masthead-border-colour: govuk-tint($govuk-brand-colour, 25%);
 $x-govuk-masthead-text-colour: govuk-colour("white");
 
 .api-guidance {
+  .x-govuk-header--inverse {
+    background: $x-govuk-masthead-background-colour;
+  }
 
   // phase banner
   .x-govuk-phase-banner--inverse {

--- a/app/controllers/api/guidance_controller.rb
+++ b/app/controllers/api/guidance_controller.rb
@@ -2,7 +2,7 @@ module API
   class GuidanceController < ApplicationController
     include ReleaseNotes
 
-    layout "api_guidance"
+    layout "api_home"
 
     after_action :allow_search_engine_indexing, only: :show
 
@@ -14,7 +14,7 @@ module API
       template = "api/guidance/#{params[:page].underscore}"
 
       if template_exists?(template)
-        render template
+        render template, layout: "api_guidance"
       else
         render "errors/not_found", status: :not_found
       end

--- a/app/helpers/environment_helper.rb
+++ b/app/helpers/environment_helper.rb
@@ -7,10 +7,6 @@ module EnvironmentHelper
     "app-header--#{ENVIRONMENT_COLOUR}"
   end
 
-  def environment_specific_phase_banner(html_attributes: {}, tag_html_attributes: {})
-    govuk_phase_banner(**environment_specific_phase_banner_arguments(html_attributes:, tag_html_attributes:))
-  end
-
   def environment_specific_phase_banner_arguments(inverse: false)
     tag_text = ENVIRONMENT_PHASE_BANNER_TAG || "Beta"
     banner_text = ENVIRONMENT_PHASE_BANNER_CONTENT || environment_phase_banner_default_content

--- a/app/helpers/environment_helper.rb
+++ b/app/helpers/environment_helper.rb
@@ -8,10 +8,18 @@ module EnvironmentHelper
   end
 
   def environment_specific_phase_banner(html_attributes: {}, tag_html_attributes: {})
+    govuk_phase_banner(**environment_specific_phase_banner_arguments(html_attributes:, tag_html_attributes:))
+  end
+
+  def environment_specific_phase_banner_arguments(html_attributes: {}, tag_html_attributes: {})
     tag_text = ENVIRONMENT_PHASE_BANNER_TAG || "Beta"
     banner_text = ENVIRONMENT_PHASE_BANNER_CONTENT || environment_phase_banner_default_content
 
-    govuk_phase_banner(text: banner_text, tag: { text: tag_text, colour: ENVIRONMENT_COLOUR, html_attributes: tag_html_attributes }.compact, html_attributes:)
+    {
+      text: banner_text,
+      tag: { text: tag_text, colour: ENVIRONMENT_COLOUR, html_attributes: tag_html_attributes }.compact,
+      html_attributes:,
+    }
   end
 
 private

--- a/app/helpers/environment_helper.rb
+++ b/app/helpers/environment_helper.rb
@@ -11,17 +11,8 @@ module EnvironmentHelper
     tag_text = ENVIRONMENT_PHASE_BANNER_TAG || "Beta"
     banner_text = ENVIRONMENT_PHASE_BANNER_CONTENT || environment_phase_banner_default_content
 
-    banner_classes = if inverse
-                       %w[govuk-width-container x-govuk-phase-banner--inverse]
-                     else
-                       %w[govuk-width-container]
-                     end
-
-    tag_classes = if inverse
-                    %w[x-govuk-tag--inverse]
-                  else
-                    []
-                  end
+    banner_classes = class_names("govuk-width-container", "x-govuk-phase-banner--inverse" => inverse)
+    tag_classes = class_names("x-govuk-tag--inverse" => inverse)
 
     {
       text: banner_text,

--- a/app/helpers/environment_helper.rb
+++ b/app/helpers/environment_helper.rb
@@ -11,14 +11,26 @@ module EnvironmentHelper
     govuk_phase_banner(**environment_specific_phase_banner_arguments(html_attributes:, tag_html_attributes:))
   end
 
-  def environment_specific_phase_banner_arguments(html_attributes: {}, tag_html_attributes: {})
+  def environment_specific_phase_banner_arguments(inverse: false)
     tag_text = ENVIRONMENT_PHASE_BANNER_TAG || "Beta"
     banner_text = ENVIRONMENT_PHASE_BANNER_CONTENT || environment_phase_banner_default_content
 
+    banner_classes = if inverse
+                       %w[govuk-width-container x-govuk-phase-banner--inverse]
+                     else
+                       %w[govuk-width-container]
+                     end
+
+    tag_classes = if inverse
+                    %w[x-govuk-tag--inverse]
+                  else
+                    []
+                  end
+
     {
       text: banner_text,
-      tag: { text: tag_text, colour: ENVIRONMENT_COLOUR, html_attributes: tag_html_attributes }.compact,
-      html_attributes:,
+      tag: { text: tag_text, colour: ENVIRONMENT_COLOUR, html_attributes: { class: tag_classes } }.compact,
+      html_attributes: { class: banner_classes },
     }
   end
 

--- a/app/views/api/guidance/show.html.erb
+++ b/app/views/api/guidance/show.html.erb
@@ -6,30 +6,6 @@
   )
 %>
 
-<% content_for :api_guidance_home_header do %>
-  <div class="x-govuk-masthead">
-    <div class="govuk-width-container">
-      <%=
-        environment_specific_phase_banner(
-          html_attributes: { class: %w[x-govuk-phase-banner--inverse] },
-          tag_html_attributes: { class: %w[x-govuk-tag--inverse] }
-        )
-      %>
-
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-          <%= yield(:page_header) %>
-
-          <p class="x-govuk-masthead__description">
-          Find out what data lead providers need to submit to DfE, how to keep it up to date, and when to report changes about early career teachers and their mentors.
-          </p>
-
-        </div>
-      </div>
-    </div>
-  </div>
-<% end %>
-
 <div class="release-notes-panel govuk-!-padding-top-7">
   <div class="govuk-width-container">
     <div class="govuk-grid-row">

--- a/app/views/layouts/api_docs.html.erb
+++ b/app/views/layouts/api_docs.html.erb
@@ -10,37 +10,9 @@
     <%= render partial: "layouts/shared/js_enabled" %>
 
     <%= govuk_skip_link %>
-    <%= govuk_header(full_width_border: true, html_attributes: { class: ['app-header', environment_specific_header_colour_class] }) do |header| %>
-      <% if multi_role_user? %>
-        <div class="app-header__item">
-          <%= govuk_link_to(current_user.organisation_name, switch_role_path, inverse: true, no_underline: true) %>
-        </div>
-      <% end %>
-
-      <% if single_role_user? %>
-        <div class="app-header__item">
-          <%= current_user.organisation_name %>
-        </div>
-      <% end %>
-
-      <% if authenticated? %>
-        <div class="app-header__item">
-          <%= govuk_link_to('Sign out', current_user.sign_out_path, inverse: true, no_underline: true) %>
-        </div>
-      <% end %>
-    <% end %>
-
-    <%=
-      govuk_service_navigation(
-        **Navigation::Primary.new(
-          current_path: request.fullpath,
-          current_user: current_user,
-        ).govuk_header_arguments
-      )
-    %>
+    <%= render partial: "layouts/shared/header" %>
 
     <div class="govuk-width-container">
-      <%= environment_specific_phase_banner %>
       <%= yield(:backlink_or_breadcrumb) %>
 
       <main class="govuk-main-wrapper" id="main-content" role="main">

--- a/app/views/layouts/api_guidance.html.erb
+++ b/app/views/layouts/api_guidance.html.erb
@@ -6,65 +6,29 @@
     <%= render partial: "layouts/shared/js_enabled" %>
 
     <%= govuk_skip_link %>
-    <%= govuk_header(full_width_border: true, html_attributes: { class: ['app-header', environment_specific_header_colour_class] }) do |header| %>
-      <% if multi_role_user? %>
-        <div class="app-header__item">
-          <%= govuk_link_to(current_user.organisation_name, switch_role_path, inverse: true, no_underline: true) %>
-        </div>
-      <% end %>
+    <%= render partial: "layouts/shared/header" %>
 
-      <% if single_role_user? %>
-        <div class="app-header__item">
-          <%= current_user.organisation_name %>
-        </div>
-      <% end %>
+    <div class="govuk-width-container">
+      <%= yield(:backlink_or_breadcrumb) %>
 
-      <% if authenticated? %>
-        <div class="app-header__item">
-          <%= govuk_link_to('Sign out', current_user.sign_out_path, inverse: true, no_underline: true) %>
-        </div>
-      <% end %>
-    <% end %>
-
-    <%=
-      govuk_service_navigation(
-        **Navigation::Primary.new(
-          current_path: request.fullpath,
-          current_user: current_user,
-          inverse: content_for?(:api_guidance_home_header),
-        ).govuk_header_arguments
-      )
-    %>
-
-    <% if content_for?(:api_guidance_home_header) %>
-      <%= yield(:api_guidance_home_header) %>
       <main class="govuk-main-wrapper" id="main-content" role="main">
-        <%= yield %>
-      </main>
-    <% else %>
-      <div class="govuk-width-container">
-        <%= environment_specific_phase_banner %>
-        <%= yield(:backlink_or_breadcrumb) %>
+        <%= render partial: "layouts/shared/main_preamble" %>
 
-        <main class="govuk-main-wrapper" id="main-content" role="main">
-          <%= render partial: "layouts/shared/main_preamble" %>
+        <div class="govuk-grid-row govuk-!-padding-top-7">
+          <%= render API::Guidance::SidebarComponent.new(
+            current_path: request.path,
+            page: params[:page],
+          ) %>
 
-          <div class="govuk-grid-row govuk-!-padding-top-7">
-            <%= render API::Guidance::SidebarComponent.new(
-              current_path: request.path,
-              page: params[:page],
-            ) %>
+          <div class="govuk-grid-column-two-thirds">
+            <%= yield(:page_caption) %>
+            <%= yield(:page_header) %>
 
-            <div class="govuk-grid-column-two-thirds">
-              <%= yield(:page_caption) %>
-              <%= yield(:page_header) %>
-
-              <%= yield %>
-            </div>
+            <%= yield %>
           </div>
-        </main>
-      </div>
-    <% end %>
+        </div>
+      </main>
+    </div>
 
     <%= render partial: "layouts/shared/footer" %>
   </body>

--- a/app/views/layouts/api_home.html.erb
+++ b/app/views/layouts/api_home.html.erb
@@ -7,24 +7,24 @@
       <%= render partial: "layouts/shared/header", locals: { inverse: true } %>
     </div>
 
-    <div class="x-govuk-masthead">
-      <div class="govuk-width-container">
-        <div class="govuk-grid-row">
-          <div class="govuk-grid-column-full">
-            <%= yield(:page_caption) %>
-            <%= yield(:page_header) %>
+    <main class="govuk-main-wrapper" id="main-content" role="main">
+      <div class="x-govuk-masthead">
+        <div class="govuk-width-container">
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-full">
+              <%= yield(:page_caption) %>
+              <%= yield(:page_header) %>
 
-            <p class="x-govuk-masthead__description">
-              Find out what data lead providers need to submit to DfE, how to keep it up to
-              date, and when to report changes about early career teachers and their mentors.
-            </p>
+              <p class="x-govuk-masthead__description">
+                Find out what data lead providers need to submit to DfE, how to keep it up to
+                date, and when to report changes about early career teachers and their mentors.
+              </p>
 
+            </div>
           </div>
         </div>
       </div>
-    </div>
 
-    <main class="govuk-main-wrapper" id="main-content" role="main">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
           <%= yield %>

--- a/app/views/layouts/api_home.html.erb
+++ b/app/views/layouts/api_home.html.erb
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<%= govuk_html_element do %>
+  <%= render partial: "layouts/shared/head" %>
+
+  <body class="govuk-template__body api-guidance" data-turbo="false">
+    <div class="govuk-!-display-none-print">
+      <%= render partial: "layouts/shared/header", locals: { inverse: true } %>
+    </div>
+
+    <div class="x-govuk-masthead">
+      <div class="govuk-width-container">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-full">
+            <%= yield(:page_caption) %>
+            <%= yield(:page_header) %>
+
+            <p class="x-govuk-masthead__description">
+              Find out what data lead providers need to submit to DfE, how to keep it up to
+              date, and when to report changes about early career teachers and their mentors.
+            </p>
+
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <main class="govuk-main-wrapper" id="main-content" role="main">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          <%= yield %>
+        </div>
+      </div>
+    </main>
+
+    <div class="govuk-!-display-none-print">
+      <%= render partial: "layouts/shared/footer" %>
+    </div>
+  </body>
+<% end %>

--- a/app/views/layouts/shared/_banners.html.erb
+++ b/app/views/layouts/shared/_banners.html.erb
@@ -1,1 +1,0 @@
-<%= environment_specific_phase_banner %>

--- a/app/views/layouts/shared/_header.html.erb
+++ b/app/views/layouts/shared/_header.html.erb
@@ -29,4 +29,6 @@
       ).govuk_header_arguments
     )
   %>
+
+  <% header.with_phase_banner(**environment_specific_phase_banner_arguments, html_attributes: { class: "govuk-width-container" }) %>
 <% end %>

--- a/app/views/layouts/shared/_header.html.erb
+++ b/app/views/layouts/shared/_header.html.erb
@@ -20,13 +20,13 @@
       <%= govuk_link_to('Sign out', current_user.sign_out_path, inverse: true, no_underline: true) %>
     </div>
   <% end %>
-<% end %>
 
-<%=
-  govuk_service_navigation(
-    **Navigation::Primary.new(
-      current_path: request.fullpath,
-      current_user: current_user
-    ).govuk_header_arguments
-  )
-%>
+  <%
+    header.with_service_navigation(
+      **Navigation::Primary.new(
+        current_path: request.fullpath,
+        current_user: current_user
+      ).govuk_header_arguments
+    )
+  %>
+<% end %>

--- a/app/views/layouts/shared/_header.html.erb
+++ b/app/views/layouts/shared/_header.html.erb
@@ -1,8 +1,15 @@
+<%# locals: (inverse: false) %>
 <%= render partial: '/layouts/shared/js_enabled' %>
 
 <%= govuk_skip_link %>
 
-<%= govuk_header(full_width_border: true, html_attributes: { class: ["app-header", environment_specific_header_colour_class] }) do |header| %>
+<%=
+  govuk_header(
+    full_width_border: true,
+    html_attributes: { class: ["app-header", environment_specific_header_colour_class] },
+    header_html_attributes: { class: class_names("x-govuk-header--inverse" => inverse) }
+  ) do |header| %>
+
   <% if multi_role_user? %>
     <div class="app-header__item">
       <%= govuk_link_to(current_user.organisation_name, switch_role_path, inverse: true, no_underline: true) %>
@@ -26,9 +33,10 @@
       **Navigation::Primary.new(
         current_path: request.fullpath,
         current_user: current_user
-      ).govuk_header_arguments
+      ).govuk_header_arguments,
+      inverse:
     )
   %>
 
-  <% header.with_phase_banner(**environment_specific_phase_banner_arguments, html_attributes: { class: "govuk-width-container" }) %>
+  <% header.with_phase_banner(**environment_specific_phase_banner_arguments(inverse:)) %>
 <% end %>

--- a/app/views/layouts/shared/_page.html.erb
+++ b/app/views/layouts/shared/_page.html.erb
@@ -9,7 +9,6 @@
 
     <div class="govuk-width-container">
       <div class="govuk-!-display-none-print">
-        <%= render partial: "layouts/shared/banners" %>
         <%= render partial: "layouts/shared/schools_registration_window_banner" %>
         <%= render TimeTravellerComponent.new %>
         <%= render Admin::ImpersonationBannerComponent.new(user: current_user, school: @school) %>

--- a/spec/helpers/environment_helper_spec.rb
+++ b/spec/helpers/environment_helper_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe EnvironmentHelper, type: :helper do
+describe EnvironmentHelper do
   include GovukLinkHelper
   include GovukVisuallyHiddenHelper
   include GovukComponentsHelper
@@ -23,24 +23,28 @@ RSpec.describe EnvironmentHelper, type: :helper do
     end
   end
 
-  describe "#environment_specific_phase_banner" do
-    subject { environment_specific_phase_banner }
+  describe "#environment_specific_phase_banner_arguments" do
+    subject { environment_specific_phase_banner_arguments }
 
     it "is 'Beta' by default" do
-      expect(subject).to include("Beta")
+      expect(subject.dig(:tag, :text)).to eql("Beta")
     end
 
     it "has a govuk tag with no colour modifier" do
-      expect(subject).not_to match(/govuk-tag--\w+/)
+      expect(subject.dig(:tag, :colour)).to be_nil
+    end
+
+    it "adds the govuk-width-container class to the phase banner arg" do
+      expect(subject.dig(:html_attributes, :class)).to include("govuk-width-container")
     end
 
     context "when ENVIRONMENT_PHASE_BANNER_TAG is not set" do
       it "includes the default text" do
-        expect(subject).to match("This is a new service")
+        expect(subject.fetch(:text)).to start_with("This is a new service")
       end
 
       it "includes the support feedback form" do
-        expect(subject).to include(EnvironmentHelper::FEEDBACK_SURVEY_FORM_URL)
+        expect(subject.fetch(:text)).to include(EnvironmentHelper::FEEDBACK_SURVEY_FORM_URL)
       end
     end
 
@@ -52,34 +56,27 @@ RSpec.describe EnvironmentHelper, type: :helper do
       end
 
       it "overwrites the default with the provided value" do
-        expect(subject).to include("Wow")
+        expect(subject.dig(:tag, :text)).to eql("Wow")
       end
 
       it "has a govuk tag with a yellow modifier class" do
-        expect(subject).to match(/govuk-tag govuk-tag--yellow govuk-phase-banner__content__tag/)
+        expect(subject.dig(:tag, :colour)).to eql("yellow")
       end
 
       it "contains the text 'Give feedback about this service'" do
-        expect(subject).to include("What a nice service")
+        expect(subject.fetch(:text)).to include("What a nice service")
       end
     end
 
-    describe "passing custom HTML attributes through" do
-      subject do
-        Nokogiri.parse(
-          environment_specific_phase_banner(
-            html_attributes: { hello: "world" },
-            tag_html_attributes: { bonjour: "le monde" }
-          )
-        )
+    context "when inverse is true" do
+      subject { environment_specific_phase_banner_arguments(inverse: true) }
+
+      it "adds the inverse class to the phase banner arg" do
+        expect(subject.dig(:html_attributes, :class)).to match_array(%w[govuk-width-container x-govuk-phase-banner--inverse])
       end
 
-      it "sets the custom attributes on the rendered phase banner" do
-        expect(subject).to have_css(%(div.govuk-phase-banner[hello='world']))
-      end
-
-      it "sets the custom attributes on the rendered phase banner tag" do
-        expect(subject).to have_css(%(strong[bonjour='le monde']))
+      it "adds the inverse class to the phase banner tag arg" do
+        expect(subject.dig(:tag, :html_attributes, :class)).to include("x-govuk-tag--inverse")
       end
     end
   end

--- a/spec/helpers/environment_helper_spec.rb
+++ b/spec/helpers/environment_helper_spec.rb
@@ -72,11 +72,11 @@ describe EnvironmentHelper do
       subject { environment_specific_phase_banner_arguments(inverse: true) }
 
       it "adds the inverse class to the phase banner arg" do
-        expect(subject.dig(:html_attributes, :class)).to match_array(%w[govuk-width-container x-govuk-phase-banner--inverse])
+        expect(subject.dig(:html_attributes, :class)).to eql("govuk-width-container x-govuk-phase-banner--inverse")
       end
 
       it "adds the inverse class to the phase banner tag arg" do
-        expect(subject.dig(:tag, :html_attributes, :class)).to include("x-govuk-tag--inverse")
+        expect(subject.dig(:tag, :html_attributes, :class)).to eql("x-govuk-tag--inverse")
       end
     end
   end


### PR DESCRIPTION
This PR moves all the service navigation and phase banner inside the `<header>`.

Refs DFE-Digital/register-ects-project-board#4082

There should be no visible changes, essentially we're going:

| From | To |
| ---- | ----- |
| <img width="1178" height="302" alt="Screenshot From 2026-07-21 17-33-24" src="https://github.com/user-attachments/assets/e7b7e1d5-1cba-446c-b375-e6c3b2f05361" /> | <img width="1178" height="302" alt="Screenshot From 2026-07-21 17-32-55" src="https://github.com/user-attachments/assets/146f92f5-51fa-48f5-ab17-c96bc60abe05" /> |

It makes use of `govuk_header`'s ability to [render the phase banner and service nav as slots](https://govuk-components.x-govuk.org/components/header/#header-with-service-navigation-and-phase-banner) so they're inside the `<header>` element.

## Refactoring the API guidance pages

This was a bit more work, the header, phase banner and service nav was replicated in several places, and logic around the inversion of colours on the landing page (in the masthead) made doing it without disruption a bit painful. I took the opportunity to refactor the tops of those pages so that:

* we now use the same `_header` partial everywhere
* the landing page with the blue masthead has its own layout (`api_home`)
* duplicate headers, phase banners and service navigations have been consolidated

| | Home | Swagger | Release notes | Guidance |
| ---- | ------ | ------- | ------ | ------- |
| Before | <img width="1495" height="1492" alt="Screenshot From 2026-07-21 17-29-26" src="https://github.com/user-attachments/assets/65becd5f-86bc-4fa4-89a6-7da32b0c15eb" /> |<img width="1495" height="1492" alt="Screenshot From 2026-07-21 17-29-21" src="https://github.com/user-attachments/assets/4c1d951d-9143-474e-bf73-7af1e7bcb3c9" /> | <img width="1495" height="1492" alt="Screenshot From 2026-07-21 17-29-29" src="https://github.com/user-attachments/assets/c778e09f-5498-4f7b-bd1e-657c07c48018" /> |<img width="1495" height="1492" alt="Screenshot From 2026-07-21 17-29-32" src="https://github.com/user-attachments/assets/99d01040-f9ce-4a5e-b75d-ec221cbf35cb" /> |
| After |  <img width="1459" height="1620" alt="Screenshot From 2026-07-21 17-43-43" src="https://github.com/user-attachments/assets/7434a4be-509c-417b-9b9a-fdbf1b6edfa8" /> | <img width="1495" height="1492" alt="Screenshot From 2026-07-21 17-29-45" src="https://github.com/user-attachments/assets/dc3f5200-ebf4-4518-9e2f-909202e62f92" /> | <img width="1495" height="1492" alt="Screenshot From 2026-07-21 17-29-49" src="https://github.com/user-attachments/assets/f391b087-9b81-440b-8c93-e5319010f3d1" /> | <img width="1495" height="1492" alt="Screenshot From 2026-07-21 17-29-52" src="https://github.com/user-attachments/assets/4a47737e-c8b9-4c1d-afa5-407b45990d04" /> |

## Review tips

The ~~last~~ "Simplify API changes" commit is the big one that did loads of moving around, I'd suggest going commit-by-commit. Happy to discuss/walk through the changes.

## Changes

- **Move service nav inside header element**
- **Split environment_specific_phase_banner method up**
- **Move phase banner inside the <header> element**
- **Simplify API pages by adding new home layout**
