### PR TITLE
Fix 4239 backdated mentorship overlap

### DIFF
--- a/app/services/schools/assign_mentor.rb
+++ b/app/services/schools/assign_mentor.rb
@@ -2,11 +2,11 @@ module Schools
   class AssignMentor
     attr_reader :ect_at_school_period, :mentor_at_school_period, :mentorship_period, :author
 
-    def initialize(ect_at_school_period:, mentor_at_school_period:, author:, mentorship_can_start_today: true)
+    def initialize(ect_at_school_period:, mentor_at_school_period:, author:, mentor_is_transferring_schools: false)
       @ect_at_school_period = ect_at_school_period
       @mentor_at_school_period = mentor_at_school_period
       @author = author
-      @mentorship_can_start_today = mentorship_can_start_today
+      @mentor_is_transferring_schools = mentor_is_transferring_schools
     end
 
     def assign!
@@ -56,7 +56,8 @@ module Schools
       MentorAssignment::MentorshipPeriods::DatesResolver.new(
         ect_at_school_period:,
         mentor_at_school_period:,
-        mentorship_can_start_today: @mentorship_can_start_today
+        mentor_is_transferring_schools:
+          @mentor_is_transferring_schools
       )
     end
 

--- a/app/services/schools/mentor_assignment/mentorship_periods/dates_resolver.rb
+++ b/app/services/schools/mentor_assignment/mentorship_periods/dates_resolver.rb
@@ -5,24 +5,31 @@ module Schools
         def initialize(
           ect_at_school_period:,
           mentor_at_school_period:,
-          mentorship_can_start_today:
+          mentor_is_transferring_schools:
         )
           @ect_at_school_period = ect_at_school_period
           @mentor_at_school_period = mentor_at_school_period
-          @mentorship_can_start_today = mentorship_can_start_today
+          @mentor_is_transferring_schools = mentor_is_transferring_schools
         end
 
         def earliest_possible_start
           [
             @ect_at_school_period.started_on,
             @mentor_at_school_period.started_on,
-            (Date.current if @mentorship_can_start_today)
+            (Date.current unless backdating_allowed?)
           ].compact.max
         end
 
         def latest_possible_finish
           [@ect_at_school_period.finished_on, @mentor_at_school_period.finished_on]
             .compact.min
+        end
+
+      private
+
+        def backdating_allowed?
+          @mentor_is_transferring_schools &&
+            @ect_at_school_period.mentorship_periods.none?
         end
       end
     end

--- a/app/wizards/schools/register_mentor_wizard/check_answers_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/check_answers_step.rb
@@ -50,17 +50,12 @@ module Schools
             ect_at_school_period: ect,
             mentor_at_school_period: mentor.register!(author:),
             author:,
-            mentorship_can_start_today: use_today_as_earliest_start?
+            mentor_is_transferring_schools: mentoring_at_new_school_only?
           ).assign!
         end
       rescue StandardError => e
         mentor.registered = false
         raise e
-      end
-
-      def use_today_as_earliest_start?
-        ect.mentorship_periods.exists? ||
-          !mentoring_at_new_school_only?
       end
     end
   end

--- a/app/wizards/schools/register_mentor_wizard/check_answers_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/check_answers_step.rb
@@ -50,12 +50,17 @@ module Schools
             ect_at_school_period: ect,
             mentor_at_school_period: mentor.register!(author:),
             author:,
-            mentorship_can_start_today: !mentoring_at_new_school_only?
+            mentorship_can_start_today: use_today_as_earliest_start?
           ).assign!
         end
       rescue StandardError => e
         mentor.registered = false
         raise e
+      end
+
+      def use_today_as_earliest_start?
+        ect.mentorship_periods.exists? ||
+          !mentoring_at_new_school_only?
       end
     end
   end

