### PR TITLE
Specify `PATTERN` when generating swagger API docs

### DIFF
--- a/.github/workflows/lead_provider_openapi_check.yml
+++ b/.github/workflows/lead_provider_openapi_check.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Install Redocly CLI
         run: npm install -g @redocly/cli@latest
-      
+
       - name: Run linting
         run: redocly lint public/api/docs/v3/swagger.yaml --format=github-actions
 
@@ -72,7 +72,7 @@ jobs:
           cat api-doc-checksums-original.txt
 
       - name: Run swaggerize
-        run: bundle exec rake rswag:specs:swaggerize
+        run: PATTERN='spec/requests/api/docs/**/*_spec.rb' bundle exec rake rswag:specs:swaggerize
 
       - name: Generate API doc checksums (after swaggerize)
         run: |


### PR DESCRIPTION
Before, we let `rswag` use the [default pattern][rswag] to select the tests to run to generate API docs.

This worked fine, but it meant we ran *all* request specs, not just the API request specs.

Sometimes, this could timeout intermittently and lead to [CI failures][ci].

This specifies the `PATTERN` explicitly, so we generate swagger docs by only running the API specs necessary.

[rswag]: https://github.com/rswag/rswag/blob/4a2885f180dc18689a898395b1aa550c0c22591a/rswag-specs/lib/tasks/rswag-specs_tasks.rake#L11
[ci]: https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/30374208300/job/90325566592?pr=3287
