### PR TITLE
[4263] Interrupt significant ECT/Mentor name change

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,6 +8,7 @@
 @forward "header/colour-overrides";
 @forward "header/navigation";
 @forward "schools/ects";
+@forward "interruption-panel";
 @forward "timeline";
 @forward "bulk_upload";
 @forward "cards";

--- a/app/assets/stylesheets/interruption-panel.scss
+++ b/app/assets/stylesheets/interruption-panel.scss
@@ -1,0 +1,27 @@
+@use "govuk-frontend/dist/govuk" as *;
+
+.govuk-panel--interruption {
+  background: govuk-colour("blue");
+  color: govuk-colour("white");
+  text-align: left;
+
+  .govuk-body,
+  .govuk-list,
+  .govuk-warning-text__text {
+    color: govuk-colour("white");
+  }
+
+  .govuk-warning-text__icon {
+    border-color: govuk-colour("black");
+    background: govuk-colour("black");
+    color: govuk-colour("white");
+  }
+
+  .govuk-panel__body > :last-child {
+    margin-bottom: 0;
+  }
+
+  .govuk-panel__actions {
+    margin-top: govuk-spacing(6);
+  }
+}

--- a/app/assets/stylesheets/interruption-panel.scss
+++ b/app/assets/stylesheets/interruption-panel.scss
@@ -1,27 +1,6 @@
 @use "govuk-frontend/dist/govuk" as *;
 
-.govuk-panel--interruption {
-  background: govuk-colour("blue");
-  color: govuk-colour("white");
-  text-align: left;
-
-  .govuk-body,
-  .govuk-list,
-  .govuk-warning-text__text {
-    color: govuk-colour("white");
-  }
-
-  .govuk-warning-text__icon {
-    border-color: govuk-colour("black");
-    background: govuk-colour("black");
-    color: govuk-colour("white");
-  }
-
-  .govuk-panel__body > :last-child {
-    margin-bottom: 0;
-  }
-
-  .govuk-panel__actions {
-    margin-top: govuk-spacing(6);
-  }
+// Required to prevent white exclamation on white circle
+.govuk-panel--interruption .govuk-warning-text__icon {
+  color: govuk-colour("black");
 }

--- a/app/services/teachers/name_change.rb
+++ b/app/services/teachers/name_change.rb
@@ -1,0 +1,32 @@
+module Teachers
+  class NameChange
+    def initialize(current_name, new_name)
+      @current_name = current_name.to_s
+      @new_name = new_name.to_s
+    end
+
+    def significant?
+      first_word_changed? && last_word_changed?
+    end
+
+  private
+
+    attr_reader :current_name, :new_name
+
+    def first_word_changed?
+      normalise(words(current_name).first) != normalise(words(new_name).first)
+    end
+
+    def last_word_changed?
+      normalise(words(current_name).last) != normalise(words(new_name).last)
+    end
+
+    def words(name)
+      name.split
+    end
+
+    def normalise(word)
+      I18n.transliterate(word.to_s).downcase.gsub(/[^a-z0-9]/, "")
+    end
+  end
+end

--- a/app/views/schools/confirm_name_change.html.erb
+++ b/app/views/schools/confirm_name_change.html.erb
@@ -6,39 +6,29 @@
 
 <% teacher_full_name = @wizard.teacher_full_name %>
 
-<%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
-  <div class="govuk-panel govuk-panel--interruption">
-    <h1 class="govuk-panel__title">Check this name change is for the same person</h1>
+<%= govuk_panel(interruption: true, title_text: "Check this name change is for the same person") do |panel| %>
+  <% panel.with_action(text: "Continue to change name", href: @wizard.next_step_path, type: :button) %>
+  <% panel.with_action(text: "Cancel and return to #{teacher_full_name}’s details", href: @wizard.details_path, type: :link) %>
 
-    <div class="govuk-panel__body">
-      <p class="govuk-body">
-        You’ve told us you want to change <strong><%= teacher_full_name %></strong>’s name to <strong><%= @wizard.store.name %></strong>.
-      </p>
+  <p class="govuk-body">
+    You’ve told us you want to change <strong><%= teacher_full_name %></strong>’s name to <strong><%= @wizard.store.name %></strong>.
+  </p>
 
-      <% if @wizard.teacher.trn.present? %>
-        <p class="govuk-body">
-          This will change the name for teacher reference number (TRN) <strong><%= @wizard.teacher.trn %></strong>.
-        </p>
-      <% end %>
+  <% if @wizard.teacher.trn.present? %>
+    <p class="govuk-body">
+      This will change the name for teacher reference number (TRN) <strong><%= @wizard.teacher.trn %></strong>.
+    </p>
+  <% end %>
 
-      <%= govuk_warning_text do %>
-        If <%= @wizard.store.name %> is a different person, do not continue. Changing <%= teacher_full_name %>’s name to that of a different person may affect your school’s funding.
-      <% end %>
+  <%= govuk_warning_text do %>
+    If <%= @wizard.store.name %> is a different person, do not continue. Changing <%= teacher_full_name %>’s name to that of a different person may affect your school’s funding.
+  <% end %>
 
-      <p class="govuk-body">Only change <%= teacher_full_name %>’s name if:</p>
+  <p class="govuk-body">Only change <%= teacher_full_name %>’s name if:</p>
 
-      <ul class="govuk-list govuk-list--bullet">
-        <li>it’s spelt incorrectly</li>
-        <li>they’ve changed their name</li>
-        <li>they want to use a shortened or less formal name</li>
-      </ul>
-    </div>
-
-    <div class="govuk-panel__actions">
-      <div class="govuk-button-group">
-        <%= f.govuk_submit "Continue to change name", class: "govuk-button--inverse" %>
-        <%= govuk_link_to "Cancel and return to #{teacher_full_name}’s details", @wizard.details_path, inverse: true %>
-      </div>
-    </div>
-  </div>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>it’s spelt incorrectly</li>
+    <li>they’ve changed their name</li>
+    <li>they want to use a shortened or less formal name</li>
+  </ul>
 <% end %>

--- a/app/views/schools/confirm_name_change.html.erb
+++ b/app/views/schools/confirm_name_change.html.erb
@@ -4,13 +4,15 @@
      backlink_href: @wizard.previous_step_path
    ) %>
 
