### PR TITLE
Display an ECT's future mentorship details

### DIFF
--- a/app/components/schools/ects/listing_card_component.rb
+++ b/app/components/schools/ects/listing_card_component.rb
@@ -108,7 +108,7 @@ module Schools
       def mentor_row
         {
           key: { text: "Mentor", classes: %w[mentor-key] },
-          value: { text: ect_mentor_name_or_assign_mentor_link(ect_at_school_period) }
+          value: { text: render(Schools::ECTs::MentorshipComponent.new(ect_at_school_period)) }
         }
       end
 

--- a/app/components/schools/ects/mentorship_component.html.erb
+++ b/app/components/schools/ects/mentorship_component.html.erb
@@ -1,0 +1,8 @@
+<% if mentorship.current_mentor.blank? %>
+  <%= govuk_warning_text(text: assign_or_create_mentor_link) %>
+<% else %>
+  <%= mentorship.current_mentor_name %>
+  <% if upcoming_mentorships.any? %>
+    <%= govuk_list(upcoming_mentorship_descriptions, classes: "govuk-hint") %>
+  <% end %>
+<% end %>

--- a/app/components/schools/ects/mentorship_component.rb
+++ b/app/components/schools/ects/mentorship_component.rb
@@ -1,0 +1,40 @@
+module Schools::ECTs
+  class MentorshipComponent < ApplicationComponent
+    include ECTHelper
+
+    def initialize(ect_at_school_period)
+      @ect_at_school_period = ect_at_school_period
+    end
+
+  private
+
+    def assign_or_create_mentor_link
+      govuk_link_to(
+        "Assign a mentor for this ECT",
+        assign_or_create_mentor_path(ect_at_school_period),
+        no_visited_state: true
+      )
+    end
+
+    attr_reader :ect_at_school_period
+
+    def mentorship
+      @mentorship ||= ECTAtSchoolPeriods::Mentorship.new(ect_at_school_period)
+    end
+
+    def upcoming_mentorships
+      mentorship.upcoming_mentorship_periods.reject do
+        it == mentorship.current_or_next_mentorship_period
+      end
+    end
+
+    def upcoming_mentorship_descriptions
+      upcoming_mentorships.map { upcoming_mentorship_description(it) }
+    end
+
+    def upcoming_mentorship_description(mentorship_period)
+      mentor_name = Teachers::Name.new(mentorship_period.mentor.teacher).full_name
+      "#{mentor_name} (from #{mentorship_period.started_on.to_fs(:govuk)})"
+    end
+  end
+end

--- a/app/components/schools/teacher_profile_summary_list_component.html.erb
+++ b/app/components/schools/teacher_profile_summary_list_component.html.erb
@@ -25,14 +25,16 @@
 
   <% list.with_row do |row| %>
     <% row.with_key { "Mentor" } %>
-    <% row.with_value { ect_mentor_name_or_assign_mentor_link(@ect) } %>
+    <% row.with_value do %>
+      <%= render Schools::ECTs::MentorshipComponent.new(@ect) %>
+    <% end %>
     <% if current_mentor.present? %>
       <% row.with_action(
-        text: "Change",
-        visually_hidden_text: "mentor",
-        href: schools_ects_change_mentor_wizard_edit_path(@ect),
-        classes: "govuk-link--no-visited-state"
-      ) %>
+          text: "Change",
+          visually_hidden_text: "mentor",
+          href: schools_ects_change_mentor_wizard_edit_path(@ect),
+          classes: "govuk-link--no-visited-state"
+        ) %>
     <% end %>
   <% end %>
 

--- a/app/controllers/schools/ects_controller.rb
+++ b/app/controllers/schools/ects_controller.rb
@@ -14,7 +14,10 @@ module Schools
     end
 
     def show
-      @ect_at_school_period = @school.ect_at_school_periods.find(params[:id])
+      @ect_at_school_period = @school
+        .ect_at_school_periods
+        .includes(upcoming_mentorship_periods: { mentor: :teacher })
+        .find(params[:id])
       @training_period = @ect_at_school_period.current_or_next_or_latest_training_period
       @teacher = @ect_at_school_period.teacher
     end

--- a/app/helpers/ect_helper.rb
+++ b/app/helpers/ect_helper.rb
@@ -79,11 +79,6 @@ module ECTHelper
   end
 
   # @param ect [ECTAtSchoolPeriod]
-  def link_to_assign_mentor(ect)
-    govuk_warning_text(text: assign_or_create_mentor_link(ect))
-  end
-
-  # @param ect [ECTAtSchoolPeriod]
   def link_to_ect(ect)
     govuk_link_to(teacher_full_name(ect.teacher), schools_ect_path(ect), no_visited_state: true)
   end
