### PR TITLE
[4267] Mark stuck declarations eligible

### DIFF
--- a/db/scripts/mark_stuck_declarations_eligible.rb
+++ b/db/scripts/mark_stuck_declarations_eligible.rb
@@ -11,7 +11,7 @@ def stuck_declarations_by_teacher
   Declaration
     .where(payment_status: "no_payment", voided_by_user: nil)
     .joins(:contract_period, :ect_teacher)
-    .where(contract_period: { year: [2023,2024,2025] })
+    .where(contract_period: { year: [2023, 2024, 2025] })
     .where.not(ect_teacher: { trs_induction_start_date: nil })
     .includes(:lead_provider, :contract_period, :ect_teacher)
     .group_by { |declaration| declaration.ect_teacher.id }
@@ -31,14 +31,12 @@ begin
     end
 
     Declarations::Actions::MarkDeclarationsEligible.new(declarations:, author:).mark
-  rescue => e
+  rescue StandardError => e
     log.puts("*** Error: #{e.message} ***")
   end
 
   log.puts
-  log.puts("Teachers: #{teacher_declarations.keys.count} | Declarations: #{teacher_declarations.values.sum { it.count }}")
-
+  log.puts("Teachers: #{teacher_declarations.keys.count} | Declarations: #{teacher_declarations.values.sum(&:count)}")
 ensure
   log.close unless log.nil?
 end
-

--- a/db/scripts/mark_stuck_declarations_eligible.rb
+++ b/db/scripts/mark_stuck_declarations_eligible.rb
@@ -1,0 +1,44 @@
+# There are declarations from ECF1 that migrated in a submitted
+# state because there was no induction start date at the time.
+# Subsequently an induction start date was recevied but the declarations
+# were not moved to 'eligible'.
+#
+#
+# $ kubectl exec -it <pod-name> -- bin/rails runner db/scripts/mark_stuck_declarations_eligible.rb
+log = nil
+
+def stuck_declarations_by_teacher
+  Declaration
+    .where(payment_status: "no_payment", voided_by_user: nil)
+    .joins(:contract_period, :ect_teacher)
+    .where(contract_period: { year: [2023,2024,2025] })
+    .where.not(ect_teacher: { trs_induction_start_date: nil })
+    .includes(:lead_provider, :contract_period, :ect_teacher)
+    .group_by { |declaration| declaration.ect_teacher.id }
+end
+
+begin
+  author = Events::SystemAuthor.new
+
+  log = File.open(Rails.root.join("tmp/mark_stuck_declarations_eligible-#{Time.zone.now.to_fs(:iso8601)}.log"), "w")
+
+  teacher_declarations = stuck_declarations_by_teacher
+
+  teacher_declarations.each do |id, declarations|
+    log.puts("Teacher ID: #{id}")
+    declarations.each do |declaration|
+      log.puts(" - Marking declaration: #{declaration.id} (#{declaration.declaration_type}) for #{declaration.contract_period.year} eligible")
+    end
+
+    Declarations::Actions::MarkDeclarationsEligible.new(declarations:, author:).mark
+  rescue => e
+    log.puts("*** Error: #{e.message} ***")
+  end
+
+  log.puts
+  log.puts("Teachers: #{teacher_declarations.keys.count} | Declarations: #{teacher_declarations.values.sum { it.count }}")
+
+ensure
+  log.close unless log.nil?
+end
+


### PR DESCRIPTION
### Context

There are declarations that are stuck in a "submitted" (or "no_payment" in RECT) payment state.
This is due to them having been received while the ECT did not have an induction start date.  This meant they did not transition to the `eligible` state and were not associated with an output statement.

Over time an induction start date was added to the teacher but this did not trigger any state change to any existing declarations so they have remained unprocessed and unpaid.

There is an existing service that can move the declarations to the `eligible` state named `Declarations::Actions::MarkDeclarationsEligible` but it appears that no route to this currently exists for the existing stuck declarations.

This PR adds a script to collect the stuck declarations and pass them to the `MarkDeclarationsEligible` service.

### Changes proposed in this pull request

Adds a script to collate the stuck declarations and pass them to the existing `MarkDeclarationsEligible` service

### Guidance to review