+<% teacher_full_name = @wizard.teacher_full_name %>
+
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
   <div class="govuk-panel govuk-panel--interruption">
     <h1 class="govuk-panel__title">Check this name change is for the same person</h1>
 
     <div class="govuk-panel__body">
       <p class="govuk-body">
-        You’ve told us you want to change <strong><%= @wizard.teacher_full_name %></strong>’s name to <strong><%= @wizard.store.name %></strong>.
+        You’ve told us you want to change <strong><%= teacher_full_name %></strong>’s name to <strong><%= @wizard.store.name %></strong>.
       </p>
 
       <% if @wizard.teacher.trn.present? %>
@@ -20,10 +22,10 @@
       <% end %>
 
       <%= govuk_warning_text do %>
-        If <%= @wizard.store.name %> is a different person, do not continue. Changing <%= @wizard.teacher_full_name %>’s name to that of a different person may affect your school’s funding.
+        If <%= @wizard.store.name %> is a different person, do not continue. Changing <%= teacher_full_name %>’s name to that of a different person may affect your school’s funding.
       <% end %>
 
-      <p class="govuk-body">Only change <%= @wizard.teacher_full_name %>’s name if:</p>
+      <p class="govuk-body">Only change <%= teacher_full_name %>’s name if:</p>
 
       <ul class="govuk-list govuk-list--bullet">
         <li>it’s spelt incorrectly</li>
@@ -35,7 +37,7 @@
     <div class="govuk-panel__actions">
       <div class="govuk-button-group">
         <%= f.govuk_submit "Continue to change name", class: "govuk-button--inverse" %>
-        <%= govuk_link_to "Cancel and return to #{@wizard.teacher_full_name}’s details", @wizard.details_path, inverse: true %>
+        <%= govuk_link_to "Cancel and return to #{teacher_full_name}’s details", @wizard.details_path, inverse: true %>
       </div>
     </div>
   </div>

--- a/app/views/schools/confirm_name_change.html.erb
+++ b/app/views/schools/confirm_name_change.html.erb
@@ -1,0 +1,42 @@
+<% page_data(
+     title: "Check this name change is for the same person",
+     header: false,
+     backlink_href: @wizard.previous_step_path
+   ) %>
+
+<%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
+  <div class="govuk-panel govuk-panel--interruption">
+    <h1 class="govuk-panel__title">Check this name change is for the same person</h1>
+
+    <div class="govuk-panel__body">
+      <p class="govuk-body">
+        You’ve told us you want to change <strong><%= @wizard.teacher_full_name %></strong>’s name to <strong><%= @wizard.store.name %></strong>.
+      </p>
+
+      <% if @wizard.teacher.trn.present? %>
+        <p class="govuk-body">
+          This will change the name for teacher reference number (TRN) <strong><%= @wizard.teacher.trn %></strong>.
+        </p>
+      <% end %>
+
+      <%= govuk_warning_text do %>
+        If <%= @wizard.store.name %> is a different person, do not continue. Changing <%= @wizard.teacher_full_name %>’s name to that of a different person may affect your school’s funding.
+      <% end %>
+
+      <p class="govuk-body">Only change <%= @wizard.teacher_full_name %>’s name if:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>it’s spelt incorrectly</li>
+        <li>they’ve changed their name</li>
+        <li>they want to use a shortened or less formal name</li>
+      </ul>
+    </div>
+
+    <div class="govuk-panel__actions">
+      <div class="govuk-button-group">
+        <%= f.govuk_submit "Continue to change name", class: "govuk-button--inverse" %>
+        <%= govuk_link_to "Cancel and return to #{@wizard.teacher_full_name}’s details", @wizard.details_path, inverse: true %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/schools/confirm_name_change.html.erb
+++ b/app/views/schools/confirm_name_change.html.erb
@@ -31,4 +31,10 @@
     <li>they’ve changed their name</li>
     <li>they want to use a shortened or less formal name</li>
   </ul>