@@ -92,15 +87,6 @@ module ECTHelper
   def ect_start_date(ect)
     date_as_hash = { 1 => ect.started_on.year, 2 => ect.started_on.month, 3 => ect.started_on.day }
     Schools::Validation::ECTStartDate.new(date_as_hash:).formatted_date
-  end
-
-  # @param ect [ECTAtSchoolPeriod]
-  def ect_mentor_name_or_assign_mentor_link(ect)
-    mentorship = ECTAtSchoolPeriods::Mentorship.new(ect)
-
-    return link_to_assign_mentor(ect) if mentorship.current_mentor.blank?
-
-    mentorship.current_mentor_name
   end
 
   # @param ect [ECTAtSchoolPeriod]
@@ -155,10 +141,6 @@ module ECTHelper
   end
 
 private
-
-  def assign_or_create_mentor_link(ect)
-    govuk_link_to("Assign a mentor for this ECT", assign_or_create_mentor_path(ect), no_visited_state: true)
-  end
 
   def assign_or_create_mentor_path(ect)
     return new_schools_ect_mentorship_path(ect) if eligible_mentors_for_ect?(ect)

--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -10,6 +10,9 @@ class ECTAtSchoolPeriod < ApplicationRecord
 
   has_many :mentorship_periods, inverse_of: :mentee, dependent: :destroy
   has_many :mentors, through: :mentorship_periods, source: :mentor
+  has_many :upcoming_mentorship_periods,
+           -> { starting_tomorrow_or_after.earliest_first },
+           class_name: "MentorshipPeriod"
   has_many :training_periods, inverse_of: :ect_at_school_period, dependent: :destroy
   has_many :mentor_at_school_periods, through: :teacher
 

--- a/app/services/ect_at_school_periods/mentorship.rb
+++ b/app/services/ect_at_school_periods/mentorship.rb
@@ -10,6 +10,10 @@ module ECTAtSchoolPeriods
       @current_or_next_mentorship_period ||= ect_at_school_period.current_or_next_mentorship_period
     end
 
+    def upcoming_mentorship_periods
+      @upcoming_mentorship_periods ||= ect_at_school_period.upcoming_mentorship_periods
+    end
+
     def latest_mentorship_period
       @latest_mentorship_period ||= ect_at_school_period.latest_mentorship_period
     end

