### PR TITLE
Add statement audit note

### DIFF
--- a/app/components/admin/statements/audit_notes_component.html.erb
+++ b/app/components/admin/statements/audit_notes_component.html.erb
@@ -1,0 +1,8 @@
+<div class="finance-panel govuk-!-margin-top-5 govuk-!-margin-bottom-5">
+  <h2 class="govuk-heading-m">Audit notes</h2>
+
+  <% audit_notes.each do |audit_note| %>
+    <p class="govuk-hint govuk-!-margin-bottom-1"><%= timestamp(audit_note) %></p>
+    <p class="govuk-body"><%= audit_note.body %></p>
+  <% end %>
+</div>

--- a/app/components/admin/statements/audit_notes_component.rb
+++ b/app/components/admin/statements/audit_notes_component.rb
@@ -1,0 +1,21 @@
+module Admin
+  module Statements
+    class AuditNotesComponent < ApplicationComponent
+      attr_reader :statement
+
+      def initialize(statement:)
+        @statement = statement
+      end
+
+      def render? = audit_notes.any?
+
+      def audit_notes
+        @audit_notes ||= statement.audit_notes.order(created_at: :asc)
+      end
+
+      def timestamp(audit_note)
+        tag.time(audit_note.created_at.to_fs(:govuk), datetime: audit_note.created_at.to_fs(:iso8601))
+      end
+    end
+  end
+end

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -10,6 +10,7 @@ class Statement < ApplicationRecord
   # Associations
   belongs_to :contract
   has_many :adjustments, dependent: :destroy
+  has_many :audit_notes, dependent: :destroy
   has_many :payment_declarations, inverse_of: :payment_statement, class_name: "Declaration"
   has_many :clawback_declarations, inverse_of: :clawback_statement, class_name: "Declaration"
   has_one :active_lead_provider, through: :contract

--- a/app/models/statement/audit_note.rb
+++ b/app/models/statement/audit_note.rb
@@ -1,0 +1,5 @@
+class Statement::AuditNote < ApplicationRecord
+  belongs_to :statement
+
+  validates :body, presence: { message: "Enter the audit note text" }
+end

--- a/app/views/admin/finance/statements/show.html.erb
+++ b/app/views/admin/finance/statements/show.html.erb
@@ -19,5 +19,6 @@
 <%= render Admin::Statements::UpliftFeesComponent.new(statement: @statement) %>
 <%= render Admin::Statements::ClawbacksComponent.new(statement: @statement) %>
 <%= render Admin::Statements::AdjustmentsComponent.new(statement: @statement) %>
+<%= render Admin::Statements::AuditNotesComponent.new(statement: @statement) %>
 <%= render Admin::Statements::ProviderTargetsComponent.new(statement: @statement) %>
 <%= render Admin::Statements::GuidanceComponent.new %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -248,6 +248,12 @@ shared:
     - amount
     - created_at
     - updated_at
+  :statement_audit_notes:
+    - id
+    - statement_id
+    - body
+    - created_at
+    - updated_at
   :statements:
     - id
     - api_id

--- a/db/migrate/20260723155410_create_statement_audit_notes.rb
+++ b/db/migrate/20260723155410_create_statement_audit_notes.rb
@@ -1,0 +1,10 @@
+class CreateStatementAuditNotes < ActiveRecord::Migration[8.0]
+  def change
+    create_table :statement_audit_notes do |t|
+      t.references :statement, null: false, foreign_key: true
+      t.text :body, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_13_075124) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_23_155410) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -806,6 +806,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_13_075124) do
     t.index ["statement_id"], name: "index_statement_adjustments_on_statement_id"
   end
 
+  create_table "statement_audit_notes", force: :cascade do |t|
+    t.text "body", null: false
+    t.datetime "created_at", null: false
+    t.bigint "statement_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["statement_id"], name: "index_statement_audit_notes_on_statement_id"
+  end
+
   create_table "statements", force: :cascade do |t|
     t.uuid "api_id", default: -> { "gen_random_uuid()" }, null: false
     t.datetime "api_updated_at", default: -> { "CURRENT_TIMESTAMP" }
@@ -1025,6 +1033,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_13_075124) do
   add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "statement_adjustments", "statements"
+  add_foreign_key "statement_audit_notes", "statements"
   add_foreign_key "statements", "contracts"
   add_foreign_key "teacher_id_changes", "teachers"
   add_foreign_key "teacher_id_changes", "teachers", column: "api_from_teacher_id", primary_key: "api_id"

--- a/db/seeds/statements.rb
+++ b/db/seeds/statements.rb
@@ -82,3 +82,19 @@ grouped_active_lead_providers.each do |lead_provider, active_lead_providers|
 
   describe_group_of_statements(lead_provider, statements)
 end
+
+ambition = LeadProvider.find_by!(name: "Ambition Institute")
+contract_period = ContractPeriod.find_by!(year: 2023)
+active_lead_provider = ActiveLeadProvider.find_by!(lead_provider: ambition, contract_period:)
+audited_statement = active_lead_provider.statements.find_by!(year: 2024, month: 8)
+
+audit_notes = [
+  { body: "Sample Note: x1 started declaration (955c45ff-32f3-4f58-8219-5804d7a5de4f) included for payment in ECF1 service but was unable to be represented in the RECT service", created_at: 2.months.ago },
+  { body: "Sample Note: Adjustment applied to account for the ECF1 declaration that could not be migrated", created_at: 1.month.ago },
+]
+
+audit_notes.each do |attributes|
+  FactoryBot.create(:statement_audit_note, statement: audited_statement, **attributes)
+end
+
+print_seed_info("#{audit_notes.size} audit notes added to the #{ambition.name} #{audited_statement.month_year} statement", indent: 2, blank_lines_before: 1)