+
+  <% if @wizard.mentor? %>
+    <p class="govuk-body">
+      If you want a different person to mentor an ECT, change the mentor from the <%= govuk_link_to "ECT’s details page", schools_ects_home_path, inverse: true %>.
+    </p>
+  <% end %>
 <% end %>

--- a/app/views/schools/ects/change_name_wizard/check_answers.html.erb
+++ b/app/views/schools/ects/change_name_wizard/check_answers.html.erb
@@ -17,7 +17,7 @@
   <% end %>
 <% end %>
 
-<%= govuk_inset_text(text: "This will change the name for teacher reference number (TRN) #{@wizard.teacher_trn}.") %>
+<%= govuk_inset_text(text: "This will change the name for teacher reference number (TRN) #{@wizard.teacher.trn}.") %>
 
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
   <%= content_for(:error_summary) { f.govuk_error_summary } %>

--- a/app/views/schools/mentors/change_name_wizard/check_answers.html.erb
+++ b/app/views/schools/mentors/change_name_wizard/check_answers.html.erb
@@ -17,7 +17,7 @@
   <% end %>
 <% end %>
 
-<%= govuk_inset_text(text: "This will change the name for teacher reference number (TRN) #{@wizard.teacher_trn}.") %>
+<%= govuk_inset_text(text: "This will change the name for teacher reference number (TRN) #{@wizard.teacher.trn}.") %>
 
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
   <%= content_for(:error_summary) { f.govuk_error_summary } %>

--- a/app/wizards/schools/change_name/confirmable.rb
+++ b/app/wizards/schools/change_name/confirmable.rb
@@ -1,0 +1,11 @@
+module Schools
+  module ChangeName
+    module Confirmable
+      def previous_step = :edit
+
+      def next_step = :check_answers
+
+      def save! = true
+    end
+  end
+end

--- a/app/wizards/schools/change_name/editable.rb
+++ b/app/wizards/schools/change_name/editable.rb
@@ -1,0 +1,44 @@
+module Schools
+  module ChangeName
+    module Editable
+      extend ActiveSupport::Concern
+
+      included do
+        attribute :name, :string
+
+        validates :name,
+                  corrected_name: true,
+                  presence: { message: "Enter the correct full name" }
+
+        validates :name,
+                  comparison: {
+                    other_than: ->(it) { it.wizard.teacher_full_name },
+                    case_sensitive: false,
+                    message: "The name must be different from the current name"
+                  }
+      end
+
+      class_methods do
+        def permitted_params = %i[name]
+      end
+
+      def next_step
+        significant_name_change? ? :confirm_name_change : :check_answers
+      end
+
+      def save!
+        store.update!(name:) if valid_step?
+      end
+
+    private
+
+      def significant_name_change?
+        ::Teachers::NameChange.new(wizard.teacher_full_name, name).significant?
+      end
+
+      def pre_populate_attributes
+        self.name = store.name.presence || wizard.teacher_full_name
+      end
+    end
+  end
+end

--- a/app/wizards/schools/ects/change_name_wizard/confirm_name_change_step.rb
+++ b/app/wizards/schools/ects/change_name_wizard/confirm_name_change_step.rb
@@ -1,0 +1,9 @@
+module Schools
+  module ECTs
+    module ChangeNameWizard
+      class ConfirmNameChangeStep < ECTs::Step
+        include Schools::ChangeName::Confirmable
+      end
+    end
+  end
+end

--- a/app/wizards/schools/ects/change_name_wizard/edit_step.rb
+++ b/app/wizards/schools/ects/change_name_wizard/edit_step.rb
@@ -2,32 +2,7 @@ module Schools
   module ECTs
     module ChangeNameWizard
       class EditStep < ECTs::Step
-        attribute :name, :string
-
-        validates :name,
-                  corrected_name: true,
-                  presence: { message: "Enter the correct full name" }
-
-        validates :name,
-                  comparison: {
-                    other_than: ->(it) { it.wizard.teacher_full_name },
-                    case_sensitive: false,
-                    message: "The name must be different from the current name"
-                  }
-
-        def self.permitted_params = %i[name]
-
-        def next_step = :check_answers
-
-        def save!
-          store.update!(name:) if valid_step?
-        end
-
-      private
-
-        def pre_populate_attributes
-          self.name = store.name.presence || wizard.teacher_full_name
-        end
+        include Schools::ChangeName::Editable
       end
     end
   end

