### PR TITLE
[4262] Add TRN reminder when changing ECT or mentor names

### DIFF
--- a/app/views/schools/ects/change_name_wizard/check_answers.html.erb
+++ b/app/views/schools/ects/change_name_wizard/check_answers.html.erb
@@ -17,6 +17,8 @@
   <% end %>
 <% end %>
 
+<%= govuk_inset_text(text: "This will change the name for the record with the teacher reference number (TRN) #{@wizard.teacher_trn}.") %>
+
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
   <%= content_for(:error_summary) { f.govuk_error_summary } %>
 

--- a/app/views/schools/ects/change_name_wizard/check_answers.html.erb
+++ b/app/views/schools/ects/change_name_wizard/check_answers.html.erb
@@ -17,7 +17,7 @@
   <% end %>
 <% end %>
 
-<%= govuk_inset_text(text: "This will change the name for the record with the teacher reference number (TRN) #{@wizard.teacher_trn}.") %>
+<%= govuk_inset_text(text: "This will change the name for teacher reference number (TRN) #{@wizard.teacher_trn}.") %>
 
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
   <%= content_for(:error_summary) { f.govuk_error_summary } %>

--- a/app/views/schools/mentors/change_name_wizard/check_answers.html.erb
+++ b/app/views/schools/mentors/change_name_wizard/check_answers.html.erb
@@ -17,6 +17,8 @@
   <% end %>
 <% end %>
 
+<%= govuk_inset_text(text: "This will change the name for the record with the teacher reference number (TRN) #{@wizard.teacher_trn}.") %>
+
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
   <%= content_for(:error_summary) { f.govuk_error_summary } %>
 

--- a/app/views/schools/mentors/change_name_wizard/check_answers.html.erb
+++ b/app/views/schools/mentors/change_name_wizard/check_answers.html.erb
@@ -17,7 +17,7 @@
   <% end %>
 <% end %>
 
-<%= govuk_inset_text(text: "This will change the name for the record with the teacher reference number (TRN) #{@wizard.teacher_trn}.") %>
+<%= govuk_inset_text(text: "This will change the name for teacher reference number (TRN) #{@wizard.teacher_trn}.") %>
 
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
   <%= content_for(:error_summary) { f.govuk_error_summary } %>

--- a/app/wizards/schools/ects/wizard.rb
+++ b/app/wizards/schools/ects/wizard.rb
@@ -15,6 +15,10 @@ module Schools
         name_for(ect_at_school_period.teacher.reload)
       end
 
+      def teacher_trn
+        ect_at_school_period.teacher.trn
+      end
+
       # @return [Hash]
       def default_path_arguments
         { ect_id: ect_at_school_period.id }

--- a/app/wizards/schools/mentors/wizard.rb
+++ b/app/wizards/schools/mentors/wizard.rb
@@ -15,6 +15,10 @@ module Schools
         ::Teachers::Name.new(mentor_at_school_period.teacher.reload).full_name
       end
 
+      def teacher_trn
+        mentor_at_school_period.teacher.trn
+      end
+
       # @return [Hash]
       def default_path_arguments
         { mentor_id: mentor_at_school_period.id }

--- a/spec/views/schools/ects/change_name_wizard/check_answers.html.erb_spec.rb
+++ b/spec/views/schools/ects/change_name_wizard/check_answers.html.erb_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe "schools/ects/change_name_wizard/check_answers.html.erb" do
+  let(:teacher) { FactoryBot.create(:teacher, trn: "1693012") }
+  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher:) }
+  let(:store) { FactoryBot.build(:session_repository, name: "Jane Smith") }
+  let(:wizard) do
+    FactoryBot.build(
+      :change_ect_name_wizard,
+      current_step: :check_answers,
+      ect_at_school_period:,
+      store:
+    )
+  end
+
+  before do
+    assign(:ect_at_school_period, ect_at_school_period)
+    assign(:wizard, wizard)
+  end
+
+  it "displays a reminder of the TRN for the record being changed" do
+    render
+
+    expect(rendered).to have_css(
+      ".govuk-inset-text",
+      text: "This will change the name for the record with the teacher reference number (TRN) 1693012."
+    )
+  end
+end

--- a/spec/views/schools/ects/change_name_wizard/check_answers.html.erb_spec.rb
+++ b/spec/views/schools/ects/change_name_wizard/check_answers.html.erb_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "schools/ects/change_name_wizard/check_answers.html.erb" do
 
     expect(rendered).to have_css(
       ".govuk-inset-text",
-      text: "This will change the name for the record with the teacher reference number (TRN) 1693012."
+      text: "This will change the name for teacher reference number (TRN) 1693012."
     )
   end
 end

--- a/spec/views/schools/mentors/change_name_wizard/check_answers.html.erb_spec.rb
+++ b/spec/views/schools/mentors/change_name_wizard/check_answers.html.erb_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe "schools/mentors/change_name_wizard/check_answers.html.erb" do
+  let(:teacher) { FactoryBot.create(:teacher, trn: "1693012") }
+  let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher:) }
+  let(:store) { FactoryBot.build(:session_repository, name: "Jane Smith") }
+  let(:wizard) do
+    FactoryBot.build(
+      :change_mentor_name_wizard,
+      current_step: :check_answers,
+      mentor_at_school_period:,
+      store:
+    )
+  end
+
+  before do
+    assign(:mentor_at_school_period, mentor_at_school_period)
+    assign(:wizard, wizard)
+  end
+
+  it "displays a reminder of the TRN for the record being changed" do
+    render
+
+    expect(rendered).to have_css(
+      ".govuk-inset-text",
+      text: "This will change the name for the record with the teacher reference number (TRN) 1693012."
+    )
+  end
+end

--- a/spec/views/schools/mentors/change_name_wizard/check_answers.html.erb_spec.rb
+++ b/spec/views/schools/mentors/change_name_wizard/check_answers.html.erb_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "schools/mentors/change_name_wizard/check_answers.html.erb" do
 
     expect(rendered).to have_css(
       ".govuk-inset-text",
-      text: "This will change the name for the record with the teacher reference number (TRN) 1693012."
+      text: "This will change the name for teacher reference number (TRN) 1693012."
     )
   end
 end


### PR DESCRIPTION
## Summary

Some SITs are attempting to assign a new mentor to an ECT by changing the current mentors name and email address.

To reduce ambiguity, this change adds a reminder of the teacher TRN on the check answers page when changing an ECT or mentors name.

<img width="619" height="410" alt="image" src="https://github.com/user-attachments/assets/726dd587-a714-4ff7-993b-6b705754cd6c" />

> [!NOTE]
> This complements the [new interruption panel](https://github.com/DFE-Digital/register-ects-project-board/issues/4263) currently in development, which more directly addresses the underlying problem. The interruption panel will be shown when both the first and last name entered differ from the existing record.