--- a/app/services/schools/ects/teachers_query.rb
+++ b/app/services/schools/ects/teachers_query.rb
@@ -16,6 +16,7 @@ module Schools::ECTs
             :school_reported_appropriate_body,
             {
               current_or_next_mentorship_period: { mentor: :teacher },
+              upcoming_mentorship_periods: { mentor: :teacher },
               current_or_next_training_period: %i[
                 lead_provider
                 expression_of_interest

--- a/app/services/teachers/search.rb
+++ b/app/services/teachers/search.rb
@@ -30,7 +30,14 @@ module Teachers
                           .when(MentorshipPeriod.arel_table[:id].eq(nil)).then(0)
                           .else(1)
                           .asc,
-          { ect_at_school_periods: { started_on: :desc } }
+          {
+            ect_at_school_periods: { started_on: :desc },
+            # Calling .order overrides the ordering on the scoped associations
+            # (e.g upcoming_mentorship_periods).
+            # We need to explicitly order mentorship periods here to avoid
+            # has_many associations being loaded in the wrong order
+            mentorship_periods: { started_on: :asc },
+          }
         ]
       else
         %i[trs_last_name trs_first_name id]

--- a/spec/components/schools/ects/mentorship_component_spec.rb
+++ b/spec/components/schools/ects/mentorship_component_spec.rb
@@ -1,0 +1,263 @@
+RSpec.describe Schools::ECTs::MentorshipComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  subject(:component) { described_class.new(ect_at_school_period) }
+
+  let(:mentee_teacher) do
+    FactoryBot.create(:teacher, corrected_name: "Test Mentee")
+  end
+  let(:ect_at_school_period) do
+    FactoryBot.create(
+      :ect_at_school_period,
+      :unfinished,
+      teacher: mentee_teacher,
+      started_on: 1.year.ago
+    )
+  end
+
+  context "when the ECT has no current mentorship" do
+    context "and there are no available mentors" do
+      it "renders warning text with a link to register a new mentor" do
+        render_inline(component)
+
+        expect(page).to have_css(".govuk-warning-text")
+        expect(page).to have_link(
+          "Assign a mentor for this ECT",
+          href: schools_register_mentor_wizard_start_path(ect_id: ect_at_school_period.id)
+        )
+      end
+    end
+
+    context "and there are available mentors" do
+      let!(:mentor_at_school_period) do
+        FactoryBot.create(
+          :mentor_at_school_period,
+          :unfinished,
+          school: ect_at_school_period.school,
+          started_on: ect_at_school_period.started_on
+        )
+      end
+
+      it "renders warning text with a link to the mentorships page" do
+        render_inline(component)
+
+        expect(page).to have_css(".govuk-warning-text")
+        expect(page).to have_link(
+          "Assign a mentor for this ECT",
+          href: new_schools_ect_mentorship_path(ect_at_school_period)
+        )
+      end
+    end
+  end
+
+  context "when the ECT has a current mentorship and no upcoming mentorships" do
+    let(:current_mentor_teacher) do
+      FactoryBot.create(:teacher, corrected_name: "Test Mentor")
+    end
+    let(:current_mentor_at_school_period) do
+      FactoryBot.create(
+        :mentor_at_school_period,
+        :unfinished,
+        teacher: current_mentor_teacher,
+        school: ect_at_school_period.school,
+        started_on: ect_at_school_period.started_on
+      )
+    end
+    let!(:current_mentorship_period) do
+      FactoryBot.create(
+        :mentorship_period,
+        :unfinished,
+        mentee: ect_at_school_period,
+        mentor: current_mentor_at_school_period,
+        started_on: current_mentor_at_school_period.started_on
+      )
+    end
+
+    it "renders the current mentor name" do
+      render_inline(component)
+
+      expect(page).to have_text("Test Mentor")
+      expect(page).not_to have_css("ul")
+    end
+  end
+
+  context "when the ECT has a current mentorship that starts in the future" do
+    let(:current_mentor_teacher) do
+      FactoryBot.create(:teacher, corrected_name: "Test Mentor")
+    end
+    let(:current_mentor_at_school_period) do
+      FactoryBot.create(
+        :mentor_at_school_period,
+        :unfinished,
+        teacher: current_mentor_teacher,
+        school: ect_at_school_period.school,
+        started_on: ect_at_school_period.started_on
+      )
+    end
+    let!(:current_mentorship_period) do
+      FactoryBot.create(
+        :mentorship_period,
+        :unfinished,
+        mentee: ect_at_school_period,
+        mentor: current_mentor_at_school_period,
+        started_on: 1.week.from_now
+      )
+    end
+
+    it "only renders the current mentor name" do
+      render_inline(component)
+
+      expect(page).to have_text("Test Mentor")
+      expect(page).to have_no_css("ul")
+    end
+  end
+
+  context "when the ECT has a current mentorship and an upcoming mentorship" do
+    let(:current_mentor) do
+      FactoryBot.create(:teacher, corrected_name: "Test Mentor")
+    end
+    let(:current_mentor_at_school_period) do
+      FactoryBot.create(
+        :mentor_at_school_period,
+        :unfinished,
+        teacher: current_mentor,
+        school: ect_at_school_period.school,
+        started_on: ect_at_school_period.started_on
+      )
+    end
+    let!(:current_mentorship_period) do
+      FactoryBot.create(
+        :mentorship_period,
+        mentee: ect_at_school_period,
+        mentor: current_mentor_at_school_period,
+        started_on: current_mentor_at_school_period.started_on,
+        finished_on: 1.month.from_now
+      )
+    end
+
+    let(:future_mentor) do
+      FactoryBot.create(:teacher, corrected_name: "Future Mentor")
+    end
+    let(:future_mentor_at_school_period) do
+      FactoryBot.create(
+        :mentor_at_school_period,
+        :unfinished,
+        teacher: future_mentor,
+        school: ect_at_school_period.school,
+        started_on: ect_at_school_period.started_on
+      )
+    end
+    let!(:future_mentorship_period) do
+      FactoryBot.create(
+        :mentorship_period,
+        :unfinished,
+        mentee: ect_at_school_period,
+        mentor: future_mentor_at_school_period,
+        started_on: current_mentorship_period.finished_on.next_day
+      )
+    end
+
+    it "renders the current mentor name and upcoming mentorship details" do
+      render_inline(component)
+
+      expect(page).to have_text("Test Mentor")
+      expect(page).to have_css("ul > li", count: 1)
+      expect(page).to have_css(
+        "ul > li",
+        text: <<~TXT.squish
+          Future Mentor (from
+          #{future_mentorship_period.started_on.to_fs(:govuk)})
+        TXT
+      )
+    end
+  end
+
+  context "when the ECT has a current mentorship and multiple upcoming mentorships" do
+    let(:current_mentor) do
+      FactoryBot.create(:teacher, corrected_name: "Test Mentor")
+    end
+    let(:current_mentor_at_school_period) do
+      FactoryBot.create(
+        :mentor_at_school_period,
+        :unfinished,
+        teacher: current_mentor,
+        school: ect_at_school_period.school,
+        started_on: ect_at_school_period.started_on
+      )
+    end
+    let!(:current_mentorship_period) do
+      FactoryBot.create(
+        :mentorship_period,
+        mentee: ect_at_school_period,
+        mentor: current_mentor_at_school_period,
+        started_on: current_mentor_at_school_period.started_on,
+        finished_on: 1.month.from_now
+      )
+    end
+
+    let(:future_mentor) do
+      FactoryBot.create(:teacher, corrected_name: "Future Mentor")
+    end
+    let(:future_mentor_at_school_period) do
+      FactoryBot.create(
+        :mentor_at_school_period,
+        :unfinished,
+        teacher: future_mentor,
+        school: ect_at_school_period.school,
+        started_on: ect_at_school_period.started_on
+      )
+    end
+    let!(:future_mentorship_period) do
+      FactoryBot.create(
+        :mentorship_period,
+        mentee: ect_at_school_period,
+        mentor: future_mentor_at_school_period,
+        started_on: current_mentorship_period.finished_on.next_day,
+        finished_on: 6.months.from_now
+      )
+    end
+
+    let(:another_future_mentor) do
+      FactoryBot.create(:teacher, corrected_name: "Another-future Mentor")
+    end
+    let(:another_future_mentor_at_school_period) do
+      FactoryBot.create(
+        :mentor_at_school_period,
+        :unfinished,
+        teacher: another_future_mentor,
+        school: ect_at_school_period.school,
+        started_on: ect_at_school_period.started_on
+      )
+    end
+    let!(:another_future_mentorship_period) do
+      FactoryBot.create(
+        :mentorship_period,
+        :unfinished,
+        mentee: ect_at_school_period,
+        mentor: another_future_mentor_at_school_period,
+        started_on: future_mentorship_period.finished_on.next_day
+      )
+    end
+
+    it "renders the current mentor name and upcoming mentorship details" do
+      render_inline(component)
+
+      expect(page).to have_text("Test Mentor")
+      expect(page).to have_css("ul > li", count: 2)
+      expect(page).to have_css(
+        "ul > li:nth-child(1)",
+        text: <<~TXT.squish
+          Future Mentor (from
+          #{future_mentorship_period.started_on.to_fs(:govuk)})
+        TXT
+      )
+      expect(page).to have_css(
+        "ul > li:nth-child(2)",
+        text: <<~TXT.squish
+          Another-future Mentor (from
+          #{another_future_mentorship_period.started_on.to_fs(:govuk)})
+        TXT
+      )
+    end
+  end
+end

--- a/spec/helpers/ect_helper_spec.rb
+++ b/spec/helpers/ect_helper_spec.rb
@@ -6,24 +6,6 @@ RSpec.describe ECTHelper, type: :helper do
   let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher: ect_teacher, school:, started_on:) }
   let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, school:, started_on:) }
 