--- a/app/wizards/schools/ects/change_name_wizard/wizard.rb
+++ b/app/wizards/schools/ects/change_name_wizard/wizard.rb
@@ -6,6 +6,7 @@ module Schools
           [
             {
               edit: EditStep,
+              confirm_name_change: ConfirmNameChangeStep,
               check_answers: CheckAnswersStep,
               confirmation: ConfirmationStep,
             }

--- a/app/wizards/schools/ects/wizard.rb
+++ b/app/wizards/schools/ects/wizard.rb
@@ -19,6 +19,8 @@ module Schools
         url_helpers.schools_ect_path(ect_at_school_period)
       end
 
+      def mentor? = false
+
       # @return [Hash]
       def default_path_arguments
         { ect_id: ect_at_school_period.id }

--- a/app/wizards/schools/ects/wizard.rb
+++ b/app/wizards/schools/ects/wizard.rb
@@ -19,11 +19,16 @@ module Schools
         ect_at_school_period.teacher.trn
       end
 
+      def details_path
+        url_helpers.schools_ect_path(ect_at_school_period)
+      end
+
       # @return [Hash]
       def default_path_arguments
         { ect_id: ect_at_school_period.id }
       end
 
+      delegate :teacher, to: :ect_at_school_period
       delegate :save!, to: :current_step
       delegate :reset, to: :store
     end

--- a/app/wizards/schools/ects/wizard.rb
+++ b/app/wizards/schools/ects/wizard.rb
@@ -15,10 +15,6 @@ module Schools
         name_for(ect_at_school_period.teacher.reload)
       end
 
-      def teacher_trn
-        ect_at_school_period.teacher.trn
-      end
-
       def details_path
         url_helpers.schools_ect_path(ect_at_school_period)
       end

--- a/app/wizards/schools/mentors/change_name_wizard/confirm_name_change_step.rb
+++ b/app/wizards/schools/mentors/change_name_wizard/confirm_name_change_step.rb
@@ -1,0 +1,9 @@
+module Schools
+  module Mentors
+    module ChangeNameWizard
+      class ConfirmNameChangeStep < Mentors::Step
+        include Schools::ChangeName::Confirmable
+      end
+    end
+  end
+end

--- a/app/wizards/schools/mentors/change_name_wizard/edit_step.rb
+++ b/app/wizards/schools/mentors/change_name_wizard/edit_step.rb
@@ -2,32 +2,7 @@ module Schools
   module Mentors
     module ChangeNameWizard
       class EditStep < Mentors::Step
-        attribute :name, :string
-
-        validates :name,
-                  corrected_name: true,
-                  presence: { message: "Enter the correct full name" }
-
-        validates :name,
-                  comparison: {
-                    other_than: ->(it) { it.wizard.teacher_full_name },
-                    case_sensitive: false,
-                    message: "The name must be different from the current name"
-                  }
-
-        def self.permitted_params = %i[name]
-
-        def next_step = :check_answers
-
-        def save!
-          store.update!(name:) if valid_step?
-        end
-
-      private
-
-        def pre_populate_attributes
-          self.name = store.name.presence || wizard.teacher_full_name
-        end
+        include Schools::ChangeName::Editable
       end
     end
   end

--- a/app/wizards/schools/mentors/change_name_wizard/wizard.rb
+++ b/app/wizards/schools/mentors/change_name_wizard/wizard.rb
@@ -6,6 +6,7 @@ module Schools
           [
             {
               edit: EditStep,
+              confirm_name_change: ConfirmNameChangeStep,
               check_answers: CheckAnswersStep,
               confirmation: ConfirmationStep,
             }

--- a/app/wizards/schools/mentors/wizard.rb
+++ b/app/wizards/schools/mentors/wizard.rb
@@ -15,10 +15,6 @@ module Schools
         ::Teachers::Name.new(mentor_at_school_period.teacher.reload).full_name
       end
 
-      def teacher_trn
-        mentor_at_school_period.teacher.trn
-      end
-
       def details_path
         url_helpers.schools_mentor_path(mentor_at_school_period)
       end

--- a/app/wizards/schools/mentors/wizard.rb
+++ b/app/wizards/schools/mentors/wizard.rb
@@ -19,11 +19,16 @@ module Schools
         mentor_at_school_period.teacher.trn
       end
 
+      def details_path
+        url_helpers.schools_mentor_path(mentor_at_school_period)
+      end
+
       # @return [Hash]
       def default_path_arguments
         { mentor_id: mentor_at_school_period.id }
       end
 
+      delegate :teacher, to: :mentor_at_school_period
       delegate :save!, to: :current_step
       delegate :reset, to: :store
     end

--- a/app/wizards/schools/mentors/wizard.rb
+++ b/app/wizards/schools/mentors/wizard.rb
@@ -19,6 +19,8 @@ module Schools
         url_helpers.schools_mentor_path(mentor_at_school_period)
       end
 
+      def mentor? = true
+
       # @return [Hash]
       def default_path_arguments
         { mentor_id: mentor_at_school_period.id }

--- a/spec/features/schools/ects/change/name_spec.rb
+++ b/spec/features/schools/ects/change/name_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe "Changing an ECT's name" do
   end
 
   def when_i_click_continue_to_change_name
-    page.get_by_role("button", name: "Continue to change name").click
+    page.get_by_role("link", name: "Continue to change name").click
   end
 
   def and_i_click_the_confirmation_button

--- a/spec/features/schools/ects/change/name_spec.rb
+++ b/spec/features/schools/ects/change/name_spec.rb
@@ -27,32 +27,52 @@ RSpec.describe "Changing an ECT's name" do
     then_i_should_see_the_change_name_page
   end
 
-  scenario "valid name" do
-    when_i_change_the_name_to("Sister Mildred")
+  scenario "minor change (only part of the name) goes straight to check answers" do
+    when_i_change_the_name_to("Miriam Mildred")
     and_i_click_the_continue_button
     then_i_should_be_taken_to_the_check_answers_page
-    and_i_should_see_the_name("Sister Mildred")
+    and_i_should_see_the_name("Miriam Mildred")
     and_i_should_see_the_name("Miriam Margolyes")
     and_i_click_the_confirmation_button
     then_i_should_be_taken_to_the_confirmation_page
-    then_the_teacher_name_should_be_corrected
+    then_the_teacher_name_should_be("Miriam Mildred")
+  end
+
+  scenario "significant change (both first and last name) shows the interruption page" do
+    when_i_change_the_name_to("Sister Mildred")
+    and_i_click_the_continue_button
+    then_i_should_see_the_interruption_page
+    when_i_click_continue_to_change_name
+    then_i_should_be_taken_to_the_check_answers_page
+    and_i_click_the_confirmation_button
+    then_i_should_be_taken_to_the_confirmation_page
+    then_the_teacher_name_should_be("Sister Mildred")
+  end
+
+  scenario "cancel from the interruption page returns to the ECT's details" do
+    when_i_change_the_name_to("Sister Mildred")
+    and_i_click_the_continue_button
+    then_i_should_see_the_interruption_page
+    and_i_click_the_cancel_link
+    then_i_should_be_taken_to_the_ect_details_page
+    then_the_teacher_name_should_be("Miriam Margolyes")
   end
 
   scenario "edit before confirming" do
-    when_i_change_the_name_to("Professor Sprout")
+    when_i_change_the_name_to("Miriam Sprout")
     and_i_click_the_continue_button
     then_i_should_be_taken_to_the_check_answers_page
     and_i_click_the_back_link
     then_i_should_see_the_change_name_page
-    and_the_name_field_should_be("Professor Sprout")
-    when_i_change_the_name_to("Sister Mildred")
+    and_the_name_field_should_be("Miriam Sprout")
+    when_i_change_the_name_to("Miriam Mildred")
     and_i_click_the_continue_button
     and_i_click_the_confirmation_button
-    then_the_teacher_name_should_be_corrected
+    then_the_teacher_name_should_be("Miriam Mildred")
   end
 
   scenario "cancel and reset" do
-    when_i_change_the_name_to("Professor Sprout")
+    when_i_change_the_name_to("Miriam Sprout")
     and_i_click_the_continue_button
     then_i_should_be_taken_to_the_check_answers_page
     and_i_click_the_cancel_link
@@ -110,7 +130,19 @@ RSpec.describe "Changing an ECT's name" do
   end
 
   def and_i_click_the_continue_button
-    page.get_by_role("button", name: "Continue").click
+    page.get_by_role("button", name: "Continue", exact: true).click
+  end
+
+  def then_i_should_see_the_interruption_page
+    expect(page).to have_path("/school/ects/#{ect_at_school_period.id}/change-name/confirm-name-change")
+    expect(page.get_by_role("heading", name: "Check this name change is for the same person")).to be_visible
+    expect(page.get_by_text("You’ve told us you want to change Miriam Margolyes’s name to Sister Mildred.")).to be_visible
+    expect(page.get_by_text("This will change the name for teacher reference number (TRN) #{teacher.trn}.")).to be_visible
+    expect(page.get_by_text("If Sister Mildred is a different person, do not continue.")).to be_visible
+  end
+
+  def when_i_click_continue_to_change_name
+    page.get_by_role("button", name: "Continue to change name").click
   end
 
   def and_i_click_the_confirmation_button
@@ -137,12 +169,16 @@ RSpec.describe "Changing an ECT's name" do
     expect(page).to have_path("/school/ects/#{ect_at_school_period.id}/change-name/confirmation")
   end
 
+  def then_i_should_be_taken_to_the_ect_details_page
+    expect(page).to have_path("/school/ects/#{ect_at_school_period.id}")
+  end
+
   def and_i_should_see_the_name(name)
     expect(page.get_by_text(name, exact: true)).to be_visible
   end
 
-  def then_the_teacher_name_should_be_corrected
-    expect(teacher.reload.corrected_name).to eq("Sister Mildred")
+  def then_the_teacher_name_should_be(name)
+    expect(Teachers::Name.new(teacher.reload).full_name).to eq(name)
   end
 
   def then_the_form_should_be_reset

--- a/spec/features/schools/ects/change/name_spec.rb
+++ b/spec/features/schools/ects/change/name_spec.rb
@@ -139,6 +139,7 @@ RSpec.describe "Changing an ECT's name" do
     expect(page.get_by_text("You’ve told us you want to change Miriam Margolyes’s name to Sister Mildred.")).to be_visible
     expect(page.get_by_text("This will change the name for teacher reference number (TRN) #{teacher.trn}.")).to be_visible
     expect(page.get_by_text("If Sister Mildred is a different person, do not continue.")).to be_visible
+    expect(page.get_by_role("link", name: "ECT’s details page")).not_to be_visible
   end
 
   def when_i_click_continue_to_change_name

--- a/spec/features/schools/mentors/change/name_spec.rb
+++ b/spec/features/schools/mentors/change/name_spec.rb
@@ -130,6 +130,8 @@ RSpec.describe "Changing a mentor's name" do
     expect(page.get_by_text("You’ve told us you want to change Miriam Margolyes’s name to Sister Mildred.")).to be_visible
     expect(page.get_by_text("This will change the name for teacher reference number (TRN) #{teacher.trn}.")).to be_visible
     expect(page.get_by_text("If Sister Mildred is a different person, do not continue.")).to be_visible
+    expect(page.get_by_text("If you want a different person to mentor an ECT, change the mentor from the ECT’s details page.")).to be_visible
+    expect(page.get_by_role("link", name: "ECT’s details page").get_attribute("href")).to eq("/school/home/ects")
   end
 
   def when_i_click_continue_to_change_name

--- a/spec/features/schools/mentors/change/name_spec.rb
+++ b/spec/features/schools/mentors/change/name_spec.rb
@@ -17,32 +17,52 @@ RSpec.describe "Changing a mentor's name" do
     then_i_should_see_the_change_name_page
   end
 
-  scenario "valid name" do
-    when_i_change_the_name_to("Sister Mildred")
+  scenario "minor change (only part of the name) goes straight to check answers" do
+    when_i_change_the_name_to("Miriam Mildred")
     and_i_click_the_continue_button
     then_i_should_be_taken_to_the_check_answers_page
-    and_i_should_see_the_name("Sister Mildred")
+    and_i_should_see_the_name("Miriam Mildred")
     and_i_should_see_the_name("Miriam Margolyes")
     and_i_click_the_confirmation_button
     then_i_should_be_taken_to_the_confirmation_page
-    then_the_teacher_name_should_be_corrected
+    then_the_teacher_name_should_be("Miriam Mildred")
+  end
+
+  scenario "significant change (both first and last name) shows the interruption page" do
+    when_i_change_the_name_to("Sister Mildred")
+    and_i_click_the_continue_button
+    then_i_should_see_the_interruption_page
+    when_i_click_continue_to_change_name
+    then_i_should_be_taken_to_the_check_answers_page
+    and_i_click_the_confirmation_button
+    then_i_should_be_taken_to_the_confirmation_page
+    then_the_teacher_name_should_be("Sister Mildred")
+  end
+
+  scenario "cancel from the interruption page returns to the mentor's details" do
+    when_i_change_the_name_to("Sister Mildred")
+    and_i_click_the_continue_button
+    then_i_should_see_the_interruption_page
+    and_i_click_the_cancel_link
+    then_i_should_be_taken_to_the_mentor_details_page
+    then_the_teacher_name_should_be("Miriam Margolyes")
   end
 
   scenario "edit before confirming" do
-    when_i_change_the_name_to("Professor Sprout")
+    when_i_change_the_name_to("Miriam Sprout")
     and_i_click_the_continue_button
     then_i_should_be_taken_to_the_check_answers_page
     and_i_click_the_back_link
     then_i_should_see_the_change_name_page
-    then_the_form_should_show("Professor Sprout")
-    when_i_change_the_name_to("Sister Mildred")
+    then_the_form_should_show("Miriam Sprout")
+    when_i_change_the_name_to("Miriam Mildred")
     and_i_click_the_continue_button
     and_i_click_the_confirmation_button
-    then_the_teacher_name_should_be_corrected
+    then_the_teacher_name_should_be("Miriam Mildred")
   end
 
   scenario "cancel and reset" do
-    when_i_change_the_name_to("Professor Sprout")
+    when_i_change_the_name_to("Miriam Sprout")
     and_i_click_the_continue_button
     then_i_should_be_taken_to_the_check_answers_page
     and_i_click_the_cancel_link
@@ -101,7 +121,19 @@ RSpec.describe "Changing a mentor's name" do
   end
 
   def and_i_click_the_continue_button
-    page.get_by_role("button", name: "Continue").click
+    page.get_by_role("button", name: "Continue", exact: true).click
+  end
+
+  def then_i_should_see_the_interruption_page
+    expect(page).to have_path("/school/mentors/#{mentor_at_school_period.id}/change-name/confirm-name-change")
+    expect(page.get_by_role("heading", name: "Check this name change is for the same person")).to be_visible
+    expect(page.get_by_text("You’ve told us you want to change Miriam Margolyes’s name to Sister Mildred.")).to be_visible
+    expect(page.get_by_text("This will change the name for teacher reference number (TRN) #{teacher.trn}.")).to be_visible
+    expect(page.get_by_text("If Sister Mildred is a different person, do not continue.")).to be_visible
+  end
+
+  def when_i_click_continue_to_change_name
+    page.get_by_role("button", name: "Continue to change name").click
   end
 
   def and_i_click_the_confirmation_button
@@ -128,12 +160,16 @@ RSpec.describe "Changing a mentor's name" do
     expect(page).to have_path("/school/mentors/#{mentor_at_school_period.id}/change-name/confirmation")
   end
 
+  def then_i_should_be_taken_to_the_mentor_details_page
+    expect(page).to have_path("/school/mentors/#{mentor_at_school_period.id}")
+  end
+
   def and_i_should_see_the_name(name)
     expect(page.get_by_text(name, exact: true)).to be_visible
   end
 
-  def then_the_teacher_name_should_be_corrected
-    expect(teacher.reload.corrected_name).to eq("Sister Mildred")
+  def then_the_teacher_name_should_be(name)
+    expect(Teachers::Name.new(teacher.reload).full_name).to eq(name)
   end
 
   def then_the_form_should_be_reset(name = "Miriam Margolyes")

--- a/spec/features/schools/mentors/change/name_spec.rb
+++ b/spec/features/schools/mentors/change/name_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe "Changing a mentor's name" do
   end
 
   def when_i_click_continue_to_change_name
-    page.get_by_role("button", name: "Continue to change name").click
+    page.get_by_role("link", name: "Continue to change name").click
   end
 
   def and_i_click_the_confirmation_button

--- a/spec/services/teachers/name_change_spec.rb
+++ b/spec/services/teachers/name_change_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe Teachers::NameChange do
+  describe "#significant?" do
+    def significant?(current_name, new_name)
+      described_class.new(current_name, new_name).significant?
+    end
+
+    it "is false when only the first name changes (typo or short form)" do
+      expect(significant?("Jonathan Smith", "Jon Smith")).to be(false)
+    end
+
+    it "is false when only the last name changes (e.g. marriage)" do
+      expect(significant?("Jane Smith", "Jane Jones")).to be(false)
+    end
+
+    it "is true when both the first and last name change" do
+      expect(significant?("John Smith", "Mary Jones")).to be(true)
+    end
+
+    it "is false when a middle name is added" do
+      expect(significant?("John Smith", "John Paul Smith")).to be(false)
+    end
+
+    it "is false for multi-part names when the first and last words are unchanged" do
+      expect(significant?("Edwin van der Smoot", "Edwin van der Smoot-Jones")).to be(false)
+    end
+
+    it "ignores case" do
+      expect(significant?("John Smith", "JOHN SMITH")).to be(false)
+    end
+
+    it "ignores accents and punctuation" do
+      expect(significant?("Zoe O'Brien", "Zoë OBrien")).to be(false)
+    end
+
+    it "ignores surrounding and repeated whitespace" do
+      expect(significant?("John Smith", "  John   Smith  ")).to be(false)
+    end
+
+    it "treats a completely different single-word name as significant" do
+      expect(significant?("Cher", "Madonna")).to be(true)
+    end
+
+    it "is false when a single-word name is unchanged" do
+      expect(significant?("Cher", "Cher")).to be(false)
+    end
+  end
+end

--- a/spec/services/teachers/name_change_spec.rb
+++ b/spec/services/teachers/name_change_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Teachers::NameChange do
       expect(significant?("John Smith", "John Paul Smith")).to be(false)
     end
 
-    it "is false for multi-part names when the first and last words are unchanged" do
+    it "is false when only the last part of a multi-part name changes" do
       expect(significant?("Edwin van der Smoot", "Edwin van der Smoot-Jones")).to be(false)
     end
 

--- a/spec/wizards/schools/ects/change_name_wizard/confirm_name_change_step_spec.rb
+++ b/spec/wizards/schools/ects/change_name_wizard/confirm_name_change_step_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe Schools::ECTs::ChangeNameWizard::ConfirmNameChangeStep, type: :model do
+  subject(:current_step) { wizard.current_step }
+
+  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period) }
+  let(:store) { FactoryBot.build(:session_repository, name: "Nanny Ogg") }
+  let(:wizard) do
+    FactoryBot.build(:change_ect_name_wizard,
+                     current_step: :confirm_name_change,
+                     store:,
+                     ect_at_school_period:)
+  end
+
+  describe "#previous_step" do
+    it { expect(current_step.previous_step).to eq(:edit) }
+  end
+
+  describe "#next_step" do
+    it { expect(current_step.next_step).to eq(:check_answers) }
+  end
+
+  describe "#save!" do
+    it "does not change the teacher's name" do
+      expect { current_step.save! }.not_to change(ect_at_school_period.teacher.reload, :corrected_name)
+    end
+
+    it "returns true so the wizard can continue" do
+      expect(current_step.save!).to be(true)
+    end
+  end
+end