--- a/spec/components/admin/statements/audit_notes_component_spec.rb
+++ b/spec/components/admin/statements/audit_notes_component_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe Admin::Statements::AuditNotesComponent, type: :component do
+  let(:statement) { FactoryBot.create(:statement) }
+  let(:component) { described_class.new statement: }
+
+  context "no audit notes" do
+    before do
+      render_inline(component)
+    end
+
+    it "does not render" do
+      expect(page).not_to have_css("h2", text: "Audit notes")
+    end
+  end
+
+  context "with audit notes" do
+    let(:older_created_at) { Time.zone.local(2024, 8, 1, 9, 30) }
+    let(:newer_created_at) { Time.zone.local(2024, 9, 2, 17, 5) }
+
+    before do
+      FactoryBot.create :statement_audit_note, statement:, body: "Older note", created_at: older_created_at
+      FactoryBot.create :statement_audit_note, statement:, body: "Newer note", created_at: newer_created_at
+
+      render_inline(component)
+    end
+
+    it "lists the notes oldest first, each below its timestamp" do
+      expect(page).to have_css("h2", text: "Audit notes")
+      expect(page.all("p").map(&:text)).to eq([
+        "1 August 2024, 9:30am",
+        "Older note",
+        "2 September 2024, 5:05pm",
+        "Newer note"
+      ])
+      expect(page.all("time").map { |element| element[:datetime] }).to eq([older_created_at.iso8601, newer_created_at.iso8601])
+    end
+  end
+end

--- a/spec/factories/statement/audit_note_factory.rb
+++ b/spec/factories/statement/audit_note_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory(:statement_audit_note, class: "Statement::AuditNote") do
+    statement
+
+    sequence(:body) { |n| "Audit note #{n}" }
+  end
+end

--- a/spec/models/statement/audit_note_spec.rb
+++ b/spec/models/statement/audit_note_spec.rb
@@ -1,0 +1,11 @@
+describe Statement::AuditNote do
+  describe "associations" do
+    it { is_expected.to belong_to(:statement) }
+  end
+
+  describe "validations" do
+    subject { FactoryBot.create(:statement_audit_note) }
+
+    it { is_expected.to validate_presence_of(:body).with_message("Enter the audit note text") }
+  end
+end

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -2,6 +2,7 @@ describe Statement do
   describe "associations" do
     it { is_expected.to have_one(:active_lead_provider).through(:contract) }
     it { is_expected.to have_many(:adjustments).dependent(:destroy) }
+    it { is_expected.to have_many(:audit_notes).dependent(:destroy) }
     it { is_expected.to have_many(:payment_declarations).class_name("Declaration").inverse_of(:payment_statement) }
     it { is_expected.to have_many(:clawback_declarations).class_name("Declaration").inverse_of(:clawback_statement) }
     it { is_expected.to have_one(:lead_provider).through(:active_lead_provider) }

--- a/spec/views/admin/finance/statements/show.html.erb_spec.rb
+++ b/spec/views/admin/finance/statements/show.html.erb_spec.rb
@@ -192,4 +192,23 @@ RSpec.describe "admin/finance/statements/show.html.erb" do
 
     expect(rendered).to have_css("table caption", text: "Additional adjustments")
   end
+
+  it "does not display an audit notes section when the statement has no audit notes" do
+    render
+
+    expect(rendered).not_to have_css("h2", text: "Audit notes")
+  end
+
+  context "when the statement has audit notes" do
+    before do
+      FactoryBot.create(:statement_audit_note, statement: feb_statement, body: "Amount differs from the invoiced amount")
+    end
+
+    it "displays the audit notes" do
+      render
+
+      expect(rendered).to have_css("h2", text: "Audit notes")
+      expect(rendered).to have_css("p", text: "Amount differs from the invoiced amount")
+    end
+  end
 end


### PR DESCRIPTION
### Context

Resolves https://github.com/DFE-Digital/register-ects-project-board/issues/4249

> There is a audit requirement that statements match what was invoiced or have a note in situ explaining any difference. Such a note will need to be added to the affected output statements.

> A new attribute needs to be added to statements, to be called audit_note (or a new entity/table that links to statements)

> Plain text

> When a statement has a populated audit_note (or notes if pursuing the table route), the text needs to appear at the bottom of the statement page after the "Additional adjustments" section (as a new section)

> the notes will be populated based on the final outcome of https://github.com/DFE-Digital/register-ects-project-board/issues/3704, to be populated by developer - this ticket is to prepare the attribute/entity, not populate it


### Changes proposed in this pull request

* Adds **Statement::AuditNote** active record
* Adds analytics for new table
* Adds view component for panel in the same style as the other statement panels

https://cpd-ec2-review-3286-web.test.teacherservices.cloud/admin/finance/statements/4014

<img width="990" height="803" alt="Screenshot 2026-07-27 at 16 09 45" src="https://github.com/user-attachments/assets/05de6bec-16cd-4734-9e17-35f41e8eff48" />


### Guidance to review

* Adds a seed for two audit note records for Ambition Institute contract period 2023, for Statement of August 2024.