-  describe "#ect_mentor_name_or_assign_mentor_link" do
-    subject(:mentor_details) { helper.ect_mentor_name_or_assign_mentor_link(ect_at_school_period) }
-
-    let(:default_link_text) { "Assign a mentor for this ECT" }
-
-    it { is_expected.to have_link(default_link_text) }
-
-    context "when the ECT has a mentor assigned" do
-      before do
-        FactoryBot.create(:mentorship_period, :unfinished, mentee: ect_at_school_period, mentor: mentor_at_school_period, started_on:)
-      end
-
-      it { is_expected.to eq(latest_mentor_name(ect_at_school_period)) }
-      it { is_expected.not_to have_link(latest_mentor_name(ect_at_school_period)) }
-      it { is_expected.not_to have_link(default_link_text) }
-    end
-  end
-
   describe "#register_mentor_back_link" do
     context "when a new mentor has been requested" do
       context "when there are no alternative mentors to choose from" do

--- a/spec/models/ect_at_school_period_spec.rb
+++ b/spec/models/ect_at_school_period_spec.rb
@@ -170,6 +170,67 @@ describe ECTAtSchoolPeriod do
       end
     end
 
+    describe ".upcoming_mentorship_periods" do
+      subject(:upcoming_mentorship_periods) do
+        ect_at_school_period.upcoming_mentorship_periods
+      end
+
+      let(:ect_at_school_period) do
+        FactoryBot.create(
+          :ect_at_school_period,
+          :unfinished,
+          started_on: 2.years.ago
+        )
+      end
+      let(:mentor_at_school_period) do
+        FactoryBot.create(
+          :mentor_at_school_period,
+          :unfinished,
+          school: ect_at_school_period.school,
+          started_on: 3.years.ago
+        )
+      end
+
+      let!(:finished_mentorship_period) do
+        FactoryBot.create(
+          :mentorship_period,
+          mentee: ect_at_school_period,
+          mentor: mentor_at_school_period,
+          started_on: 2.years.ago,
+          finished_on: 9.months.ago
+        )
+      end
+      let!(:current_mentorship_period) do
+        FactoryBot.create(
+          :mentorship_period,
+          mentee: ect_at_school_period,
+          mentor: mentor_at_school_period,
+          started_on: finished_mentorship_period.finished_on.next_day,
+          finished_on: 2.weeks.from_now
+        )
+      end
+      let!(:upcoming_mentorship_period) do
+        FactoryBot.create(
+          :mentorship_period,
+          mentee: ect_at_school_period,
+          mentor: mentor_at_school_period,
+          started_on: current_mentorship_period.finished_on.next_day,
+          finished_on: current_mentorship_period.finished_on.next_day + 6.months
+        )
+      end
+      let!(:another_upcoming_mentorship_period) do
+        FactoryBot.create(
+          :mentorship_period,
+          :unfinished,
+          mentee: ect_at_school_period,
+          mentor: mentor_at_school_period,
+          started_on: upcoming_mentorship_period.finished_on.next_day
+        )
+      end
+
+      it { is_expected.to contain_exactly(upcoming_mentorship_period, another_upcoming_mentorship_period) }
+    end
+
     describe ".current_or_next_mentorship_period" do
       let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, started_on: 1.year.ago, finished_on: nil) }
       let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, school: ect_at_school_period.school) }