--- a/spec/wizards/schools/ects/change_name_wizard/edit_step_spec.rb
+++ b/spec/wizards/schools/ects/change_name_wizard/edit_step_spec.rb
@@ -38,7 +38,23 @@ RSpec.describe Schools::ECTs::ChangeNameWizard::EditStep, type: :model do
   end
 
   describe "#next_step" do
-    it { expect(current_step.next_step).to eq(:check_answers) }
+    before { ect_at_school_period.teacher.update!(corrected_name: "Terry Smith") }
+
+    context "when only part of the name changes" do
+      let(:params) { { "name" => "Terry Pratchett" } }
+
+      it "goes straight to the check answers page" do
+        expect(current_step.next_step).to eq(:check_answers)
+      end
+    end
+
+    context "when both the first and last name change" do
+      let(:params) { { "name" => "Nanny Ogg" } }
+
+      it "routes through the interruption page" do
+        expect(current_step.next_step).to eq(:confirm_name_change)
+      end
+    end
   end
 
   describe "#previous_step" do

--- a/spec/wizards/schools/mentors/change_name_wizard/confirm_name_change_step_spec.rb
+++ b/spec/wizards/schools/mentors/change_name_wizard/confirm_name_change_step_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe Schools::Mentors::ChangeNameWizard::ConfirmNameChangeStep, type: :model do
+  subject(:current_step) { wizard.current_step }
+
+  let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period) }
+  let(:store) { FactoryBot.build(:session_repository, name: "Nanny Ogg") }
+  let(:wizard) do
+    FactoryBot.build(:change_mentor_name_wizard,
+                     current_step: :confirm_name_change,
+                     store:,
+                     mentor_at_school_period:)
+  end
+
+  describe "#previous_step" do
+    it { expect(current_step.previous_step).to eq(:edit) }
+  end
+
+  describe "#next_step" do
+    it { expect(current_step.next_step).to eq(:check_answers) }
+  end
+
+  describe "#save!" do
+    it "does not change the teacher's name" do
+      expect { current_step.save! }.not_to change(mentor_at_school_period.teacher.reload, :corrected_name)
+    end
+
+    it "returns true so the wizard can continue" do
+      expect(current_step.save!).to be(true)
+    end
+  end
+end