--- a/spec/services/schools/assign_mentor_spec.rb
+++ b/spec/services/schools/assign_mentor_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Schools::AssignMentor do
     described_class.new(
       ect_at_school_period: mentee,
       mentor_at_school_period: new_mentor,
-      mentorship_can_start_today:,
+      mentor_is_transferring_schools:,
       author:
     )
   end
@@ -30,7 +30,7 @@ RSpec.describe Schools::AssignMentor do
   let(:mentee_finished_on) { nil }
   let(:new_mentor_started_on) { 1.year.ago }
   let(:new_mentor_finished_on) { nil }
-  let(:mentorship_can_start_today) { true }
+  let(:mentor_is_transferring_schools) { false }
 
   describe "#assign!" do
     subject(:assign!) { service.assign! }
@@ -122,6 +122,19 @@ RSpec.describe Schools::AssignMentor do
           started_on: Date.current,
           finished_on: 1.year.from_now.to_date
         )
+      end
+
+      it "passes whether the mentor is transferring schools to the dates resolver" do
+        assign!
+
+        expect(Schools::MentorAssignment::MentorshipPeriods::DatesResolver)
+          .to have_received(:new)
+          .with(
+            ect_at_school_period: mentee,
+            mentor_at_school_period: new_mentor,
+            mentor_is_transferring_schools:
+          )
+          .at_least(:once)
       end
     end
 

--- a/spec/services/schools/assign_mentor_spec.rb
+++ b/spec/services/schools/assign_mentor_spec.rb
@@ -44,6 +44,42 @@ RSpec.describe Schools::AssignMentor do
         end
       end
 
+      context "when a previous mentorship has finished" do
+        let(:mentorship_can_start_today) { false }
+        let(:new_mentor_started_on) { 1.month.ago }
+
+        let(:previous_mentor) do
+          FactoryBot.create(
+            :mentor_at_school_period,
+            :ongoing,
+            school: mentee.school,
+            started_on: 1.year.ago
+          )
+        end
+
+        let!(:previous_mentorship_period) do
+          FactoryBot.create(
+            :mentorship_period,
+            mentee:,
+            mentor: previous_mentor,
+            started_on: 1.year.ago,
+            finished_on: 2.weeks.ago
+          )
+        end
+
+        it "assigns the new mentor without overlapping the previous mentorship" do
+          expect { assign! }.not_to raise_error
+
+          new_mentorship = mentee.reload.mentorship_periods.find_by!(
+            mentor: new_mentor
+          )
+
+          expect(new_mentorship.started_on)
+            .to eq(previous_mentorship_period.finished_on.next_day)
+        end
+      end
+
+
       context "when the mentee is currently being mentored" do
         let(:current_mentor) do
           FactoryBot.create(
@@ -97,6 +133,34 @@ RSpec.describe Schools::AssignMentor do
             expect { current_mentorship_period.reload }
               .to raise_error(ActiveRecord::RecordNotFound)
           end
+        end
+      end
+
+      context "when the current mentorship already has a future end date" do
+        let(:current_mentor) do
+          FactoryBot.create(
+            :mentor_at_school_period,
+            :ongoing,
+            started_on: 6.months.ago,
+            school: mentee.school
+          )
+        end
+
+        let!(:current_mentorship_period) do
+          FactoryBot.create(
+            :mentorship_period,
+            started_on: current_mentor.started_on,
+            finished_on: 1.week.from_now,
+            mentee:,
+            mentor: current_mentor
+          )
+        end
+
+        it "finishes the current mentorship before assigning the new mentor" do
+          expect { assign! }.not_to raise_error
+
+          expect(current_mentorship_period.reload.finished_on)
+            .to eq(Date.yesterday)
         end
       end
     end

--- a/spec/services/schools/assign_mentor_spec.rb
+++ b/spec/services/schools/assign_mentor_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Schools::AssignMentor do
       end
 
       context "when a previous mentorship has finished" do
-        let(:mentorship_can_start_today) { false }
+        let(:mentorship_can_start_today) { true }
         let(:new_mentor_started_on) { 1.month.ago }
 
         let(:previous_mentor) do
@@ -67,18 +67,16 @@ RSpec.describe Schools::AssignMentor do
           )
         end
 