--- a/spec/requests/schools/ects_spec.rb
+++ b/spec/requests/schools/ects_spec.rb
@@ -33,6 +33,106 @@ RSpec.describe "ECT summary" do
 
         expect(response).to have_http_status(:ok)
       end
+
+      context "when a school's ECT has current and upcoming mentorship periods" do
+        let(:ect_at_school_period) do
+          FactoryBot.create(
+            :ect_at_school_period,
+            :unfinished,
+            school:,
+            started_on: 2.years.ago
+          )
+        end
+
+        let(:current_mentor) do
+          FactoryBot.create(:teacher, trs_first_name: "Moby", trs_last_name: "Dick")
+        end
+        let(:current_mentor_at_school_period) do
+          FactoryBot.create(
+            :mentor_at_school_period,
+            :unfinished,
+            started_on: ect_at_school_period.started_on,
+            school:,
+            teacher: current_mentor
+          )
+        end
+        let!(:current_mentorship_period) do
+          FactoryBot.create(
+            :mentorship_period,
+            started_on: current_mentor_at_school_period.started_on,
+            finished_on: 1.month.from_now,
+            mentee: ect_at_school_period,
+            mentor: current_mentor_at_school_period
+          )
+        end
+
+        let(:future_mentor) do
+          FactoryBot.create(:teacher, trs_first_name: "John", trs_last_name: "Smith")
+        end
+        let(:future_mentor_at_school_period) do
+          FactoryBot.create(
+            :mentor_at_school_period,
+            :unfinished,
+            started_on: ect_at_school_period.started_on,
+            school:,
+            teacher: future_mentor
+          )
+        end
+        let!(:future_mentorship_period) do
+          FactoryBot.create(
+            :mentorship_period,
+            started_on: current_mentorship_period.finished_on.next_day,
+            finished_on: current_mentorship_period.finished_on.next_year,
+            mentee: ect_at_school_period,
+            mentor: future_mentor_at_school_period
+          )
+        end
+
+        let(:another_future_mentor) do
+          FactoryBot.create(:teacher, trs_first_name: "Jane", trs_last_name: "Smith")
+        end
+        let(:another_future_mentor_at_school_period) do
+          FactoryBot.create(
+            :mentor_at_school_period,
+            :unfinished,
+            started_on: ect_at_school_period.started_on,
+            school:,
+            teacher: another_future_mentor
+          )
+        end
+        let!(:another_future_mentorship_period) do
+          FactoryBot.create(
+            :mentorship_period,
+            :unfinished,
+            started_on: future_mentorship_period.finished_on.next_day,
+            mentee: ect_at_school_period,
+            mentor: another_future_mentor_at_school_period
+          )
+        end
+
+        it "displays the current and upcoming mentorship periods" do
+          subject
+          page = Capybara.string(response.body)
+
+          current_mentor_name = Teachers::Name.new(current_mentor).full_name
+          expect(page).to have_text(current_mentor_name)
+          expect(page).not_to have_css(".govuk-hint", text: current_mentor_name)
+
+          future_mentor_name = Teachers::Name.new(future_mentor).full_name
+          future_mentor_start_date = future_mentorship_period.started_on.to_fs(:govuk)
+          expect(page).to have_css(
+            ".govuk-hint",
+            text: "#{future_mentor_name} (from #{future_mentor_start_date})"
+          )
+
+          another_future_mentor_name = Teachers::Name.new(another_future_mentor).full_name
+          another_future_mentor_start_date = another_future_mentorship_period.started_on.to_fs(:govuk)
+          expect(page).to have_css(
+            ".govuk-hint",
+            text: "#{another_future_mentor_name} (from #{another_future_mentor_start_date})"
+          )
+        end
+      end
     end
   end
 

