### PR TITLE
[4192] Include contract period in CSV filename

### DIFF
--- a/app/controllers/admin/finance/statements_controller.rb
+++ b/app/controllers/admin/finance/statements_controller.rb
@@ -39,7 +39,7 @@ module Admin::Finance
   private
 
     def set_statement
-      @statement = Statement.eager_load(active_lead_provider: :lead_provider).find(params[:id])
+      @statement = Statement.eager_load(active_lead_provider: %i[lead_provider contract_period]).find(params[:id])
     end
 
     def ensure_output_fee_statement!

--- a/app/services/statements/declarations_csv.rb
+++ b/app/services/statements/declarations_csv.rb
@@ -43,7 +43,8 @@ module Statements
 
     def filename
       [
-        statement.lead_provider.name.parameterize,
+        statement.lead_provider.name.parameterize(separator: ""),
+        "#{statement.contract_period.year}-contract",
         Statements::Period.for(statement).parameterize,
         "declarations.csv"
       ].join("-")

--- a/spec/services/statements/declarations_csv_spec.rb
+++ b/spec/services/statements/declarations_csv_spec.rb
@@ -3,7 +3,9 @@ require "csv"
 RSpec.describe Statements::DeclarationsCSV do
   subject(:export) { described_class.new(statement:) }
 
-  let(:contract_period) { FactoryBot.create(:contract_period, year: 2024, uplift_fees_enabled: true) }
+  let(:contract_period) { FactoryBot.create(:contract_period, year: 2025, uplift_fees_enabled: true) }
+  let(:statement_month) { 11 }
+  let(:statement_year) { 2024 }
   let(:ect_started_on) { Date.new(2024, 9, 1) }
   let(:declaration_timestamp) { Time.zone.local(2024, 10, 15, 10, 0, 0) }
   let(:created_timestamp) { Time.zone.local(2024, 10, 16, 11, 30, 0) }
@@ -22,8 +24,8 @@ RSpec.describe Statements::DeclarationsCSV do
       :paid,
       contract:,
       active_lead_provider:,
-      month: 11,
-      year: 2024,
+      month: statement_month,
+      year: statement_year,
       api_id: "df66db14-0f96-4b31-be92-1c1f1c6e4efe"
     )
   end
@@ -89,8 +91,11 @@ RSpec.describe Statements::DeclarationsCSV do
   end
 
   describe "#filename" do
-    it "uses the lead provider and statement period" do
-      expect(export.filename).to eq("ambition-institute-november-2024-declarations.csv")
+    let(:statement_month) { 8 }
+    let(:statement_year) { 2026 }
+
+    it "uses the lead provider, contract period and statement period" do
+      expect(export.filename).to eq("ambitioninstitute-2025-contract-august-2026-declarations.csv")
     end
   end
 


### PR DESCRIPTION
## Summary

To make assurance macros easier to work with we are removing hyphens from the lead provider names and including the contract period year in the declarations CSV filename.

Before: `ambition-institute-january-2021-declarations.csv`

After: `ambitioninstitute-2021-contract-january-2021-declarations.csv`