-        it "assigns the new mentor without overlapping the previous mentorship" do
+        it "starts the new mentorship from today" do
           expect { assign! }.not_to raise_error
 
           new_mentorship = mentee.reload.mentorship_periods.find_by!(
             mentor: new_mentor
           )
 
-          expect(new_mentorship.started_on)
-            .to eq(previous_mentorship_period.finished_on.next_day)
+          expect(new_mentorship.started_on).to eq(Date.current)
         end
       end
-
 
       context "when the mentee is currently being mentored" do
         let(:current_mentor) do
@@ -133,34 +131,6 @@ RSpec.describe Schools::AssignMentor do
             expect { current_mentorship_period.reload }
               .to raise_error(ActiveRecord::RecordNotFound)
           end
-        end
-      end
-
-      context "when the current mentorship already has a future end date" do
-        let(:current_mentor) do
-          FactoryBot.create(
-            :mentor_at_school_period,
-            :ongoing,
-            started_on: 6.months.ago,
-            school: mentee.school
-          )
-        end
-
-        let!(:current_mentorship_period) do
-          FactoryBot.create(
-            :mentorship_period,
-            started_on: current_mentor.started_on,
-            finished_on: 1.week.from_now,
-            mentee:,
-            mentor: current_mentor
-          )
-        end
-
-        it "finishes the current mentorship before assigning the new mentor" do
-          expect { assign! }.not_to raise_error
-
-          expect(current_mentorship_period.reload.finished_on)
-            .to eq(Date.yesterday)
         end
       end
     end

--- a/spec/services/schools/assign_mentor_spec.rb
+++ b/spec/services/schools/assign_mentor_spec.rb
@@ -44,40 +44,6 @@ RSpec.describe Schools::AssignMentor do
         end
       end
 