--- a/spec/services/ect_at_school_periods/mentorship_spec.rb
+++ b/spec/services/ect_at_school_periods/mentorship_spec.rb
@@ -1,11 +1,15 @@
-describe ECTAtSchoolPeriods::Mentorship do
+RSpec.describe ECTAtSchoolPeriods::Mentorship do
+  subject(:service) { described_class.new(mentee) }
+
   let(:school) { FactoryBot.create(:school) }
   let(:mentee) { FactoryBot.create(:ect_at_school_period, :unfinished, school:, started_on: 3.years.ago) }
   let(:mentor) { FactoryBot.create(:mentor_at_school_period, :unfinished, school:, started_on: 3.years.ago) }
   let(:old_mentor) { FactoryBot.create(:mentor_at_school_period, :unfinished, school:, started_on: 3.years.ago) }
 
   describe "#current_or_next_mentorship_period" do
-    subject { described_class.new(mentee).current_or_next_mentorship_period }
+    subject(:current_or_next_mentorship_period) do
+      service.current_or_next_mentorship_period
+    end
 
     context "when the ect has had no mentorships ever" do
       it { is_expected.to be_nil }
@@ -27,8 +31,69 @@ describe ECTAtSchoolPeriods::Mentorship do
     end
   end
 
+  describe "#upcoming_mentorship_periods" do
+    subject(:upcoming_mentorship_periods) do
+      service.upcoming_mentorship_periods
+    end
+
+    context "when the ECT has no mentorships" do
+      it { is_expected.to be_empty }
+    end
+
+    context "when the ECT has past mentorships" do
+      let!(:mentorship) do
+        FactoryBot.create(
+          :mentorship_period,
+          mentee:,
+          mentor:,
+          started_on: 1.year.ago,
+          finished_on: 1.week.ago
+        )
+      end
+
+      it { is_expected.to be_empty }
+    end
+
+    context "when the ECT has an ongoing mentorship" do
+      let!(:mentorship) do
+        FactoryBot.create(
+          :mentorship_period,
+          :unfinished,
+          mentee:,
+          mentor:,
+          started_on: 1.year.ago
+        )
+      end
+
+      it { is_expected.to be_empty }
+    end
+
+    context "when the ECT has upcoming mentorships" do
+      let!(:upcoming_mentorship) do
+        FactoryBot.create(
+          :mentorship_period,
+          mentee:,
+          mentor:,
+          started_on: 1.week.from_now,
+          finished_on: 6.months.from_now
+        )
+      end
+      let!(:another_upcoming_mentorship) do
+        FactoryBot.create(
+          :mentorship_period,
+          :unfinished,
+          mentee:,
+          mentor:,
+          started_on: 7.months.from_now
+        )
+      end
+
+      it { is_expected.to contain_exactly(upcoming_mentorship, another_upcoming_mentorship) }
+    end
+  end
+
   describe "#current_mentor" do
-    subject { described_class.new(mentee).current_mentor }
+    subject(:current_mentor) { service.current_mentor }
 
     context "when the ect has had no mentorships ever" do
       it { is_expected.to be_nil }
@@ -53,7 +118,7 @@ describe ECTAtSchoolPeriods::Mentorship do
   end
 
   describe "#current_mentor_name" do
-    subject { described_class.new(mentee).current_mentor_name }
+    subject(:current_mentor_name) { service.current_mentor_name }
 
     context "when the ect has had no mentorships ever" do
       it { is_expected.to be_nil }
@@ -78,7 +143,7 @@ describe ECTAtSchoolPeriods::Mentorship do
   end
 
   describe "#latest_mentorship_period" do
-    subject { described_class.new(mentee).latest_mentorship_period }
+    subject(:latest_mentorship_period) { service.latest_mentorship_period }
 
     context "when the ect has had no mentorships ever" do
       it { is_expected.to be_nil }
@@ -99,7 +164,7 @@ describe ECTAtSchoolPeriods::Mentorship do
   end
 
   describe "#latest_mentor" do
-    subject { described_class.new(mentee).latest_mentor }
+    subject(:latest_mentor) { service.latest_mentor }
 
     context "when the ect has had no mentorships ever" do
       it { is_expected.to be_nil }
@@ -125,7 +190,7 @@ describe ECTAtSchoolPeriods::Mentorship do
   end
 
   describe "#latest_mentor_name" do
-    subject { described_class.new(mentee).latest_mentor_name }
+    subject(:latest_mentor_name) { service.latest_mentor_name }
 
     context "when the ect has had no mentorships ever" do
       it { is_expected.to be_nil }

--- a/spec/support/matchers/have_summary_list_row.rb
+++ b/spec/support/matchers/have_summary_list_row.rb
@@ -1,9 +1,10 @@
 module HaveSummaryListRow
   class Matcher
-    def initialize(key, value: "", visible: :visible)
+    def initialize(key, value: "", visible: :visible, matcher: [:has_text?, { exact: true, normalize_ws: true }])
       @key = key
       @value = value
       @visible = visible
+      @matcher = matcher
     end
 
     def matches?(page)
