### PR TITLE
Increase Playwright navigation timeout in feature specs

### DIFF
--- a/spec/support/rspec_playwright.rb
+++ b/spec/support/rspec_playwright.rb
@@ -5,6 +5,7 @@ module RSpecPlaywright
   class PlaywrightMajorVersionMismatch < StandardError; end
 
   DEFAULT_TIMEOUT = 3_000
+  DEFAULT_NAVIGATION_TIMEOUT = 10_000
   PLAYWRIGHT_CLI_EXECUTABLE_PATH = "./node_modules/.bin/playwright"
 
   def self.start_browser

--- a/spec/support/testing_with_playwright.rb
+++ b/spec/support/testing_with_playwright.rb
@@ -22,6 +22,7 @@ RSpec.configure do |config|
                                    .new_page(baseURL: Capybara.current_session.server.base_url,
                                              javaScriptEnabled: Capybara.current_driver == :js_enabled)
     config.playwright_page.set_default_timeout(RSpecPlaywright::DEFAULT_TIMEOUT)
+    config.playwright_page.set_default_navigation_timeout(RSpecPlaywright::DEFAULT_NAVIGATION_TIMEOUT)
   end
 
   # Close Playwright page after each feature spec


### PR DESCRIPTION
## Summary

CI runners occasionally take longer than the existing 3 second timeout to complete page navigation. This causes otherwise valid feature specs to fail.

Use a 10 second timeout for navigation while keeping the 3 second default for other Playwright actions. Successful navigations continue immediately, so this doesn't slow down passing specs.

Failed examples:

- https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/30345529769/job/90230723346
- https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/30335249431/job/90198631492
- https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/30280383787/job/90024962044
