### PR TITLE
[3733] fix running a script with custom logging on a pod

### DIFF
--- a/lib/appropriate_bodies/importers/induction_period_parser.rb
+++ b/lib/appropriate_bodies/importers/induction_period_parser.rb
@@ -2,7 +2,7 @@ require "csv"
 
 module AppropriateBodies::Importers
   class InductionPeriodParser
-    PARSER_ERROR_LOG = "log/dqt_induction_period_parser.log"
+    PARSER_ERROR_LOG = "tmp/dqt_induction_period_parser.log"
 
     # 2 legacy teachers with inductions have already been imported manually
     UNWANTED_TEACHER_IDS = [76_075, 93_314].freeze

--- a/lib/appropriate_bodies/importers/teacher_induction_importer.rb
+++ b/lib/appropriate_bodies/importers/teacher_induction_importer.rb
@@ -13,7 +13,7 @@ module AppropriateBodies::Importers
   class TeacherInductionImporter
     BATCH_SIZE = 10_000
 
-    IMPORT_INFO_LOG = "log/dqt_import_info.log"
+    IMPORT_INFO_LOG = "tmp/dqt_import_info.log"
 
     # Bulk replace placeholder event headings
     STATEMENTS = [<<~CLAIMED, <<~RELEASED, <<~PASSED, <<~FAILED].freeze


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/3733

The log directory on the pod is owned by `root` and not writable by `appuser`.

### Changes proposed in this pull request

DQT importers need to all use `/app/tmp` instead when we run the script on a deployment.

### Guidance to review