--- a/spec/wizards/schools/mentors/change_name_wizard/edit_step_spec.rb
+++ b/spec/wizards/schools/mentors/change_name_wizard/edit_step_spec.rb
@@ -38,7 +38,23 @@ RSpec.describe Schools::Mentors::ChangeNameWizard::EditStep, type: :model do
   end
 
   describe "#next_step" do
-    it { expect(current_step.next_step).to eq(:check_answers) }
+    before { mentor_at_school_period.teacher.update!(corrected_name: "Terry Smith") }
+
+    context "when only part of the name changes" do
+      let(:params) { { "name" => "Terry Pratchett" } }
+
+      it "goes straight to the check answers page" do
+        expect(current_step.next_step).to eq(:check_answers)
+      end
+    end
+
+    context "when both the first and last name change" do
+      let(:params) { { "name" => "Nanny Ogg" } }
+
+      it "routes through the interruption page" do
+        expect(current_step.next_step).to eq(:confirm_name_change)
+      end
+    end
   end
 
   describe "#previous_step" do


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/4263

### Changes proposed in this pull request

Tries to detect significant name changes as per the algorithm described in the ticket, and if detected, interrupts the "change name" flow for both ECTs and Mentors with a special panel as designed in the prototype.

### Guidance to review

I was on the fence about a feature test for this since it is kind of an edge case, however there is a distinct user journey described here that's integrated across several steps, so I settled on adding one.

This PR includes a slight refactor to #4262 in [1d8d5aa](https://github.com/DFE-Digital/register-early-career-teachers-public/pull/3297/commits/1d8d5aaf1b188759224030c388ffa0c8c193a327)

Also sorry for all the Copilot noise! This seems to have been turned on ✨magically✨ for me, thanks GitHub! It's off again now 🤓 