### PR TITLE
Add `govuk_body_element` helper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -92,4 +92,10 @@ module ApplicationHelper
   def govuk_html_element(&block)
     tag.html(lang: "en", class: "govuk-template", &block)
   end
+
+  def govuk_body_element(classes: [], &block)
+    tag.body(class: ["govuk-template__body", *classes], data: { turbo: "false" }) do
+      safe_join([govuk_skip_link, capture(&block)])
+    end
+  end
 end

--- a/app/views/layouts/api_docs.html.erb
+++ b/app/views/layouts/api_docs.html.erb
@@ -6,10 +6,8 @@
 <%= govuk_html_element do %>
   <%= render partial: "layouts/shared/head" %>
 
-  <body class="govuk-template__body" data-turbo="false">
+  <%= govuk_body_element do %>
     <%= render partial: "layouts/shared/js_enabled" %>
-
-    <%= govuk_skip_link %>
     <%= render partial: "layouts/shared/header" %>
 
     <div class="govuk-width-container">
@@ -25,5 +23,5 @@
     </div>
 
     <%= render partial: "layouts/shared/footer" %>
-  </body>
+  <% end %>
 <% end %>

--- a/app/views/layouts/api_guidance.html.erb
+++ b/app/views/layouts/api_guidance.html.erb
@@ -2,10 +2,8 @@
 <%= govuk_html_element do %>
   <%= render partial: "layouts/shared/head" %>
 
-  <body class="govuk-template__body api-guidance" data-turbo="false">
+  <%= govuk_body_element(classes: "api-guidance") do %>
     <%= render partial: "layouts/shared/js_enabled" %>
-
-    <%= govuk_skip_link %>
     <%= render partial: "layouts/shared/header" %>
 
     <div class="govuk-width-container">
@@ -31,5 +29,5 @@
     </div>
 
     <%= render partial: "layouts/shared/footer" %>
-  </body>
+  <% end %>
 <% end %>

--- a/app/views/layouts/api_home.html.erb
+++ b/app/views/layouts/api_home.html.erb
@@ -2,7 +2,7 @@
 <%= govuk_html_element do %>
   <%= render partial: "layouts/shared/head" %>
 
-  <body class="govuk-template__body api-guidance" data-turbo="false">
+  <%= govuk_body_element(classes: "api-guidance") do %>
     <div class="govuk-!-display-none-print">
       <%= render partial: "layouts/shared/header", locals: { inverse: true } %>
     </div>
@@ -35,5 +35,5 @@
     <div class="govuk-!-display-none-print">
       <%= render partial: "layouts/shared/footer" %>
     </div>
-  </body>
+  <% end %>
 <% end %>

--- a/app/views/layouts/shared/_header.html.erb
+++ b/app/views/layouts/shared/_header.html.erb
@@ -1,8 +1,6 @@
 <%# locals: (inverse: false) %>
 <%= render partial: '/layouts/shared/js_enabled' %>
 
-<%= govuk_skip_link %>
-
 <%=
   govuk_header(
     full_width_border: true,

--- a/app/views/layouts/shared/_page.html.erb
+++ b/app/views/layouts/shared/_page.html.erb
@@ -2,7 +2,7 @@
 <%= govuk_html_element do %>
   <%= render partial: "layouts/shared/head" %>
 
-  <body class="govuk-template__body" data-turbo="false">
+  <%= govuk_body_element do %>
     <div class="govuk-!-display-none-print">
       <%= render partial: "layouts/shared/header" %>
     </div>
@@ -26,5 +26,5 @@
     <div class="govuk-!-display-none-print">
       <%= render partial: "layouts/shared/footer" %>
     </div>
-  </body>
+  <% end %>
 <% end %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe ApplicationHelper, type: :helper do
   include GovukVisuallyHiddenHelper
   include GovukLinkHelper
   include GovukComponentsHelper
+  include GovukSkipLinkHelper
   include TitleWithErrorPrefixHelper
 
   describe "#page_data" do
@@ -292,6 +293,32 @@ RSpec.describe ApplicationHelper, type: :helper do
 
     it "defaults to english" do
       expect(subject).to include('lang="en"')
+    end
+  end
+
+  describe "#govuk_body_element" do
+    subject { govuk_body_element { content } }
+
+    let(:content) { "interesting body content" }
+
+    it "renders the provided content in a HTML element" do
+      expect(subject).to match(%r{<body.*#{content}</body>})
+    end
+
+    it "includes the govuk-template class" do
+      expect(subject).to include("govuk-template__body")
+    end
+
+    it "renders the govuk skip link before any other content" do
+      expect(subject).to match(%r{govuk-skip-link.*#{content}})
+    end
+
+    context "when extra classes are passed in" do
+      subject { govuk_body_element(classes: "fancy") { content } }
+
+      it "includes the provided classes" do
+        expect(subject).to include(%(<body class="govuk-template__body fancy"))
+      end
     end
   end
 


### PR DESCRIPTION
We render the body element in various layouts and it [should be followed immediately by a skip link](https://design-system.service.gov.uk/components/skip-link/#when-to-use-this-component).

The `govuk_body_element` helper automatically renders the govuk_skip_link component at the very top of `<body>`