-      context "when a previous mentorship has finished" do
-        let(:mentorship_can_start_today) { true }
-        let(:new_mentor_started_on) { 1.month.ago }
-
-        let(:previous_mentor) do
-          FactoryBot.create(
-            :mentor_at_school_period,
-            :ongoing,
-            school: mentee.school,
-            started_on: 1.year.ago
-          )
-        end
-
-        let!(:previous_mentorship_period) do
-          FactoryBot.create(
-            :mentorship_period,
-            mentee:,
-            mentor: previous_mentor,
-            started_on: 1.year.ago,
-            finished_on: 2.weeks.ago
-          )
-        end
-
-        it "starts the new mentorship from today" do
-          expect { assign! }.not_to raise_error
-
-          new_mentorship = mentee.reload.mentorship_periods.find_by!(
-            mentor: new_mentor
-          )
-
-          expect(new_mentorship.started_on).to eq(Date.current)
-        end
-      end
-
       context "when the mentee is currently being mentored" do
         let(:current_mentor) do
           FactoryBot.create(

--- a/spec/services/schools/mentor_assignment/mentorship_periods/dates_resolver_spec.rb
+++ b/spec/services/schools/mentor_assignment/mentorship_periods/dates_resolver_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Schools::MentorAssignment::MentorshipPeriods::DatesResolver do
     described_class.new(
       ect_at_school_period:,
       mentor_at_school_period:,
-      mentorship_can_start_today:
+      mentor_is_transferring_schools:
     )
   end
 
@@ -26,12 +26,13 @@ RSpec.describe Schools::MentorAssignment::MentorshipPeriods::DatesResolver do
   let(:mentor_started_on) { 2.years.ago }
   let(:ect_finished_on) { nil }
   let(:mentor_finished_on) { nil }
+  let(:mentor_is_transferring_schools) { false }
 
   describe "#earliest_possible_start" do
     subject(:earliest_possible_start) { service.earliest_possible_start }
 
-    context "when the mentorship can start today" do
-      let(:mentorship_can_start_today) { true }
+    context "when the mentor is not transferring schools" do
+      let(:mentor_is_transferring_schools) { false }
 
       context "and both the ECT and the mentor started at the school " \
               "in the past" do
@@ -74,21 +75,61 @@ RSpec.describe Schools::MentorAssignment::MentorshipPeriods::DatesResolver do
       end
     end
 
-    context "when the mentorship cannot start today" do
-      let(:mentorship_can_start_today) { false }
+    context "when the mentor is transferring schools" do
+      let(:mentor_is_transferring_schools) { true }
 
-      context "and the ECT started at the school after the mentor" do
-        let(:ect_started_on) { 1.year.ago }
-        let(:mentor_started_on) { 2.years.ago }
+      context "and the ECT has no previous mentorships" do
+        context "and the ECT started at the school after the mentor" do
+          let(:ect_started_on) { 1.year.ago }
+          let(:mentor_started_on) { 2.years.ago }
 
-        it { is_expected.to eq(ect_at_school_period.started_on) }
+          it { is_expected.to eq(ect_at_school_period.started_on) }
+        end
+
+        context "and the mentor started at the school after the ECT" do
+          let(:ect_started_on) { 2.years.ago }
+          let(:mentor_started_on) { 1.year.ago }
+
+          it { is_expected.to eq(mentor_at_school_period.started_on) }
+        end
       end
 
-      context "and the mentor started at the school after the ECT" do
-        let(:ect_started_on) { 2.years.ago }
-        let(:mentor_started_on) { 1.year.ago }
+      context "and the ECT has a previous mentorship" do
+        let(:previous_mentorship_started_on) { 1.year.ago.to_date }
 
-        it { is_expected.to eq(mentor_at_school_period.started_on) }
+        let(:previous_mentor_at_school_period) do
+          FactoryBot.create(
+            :mentor_at_school_period,
+            :ongoing,
+            started_on: previous_mentorship_started_on,
+            school: ect_at_school_period.school
+          )
+        end
+
+        let!(:previous_mentorship_period) do
+          FactoryBot.create(
+            :mentorship_period,
+            mentee: ect_at_school_period,
+            mentor: previous_mentor_at_school_period,
+            started_on: previous_mentorship_started_on,
+            finished_on: 2.weeks.ago.to_date
+          )
+        end
+
+        context "and both the ECT and the new mentor started at the school " \
+                "in the past" do
+          let(:ect_started_on) { 2.years.ago }
+          let(:mentor_started_on) { 1.month.ago }
+
+          it { is_expected.to eq(Date.current) }
+        end
+
+        context "and the new mentor starts at the school in the future" do
+          let(:ect_started_on) { 2.years.ago }
+          let(:mentor_started_on) { 1.month.from_now }
+
+          it { is_expected.to eq(mentor_at_school_period.started_on) }
+        end
       end
     end
   end
@@ -96,9 +137,7 @@ RSpec.describe Schools::MentorAssignment::MentorshipPeriods::DatesResolver do
   describe "#latest_possible_finish" do
     subject(:latest_possible_finish) { service.latest_possible_finish }
 
-    let(:mentorship_can_start_today) { nil }
-
-    context "when neither the ECT or the mentor are due to leave the school" do
+    context "when neither the ECT nor the mentor are due to leave the school" do
       let(:ect_finished_on) { nil }
       let(:mentor_finished_on) { nil }
 

--- a/spec/wizards/schools/register_mentor_wizard/check_answers_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/check_answers_step_spec.rb
@@ -123,16 +123,39 @@ describe Schools::RegisterMentorWizard::CheckAnswersStep, type: :model do
       context "when the mentor is mentoring only at the new school" do
         before { store.mentoring_at_new_school_only = "yes" }
 
-        it "assigns the created mentor to the ECT" do
-          subject.save!
-          expect(Schools::AssignMentor)
-            .to have_received(:new)
-            .with(
-              ect_at_school_period: wizard.ect,
-              mentor_at_school_period: new_mentor,
-              author:,
-              mentorship_can_start_today: false
-            )
+        context "when the ECT has not previously had a mentor" do
+          it "allows the mentorship to be backdated" do
+            subject.save!
+            expect(Schools::AssignMentor)
+              .to have_received(:new)
+              .with(
+                ect_at_school_period: wizard.ect,
+                mentor_at_school_period: new_mentor,
+                author:,
+                mentorship_can_start_today: false
+              )
+          end
+        end
+
+        context "when the ECT has previously had a mentor" do
+          before do
+            allow(wizard.ect.mentorship_periods)
+              .to receive(:exists?)
+              .and_return(true)
+          end
+
+          it "starts the new mentorship from the date of the change" do
+            subject.save!
+
+            expect(Schools::AssignMentor)
+              .to have_received(:new)
+              .with(
+                ect_at_school_period: wizard.ect,
+                mentor_at_school_period: new_mentor,
+                author:,
+                mentorship_can_start_today: true
+              )
+          end
         end
       end
 

--- a/spec/wizards/schools/register_mentor_wizard/check_answers_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/check_answers_step_spec.rb
@@ -123,54 +123,33 @@ describe Schools::RegisterMentorWizard::CheckAnswersStep, type: :model do
       context "when the mentor is mentoring only at the new school" do
         before { store.mentoring_at_new_school_only = "yes" }
 
-        context "when the ECT has not previously had a mentor" do
-          it "allows the mentorship to be backdated" do
-            subject.save!
-            expect(Schools::AssignMentor)
-              .to have_received(:new)
-              .with(
-                ect_at_school_period: wizard.ect,
-                mentor_at_school_period: new_mentor,
-                author:,
-                mentorship_can_start_today: false
-              )
-          end
-        end
-
-        context "when the ECT has previously had a mentor" do
-          before do
-            allow(wizard.ect.mentorship_periods)
-              .to receive(:exists?)
-              .and_return(true)
-          end
-
-          it "starts the new mentorship from the date of the change" do
-            subject.save!
-
-            expect(Schools::AssignMentor)
-              .to have_received(:new)
-              .with(
-                ect_at_school_period: wizard.ect,
-                mentor_at_school_period: new_mentor,
-                author:,
-                mentorship_can_start_today: true
-              )
-          end
-        end
-      end
-
-      context "when the mentor is continuing to mentor at their current school" do
-        before { store.mentoring_at_new_school_only = "no" }
-
-        it "assigns the created mentor to the ECT" do
+        it "assigns the created mentor as transferring schools" do
           subject.save!
+
           expect(Schools::AssignMentor)
             .to have_received(:new)
             .with(
               ect_at_school_period: wizard.ect,
               mentor_at_school_period: new_mentor,
               author:,
-              mentorship_can_start_today: true
+              mentor_is_transferring_schools: true
+            )
+        end
+      end
+
+      context "when the mentor is continuing to mentor at their current school" do
+        before { store.mentoring_at_new_school_only = "no" }
+
+        it "assigns the created mentor as not transferring schools" do
+          subject.save!
+
+          expect(Schools::AssignMentor)
+            .to have_received(:new)
+            .with(
+              ect_at_school_period: wizard.ect,
+              mentor_at_school_period: new_mentor,
+              author:,
+              mentor_is_transferring_schools: false
             )
         end
       end


### PR DESCRIPTION
Ticket [here](https://github.com/DFE-Digital/register-ects-project-board/issues/4239)

### Context
When registering a transferring mentor for an ECT with a previous finished mentorship, the new mentorship could be backdated to the mentor’s school start date. If that date overlapped the previous mentorship, the assignment failed validation.

### Changes proposed in this pull request
- keeps the previous mentorship unchanged
- creates a new mentorship from the date of the change
- prevents the new period from overlapping a previous mentorship

### Guidance to review