@@ -15,7 +16,7 @@ module HaveSummaryListRow
         @matching_row && @matching_row.text == @key
       else
         @sibling = @matching_row&.sibling("dd.govuk-summary-list__value", visible: @visible)
-        @sibling && @sibling.text == @value
+        @sibling && @sibling.public_send(@matcher.first, @value, **@matcher.second)
       end
     end
 
@@ -51,10 +52,12 @@ module HaveSummaryListRow
 
     def sibling_failure_message
       if @matching_row.present?
-        %(Found matching summary list row, but its value is "#{@sibling.text}".)
+        %(Found matching summary list row, but its value is "#{@sibling.text.strip}".)
       end
     end
   end
 
-  def have_summary_list_row(key, value: "", visible: :visible) = Matcher.new(key, value:, visible:)
+  def have_summary_list_row(key, value: "", visible: :visible, matcher: [:has_text?, { exact: true, normalize_ws: true }])
+    Matcher.new(key, value:, visible:, matcher:)
+  end
 end

--- a/spec/views/schools/ects/show.html.erb_spec.rb
+++ b/spec/views/schools/ects/show.html.erb_spec.rb
@@ -1,5 +1,8 @@
 RSpec.describe "schools/ects/show.html.erb" do
-  subject { render }
+  subject do
+    render
+    Capybara.string(rendered)
+  end
 
   let(:contract_period) { FactoryBot.create(:contract_period) }
   let!(:current_ect_period) do
@@ -68,23 +71,200 @@ RSpec.describe "schools/ects/show.html.erb" do
 
     describe "mentor" do
       context "when assigned" do
-        before do
-          mentor = FactoryBot.create(:teacher, trs_first_name: "Moby", trs_last_name: "Dick")
-          mentor_at_school_period = FactoryBot.create(:mentor_at_school_period,
-                                                      started_on: current_ect_period.started_on,
-                                                      finished_on: nil,
-                                                      school: current_school,
-                                                      teacher: mentor)
-
-          FactoryBot.create(:mentorship_period, :unfinished,
-                            started_on: current_ect_period.started_on,
-                            mentee: current_ect_period,
-                            mentor: mentor_at_school_period)
+        let(:mentor) do
+          FactoryBot.create(:teacher, trs_first_name: "Moby", trs_last_name: "Dick")
+        end
+        let(:mentor_at_school_period) do
+          FactoryBot.create(
+            :mentor_at_school_period,
+            :unfinished,
+            started_on: current_ect_period.started_on,
+            school: current_school,
+            teacher: mentor
+          )
+        end
+        let!(:mentorship_period) do
+          FactoryBot.create(
+            :mentorship_period,
+            :unfinished,
+            started_on: mentor_at_school_period.started_on,
+            mentee: current_ect_period,
+            mentor: mentor_at_school_period
+          )
         end
 
         it "has mentor's full name" do
