### PR TITLE
[3733] migration memory bump for DQT importer

### DIFF
--- a/config/queue.yml
+++ b/config/queue.yml
@@ -31,33 +31,7 @@ default: &default
 
 migration: &migration
   workers:
-    # Dedicated critical queues
-    - queues: [mailers]
-      threads: 2
-      processes: 2
-      polling_interval: 0.1
-
-    - queues: [default]
-      threads: 2
-      processes: 2
-      polling_interval: 0.1
-
-    # Metadata workers (2 jobs max, will be 2 jobs with 2 workers)
-    # The jobs to refresh school metadata have DB-heavy and can
-    # lock up the database if we run too many at once.
-    - queues: [metadata]
-      threads: 1
-      processes: 1
-      polling_interval: 0.1
-
-    # Everything else
-    - queues: [process_batch, trs_sync, events, dfe_analytics, solid_queue_recurring]
-      threads: 2
-      processes: 2
-      polling_interval: 0.1
-
-    # Migration
-    - queues: [migration]
+    - queues: ["*"]
       threads: 2
       processes: 2
       polling_interval: 0.1

--- a/config/terraform/application/config/migration.tfvars.json
+++ b/config/terraform/application/config/migration.tfvars.json
@@ -3,8 +3,8 @@
     "namespace": "cpd-production",
     "environment": "migration",
     "enable_logit": true,
-    "worker_memory_max": "2Gi",
-    "webapp_memory_max": "2Gi",
+    "worker_memory_max": "4Gi",
+    "webapp_memory_max": "4Gi",
     "worker_replicas": 2,
     "webapp_replicas": 1,
     "postgres_flexible_server_sku": "GP_Standard_D4ds_v5"

--- a/config/terraform/application/config/migration.tfvars.json
+++ b/config/terraform/application/config/migration.tfvars.json
@@ -5,7 +5,7 @@
     "enable_logit": true,
     "worker_memory_max": "4Gi",
     "webapp_memory_max": "4Gi",
-    "worker_replicas": 2,
+    "worker_replicas": 1,
     "webapp_replicas": 1,
     "postgres_flexible_server_sku": "GP_Standard_D4ds_v5"
 }


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/3733

Following #3280 we hit an OOM error.

### Changes proposed in this pull request

- increase memory to 4GB to match production
- reduce workers from 2 to 1
- simplify job config for migration to a wildcard

### Guidance to review
