### PR TITLE
Add band terms id as hidden field

### DIFF
--- a/app/views/admin/finance/active_lead_providers/contracts/_fields.html.erb
+++ b/app/views/admin/finance/active_lead_providers/contracts/_fields.html.erb
@@ -74,6 +74,7 @@
           <% body.with_row(html_attributes: { data: { controller: "band" } }) do |row| %>
             <% row.with_cell(header: true) do %>
               <%= ("A".ord + index).chr %>
+              <%= bt.hidden_field :id if bt.object.persisted? %>
               <%= bt.hidden_field :band_id %>
             <% end %>
             <% row.with_cell(text: band_term.min_declarations.to_s) %>

--- a/spec/requests/admin/finance/active_lead_providers/contracts_spec.rb
+++ b/spec/requests/admin/finance/active_lead_providers/contracts_spec.rb
@@ -188,6 +188,44 @@ RSpec.describe "Admin finance active lead provider contracts", type: :request do
     end
   end
 
+  describe "GET .../contracts/:id/edit" do
+    let(:contract_period) { FactoryBot.create(:contract_period, :next) }
+    let!(:contract) do
+      FactoryBot.create(:contract, :for_ittecf_ectp,
+                        :with_bands_and_band_terms, active_lead_provider:)
+    end
+
+    it "redirects to sign in path when not signed in" do
+      get edit_path
+      expect(response).to redirect_to(sign_in_path)
+    end
+
+    context "with an authenticated non-DfE user" do
+      include_context "sign in as non-DfE user"
+
+      it "requires authorisation" do
+        get edit_path
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context "when signed in as a finance DfE user" do
+      include_context "sign in as finance DfE user"
+
+      it "renders a hidden id for each persisted band term so they are updated rather than recreated" do
+        get edit_path
+
+        expect(response.status).to eq(200)
+
+        contract.banded_fee_structure.band_terms.each_with_index do |band_term, index|
+          expect(response.body).to include(
+            %(value="#{band_term.id}" name="contract[banded_fee_structure_attributes][band_terms_attributes][#{index}][id]")
+          )
+        end
+      end
+    end
+  end
+
   describe "PATCH .../contracts/:id" do
     let(:contract_period) { FactoryBot.create(:contract_period, :next) }
     let(:active_lead_provider) do


### PR DESCRIPTION
### Context

When we try to update Band terms for a contract we get:
```
PG::UniqueViolation: ERROR: duplicate key value violates unique constraint "idx_on_banded_fee_structure_id_band_id_04f5837f9d" (ActiveRecord::RecordNotUnique) DETAIL: Key (banded_fee_structure_id, band_id)=(67, 100) already exists.
```

This is because the band term id is not sent in the form when it should be, 
so the server attempts to create a new band term record when it should be updating the existing one, 
violating the unique constraint. 

https://dfe-teacher-services.sentry.io/issues/7635451796/?query=is%3Aunresolved%20issue.category%3A%5Berror%2Coutage%5D&referrer=issue-stream

### Changes proposed in this pull request

Add band term id as a hidden field in the nested attributes.

### Guidance to review

Simple fix.