-          expect(subject).to have_css("dt.govuk-summary-list__key", text: "Mentor")
-          expect(subject).to have_css("dd.govuk-summary-list__value", text: "Moby Dick")
+          expect(subject).to have_summary_list_row("Mentor", value: "Moby Dick")
+        end
+      end
+
+      context "when current and future mentors are assigned" do
+        let(:current_mentor) do
+          FactoryBot.create(:teacher, trs_first_name: "Moby", trs_last_name: "Dick")
+        end
+        let(:current_mentor_at_school_period) do
+          FactoryBot.create(
+            :mentor_at_school_period,
+            :unfinished,
+            started_on: current_ect_period.started_on,
+            school: current_school,
+            teacher: current_mentor
+          )
+        end
+        let!(:current_mentorship_period) do
+          FactoryBot.create(
+            :mentorship_period,
+            started_on: current_mentor_at_school_period.started_on,
+            finished_on: 1.month.from_now,
+            mentee: current_ect_period,
+            mentor: current_mentor_at_school_period
+          )
+        end
+
+        let(:future_mentor) do
+          FactoryBot.create(:teacher, trs_first_name: "John", trs_last_name: "Smith")
+        end
+        let(:future_mentor_at_school_period) do
+          FactoryBot.create(
+            :mentor_at_school_period,
+            :unfinished,
+            started_on: current_ect_period.started_on,
+            school: current_school,
+            teacher: future_mentor
+          )
+        end
+        let!(:future_mentorship_period) do
+          FactoryBot.create(
+            :mentorship_period,
+            :unfinished,
+            started_on: current_mentorship_period.finished_on.next_day,
+            mentee: current_ect_period,
+            mentor: future_mentor_at_school_period
+          )
+        end
+
+        it "has current mentor's full name" do
+          expect(subject).to have_summary_list_row(
+            "Mentor",
+            value: "Moby Dick",
+            matcher: [:has_text?, { exact: false }]
+          )
+        end
+
+        it "displays upcoming mentorship details" do
+          upcoming_mentorship_detail = <<~TXT.squish
+            John Smith (from #{future_mentorship_period.started_on.to_fs(:govuk)})
+          TXT
+          expect(subject).to have_summary_list_row(
+            "Mentor",
+            value: "ul > li",
+            matcher: [:has_css?, { count: 1 }]
+          )
+          expect(subject).to have_summary_list_row(
+            "Mentor",
+            value: "ul > li:nth-child(1)",
+            matcher: [:has_css?, { text: upcoming_mentorship_detail }]
+          )
+        end
+      end
+
+      context "when current and multiple future mentors are assigned" do
+        let(:current_mentor) do
+          FactoryBot.create(:teacher, trs_first_name: "Moby", trs_last_name: "Dick")
+        end
+        let(:current_mentor_at_school_period) do
+          FactoryBot.create(
+            :mentor_at_school_period,
+            :unfinished,
+            started_on: current_ect_period.started_on,
+            school: current_school,
+            teacher: current_mentor
+          )
+        end
+        let!(:current_mentorship_period) do
+          FactoryBot.create(
+            :mentorship_period,
+            started_on: current_mentor_at_school_period.started_on,
+            finished_on: 1.month.from_now,
+            mentee: current_ect_period,
+            mentor: current_mentor_at_school_period
+          )
+        end
+
+        let(:future_mentor) do
+          FactoryBot.create(:teacher, trs_first_name: "John", trs_last_name: "Smith")
+        end
+        let(:future_mentor_at_school_period) do
+          FactoryBot.create(
+            :mentor_at_school_period,
+            :unfinished,
+            started_on: current_ect_period.started_on,
+            school: current_school,
+            teacher: future_mentor
+          )
+        end
+        let!(:future_mentorship_period) do
+          FactoryBot.create(
+            :mentorship_period,
+            started_on: current_mentorship_period.finished_on.next_day,
+            finished_on: current_mentorship_period.finished_on.next_year,
+            mentee: current_ect_period,
+            mentor: future_mentor_at_school_period
+          )
+        end
+
+        let(:another_future_mentor) do
+          FactoryBot.create(:teacher, trs_first_name: "Jane", trs_last_name: "Smith")
+        end
+        let(:another_future_mentor_at_school_period) do
+          FactoryBot.create(
+            :mentor_at_school_period,
+            :unfinished,
+            started_on: current_ect_period.started_on,
+            school: current_school,
+            teacher: another_future_mentor
+          )
+        end
+        let!(:another_future_mentorship_period) do
+          FactoryBot.create(
+            :mentorship_period,
+            :unfinished,
+            started_on: future_mentorship_period.finished_on.next_day,
+            mentee: current_ect_period,
+            mentor: another_future_mentor_at_school_period
+          )
+        end
+
+        it "has current mentor's full name" do
+          expect(subject).to have_summary_list_row(
+            "Mentor",
+            value: "Moby Dick",
+            matcher: [:has_text?, { exact: false }]
+          )
+        end
+
+        it "displays upcoming mentorship details in order" do
+          upcoming_mentorship_detail = <<~TXT.squish
+            John Smith (from #{future_mentorship_period.started_on.to_fs(:govuk)})
+          TXT
+          another_upcoming_mentorship_detail = <<~TXT.squish
+            Jane Smith (from #{another_future_mentorship_period.started_on.to_fs(:govuk)})
+          TXT
+          expect(subject).to have_summary_list_row(
+            "Mentor",
+            value: "ul > li",
+            matcher: [:has_css?, { count: 2 }]
+          )
+          expect(subject).to have_summary_list_row(
+            "Mentor",
+            value: "ul > li:nth-child(1)",
+            matcher: [:has_css?, { text: upcoming_mentorship_detail }]
+          )
+          expect(subject).to have_summary_list_row(
+            "Mentor",
+            value: "ul > li:nth-child(2)",
+            matcher: [:has_css?, { text: another_upcoming_mentorship_detail }]
+          )
         end
       end
 


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/4265

### Changes proposed in this pull request

Before, we only showed schools the `current_or_next` mentorship details for a
given ECT.

However this means when a school assigns a new mentor in the future, there is no
indication that change was successful.

This led to several schools running in to errors, and contacting support when
they failed to re-assign that same mentor again and again. Sometimes, up to 10+
times!

This reworks the ECT listing card and teacher profile components to render
upcoming mentorship details too.

The existing behaviour has been extended to display any upcoming mentorship
periods for the ECT in some hint text.

### Guidance to review

<img width="976" height="427" alt="image" src="https://github.com/user-attachments/assets/e68b6106-ab57-4ebb-95ee-4ea8405e4a6b" />
<img width="671" height="613" alt="image" src="https://github.com/user-attachments/assets/c6cfae74-4c73-4564-8097-0df8c63934b7" />

