### PR TITLE
Rename ongoing_today and unfinished

### DIFF
--- a/app/components/admin/schools/partnerships_summary_component.rb
+++ b/app/components/admin/schools/partnerships_summary_component.rb
@@ -44,7 +44,7 @@ module Admin
 
       def teachers_for(training_periods, period_type)
         training_periods
-          .select(&:ongoing_today?)
+          .select(&:contains_today?)
           .filter_map { |period| period.public_send(period_type)&.teacher }
           .uniq
           .sort_by { |teacher| teacher_full_name(teacher) }

--- a/app/components/tasks_index/leavers/table_row_component.rb
+++ b/app/components/tasks_index/leavers/table_row_component.rb
@@ -9,10 +9,10 @@ module TasksIndex
 
       delegate :induction_tutor_name, to: :school
       delegate :ect_at_school_periods, to: :teacher
-      delegate :ongoing, to: :ect_at_school_periods, prefix: true
+      delegate :unfinished, to: :ect_at_school_periods, prefix: true
 
       def recorded_by_school_name
-        ect_at_school_periods_ongoing.first&.school_name || school_name
+        ect_at_school_periods_unfinished.first&.school_name || school_name
       end
     end
   end

--- a/app/helpers/register_ect_helper.rb
+++ b/app/helpers/register_ect_helper.rb
@@ -7,7 +7,7 @@ module RegisterECTHelper
   end
 
   def formatted_year_range_for_registration_date(date)
-    contract_period = ContractPeriod.ongoing_on(date).first
+    contract_period = ContractPeriod.contains_date(date).first
     return "" if contract_period.blank?
 
     academic_year_string(contract_period.year)

--- a/app/models/concerns/interval.rb
+++ b/app/models/concerns/interval.rb
@@ -7,7 +7,7 @@ module Interval
     validate :period_dates_validation
 
     # Scopes
-    scope :ongoing, -> { where(finished_on: nil) }
+    scope :unfinished, -> { where(finished_on: nil) }
     scope :finished, -> { where.not(finished_on: nil) }
     scope :earliest_first, -> { order(started_on: "asc") }
     scope :latest_first, -> { order(started_on: "desc") }
@@ -19,7 +19,7 @@ module Interval
     scope :finished_on_or_after, ->(date) { where(finished_on: date..) }
     scope :overlapping_with, ->(period) { where(*overlapping_with_range(period.started_on, period.finished_on)) }
     scope :containing_period, ->(period) { where(*containing_range(period.started_on, period.finished_on)) }
-    scope :ongoing_on, ->(date) { where(*date_in_range(date)) }
+    scope :contains_date, ->(date) { where(*date_in_range(date)) }
     scope :closest_to, ->(date) {
       # this scope orders records by their proximity to the given date.
       # if a record covers the date, it will be prioritized.
@@ -43,9 +43,9 @@ module Interval
     }
 
     # Date relative scopes
-    scope :ongoing_today, -> { ongoing_on(Time.zone.today) }
+    scope :contains_today, -> { contains_date(Time.zone.today) }
     scope :starting_tomorrow_or_after, -> { started_on_or_after(Time.zone.tomorrow) }
-    scope :current_or_future, -> { ongoing_today.or(starting_tomorrow_or_after) }
+    scope :current_or_future, -> { contains_today.or(starting_tomorrow_or_after) }
   end
 
   # Validations
@@ -95,9 +95,9 @@ module Interval
 
   def invalid_date_order? = !valid_date_order?
 
-  def ongoing? = finished_on.nil?
+  def unfinished? = finished_on.nil?
 
-  def ongoing_today? = finished_on.nil? || finished_on.future?
+  def contains_today? = finished_on.nil? || finished_on.future?
 
   def complete? = finished_on.present?
 

--- a/app/models/induction_period.rb
+++ b/app/models/induction_period.rb
@@ -53,7 +53,6 @@ class InductionPeriod < ApplicationRecord
   # Scopes
   scope :for_teacher, ->(teacher) { where(teacher:) }
   scope :for_appropriate_body_period, ->(appropriate_body_period) { where(appropriate_body_period:) }
-  scope :ongoing, -> { where(finished_on: nil) }
   scope :with_outcome, -> { where.not(outcome: nil) }
   scope :without_outcome, -> { where(outcome: nil) }
   scope :released, -> { finished.without_outcome }

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -181,10 +181,10 @@ class School < ApplicationRecord
   def eligible? = marked_as_eligible? || gias_school.eligible?
 
   def blocked_from_registering_new_ects?
-    independent? && section_41_approved? == false && TrainingPeriod.at_school(self).ongoing.exists?
+    independent? && section_41_approved? == false && TrainingPeriod.at_school(self).unfinished.exists?
   end
 
   def blocked_from_service_access?
-    independent? && section_41_approved? == false && !TrainingPeriod.at_school(self).ongoing.exists?
+    independent? && section_41_approved? == false && !TrainingPeriod.at_school(self).unfinished.exists?
   end
 end

--- a/app/models/school_partnership.rb
+++ b/app/models/school_partnership.rb
@@ -5,7 +5,7 @@ class SchoolPartnership < ApplicationRecord
   belongs_to :lead_provider_delivery_partnership, inverse_of: :school_partnerships
   belongs_to :school
   has_many :events
-  has_many :ongoing_training_periods, -> { ongoing_today }, class_name: "TrainingPeriod"
+  has_many :ongoing_training_periods, -> { contains_today }, class_name: "TrainingPeriod"
   has_many :training_periods
   has_many :declarations, through: :training_periods
   has_one :active_lead_provider, through: :lead_provider_delivery_partnership

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -40,7 +40,7 @@ class Teacher < ApplicationRecord
 
   has_one :first_induction_period, -> { order(started_on: :asc) }, class_name: "InductionPeriod"
   has_one :last_induction_period, -> { order(started_on: :desc) }, class_name: "InductionPeriod"
-  has_one :ongoing_induction_period, -> { ongoing }, class_name: "InductionPeriod"
+  has_one :ongoing_induction_period, -> { unfinished }, class_name: "InductionPeriod"
   has_one :started_induction_period, -> { earliest_first }, class_name: "InductionPeriod"
   has_one :finished_induction_period, -> { finished.with_outcome.latest_first }, class_name: "InductionPeriod"
   has_one :earliest_ect_at_school_period, -> { earliest_first }, class_name: "ECTAtSchoolPeriod"

--- a/app/presenters/admin/school_period_presenter.rb
+++ b/app/presenters/admin/school_period_presenter.rb
@@ -23,7 +23,7 @@ module Admin
     end
 
     def mentees
-      school_period.mentorship_periods.ongoing.map { |mp| mp.mentee.teacher }.sort(&:trs_last_name)
+      school_period.mentorship_periods.unfinished.map { |mp| mp.mentee.teacher }.sort(&:trs_last_name)
     end
 
     def mentorship_periods

--- a/app/presenters/admin/teacher_presenter.rb
+++ b/app/presenters/admin/teacher_presenter.rb
@@ -45,8 +45,8 @@ module Admin
 
     def current_schools
       @current_schools ||= begin
-        ect_schools = teacher.ect_at_school_periods.ongoing_today.includes(school: :gias_school).map(&:school)
-        mentor_schools = teacher.mentor_at_school_periods.ongoing_today.includes(school: :gias_school).map(&:school)
+        ect_schools = teacher.ect_at_school_periods.contains_today.includes(school: :gias_school).map(&:school)
+        mentor_schools = teacher.mentor_at_school_periods.contains_today.includes(school: :gias_school).map(&:school)
         (ect_schools + mentor_schools).compact.uniq(&:id)
       end
     end

--- a/app/services/admin/current_teachers.rb
+++ b/app/services/admin/current_teachers.rb
@@ -7,7 +7,7 @@ module Admin
     end
 
     def current
-      scope = Teacher.joins(:induction_periods).merge(InductionPeriod.ongoing)
+      scope = Teacher.joins(:induction_periods).merge(InductionPeriod.unfinished)
 
       if appropriate_body_ids.any?
         scope = scope.merge(InductionPeriod.for_appropriate_body_period(appropriate_body_ids))

--- a/app/services/api/declarations/create.rb
+++ b/app/services/api/declarations/create.rb
@@ -225,7 +225,7 @@ module API::Declarations
       return if errors[:contract_period_year].any?
       return unless teacher
 
-      training_period_ongoing_today = training_periods.ongoing_today.first
+      training_period_ongoing_today = training_periods.contains_today.first
       return unless training_period_ongoing_today
 
       current_contract_period = training_period_ongoing_today.contract_period

--- a/app/services/api/teachers/resume.rb
+++ b/app/services/api/teachers/resume.rb
@@ -44,7 +44,7 @@ module API::Teachers
       school_period = training_period.at_school_period
 
       if school_period.training_periods
-        .ongoing_today
+        .contains_today
         .without(training_period)
         .exists?
         errors.add(:teacher_api_id, "This participant cannot be resumed because they are already active with another provider.")
@@ -56,7 +56,7 @@ module API::Teachers
       return unless training_period
 
       school_period = training_period.at_school_period
-      errors.add(:teacher_api_id, "The participant is no longer at the school. Please contact the induction tutor to resolve.") unless school_period.ongoing_today?
+      errors.add(:teacher_api_id, "The participant is no longer at the school. Please contact the induction tutor to resolve.") unless school_period.contains_today?
     end
   end
 end

--- a/app/services/api_seed_data/ect_become_mentor_scenarios.rb
+++ b/app/services/api_seed_data/ect_become_mentor_scenarios.rb
@@ -103,7 +103,7 @@ module APISeedData
 
       mentor_school_period = FactoryBot.create(
         :mentor_at_school_period,
-        :ongoing,
+        :unfinished,
         teacher:,
         started_on:
       )
@@ -120,7 +120,7 @@ module APISeedData
         :training_period,
         :for_mentor,
         :provider_led,
-        :ongoing,
+        :unfinished,
         :with_schedule,
         mentor_at_school_period: mentor_school_period,
         school_partnership:,

--- a/app/services/api_seed_data/mentor_scenarios.rb
+++ b/app/services/api_seed_data/mentor_scenarios.rb
@@ -77,7 +77,7 @@ module APISeedData
     def create_open_mentor_school_period(mentor, school_partnership)
       FactoryBot.create(
         :mentor_at_school_period,
-        :ongoing,
+        :unfinished,
         teacher: mentor,
         school: school_partnership.school
       )
@@ -87,7 +87,7 @@ module APISeedData
       FactoryBot.create(
         :training_period,
         :for_mentor,
-        :ongoing,
+        :unfinished,
         started_on: mentor_school_period.started_on,
         mentor_at_school_period: mentor_school_period,
         school_partnership:
@@ -97,14 +97,14 @@ module APISeedData
     def create_open_ect_with_mentorship(mentor_school_period, school_partnership)
       mentee_school_period = FactoryBot.create(
         :ect_at_school_period,
-        :ongoing,
+        :unfinished,
         school: school_partnership.school
       )
 
       FactoryBot.create(
         :training_period,
         :for_ect,
-        :ongoing,
+        :unfinished,
         started_on: mentee_school_period.started_on,
         ect_at_school_period: mentee_school_period,
         school_partnership:
@@ -112,7 +112,7 @@ module APISeedData
 
       FactoryBot.create(
         :mentorship_period,
-        :ongoing,
+        :unfinished,
         mentee: mentee_school_period,
         mentor: mentor_school_period,
         started_on: mentor_school_period.started_on

--- a/app/services/api_seed_data/participant_scenarios.rb
+++ b/app/services/api_seed_data/participant_scenarios.rb
@@ -76,7 +76,7 @@ module APISeedData
 
             school_period = FactoryBot.create(
               :"#{type}_at_school_period",
-              :ongoing,
+              :unfinished,
               school:,
               started_on: start_date
             )
@@ -87,7 +87,7 @@ module APISeedData
               :training_period,
               :"for_#{type}",
               :provider_led,
-              :ongoing,
+              :unfinished,
               "#{type}_at_school_period" => school_period,
               school_partnership:,
               schedule:,
@@ -133,7 +133,7 @@ module APISeedData
 
             school_period = FactoryBot.create(
               :"#{type}_at_school_period",
-              :ongoing,
+              :unfinished,
               school:,
               started_on: start_date
             )
@@ -144,7 +144,7 @@ module APISeedData
               :training_period,
               :"for_#{type}",
               :provider_led,
-              :ongoing,
+              :unfinished,
               "#{type}_at_school_period" => school_period,
               school_partnership: nil,
               expression_of_interest: active_lead_provider,
@@ -180,7 +180,7 @@ module APISeedData
 
             school_period = FactoryBot.create(
               :ect_at_school_period,
-              :ongoing,
+              :unfinished,
               school:,
               started_on: start_date
             )
@@ -191,7 +191,7 @@ module APISeedData
               :training_period,
               :for_ect,
               :provider_led,
-              :ongoing,
+              :unfinished,
               ect_at_school_period: school_period,
               school_partnership:,
               schedule:,
@@ -233,7 +233,7 @@ module APISeedData
 
             school_period = FactoryBot.create(
               :ect_at_school_period,
-              :ongoing,
+              :unfinished,
               school:,
               started_on: start_date
             )
@@ -244,7 +244,7 @@ module APISeedData
               :training_period,
               :for_ect,
               :provider_led,
-              :ongoing,
+              :unfinished,
               ect_at_school_period: school_period,
               school_partnership:,
               schedule:,
@@ -304,7 +304,7 @@ module APISeedData
               school_partnership = school_partnership(active_lead_provider)
               school = school_partnership.school
               start_date = Date.new(contract_period_year, 9, 1)
-              school_period = FactoryBot.create(:"#{type}_at_school_period", :ongoing, school:, started_on: start_date)
+              school_period = FactoryBot.create(:"#{type}_at_school_period", :unfinished, school:, started_on: start_date)
               schedule = find_schedule(contract_period, type)
               teacher = school_period.teacher
 
@@ -312,7 +312,7 @@ module APISeedData
                 :training_period,
                 :"for_#{type}",
                 :provider_led,
-                :ongoing,
+                :unfinished,
                 "#{type}_at_school_period" => school_period,
                 school_partnership:,
                 schedule:,
@@ -392,7 +392,7 @@ module APISeedData
               start_date = Date.new(contract_period_year, 9, 1)
               finished_date = Time.zone.today + rand(1..6).months
 
-              school_period = FactoryBot.create(:"#{type}_at_school_period", :ongoing, school:, started_on: start_date, finished_on: finished_date)
+              school_period = FactoryBot.create(:"#{type}_at_school_period", :unfinished, school:, started_on: start_date, finished_on: finished_date)
 
               schedule = find_schedule(contract_period, type)
 
@@ -455,7 +455,7 @@ module APISeedData
 
               school_period = FactoryBot.create(
                 :"#{type}_at_school_period",
-                :ongoing,
+                :unfinished,
                 school:,
                 started_on: start_date
               )
@@ -467,7 +467,7 @@ module APISeedData
                 :"for_#{type}",
                 :provider_led,
                 :active,
-                :ongoing,
+                :unfinished,
                 "#{type}_at_school_period" => school_period,
                 school_partnership:,
                 schedule:,

--- a/app/services/api_seed_data/school_scenarios.rb
+++ b/app/services/api_seed_data/school_scenarios.rb
@@ -138,7 +138,7 @@ module APISeedData
           # Create school period starting in 2024, still ongoing
           school_period = FactoryBot.create(
             :ect_at_school_period,
-            :ongoing,
+            :unfinished,
             school:,
             started_on: Date.new(2024, 9, 1)
           )
@@ -171,7 +171,7 @@ module APISeedData
             :training_period,
             :for_ect,
             :provider_led,
-            :ongoing,
+            :unfinished,
             ect_at_school_period: school_period,
             school_partnership: school_partnership_2025,
             schedule: schedule_2025,
@@ -214,7 +214,7 @@ module APISeedData
           # Create school period
           school_period = FactoryBot.create(
             :ect_at_school_period,
-            :ongoing,
+            :unfinished,
             school:
           )
 
@@ -293,7 +293,7 @@ module APISeedData
           # Create school period starting in 2024
           school_period = FactoryBot.create(
             :ect_at_school_period,
-            :ongoing,
+            :unfinished,
             school:,
             started_on: Date.new(2024, 9, 1)
           )
@@ -490,12 +490,12 @@ module APISeedData
 
           # Create an ECT training with this lead provider
           ect_teacher = FactoryBot.create(:teacher)
-          ect_school_period = FactoryBot.create(:ect_at_school_period, :ongoing, teacher: ect_teacher, school:, started_on: start_date)
+          ect_school_period = FactoryBot.create(:ect_at_school_period, :unfinished, teacher: ect_teacher, school:, started_on: start_date)
           add_training_period(ect_school_period, programme_type: :provider_led, from: start_date, with: lead_provider)
 
           # Create a mentor training with this lead provider
           mentor_teacher = FactoryBot.create(:teacher)
-          mentor_school_period = FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: mentor_teacher, school:, started_on: start_date)
+          mentor_school_period = FactoryBot.create(:mentor_at_school_period, :unfinished, teacher: mentor_teacher, school:, started_on: start_date)
           add_training_period(mentor_school_period, programme_type: :provider_led, from: start_date, with: lead_provider)
 
           log_seed_info("Created school with ECT and mentor training with #{lead_provider.name}", colour: Colourize::COLOURS.keys.sample)

--- a/app/services/appropriate_bodies/ects.rb
+++ b/app/services/appropriate_bodies/ects.rb
@@ -21,7 +21,7 @@ module AppropriateBodies
     end
 
     def current
-      @scope.merge(InductionPeriod.ongoing)
+      @scope.merge(InductionPeriod.unfinished)
     end
 
     def former

--- a/app/services/declarations/mentor_completion.rb
+++ b/app/services/declarations/mentor_completion.rb
@@ -16,7 +16,7 @@ module Declarations
           finish_training_period! if training_period_ongoing_or_finishing_in_the_future?
         else
           mentor_not_completed_training!
-          create_training_period! unless latest_training_period.ongoing_today?
+          create_training_period! unless latest_training_period.contains_today?
         end
 
         record_completion_change_event!

--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -420,7 +420,7 @@ module Events
           urn: period.school.urn }
       end
 
-      time_period = if successor_period.ongoing?
+      time_period = if successor_period.unfinished?
                       "from #{successor_period.started_on}"
                     else
                       "between #{successor_period.started_on} and #{successor_period.finished_on}"

--- a/app/services/gias/schools/close.rb
+++ b/app/services/gias/schools/close.rb
@@ -27,7 +27,7 @@ module GIAS::Schools
     end
 
     def finish_ongoing_periods!
-      ect_at_school_periods.ongoing_on(closed_on).each do |ect_at_school_period|
+      ect_at_school_periods.contains_date(closed_on).each do |ect_at_school_period|
         ::ECTAtSchoolPeriods::Finish.new(
           ect_at_school_period:,
           finished_on: closed_on,
@@ -36,7 +36,7 @@ module GIAS::Schools
         ).finish!
       end
 
-      mentor_at_school_periods.ongoing_on(closed_on).each do |mentor_at_school_period|
+      mentor_at_school_periods.contains_date(closed_on).each do |mentor_at_school_period|
         ::MentorAtSchoolPeriods::Finish.new(
           teacher: mentor_at_school_period.teacher,
           reported_by_school_id:,

--- a/app/services/gias/schools/mentor_at_school_periods/merge.rb
+++ b/app/services/gias/schools/mentor_at_school_periods/merge.rb
@@ -94,7 +94,7 @@ module GIAS::Schools
       end
 
       def calculate_finished_on
-        return nil if periods.any?(&:ongoing?)
+        return nil if periods.any?(&:unfinished?)
 
         periods.map(&:finished_on).compact.max
       end

--- a/app/services/gias/schools/mentor_at_school_periods/overlapping.rb
+++ b/app/services/gias/schools/mentor_at_school_periods/overlapping.rb
@@ -47,7 +47,7 @@ module GIAS::Schools
       end
 
       def gap_between?(group, period)
-        return false if group.any?(&:ongoing?)
+        return false if group.any?(&:unfinished?)
 
         group.map(&:finished_on).max < period.started_on
       end

--- a/app/services/induction_periods/partial_transfer_induction_periods.rb
+++ b/app/services/induction_periods/partial_transfer_induction_periods.rb
@@ -55,7 +55,7 @@ module InductionPeriods
     # @return [InductionPeriod::ActiveRecord_Relation] inductions that span cut off date
     def target_inductions
       inductions_before_cut_off = InductionPeriod.for_appropriate_body_period(current_appropriate_body).started_before(cut_off_date)
-      inductions_before_cut_off.finished_on_or_after(cut_off_date).or(inductions_before_cut_off.ongoing)
+      inductions_before_cut_off.finished_on_or_after(cut_off_date).or(inductions_before_cut_off.unfinished)
     end
 
     # @param trns [Array<String>]

--- a/app/services/mentor_at_school_periods/finish.rb
+++ b/app/services/mentor_at_school_periods/finish.rb
@@ -41,7 +41,7 @@ private
   end
 
   def ongoing_mentor_at_school_periods
-    teacher.mentor_at_school_periods.ongoing_on(finished_on)
+    teacher.mentor_at_school_periods.contains_date(finished_on)
   end
 
   def ongoing_mentor_at_school_periods_at_reported_school
@@ -51,7 +51,7 @@ private
   def finish_mentorship_periods!(period)
     destroy_unstarted_mentorship_periods!(period)
 
-    period.mentorship_periods.ongoing_on(finished_on).each do |mentorship_period|
+    period.mentorship_periods.contains_date(finished_on).each do |mentorship_period|
       effective_date = [finished_on, mentorship_period.mentee.finished_on].compact.min
 
       MentorshipPeriods::Finish.new(mentorship_period:, finished_on: effective_date, author:).finish!
@@ -75,7 +75,7 @@ private
   def finish_training_periods!(period)
     destroy_unstarted_training_periods!(period)
 
-    period.training_periods.ongoing_on(finished_on).each do |training_period|
+    period.training_periods.contains_date(finished_on).each do |training_period|
       TrainingPeriods::Finish.mentor_training(training_period:, mentor_at_school_period: period, finished_on:, author:).finish!
     end
   end

--- a/app/services/migration_fixes/defer_training_period.rb
+++ b/app/services/migration_fixes/defer_training_period.rb
@@ -10,7 +10,7 @@ class MigrationFixes::DeferTrainingPeriod
   def defer!
     return if training_period.blank?
 
-    if training_period.ongoing?
+    if training_period.unfinished?
       training_period.assign_attributes(finished_on: deferred_at,
                                         deferred_at:,
                                         deferral_reason:)

--- a/app/services/migration_fixes/withdraw_training_period.rb
+++ b/app/services/migration_fixes/withdraw_training_period.rb
@@ -10,7 +10,7 @@ class MigrationFixes::WithdrawTrainingPeriod
   def withdraw!
     return if training_period.blank?
 
-    if training_period.ongoing?
+    if training_period.unfinished?
       training_period.update!(finished_on: withdrawn_at,
                               withdrawn_at:,
                               withdrawal_reason:)

--- a/app/services/schools/eligible_mentors.rb
+++ b/app/services/schools/eligible_mentors.rb
@@ -5,13 +5,13 @@ module Schools
     end
 
     def for_ect(ect)
-      @school.mentor_at_school_periods.ongoing.excluding(ect_as_mentor_at_school(ect))
+      @school.mentor_at_school_periods.unfinished.excluding(ect_as_mentor_at_school(ect))
     end
 
   private
 
     def ect_as_mentor_at_school(ect)
-      ect.mentor_at_school_periods.for_school(@school).ongoing
+      ect.mentor_at_school_periods.for_school(@school).unfinished
     end
   end
 end

--- a/app/services/schools/home.rb
+++ b/app/services/schools/home.rb
@@ -10,7 +10,7 @@ module Schools
       ECTAtSchoolPeriod
         .where(school:)
         .eager_load(:teacher, :school, mentors: :teacher)
-        .merge(MentorshipPeriod.ongoing)
+        .merge(MentorshipPeriod.unfinished)
     end
 
     def mentors_with_ects

--- a/app/services/schools/register_ect.rb
+++ b/app/services/schools/register_ect.rb
@@ -66,7 +66,7 @@ module Schools
   private
 
     def already_registered_as_an_ect?
-      teacher.ect_at_school_periods.where(school:).ongoing.exists?
+      teacher.ect_at_school_periods.where(school:).unfinished.exists?
     end
 
     def not_registered_as_an_ect!
@@ -132,7 +132,7 @@ module Schools
     end
 
     def ongoing_previous_period
-      previous_periods.ongoing.first
+      previous_periods.unfinished.first
     end
 
     def previous_period_with_future_end

--- a/app/services/schools/teacher_email.rb
+++ b/app/services/schools/teacher_email.rb
@@ -14,11 +14,11 @@ module Schools
     attr_reader :email, :trn
 
     def email_in_use_by_ongoing_mentor?
-      MentorAtSchoolPeriod.joins(:teacher).where(email:).where.not(teacher: { trn: }).ongoing.exists?
+      MentorAtSchoolPeriod.joins(:teacher).where(email:).where.not(teacher: { trn: }).unfinished.exists?
     end
 
     def email_in_use_by_ongoing_ect?
-      ECTAtSchoolPeriod.joins(:teacher).where(email:).where.not(teacher: { trn: }).ongoing.exists?
+      ECTAtSchoolPeriod.joins(:teacher).where(email:).where.not(teacher: { trn: }).unfinished.exists?
     end
   end
 end

--- a/app/services/teachers/induction_period.rb
+++ b/app/services/teachers/induction_period.rb
@@ -34,13 +34,13 @@ class Teachers::InductionPeriod
   #
   # @return [InductionPeriod, nil]
   def ongoing_induction_period
-    teacher.induction_periods.ongoing.first
+    teacher.induction_periods.unfinished.first
   end
 
   # @param date [Date]
   # @return [Boolean]
   def overlapping_with?(date)
-    teacher.induction_periods.ongoing_on(date).exists?
+    teacher.induction_periods.contains_date(date).exists?
   end
 
   delegate :first_induction_period, to: :teacher

--- a/app/services/teachers/role.rb
+++ b/app/services/teachers/role.rb
@@ -23,13 +23,13 @@ private
     mentor_periods = school ? teacher.mentor_at_school_periods.where(school:) : teacher.mentor_at_school_periods
     induction_periods = school ? ::InductionPeriod.none : teacher.induction_periods
 
-    if ect_periods.ongoing.any?
+    if ect_periods.unfinished.any?
       result << "ECT"
     elsif ect_periods.any?
       result << "ECT (Inactive)"
     end
 
-    if mentor_periods.ongoing.any?
+    if mentor_periods.unfinished.any?
       result << "Mentor"
     elsif mentor_periods.any?
       result << "Mentor (Inactive)"

--- a/app/services/teachers/set_ect_funding_eligibility.rb
+++ b/app/services/teachers/set_ect_funding_eligibility.rb
@@ -35,7 +35,7 @@ private
   end
 
   def eligible_for_ect_training?
-    teacher.induction_periods.ongoing_today.any? && teacher.ect_at_school_periods.any?
+    teacher.induction_periods.contains_today.any? && teacher.ect_at_school_periods.any?
   end
 
   def record_teacher_set_funding_eligibility_event!

--- a/app/services/training_periods/related_periods.rb
+++ b/app/services/training_periods/related_periods.rb
@@ -7,7 +7,7 @@ module TrainingPeriods
     end
 
     def current_active_period
-      related_periods.ongoing_today.first
+      related_periods.contains_today.first
     end
 
     def future_periods

--- a/app/views/admin/appropriate_bodies/index.html.erb
+++ b/app/views/admin/appropriate_bodies/index.html.erb
@@ -24,7 +24,7 @@
           card.with_summary_list do |summary_list|
             summary_list.with_row do |row|
               row.with_key(text: "Ongoing inductions")
-              row.with_value(text: appropriate_body.induction_periods.ongoing.count)
+              row.with_value(text: appropriate_body.induction_periods.unfinished.count)
             end
           end
         end

--- a/app/wizards/schools/register_ect_wizard/registration_store/queries.rb
+++ b/app/wizards/schools/register_ect_wizard/registration_store/queries.rb
@@ -11,7 +11,7 @@ module Schools
         end
 
         def active_record_at_school(urn)
-          @active_record_at_school ||= ECTAtSchoolPeriods::Search.new.ect_periods(trn: registration_store.trn, urn:).ongoing.last
+          @active_record_at_school ||= ECTAtSchoolPeriods::Search.new.ect_periods(trn: registration_store.trn, urn:).unfinished.last
         end
 
         def appropriate_body

--- a/app/wizards/schools/register_ect_wizard/start_date_step.rb
+++ b/app/wizards/schools/register_ect_wizard/start_date_step.rb
@@ -26,7 +26,7 @@ module Schools
     private
 
       def currently_ect_at_another_school?
-        ect.previously_registered? && previous_period.ongoing?
+        ect.previously_registered? && previous_period.unfinished?
       end
 
       def previous_period

--- a/app/wizards/schools/register_mentor_wizard/registration_store/queries.rb
+++ b/app/wizards/schools/register_mentor_wizard/registration_store/queries.rb
@@ -10,7 +10,7 @@ module Schools
           @active_record_at_school ||= MentorAtSchoolPeriods::Search
             .new
             .mentor_periods(trn: registration_store.trn, urn: registration_store.school_urn)
-            .ongoing
+            .unfinished
             .last
         end
 
@@ -51,7 +51,7 @@ module Schools
         def previous_school_mentor_at_school_periods
           finished_on_or_after_date = registration_store.started_on.presence || Date.current
           finishes_in_the_future_scope = ::MentorAtSchoolPeriod.finished_on_or_after(finished_on_or_after_date)
-          scope = ::MentorAtSchoolPeriod.ongoing.or(finishes_in_the_future_scope)
+          scope = ::MentorAtSchoolPeriod.unfinished.or(finishes_in_the_future_scope)
           mentor_at_school_periods.where.not(school:).merge(scope)
         end
 

--- a/app/wizards/schools/register_mentor_wizard/registration_store/status.rb
+++ b/app/wizards/schools/register_mentor_wizard/registration_store/status.rb
@@ -58,7 +58,7 @@ module Schools
         def mentorship_status
           mentor_at_school_periods = queries.mentor_at_school_periods
 
-          if mentor_at_school_periods.ongoing_today.exists?
+          if mentor_at_school_periods.contains_today.exists?
             :currently_a_mentor
           elsif mentor_at_school_periods.exists?
             :previously_a_mentor

--- a/db/scripts/close_teacher_periods.rb
+++ b/db/scripts/close_teacher_periods.rb
@@ -8,7 +8,7 @@ def close_teacher_periods(trns:, author_email:, finished_on: Date.current)
       teacher = Teacher.find_by!(trn:)
 
       # ect_at_school_periods + associated periods
-      teacher.ect_at_school_periods.ongoing.each do |period|
+      teacher.ect_at_school_periods.unfinished.each do |period|
         ECTAtSchoolPeriods::Finish.new(ect_at_school_period: period, finished_on:, author:).finish!
       end
 

--- a/db/seeds/support/builders/ect_at_school_period_builder.rb
+++ b/db/seeds/support/builders/ect_at_school_period_builder.rb
@@ -41,7 +41,7 @@ module TeacherHistories
           )
         end
 
-        if !ect_at_school_period.ongoing? && ect_at_school_period.finished_on == training_period.finished_on
+        if !ect_at_school_period.unfinished? && ect_at_school_period.finished_on == training_period.finished_on
           Events::Record.record_teacher_left_school_as_ect!(
             author:,
             school: ect_at_school_period.school,

--- a/db/seeds/support/mentorship_period_helpers.rb
+++ b/db/seeds/support/mentorship_period_helpers.rb
@@ -15,7 +15,7 @@ module MentorshipPeriodHelpers
 
     mentee_school_period = FactoryBot.create(
       :ect_at_school_period,
-      :ongoing,
+      :unfinished,
       teacher: mentee,
       school:,
       started_on: school_started_on
@@ -24,7 +24,7 @@ module MentorshipPeriodHelpers
     FactoryBot.create(
       :training_period,
       :for_ect,
-      :ongoing,
+      :unfinished,
       started_on: training_started_on,
       ect_at_school_period: mentee_school_period,
       school_partnership: mentee_school_partnership
@@ -32,7 +32,7 @@ module MentorshipPeriodHelpers
 
     mentor_school_period = FactoryBot.create(
       :mentor_at_school_period,
-      :ongoing,
+      :unfinished,
       teacher: mentor,
       school:,
       started_on: school_started_on
@@ -42,7 +42,7 @@ module MentorshipPeriodHelpers
       FactoryBot.create(
         :training_period,
         :for_mentor,
-        :ongoing,
+        :unfinished,
         started_on: training_started_on,
         mentor_at_school_period: mentor_school_period,
         school_partnership: mentor_school_partnership
@@ -51,7 +51,7 @@ module MentorshipPeriodHelpers
 
     mentorship_period = FactoryBot.create(
       :mentorship_period,
-      :ongoing,
+      :unfinished,
       mentee: mentee_school_period,
       mentor: mentor_school_period
     )

--- a/spec/components/admin/appropriate_bodies/details_component_spec.rb
+++ b/spec/components/admin/appropriate_bodies/details_component_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Admin::AppropriateBodies::DetailsComponent, type: :component do
   describe "ECTs" do
     context "with current ECTs" do
       before do
-        FactoryBot.create(:induction_period, :ongoing, appropriate_body_period:)
+        FactoryBot.create(:induction_period, :unfinished, appropriate_body_period:)
         render_inline(component)
       end
 

--- a/spec/components/admin/schools/partnerships_summary_component_spec.rb
+++ b/spec/components/admin/schools/partnerships_summary_component_spec.rb
@@ -88,8 +88,8 @@ RSpec.describe Admin::Schools::PartnershipsSummaryComponent, type: :component do
                         delivery_partner: FactoryBot.create(:delivery_partner, name: "Gamma Partner"))
     end
 
-    let!(:ect_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school:) }
-    let!(:mentor_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:) }
+    let!(:ect_period) { FactoryBot.create(:ect_at_school_period, :unfinished, school:) }
+    let!(:mentor_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, school:) }
     let!(:finished_ect_period) { FactoryBot.create(:ect_at_school_period, school:, started_on: 2.years.ago, finished_on: 1.year.ago) }
     let!(:finished_mentor_period) { FactoryBot.create(:mentor_at_school_period, school:, started_on: 2.years.ago, finished_on: 1.year.ago) }
     let!(:future_ect_period) { FactoryBot.create(:ect_at_school_period, school:, started_on: 1.month.from_now, finished_on: nil) }
@@ -98,7 +98,7 @@ RSpec.describe Admin::Schools::PartnershipsSummaryComponent, type: :component do
     let!(:ect_training_period) do
       FactoryBot.create(:training_period,
                         :for_ect,
-                        :ongoing,
+                        :unfinished,
                         ect_at_school_period: ect_period,
                         school_partnership: partnership_with_teachers)
     end
@@ -106,7 +106,7 @@ RSpec.describe Admin::Schools::PartnershipsSummaryComponent, type: :component do
     let!(:mentor_training_period) do
       FactoryBot.create(:training_period,
                         :for_mentor,
-                        :ongoing,
+                        :unfinished,
                         mentor_at_school_period: mentor_period,
                         school_partnership: partnership_with_teachers)
     end
@@ -162,11 +162,11 @@ RSpec.describe Admin::Schools::PartnershipsSummaryComponent, type: :component do
         z_teacher = FactoryBot.create(:teacher, corrected_name: "Z Teacher")
         a_teacher = FactoryBot.create(:teacher, corrected_name: "A Teacher")
 
-        z_period = FactoryBot.create(:mentor_at_school_period, :ongoing, school:, teacher: z_teacher)
-        a_period = FactoryBot.create(:mentor_at_school_period, :ongoing, school:, teacher: a_teacher)
+        z_period = FactoryBot.create(:mentor_at_school_period, :unfinished, school:, teacher: z_teacher)
+        a_period = FactoryBot.create(:mentor_at_school_period, :unfinished, school:, teacher: a_teacher)
 
-        FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period: z_period, school_partnership: partnership_with_teachers)
-        FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period: a_period, school_partnership: partnership_with_teachers)
+        FactoryBot.create(:training_period, :for_mentor, :unfinished, mentor_at_school_period: z_period, school_partnership: partnership_with_teachers)
+        FactoryBot.create(:training_period, :for_mentor, :unfinished, mentor_at_school_period: a_period, school_partnership: partnership_with_teachers)
 
         body = mentor_row.to_html
         a_index = body.index("A Teacher")

--- a/spec/components/admin/schools/teachers_table_component_spec.rb
+++ b/spec/components/admin/schools/teachers_table_component_spec.rb
@@ -15,27 +15,27 @@ RSpec.describe Admin::Schools::TeachersTableComponent, type: :component do
 
   context "when there are teachers" do
     let!(:ect) do
-      ect_at_school_period = FactoryBot.create(:ect_at_school_period, :ongoing, school:, started_on: Date.new(2022, 7, 1))
+      ect_at_school_period = FactoryBot.create(:ect_at_school_period, :unfinished, school:, started_on: Date.new(2022, 7, 1))
       school_partnership = FactoryBot.create(:school_partnership, :for_year, school:, year: 2022)
-      FactoryBot.create(:training_period, :ongoing, ect_at_school_period:, school_partnership:)
+      FactoryBot.create(:training_period, :unfinished, ect_at_school_period:, school_partnership:)
       ect_at_school_period.teacher
     end
 
     let!(:mentor) do
-      mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :ongoing, school:, started_on: Date.new(2023, 7, 1))
+      mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :unfinished, school:, started_on: Date.new(2023, 7, 1))
       school_partnership = FactoryBot.create(:school_partnership, :for_year, school:, year: 2023)
-      FactoryBot.create(:training_period, :provider_led, :for_mentor, :with_schedule, :ongoing, mentor_at_school_period:, school_partnership:)
+      FactoryBot.create(:training_period, :provider_led, :for_mentor, :with_schedule, :unfinished, mentor_at_school_period:, school_partnership:)
       mentor_at_school_period.teacher
     end
 
     let!(:ect_and_mentor) do
-      ect_at_school_period = FactoryBot.create(:ect_at_school_period, :ongoing, school:, started_on: Date.new(2024, 7, 1))
+      ect_at_school_period = FactoryBot.create(:ect_at_school_period, :unfinished, school:, started_on: Date.new(2024, 7, 1))
       school_partnership = FactoryBot.create(:school_partnership, :for_year, school:, year: 2024)
-      FactoryBot.create(:training_period, :ongoing, ect_at_school_period:, school_partnership:)
+      FactoryBot.create(:training_period, :unfinished, ect_at_school_period:, school_partnership:)
 
-      mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :ongoing, school:, teacher: ect_at_school_period.teacher, started_on: Date.new(2025, 7, 1))
+      mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :unfinished, school:, teacher: ect_at_school_period.teacher, started_on: Date.new(2025, 7, 1))
       school_partnership = FactoryBot.create(:school_partnership, :for_year, school:, year: 2025)
-      FactoryBot.create(:training_period, :provider_led, :for_mentor, :with_schedule, :ongoing, mentor_at_school_period:, school_partnership:)
+      FactoryBot.create(:training_period, :provider_led, :for_mentor, :with_schedule, :unfinished, mentor_at_school_period:, school_partnership:)
 
       ect_at_school_period.teacher
     end
@@ -52,7 +52,7 @@ RSpec.describe Admin::Schools::TeachersTableComponent, type: :component do
     end
 
     let!(:mentor_without_training_period) do
-      FactoryBot.create(:mentor_at_school_period, :ongoing, school:, started_on: Date.new(2025, 7, 1)).teacher
+      FactoryBot.create(:mentor_at_school_period, :unfinished, school:, started_on: Date.new(2025, 7, 1)).teacher
     end
 
     let!(:ect_at_different_school) do

--- a/spec/components/admin/statements/declaration_component_spec.rb
+++ b/spec/components/admin/statements/declaration_component_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe Admin::Statements::DeclarationComponent, type: :component do
   let(:statement_trait) { :output_fee }
   let(:statement) { FactoryBot.create(:statement, :payable, statement_trait, active_lead_provider:, contract:) }
 
-  let(:ect_training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, :with_active_lead_provider, active_lead_provider:, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)) }
+  let(:ect_training_period) { FactoryBot.create(:training_period, :for_ect, :unfinished, :with_active_lead_provider, active_lead_provider:, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished)) }
   let!(:ect_declaration) { FactoryBot.create(:declaration, :voided, training_period: ect_training_period, payment_statement: statement) }
-  let(:mentor_training_period) { FactoryBot.create(:training_period, :for_mentor, :ongoing, :with_active_lead_provider, active_lead_provider:, mentor_at_school_period: FactoryBot.create(:mentor_at_school_period, :ongoing)) }
+  let(:mentor_training_period) { FactoryBot.create(:training_period, :for_mentor, :unfinished, :with_active_lead_provider, active_lead_provider:, mentor_at_school_period: FactoryBot.create(:mentor_at_school_period, :unfinished)) }
   let!(:mentor_declaration) { FactoryBot.create(:declaration, :voided, training_period: mentor_training_period, payment_statement: statement) }
 
   let(:started_flatrate) do

--- a/spec/components/admin/teachers/overview_summary_component_spec.rb
+++ b/spec/components/admin/teachers/overview_summary_component_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Admin::Teachers::OverviewSummaryComponent, type: :component do
     let(:teacher) { FactoryBot.create(:teacher, corrected_name: "New Name", api_id: SecureRandom.uuid, trs_induction_status: "InProgress") }
 
     before do
-      FactoryBot.create(:induction_period, :ongoing, teacher:)
-      FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:, email: "teacher@example.com")
+      FactoryBot.create(:induction_period, :unfinished, teacher:)
+      FactoryBot.create(:ect_at_school_period, :unfinished, teacher:, school:, email: "teacher@example.com")
     end
 
     it "renders the core summary rows" do
@@ -44,7 +44,7 @@ RSpec.describe Admin::Teachers::OverviewSummaryComponent, type: :component do
     let(:teacher) { FactoryBot.create(:teacher, api_id: SecureRandom.uuid, trs_induction_status: nil) }
 
     before do
-      FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:, school:, email: "mentor@example.com")
+      FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:, school:, email: "mentor@example.com")
     end
 
     it "does not render the induction status row" do

--- a/spec/components/admin/teachers/school_summary_component_spec.rb
+++ b/spec/components/admin/teachers/school_summary_component_spec.rb
@@ -87,8 +87,8 @@ RSpec.describe Admin::Teachers::SchoolSummaryComponent, type: :component do
     end
 
     context "Mentor row" do
-      let(:older_mentor_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, started_on: school_period.started_on) }
-      let(:newer_mentor_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, started_on: school_period.started_on + 1.month) }
+      let(:older_mentor_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, school:, started_on: school_period.started_on) }
+      let(:newer_mentor_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, school:, started_on: school_period.started_on + 1.month) }
 
       it "appears as the last row" do
         expect(rendered).to have_css(".govuk-summary-list__row:last-child dt", text: "Mentor")

--- a/spec/components/admin/teachers/training_summary_component_spec.rb
+++ b/spec/components/admin/teachers/training_summary_component_spec.rb
@@ -297,8 +297,8 @@ RSpec.describe Admin::Teachers::TrainingSummaryComponent, type: :component do
         FactoryBot.create(
           :training_period,
           :provider_led,
-          :ongoing,
-          ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)
+          :unfinished,
+          ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished)
         )
       end
 
@@ -318,8 +318,8 @@ RSpec.describe Admin::Teachers::TrainingSummaryComponent, type: :component do
           :training_period,
           :for_mentor,
           :provider_led,
-          :ongoing,
-          mentor_at_school_period: FactoryBot.create(:mentor_at_school_period, :ongoing)
+          :unfinished,
+          mentor_at_school_period: FactoryBot.create(:mentor_at_school_period, :unfinished)
         )
       end
 

--- a/spec/components/appropriate_bodies/claim_ect_eligibility_component_spec.rb
+++ b/spec/components/appropriate_bodies/claim_ect_eligibility_component_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe AppropriateBodies::ClaimECTEligibilityComponent, type: :component
 
     context "and the teacher is claimed by another appropriate body" do
       before do
-        FactoryBot.create(:induction_period, :ongoing, teacher:)
+        FactoryBot.create(:induction_period, :unfinished, teacher:)
         render_inline(component)
       end
 

--- a/spec/components/schools/ect_induction_details_component_spec.rb
+++ b/spec/components/schools/ect_induction_details_component_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Schools::ECTInductionDetailsComponent, type: :component do
 
   context "when induction start date is available" do
     let!(:induction_period) do
-      FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:, started_on: Date.new(2023, 9, 1))
+      FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:, started_on: Date.new(2023, 9, 1))
     end
 
     before do
@@ -86,7 +86,7 @@ RSpec.describe Schools::ECTInductionDetailsComponent, type: :component do
 
     context "when the teacher has an ongoing induction period" do
       before do
-        FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:)
+        FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:)
         teacher.reload
         render_inline(described_class.new(ect))
       end
@@ -120,7 +120,7 @@ RSpec.describe Schools::ECTInductionDetailsComponent, type: :component do
 
     context "when the school reported appropriate body has claimed the induction" do
       let!(:induction_period) do
-        FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:, started_on: Date.new(2023, 9, 1))
+        FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:, started_on: Date.new(2023, 9, 1))
       end
 
       before do
@@ -138,7 +138,7 @@ RSpec.describe Schools::ECTInductionDetailsComponent, type: :component do
     context "when an appropriate body other than the one the school reported has claimed the induction" do
       let(:other_appropriate_body_period) { FactoryBot.create(:appropriate_body_period, name: "Beta Teaching School Hub") }
       let!(:induction_period) do
-        FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period: other_appropriate_body_period, started_on: Date.new(2023, 9, 1))
+        FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period: other_appropriate_body_period, started_on: Date.new(2023, 9, 1))
       end
 
       before do
@@ -157,7 +157,7 @@ RSpec.describe Schools::ECTInductionDetailsComponent, type: :component do
     context "when an ongoing induction period predates this school placement (claimed before registration, or carried over from a previous school)" do
       let(:other_appropriate_body_period) { FactoryBot.create(:appropriate_body_period, name: "Beta Teaching School Hub") }
       let!(:induction_period) do
-        FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period: other_appropriate_body_period, started_on: Date.new(2022, 9, 1))
+        FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period: other_appropriate_body_period, started_on: Date.new(2022, 9, 1))
       end
 
       before do

--- a/spec/components/schools/ects/listing_card_component_spec.rb
+++ b/spec/components/schools/ects/listing_card_component_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
 
   context "when the ECT has a mentor assigned" do
     before do
-      FactoryBot.create(:mentorship_period, :ongoing, started_on: ect_at_school_period.started_on, mentee: ect_at_school_period, mentor:)
+      FactoryBot.create(:mentorship_period, :unfinished, started_on: ect_at_school_period.started_on, mentee: ect_at_school_period, mentor:)
       render_inline(described_class.new(teacher:, ect_at_school_period:, training_period:))
     end
 
@@ -91,7 +91,7 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
     let!(:induction_period) do
       FactoryBot.create(
         :induction_period,
-        :ongoing,
+        :unfinished,
         teacher: ect_at_school_period.teacher,
         started_on: ect_at_school_period.started_on
       )
@@ -108,7 +108,7 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
   end
 
   context "when provider led chosen" do
-    let!(:training_period) { FactoryBot.create(:training_period, :ongoing, :provider_led, ect_at_school_period:, started_on:) }
+    let!(:training_period) { FactoryBot.create(:training_period, :unfinished, :provider_led, ect_at_school_period:, started_on:) }
 
     it "renders their latest providers" do
       render_inline(described_class.new(teacher:, ect_at_school_period:, training_period:))
@@ -122,7 +122,7 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
   end
 
   context "when school led chosen" do
-    let(:training_period) { FactoryBot.create(:training_period, :ongoing, :school_led, ect_at_school_period:, started_on:) }
+    let(:training_period) { FactoryBot.create(:training_period, :unfinished, :school_led, ect_at_school_period:, started_on:) }
 
     it "doesn't render providers" do
       render_inline(described_class.new(teacher:, ect_at_school_period:, training_period:))
@@ -134,11 +134,11 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
 
   context "when school-led training period has withdrawn/deferred timestamps (bad data)" do
     let(:training_period) do
-      FactoryBot.create(:training_period, :ongoing, :school_led, ect_at_school_period:, started_on:)
+      FactoryBot.create(:training_period, :unfinished, :school_led, ect_at_school_period:, started_on:)
     end
 
     before do
-      FactoryBot.create(:mentorship_period, :ongoing, started_on: ect_at_school_period.started_on, mentee: ect_at_school_period, mentor:)
+      FactoryBot.create(:mentorship_period, :unfinished, started_on: ect_at_school_period.started_on, mentee: ect_at_school_period, mentor:)
 
       training_period.update!(
         withdrawn_at: Time.zone.today,
@@ -169,7 +169,7 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
     let(:training_period) do
       FactoryBot.create(
         :training_period,
-        :ongoing,
+        :unfinished,
         :provider_led,
         :with_only_expression_of_interest,
         ect_at_school_period:,
@@ -193,7 +193,7 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
   end
 
   context "when training is withdrawn" do
-    let!(:training_period) { FactoryBot.create(:training_period, :ongoing, :provider_led, ect_at_school_period:, started_on:) }
+    let!(:training_period) { FactoryBot.create(:training_period, :unfinished, :provider_led, ect_at_school_period:, started_on:) }
 
     before do
       training_period.update!(
@@ -227,7 +227,7 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
   end
 
   context "when training is withdrawn and the ECT is leaving" do
-    let!(:training_period) { FactoryBot.create(:training_period, :ongoing, :provider_led, ect_at_school_period:, started_on:) }
+    let!(:training_period) { FactoryBot.create(:training_period, :unfinished, :provider_led, ect_at_school_period:, started_on:) }
 
     before do
       training_period.update!(
@@ -264,7 +264,7 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
   end
 
   context "when training is withdrawn and the ECT has no mentor assigned" do
-    let!(:training_period) { FactoryBot.create(:training_period, :ongoing, :provider_led, ect_at_school_period:, started_on:) }
+    let!(:training_period) { FactoryBot.create(:training_period, :unfinished, :provider_led, ect_at_school_period:, started_on:) }
 
     before do
       training_period.update!(
@@ -286,10 +286,10 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
   end
 
   context "when training is withdrawn and the ECT has a mentor assigned" do
-    let!(:training_period) { FactoryBot.create(:training_period, :ongoing, :provider_led, ect_at_school_period:, started_on:) }
+    let!(:training_period) { FactoryBot.create(:training_period, :unfinished, :provider_led, ect_at_school_period:, started_on:) }
 
     before do
-      FactoryBot.create(:mentorship_period, :ongoing, started_on: ect_at_school_period.started_on, mentee: ect_at_school_period, mentor:)
+      FactoryBot.create(:mentorship_period, :unfinished, started_on: ect_at_school_period.started_on, mentee: ect_at_school_period, mentor:)
       training_period.update!(withdrawn_at: Time.zone.today, withdrawal_reason: valid_withdrawal_reason, finished_on: Time.zone.today)
       render_inline(described_class.new(teacher:, ect_at_school_period:, training_period:, current_school: school))
     end
@@ -302,7 +302,7 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
   end
 
   context "when training is deferred and the ECT has no mentor assigned" do
-    let!(:training_period) { FactoryBot.create(:training_period, :ongoing, :provider_led, ect_at_school_period:, started_on:) }
+    let!(:training_period) { FactoryBot.create(:training_period, :unfinished, :provider_led, ect_at_school_period:, started_on:) }
 
     before do
       training_period.update!(
@@ -324,7 +324,7 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
   end
 
   context "when training is deferred" do
-    let!(:training_period) { FactoryBot.create(:training_period, :ongoing, :provider_led, ect_at_school_period:, started_on:) }
+    let!(:training_period) { FactoryBot.create(:training_period, :unfinished, :provider_led, ect_at_school_period:, started_on:) }
 
     before do
       training_period.update!(
@@ -350,7 +350,7 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
   end
 
   context "when training is deferred and the ECT is reported as leaving by the current school" do
-    let!(:training_period) { FactoryBot.create(:training_period, :ongoing, :provider_led, ect_at_school_period:, started_on:) }
+    let!(:training_period) { FactoryBot.create(:training_period, :unfinished, :provider_led, ect_at_school_period:, started_on:) }
 
     before do
       training_period.update!(

--- a/spec/components/schools/mentors/summary_component_spec.rb
+++ b/spec/components/schools/mentors/summary_component_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe Schools::Mentors::SummaryComponent, type: :component do
     context "when there are multiple mentors at the same school" do
       let(:second_mentor) { FactoryBot.create(:teacher, trs_first_name: "Sasuke", trs_last_name: "Uchiha") }
       let!(:second_mentor_at_school_period) do
-        FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: second_mentor, school:, started_on:)
+        FactoryBot.create(:mentor_at_school_period, :unfinished, teacher: second_mentor, school:, started_on:)
       end
 
       let(:ect1) { FactoryBot.create(:ect_at_school_period, teacher: ect1_teacher, school:, started_on:, finished_on: nil) }
@@ -183,7 +183,7 @@ RSpec.describe Schools::Mentors::SummaryComponent, type: :component do
 
       context "and there is also a current training period" do
         before do
-          FactoryBot.create(:training_period, :ongoing, :provider_led, :for_mentor, mentor_at_school_period:)
+          FactoryBot.create(:training_period, :unfinished, :provider_led, :for_mentor, mentor_at_school_period:)
         end
 
         include_examples "does not show training details"

--- a/spec/components/schools/summary_card_component_spec.rb
+++ b/spec/components/schools/summary_card_component_spec.rb
@@ -7,20 +7,20 @@ RSpec.describe Schools::SummaryCardComponent, type: :component do
   let(:school_partnership) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:) }
 
   let(:school_led_ect_at_school_period) do
-    FactoryBot.create(:ect_at_school_period, :ongoing, school_reported_appropriate_body:)
+    FactoryBot.create(:ect_at_school_period, :unfinished, school_reported_appropriate_body:)
   end
 
-  let(:school_led_training_period) { FactoryBot.create(:training_period, :school_led, :ongoing, ect_at_school_period: school_led_ect_at_school_period) }
+  let(:school_led_training_period) { FactoryBot.create(:training_period, :school_led, :unfinished, ect_at_school_period: school_led_ect_at_school_period) }
 
   let(:provider_led_ect_at_school_period) do
     FactoryBot.create(:ect_at_school_period,
-                      :ongoing,
+                      :unfinished,
                       school_reported_appropriate_body:,
                       started_on: "2021-01-01")
   end
 
   let(:provider_led_training_period) do
-    FactoryBot.create(:training_period, :provider_led, :ongoing, school_partnership:, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing))
+    FactoryBot.create(:training_period, :provider_led, :unfinished, school_partnership:, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished))
   end
 
   context "when data is reported by the school" do
@@ -86,8 +86,8 @@ RSpec.describe Schools::SummaryCardComponent, type: :component do
   end
 
   context "when data is reported by the appropriate body" do
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school_reported_appropriate_body:) }
-    let(:training_period) { FactoryBot.create(:training_period, :ongoing, :school_led, ect_at_school_period:) }
+    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, school_reported_appropriate_body:) }
+    let(:training_period) { FactoryBot.create(:training_period, :unfinished, :school_led, ect_at_school_period:) }
 
     before do
       FactoryBot.create(:induction_period, teacher: ect_at_school_period.teacher, started_on: "2023-01-01")
@@ -143,7 +143,7 @@ RSpec.describe Schools::SummaryCardComponent, type: :component do
 
   context "when no training periods exist for a provider-led ECT" do
     let(:provider_led_ect_at_school_period_without_training_periods) do
-      FactoryBot.create(:ect_at_school_period, :ongoing, school_reported_appropriate_body:)
+      FactoryBot.create(:ect_at_school_period, :unfinished, school_reported_appropriate_body:)
     end
 
     before do

--- a/spec/components/schools/teacher_profile_summary_list_component_spec.rb
+++ b/spec/components/schools/teacher_profile_summary_list_component_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe Schools::TeacherProfileSummaryListComponent, type: :component do
   let(:school) { FactoryBot.create(:school) }
   let(:mentee_teacher) { FactoryBot.create(:teacher, trn: "9876543", trs_first_name: "Kakarot", trs_last_name: "SSJ") }
   let(:mentor_teacher) { FactoryBot.create(:teacher, trn: "987654", trs_first_name: "Naruto", trs_last_name: "Ninetails") }
-  let(:previous_mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, started_on: 3.years.ago) }
-  let(:current_mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, teacher: mentor_teacher, started_on: 3.years.ago) }
+  let(:previous_mentor) { FactoryBot.create(:mentor_at_school_period, :unfinished, school:, started_on: 3.years.ago) }
+  let(:current_mentor) { FactoryBot.create(:mentor_at_school_period, :unfinished, school:, teacher: mentor_teacher, started_on: 3.years.ago) }
   let(:current_mentor_name) { Teachers::Name.new(current_mentor.teacher).full_name }
   let(:mentee) do
-    FactoryBot.create(:ect_at_school_period, :ongoing, school:, teacher: mentee_teacher, started_on: Date.new(2021, 9, 1),
-                                                       email: "foobarect@madeup.com", working_pattern: "full_time")
+    FactoryBot.create(:ect_at_school_period, :unfinished, school:, teacher: mentee_teacher, started_on: Date.new(2021, 9, 1),
+                                                          email: "foobarect@madeup.com", working_pattern: "full_time")
   end
   let(:training_period) { mentee.current_or_next_or_latest_training_period }
   let(:component) { described_class.new(mentee, training_period:, current_school: school) }
@@ -20,8 +20,8 @@ RSpec.describe Schools::TeacherProfileSummaryListComponent, type: :component do
     let(:mentor_row) { page.find(".govuk-summary-list__row", text: "Mentor") }
 
     before do
-      FactoryBot.create(:mentorship_period, :ongoing, mentee:, mentor: previous_mentor, started_on: 3.years.ago, finished_on: 2.years.ago - 1.day)
-      FactoryBot.create(:mentorship_period, :ongoing, mentee:, mentor: current_mentor, started_on: 2.years.ago)
+      FactoryBot.create(:mentorship_period, :unfinished, mentee:, mentor: previous_mentor, started_on: 3.years.ago, finished_on: 2.years.ago - 1.day)
+      FactoryBot.create(:mentorship_period, :unfinished, mentee:, mentor: current_mentor, started_on: 2.years.ago)
 
       render_inline(component)
     end

--- a/spec/components/tasks_index/detailed_review_section_component_spec.rb
+++ b/spec/components/tasks_index/detailed_review_section_component_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe TasksIndex::DetailedReviewSectionComponent, type: :component do
     let(:teacher) { FactoryBot.create(:teacher) }
     let(:school) { FactoryBot.create(:school) }
     let(:another_school) { FactoryBot.create(:school) }
-    let(:appropriate_body_induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:) }
+    let(:appropriate_body_induction_period) { FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:) }
     let(:finished_etc_period_with_appropriate_body) do
       FactoryBot.create(
         :ect_at_school_period, teacher:, school:,

--- a/spec/components/tasks_index/table_section_component_spec.rb
+++ b/spec/components/tasks_index/table_section_component_spec.rb
@@ -37,10 +37,10 @@ RSpec.describe TasksIndex::TableSectionComponent, type: :component do
                       trs_initial_teacher_training_provider_name: "ITT")
   end
 
-  let(:postman_pat_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: postman_pat, school:) }
-  let(:bob_builder_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: bob_builder, school:) }
+  let(:postman_pat_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher: postman_pat, school:) }
+  let(:bob_builder_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher: bob_builder, school:) }
 
-  let(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher: postman_pat, appropriate_body_period:) }
+  let(:induction_period) { FactoryBot.create(:induction_period, :unfinished, teacher: postman_pat, appropriate_body_period:) }
 
   before { postman_pat_at_school_period && bob_builder_at_school_period && induction_period }
 
@@ -132,8 +132,8 @@ RSpec.describe TasksIndex::TableSectionComponent, type: :component do
       context "when the teacher has started at another school" do
         let(:new_school) { FactoryBot.create(:school, :with_induction_tutor) }
         let(:new_school_ect_at_school_period) do
-          FactoryBot.create(:ect_at_school_period, :ongoing, teacher: postman_pat,
-                                                             school: new_school, started_on: 1.week.from_now)
+          FactoryBot.create(:ect_at_school_period, :unfinished, teacher: postman_pat,
+                                                                school: new_school, started_on: 1.week.from_now)
         end
 
         before { new_school_ect_at_school_period }

--- a/spec/components/teachers/details/current_induction_period_component_spec.rb
+++ b/spec/components/teachers/details/current_induction_period_component_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Teachers::Details::CurrentInductionPeriodComponent, type: :compon
   context "when teacher has a current induction period" do
     let(:appropriate_body_period) { FactoryBot.create(:appropriate_body_period, name: "Test AB") }
     let!(:current_period) do
-      FactoryBot.create(:induction_period, :ongoing,
+      FactoryBot.create(:induction_period, :unfinished,
                         teacher:,
                         appropriate_body_period:,
                         started_on: "2025-06-30",
@@ -94,7 +94,7 @@ RSpec.describe Teachers::Details::CurrentInductionPeriodComponent, type: :compon
 
         context "when the induction period has an outcome" do
           let!(:current_period) do
-            FactoryBot.create(:induction_period, :ongoing,
+            FactoryBot.create(:induction_period, :unfinished,
                               teacher:,
                               appropriate_body_period:,
                               started_on: 6.months.ago,

--- a/spec/components/teachers/details/induction_outcome_actions_component_spec.rb
+++ b/spec/components/teachers/details/induction_outcome_actions_component_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Teachers::Details::InductionOutcomeActionsComponent, type: :compo
 
   context "with ongoing induction period" do
     before do
-      FactoryBot.create(:induction_period, :ongoing, teacher:)
+      FactoryBot.create(:induction_period, :unfinished, teacher:)
       render_inline(component)
     end
 

--- a/spec/components/teachers/record_outcome_component_spec.rb
+++ b/spec/components/teachers/record_outcome_component_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Teachers::RecordOutcomeComponent, type: :component do
   end
 
   before do
-    FactoryBot.create(:induction_period, :ongoing,
+    FactoryBot.create(:induction_period, :unfinished,
                       appropriate_body_period:,
                       teacher:)
   end

--- a/spec/components/teachers_index/table_section_component_spec.rb
+++ b/spec/components/teachers_index/table_section_component_spec.rb
@@ -25,13 +25,13 @@ RSpec.describe TeachersIndex::TableSectionComponent, type: :component do
 
     let!(:teacher_1) do
       teacher = FactoryBot.create(:teacher, trs_first_name: "Alice", trs_last_name: "Smith", trn: "1234567")
-      FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:, started_on: Date.new(2024, 3, 15))
+      FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:, started_on: Date.new(2024, 3, 15))
       teacher
     end
 
     let!(:teacher_2) do
       teacher = FactoryBot.create(:teacher, trs_first_name: "Bob", trs_last_name: "Jones", trn: "2345678")
-      FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:, started_on: Date.new(2024, 4, 1))
+      FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:, started_on: Date.new(2024, 4, 1))
       teacher
     end
 
@@ -251,7 +251,7 @@ RSpec.describe TeachersIndex::TableSectionComponent, type: :component do
 
     let!(:integration_teacher) do
       teacher = FactoryBot.create(:teacher, trs_first_name: "Alice", trs_last_name: "Smith", trn: "1234567")
-      FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:, started_on: Date.new(2024, 3, 15))
+      FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:, started_on: Date.new(2024, 3, 15))
       teacher
     end
 

--- a/spec/components/teachers_index_component_spec.rb
+++ b/spec/components/teachers_index_component_spec.rb
@@ -14,13 +14,13 @@ RSpec.describe TeachersIndexComponent, type: :component do
 
   let!(:teacher_1) do
     teacher = FactoryBot.create(:teacher, trs_first_name: "Alice", trs_last_name: "Smith", trn: "1234567")
-    FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:, started_on: 3.months.ago)
+    FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:, started_on: 3.months.ago)
     teacher
   end
 
   let!(:teacher_2) do
     teacher = FactoryBot.create(:teacher, trs_first_name: "Bob", trs_last_name: "Jones", trn: "2345678")
-    FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:, started_on: 2.months.ago)
+    FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:, started_on: 2.months.ago)
     teacher
   end
 
@@ -32,7 +32,7 @@ RSpec.describe TeachersIndexComponent, type: :component do
 
   let!(:teacher_4_other_ab) do
     teacher = FactoryBot.create(:teacher, trs_first_name: "David", trs_last_name: "Wilson", trn: "4567890")
-    FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period: other_appropriate_body, started_on: 1.month.ago)
+    FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period: other_appropriate_body, started_on: 1.month.ago)
     teacher
   end
 

--- a/spec/factories/ect_at_school_period_factory.rb
+++ b/spec/factories/ect_at_school_period_factory.rb
@@ -31,7 +31,7 @@ FactoryBot.define do
       finished_on { 2.weeks.ago }
     end
 
-    trait :ongoing do
+    trait :unfinished do
       started_on { 1.year.ago }
       finished_on { nil }
     end

--- a/spec/factories/induction_period_factory.rb
+++ b/spec/factories/induction_period_factory.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     induction_programme { "fip" }
     training_programme { "provider_led" }
 
-    trait :ongoing do
+    trait :unfinished do
       finished_on { nil }
       number_of_terms { nil }
     end

--- a/spec/factories/mentor_at_school_period_factory.rb
+++ b/spec/factories/mentor_at_school_period_factory.rb
@@ -29,7 +29,7 @@ FactoryBot.define do
     finished_on { end_date }
     email { Faker::Internet.email }
 
-    trait :ongoing do
+    trait :unfinished do
       started_on { 1.year.ago }
       finished_on { nil }
     end

--- a/spec/factories/mentorship_period_factory.rb
+++ b/spec/factories/mentorship_period_factory.rb
@@ -30,7 +30,7 @@ FactoryBot.define do
       [calculated_end_date, mentee_end_date, mentor_end_date].compact.min
     end
 
-    trait :ongoing do
+    trait :unfinished do
       finished_on { nil }
     end
   end

--- a/spec/factories/metadata/teacher_lead_provider_factory.rb
+++ b/spec/factories/metadata/teacher_lead_provider_factory.rb
@@ -41,7 +41,7 @@ FactoryBot.define do
       ].compact.each do |teacher_type|
         at_school_period = FactoryBot.create(
           :"#{teacher_type}_at_school_period",
-          :ongoing,
+          :unfinished,
           school:,
           teacher:
         )

--- a/spec/factories/training_period_factory.rb
+++ b/spec/factories/training_period_factory.rb
@@ -123,7 +123,7 @@ FactoryBot.define do
       association :expression_of_interest, factory: :active_lead_provider
     end
 
-    trait :ongoing do
+    trait :unfinished do
       finished_on { nil }
     end
 

--- a/spec/features/admin/teachers/change_contract_period_spec.rb
+++ b/spec/features/admin/teachers/change_contract_period_spec.rb
@@ -59,7 +59,7 @@ private
     @teacher_name = Teachers::Name.new(@teacher).full_name
     @ect_at_school_period = FactoryBot.create(
       :ect_at_school_period,
-      :ongoing,
+      :unfinished,
       teacher: @teacher,
       school: @school,
       started_on: Date.current.prev_year
@@ -106,7 +106,7 @@ private
     @target_partnership_name = "#{lead_provider.name} & #{delivery_partner.name}"
     @training_period = FactoryBot.create(
       :training_period,
-      :ongoing,
+      :unfinished,
       ect_at_school_period: @ect_at_school_period,
       school_partnership: @current_school_partnership,
       schedule: @current_schedule,

--- a/spec/features/admin/teachers/delete_induction_period_spec.rb
+++ b/spec/features/admin/teachers/delete_induction_period_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Admin deleting an induction" do
   end
 
   context "when it is the only induction period" do
-    let!(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:, started_on: Date.new(2020, 1, 1), finished_on: Date.new(2020, 12, 31), number_of_terms: 2) }
+    let!(:induction_period) { FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:, started_on: Date.new(2020, 1, 1), finished_on: Date.new(2020, 12, 31), number_of_terms: 2) }
 
     context "with a ticket and reason" do
       it "deletes the induction, resets TRS, adds context to the timeline" do
@@ -70,8 +70,8 @@ RSpec.describe "Admin deleting an induction" do
   end
 
   context "when there are multiple induction periods" do
-    let!(:induction_period1) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:, started_on: Date.new(2020, 1, 1), finished_on: Date.new(2020, 12, 31), number_of_terms: 2) }
-    let!(:induction_period2) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:, started_on: Date.new(2021, 1, 1), finished_on: Date.new(2021, 12, 31), number_of_terms: 2) }
+    let!(:induction_period1) { FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:, started_on: Date.new(2020, 1, 1), finished_on: Date.new(2020, 12, 31), number_of_terms: 2) }
+    let!(:induction_period2) { FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:, started_on: Date.new(2021, 1, 1), finished_on: Date.new(2021, 12, 31), number_of_terms: 2) }
 
     scenario "TRS start date is updated to next earliest period" do
       given_i_am_on_the_teacher_induction_page
@@ -93,8 +93,8 @@ RSpec.describe "Admin deleting an induction" do
   end
 
   context "when deleting the later induction period" do
-    let!(:induction_period1) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:, started_on: Date.new(2020, 1, 1), finished_on: Date.new(2020, 12, 31), number_of_terms: 2) }
-    let!(:induction_period2) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:, started_on: Date.new(2021, 1, 1), finished_on: Date.new(2021, 12, 31), number_of_terms: 2) }
+    let!(:induction_period1) { FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:, started_on: Date.new(2020, 1, 1), finished_on: Date.new(2020, 12, 31), number_of_terms: 2) }
+    let!(:induction_period2) { FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:, started_on: Date.new(2021, 1, 1), finished_on: Date.new(2021, 12, 31), number_of_terms: 2) }
 
     scenario "TRS start date remains unchanged" do
       given_i_am_on_the_teacher_induction_page

--- a/spec/features/admin/teachers/edit_induction_period_spec.rb
+++ b/spec/features/admin/teachers/edit_induction_period_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Admin editing an induction" do
   let(:teacher) { FactoryBot.create(:teacher) }
 
   let!(:induction_period) do
-    FactoryBot.create(:induction_period, :ongoing,
+    FactoryBot.create(:induction_period, :unfinished,
                       teacher:,
                       appropriate_body_period:,
                       started_on: Date.new(2024, 1, 1))

--- a/spec/features/admin/teachers/record_failed_induction_spec.rb
+++ b/spec/features/admin/teachers/record_failed_induction_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "Admin recording a failed induction" do
   include ActiveJob::TestHelper
 
   let(:appropriate_body_period) { FactoryBot.create(:appropriate_body_period) }
-  let!(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:) }
+  let!(:induction_period) { FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:) }
   let(:teacher) { FactoryBot.create(:teacher, :with_name) }
   let(:today) { Time.zone.today }
 

--- a/spec/features/admin/teachers/record_passed_induction_spec.rb
+++ b/spec/features/admin/teachers/record_passed_induction_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "Admin recording a passed induction" do
   include ActiveJob::TestHelper
 
   let(:appropriate_body_period) { FactoryBot.create(:appropriate_body_period) }
-  let!(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:) }
+  let!(:induction_period) { FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:) }
   let(:teacher) { FactoryBot.create(:teacher, :with_name) }
   let(:today) { Time.zone.today }
 

--- a/spec/features/appropriate_bodies/claim_an_ect_spec.rb
+++ b/spec/features/appropriate_bodies/claim_an_ect_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Claiming an ECT" do
     include_context "test TRS API returns a teacher with specific induction status", "InProgress"
 
     before do
-      FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period: other_body)
+      FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period: other_body)
     end
 
     scenario "the teacher cannot be claimed" do

--- a/spec/features/appropriate_bodies/edit_induction_period_spec.rb
+++ b/spec/features/appropriate_bodies/edit_induction_period_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Appropriate body editing an induction period" do
   let(:teacher) { FactoryBot.create(:teacher, trs_qts_awarded_on: 1.year.ago) }
 
   let!(:induction_period) do
-    FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:)
+    FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:)
   end
 
   before do

--- a/spec/features/appropriate_bodies/record_failed_outcome_spec.rb
+++ b/spec/features/appropriate_bodies/record_failed_outcome_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "Recording a failed outcome for an ECT" do
   let(:appropriate_body_period) { FactoryBot.create(:appropriate_body_period) }
-  let!(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:) }
+  let!(:induction_period) { FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:) }
   let(:teacher) { FactoryBot.create(:teacher, :with_name) }
   let(:today) { Time.zone.today }
   let(:number_of_completed_terms) { 4 }

--- a/spec/features/appropriate_bodies/record_passed_outcome_spec.rb
+++ b/spec/features/appropriate_bodies/record_passed_outcome_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "Recording a passed outcome for an ECT" do
   let!(:appropriate_body_period) { FactoryBot.create(:appropriate_body_period) }
   let(:teacher) { FactoryBot.create(:teacher, :with_name) }
-  let!(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:) }
+  let!(:induction_period) { FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:) }
   let(:today) { Time.zone.today }
   let(:number_of_completed_terms) { 4 }
 

--- a/spec/features/appropriate_bodies/release_an_ect_spec.rb
+++ b/spec/features/appropriate_bodies/release_an_ect_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "Releasing an ECT" do
   let(:appropriate_body_period) { FactoryBot.create(:appropriate_body_period) }
-  let!(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:) }
+  let!(:induction_period) { FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:) }
   let(:teacher) { FactoryBot.create(:teacher) }
   let(:today) { Time.zone.today }
   let(:number_of_completed_terms) { 4 }

--- a/spec/features/schools/ects/change/appropriate_body_spec.rb
+++ b/spec/features/schools/ects/change/appropriate_body_spec.rb
@@ -102,7 +102,7 @@ describe "School user can change ECT's appropriate body" do
     )
     @ect = FactoryBot.create(
       :ect_at_school_period,
-      :ongoing,
+      :unfinished,
       teacher: @teacher,
       school: @school,
       email: "ect@example.com",

--- a/spec/features/schools/ects/change/edge_cases/changing_lead_provider_before_reported_leaving_date_spec.rb
+++ b/spec/features/schools/ects/change/edge_cases/changing_lead_provider_before_reported_leaving_date_spec.rb
@@ -183,7 +183,7 @@ private
     FactoryBot.create(
       :training_period,
       :for_ect,
-      :ongoing,
+      :unfinished,
       :provider_led,
       :with_active_lead_provider,
       ect_at_school_period: @ect_at_school_period,

--- a/spec/features/schools/ects/change/edge_cases/changing_lead_provider_for_ects_in_closed_contract_periods_spec.rb
+++ b/spec/features/schools/ects/change/edge_cases/changing_lead_provider_for_ects_in_closed_contract_periods_spec.rb
@@ -74,7 +74,7 @@ private
     )
     @ect_at_school_period = FactoryBot.create(
       :ect_at_school_period,
-      :ongoing,
+      :unfinished,
       teacher: @teacher,
       school: @school,
       email: "ect@example.com",
@@ -98,7 +98,7 @@ private
   def with_confirmed_provider_led_training
     @provider_led_training_period = FactoryBot.create(
       :training_period,
-      :ongoing,
+      :unfinished,
       :for_ect,
       :provider_led,
       :with_school_partnership,

--- a/spec/features/schools/ects/change/edge_cases/changing_to_provider_led_training_before_reported_leaving_date_spec.rb
+++ b/spec/features/schools/ects/change/edge_cases/changing_to_provider_led_training_before_reported_leaving_date_spec.rb
@@ -192,7 +192,7 @@ private
     FactoryBot.create(
       :training_period,
       :for_ect,
-      :ongoing,
+      :unfinished,
       :school_led,
       ect_at_school_period: @ect_at_school_period
     )

--- a/spec/features/schools/ects/change/edge_cases/changing_to_school_led_training_before_reported_leaving_date_spec.rb
+++ b/spec/features/schools/ects/change/edge_cases/changing_to_school_led_training_before_reported_leaving_date_spec.rb
@@ -130,7 +130,7 @@ private
     FactoryBot.create(
       :training_period,
       :for_ect,
-      :ongoing,
+      :unfinished,
       :provider_led,
       :with_active_lead_provider,
       ect_at_school_period: @ect_at_school_period,

--- a/spec/features/schools/ects/change/edge_cases/changing_training_programme_for_ects_in_closed_contract_periods_spec.rb
+++ b/spec/features/schools/ects/change/edge_cases/changing_training_programme_for_ects_in_closed_contract_periods_spec.rb
@@ -122,7 +122,7 @@ private
     )
     @ect_at_school_period = FactoryBot.create(
       :ect_at_school_period,
-      :ongoing,
+      :unfinished,
       started_on: Date.new(2021, 9, 1),
       teacher: @teacher,
       school: @school,
@@ -133,7 +133,7 @@ private
   def with_a_mentor
     mentor_at_school_period = FactoryBot.create(
       :mentor_at_school_period,
-      :ongoing,
+      :unfinished,
       school: @school,
       started_on: @ect_at_school_period.started_on
     )
@@ -148,7 +148,7 @@ private
   end
 
   def and_the_ect_switched_to_school_led_training
-    @school_led_training_period = FactoryBot.create(:training_period, :for_ect, :ongoing, :school_led, ect_at_school_period: @ect_at_school_period, started_on: @provider_led_training_period.finished_on + 1.day)
+    @school_led_training_period = FactoryBot.create(:training_period, :for_ect, :unfinished, :school_led, ect_at_school_period: @ect_at_school_period, started_on: @provider_led_training_period.finished_on + 1.day)
   end
 
   def when_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/ects/change/email_address_spec.rb
+++ b/spec/features/schools/ects/change/email_address_spec.rb
@@ -50,7 +50,7 @@ private
     )
     @ect = FactoryBot.create(
       :ect_at_school_period,
-      :ongoing,
+      :unfinished,
       teacher: @teacher,
       school: @school,
       email: "ect@example.com"

--- a/spec/features/schools/ects/change/lead_provider_spec.rb
+++ b/spec/features/schools/ects/change/lead_provider_spec.rb
@@ -84,7 +84,7 @@ private
     )
     @ect = FactoryBot.create(
       :ect_at_school_period,
-      :ongoing,
+      :unfinished,
       teacher: @teacher,
       school: @school,
       email: "ect@example.com",
@@ -108,7 +108,7 @@ private
   def with_provider_led_training
     @provider_led_training_period = FactoryBot.create(
       :training_period,
-      :ongoing,
+      :unfinished,
       :for_ect,
       :provider_led,
       :with_only_expression_of_interest,
@@ -131,7 +131,7 @@ private
     )
     @provider_led_training_period = FactoryBot.create(
       :training_period,
-      :ongoing,
+      :unfinished,
       :for_ect,
       :provider_led,
       :with_school_partnership,

--- a/spec/features/schools/ects/change/mentor_spec.rb
+++ b/spec/features/schools/ects/change/mentor_spec.rb
@@ -170,7 +170,7 @@ private
     )
     @ect_at_school_period = FactoryBot.create(
       :ect_at_school_period,
-      :ongoing,
+      :unfinished,
       teacher: @teacher,
       school: @school,
       email: "ect@example.com",
@@ -196,7 +196,7 @@ private
       :training_period,
       :school_led,
       :for_ect,
-      :ongoing,
+      :unfinished,
       ect_at_school_period: @ect_at_school_period,
       started_on: @ect_at_school_period.started_on
     )
@@ -207,7 +207,7 @@ private
       :training_period,
       :provider_led,
       :for_ect,
-      :ongoing,
+      :unfinished,
       ect_at_school_period: @ect_at_school_period,
       started_on: @ect_at_school_period.started_on
     )
@@ -224,14 +224,14 @@ private
     )
     mentor_at_school_period = FactoryBot.create(
       :mentor_at_school_period,
-      :ongoing,
+      :unfinished,
       teacher:,
       school: @school,
       started_on: @ect_at_school_period.started_on - 2.months
     )
     FactoryBot.create(
       :mentorship_period,
-      :ongoing,
+      :unfinished,
       mentee: @ect_at_school_period,
       mentor: mentor_at_school_period,
       started_on: @ect_at_school_period.started_on
@@ -246,7 +246,7 @@ private
     )
     FactoryBot.create(
       :mentor_at_school_period,
-      :ongoing,
+      :unfinished,
       teacher: @mentor_teacher,
       school: @school,
       started_on: @ect_at_school_period.started_on - 1.month

--- a/spec/features/schools/ects/change/training_programme_spec.rb
+++ b/spec/features/schools/ects/change/training_programme_spec.rb
@@ -89,7 +89,7 @@ private
     )
     @ect = FactoryBot.create(
       :ect_at_school_period,
-      :ongoing,
+      :unfinished,
       started_on: 2.months.ago,
       teacher: @teacher,
       school: @school,
@@ -100,7 +100,7 @@ private
   def with_a_mentor
     mentor_at_school_period = FactoryBot.create(
       :mentor_at_school_period,
-      :ongoing,
+      :unfinished,
       school: @school,
       started_on: @ect.started_on
     )
@@ -125,7 +125,7 @@ private
       :training_period,
       :provider_led,
       :for_ect,
-      :ongoing,
+      :unfinished,
       ect_at_school_period: @ect,
       started_on: @ect.started_on
     )
@@ -136,7 +136,7 @@ private
       :training_period,
       :school_led,
       :for_ect,
-      :ongoing,
+      :unfinished,
       ect_at_school_period: @ect,
       started_on: @ect.started_on
     )

--- a/spec/features/schools/ects/change_working_pattern_spec.rb
+++ b/spec/features/schools/ects/change_working_pattern_spec.rb
@@ -29,7 +29,7 @@ private
     )
     @ect = FactoryBot.create(
       :ect_at_school_period,
-      :ongoing,
+      :unfinished,
       teacher: @teacher,
       school: @school,
       working_pattern: :full_time

--- a/spec/features/schools/ects/leaving_spec.rb
+++ b/spec/features/schools/ects/leaving_spec.rb
@@ -35,7 +35,7 @@ private
 
     @ect_at_school_period = FactoryBot.create(
       :ect_at_school_period,
-      :ongoing,
+      :unfinished,
       teacher: @teacher,
       school: @school,
       started_on: Date.new(2024, 9, 1)

--- a/spec/features/schools/ects/register/edge_cases/cant_use_email_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/cant_use_email_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "Registering an ECT", :js do
   end
 
   def and_an_ongoing_ect_is_assigned_to_the_school
-    @ect = FactoryBot.create(:ect_at_school_period, :ongoing, school: @school)
+    @ect = FactoryBot.create(:ect_at_school_period, :unfinished, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 

--- a/spec/features/schools/ects/register/edge_cases/teacher_at_school_already_registered_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/teacher_at_school_already_registered_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Registering an ECT" do
 
   def and_an_ect_has_already_registered_at_my_school
     teacher = FactoryBot.create(:teacher, trn: "9876543")
-    FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:)
+    FactoryBot.create(:ect_at_school_period, :unfinished, teacher:, school:)
   end
 
   def when_i_click_continue

--- a/spec/features/schools/ects/search_spec.rb
+++ b/spec/features/schools/ects/search_spec.rb
@@ -30,10 +30,10 @@ RSpec.describe "Searching for an ECT" do
     @school = FactoryBot.create(:school)
 
     @matching_teacher = FactoryBot.create(:teacher, trs_first_name: "Jimmy", trs_last_name: "Searchable")
-    FactoryBot.create(:ect_at_school_period, :ongoing, teacher: @matching_teacher, school: @school)
+    FactoryBot.create(:ect_at_school_period, :unfinished, teacher: @matching_teacher, school: @school)
 
     @non_matching_teacher = FactoryBot.create(:teacher, trs_first_name: "Bob", trs_last_name: "Invisible")
-    FactoryBot.create(:ect_at_school_period, :ongoing, teacher: @non_matching_teacher, school: @school)
+    FactoryBot.create(:ect_at_school_period, :unfinished, teacher: @non_matching_teacher, school: @school)
   end
 
   def and_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/mentors/change/edge_cases/lead_provider_when_registered_previous_contract_year_spec.rb
+++ b/spec/features/schools/mentors/change/edge_cases/lead_provider_when_registered_previous_contract_year_spec.rb
@@ -47,7 +47,7 @@ private
     )
     @mentor_at_school_period = FactoryBot.create(
       :mentor_at_school_period,
-      :ongoing,
+      :unfinished,
       teacher: @teacher,
       school: @school,
       started_on: Date.new(2024, 9, 1)
@@ -81,7 +81,7 @@ private
   def with_provider_led_training
     @provider_led_training_period = FactoryBot.create(
       :training_period,
-      :ongoing,
+      :unfinished,
       :for_mentor,
       :provider_led,
       school_partnership: @school_partnership,
@@ -175,7 +175,7 @@ private
     training_periods = @mentor_at_school_period.training_periods
     expect(training_periods.count).to eq(2)
 
-    new_training_period = training_periods.ongoing.first
+    new_training_period = training_periods.unfinished.first
 
     expect(new_training_period).not_to be_nil
     expect(new_training_period.school_partnership).to be_nil

--- a/spec/features/schools/mentors/change/email_address_spec.rb
+++ b/spec/features/schools/mentors/change/email_address_spec.rb
@@ -50,7 +50,7 @@ private
     )
     @mentor = FactoryBot.create(
       :mentor_at_school_period,
-      :ongoing,
+      :unfinished,
       teacher: @teacher,
       school: @school,
       email: "mentor@example.com"

--- a/spec/features/schools/mentors/change/lead_provider_spec.rb
+++ b/spec/features/schools/mentors/change/lead_provider_spec.rb
@@ -75,7 +75,7 @@ private
     )
     @mentor_at_school_period = FactoryBot.create(
       :mentor_at_school_period,
-      :ongoing,
+      :unfinished,
       teacher: @teacher,
       school: @school,
       started_on: @contract_period.started_on
@@ -108,7 +108,7 @@ private
   def with_provider_led_training
     @provider_led_training_period = FactoryBot.create(
       :training_period,
-      :ongoing,
+      :unfinished,
       :for_mentor,
       :provider_led,
       school_partnership: @school_partnership,

--- a/spec/features/schools/mentors/change/name_spec.rb
+++ b/spec/features/schools/mentors/change/name_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "Changing a mentor's name" do
   let!(:mentor_at_school_period) do
-    FactoryBot.create(:mentor_at_school_period, :ongoing, school:, teacher:)
+    FactoryBot.create(:mentor_at_school_period, :unfinished, school:, teacher:)
   end
 
   let(:teacher) do

--- a/spec/features/schools/mentors/leaving_spec.rb
+++ b/spec/features/schools/mentors/leaving_spec.rb
@@ -40,7 +40,7 @@ private
 
     @mentor_at_school_period = FactoryBot.create(
       :mentor_at_school_period,
-      :ongoing,
+      :unfinished,
       teacher: @teacher,
       school: @school,
       started_on: Date.new(2024, 9, 1)
@@ -51,7 +51,7 @@ private
     @other_school = FactoryBot.create(:school)
     @other_mentor_at_school_period = FactoryBot.create(
       :mentor_at_school_period,
-      :ongoing,
+      :unfinished,
       teacher: @teacher,
       school: @other_school,
       started_on: Date.new(2024, 10, 1)

--- a/spec/features/schools/mentors/register_mentor/edge_cases/already_active_at_school_after_nino_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/already_active_at_school_after_nino_spec.rb
@@ -37,13 +37,13 @@ RSpec.describe "Registering a mentor", :js do
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
     lead_provider = FactoryBot.create(:lead_provider, name: "Xavier's School for Gifted Youngsters")
-    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :ongoing, lead_provider:, school: @school)
+    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :unfinished, lead_provider:, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 
   def and_there_is_an_active_mentor_registered_at_the_school
     teacher = FactoryBot.create(:teacher, trs_first_name: "Kirk", trs_last_name: "Van Houten", corrected_name: nil)
-    @mentor = FactoryBot.create(:mentor_at_school_period, :ongoing, school: @school, teacher:)
+    @mentor = FactoryBot.create(:mentor_at_school_period, :unfinished, school: @school, teacher:)
     @mentor_name = Teachers::Name.new(teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/already_active_at_school_after_trn_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/already_active_at_school_after_trn_spec.rb
@@ -34,13 +34,13 @@ RSpec.describe "Registering a mentor", :js do
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
     lead_provider = FactoryBot.create(:lead_provider, name: "Xavier's School for Gifted Youngsters")
-    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :ongoing, lead_provider:, school: @school)
+    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :unfinished, lead_provider:, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 
   def and_there_is_an_active_mentor_registered_at_the_school
     teacher = FactoryBot.create(:teacher, trs_first_name: "Kirk", trs_last_name: "Van Houten", corrected_name: nil)
-    @mentor = FactoryBot.create(:mentor_at_school_period, :ongoing, school: @school, teacher:)
+    @mentor = FactoryBot.create(:mentor_at_school_period, :unfinished, school: @school, teacher:)
     @mentor_name = Teachers::Name.new(teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/cannot_mentor_themself_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/cannot_mentor_themself_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Registering a mentor" do
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    @ect = FactoryBot.create(:ect_at_school_period, :ongoing, school: @school)
+    @ect = FactoryBot.create(:ect_at_school_period, :unfinished, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/cant_use_email_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/cant_use_email_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "Registering a mentor", :js do
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    @ect = FactoryBot.create(:ect_at_school_period, :ongoing, school: @school)
+    @ect = FactoryBot.create(:ect_at_school_period, :unfinished, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/changing_start_date_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/changing_start_date_spec.rb
@@ -149,9 +149,9 @@ RSpec.describe "Registering a mentor", :js do
     @another_lead_provider = FactoryBot.create(:lead_provider, name: "Another lead provider")
     FactoryBot.create(:active_lead_provider, lead_provider: @another_lead_provider, contract_period: @contract_period)
 
-    @ect_at_school_period = FactoryBot.create(:ect_at_school_period, :ongoing, school: @school)
+    @ect_at_school_period = FactoryBot.create(:ect_at_school_period, :unfinished, school: @school)
     @training_period = FactoryBot.create(
-      :training_period, :ongoing,
+      :training_period, :unfinished,
       ect_at_school_period: @ect_at_school_period,
       school_partnership: school_partnership_for_ect
     )
@@ -162,11 +162,11 @@ RSpec.describe "Registering a mentor", :js do
   def and_mentor_has_existing_mentorship_at_another_school
     another_school = FactoryBot.create(:school, urn: "7654321")
     @teacher = FactoryBot.create(:teacher, trn:, trs_first_name: "Kirk", trs_last_name: "Van Houten", corrected_name: nil)
-    @existing_mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :ongoing, school: another_school, teacher: @teacher)
+    @existing_mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :unfinished, school: another_school, teacher: @teacher)
     school_partnership_for_prev_lp = make_partnership_for(another_school, @contract_period, lead_provider_name: "Mentor Prev LP")
 
     @training_period = FactoryBot.create(
-      :training_period, :for_mentor, :provider_led, :ongoing,
+      :training_period, :for_mentor, :provider_led, :unfinished,
       mentor_at_school_period: @existing_mentor_at_school_period,
       school_partnership: school_partnership_for_prev_lp,
       started_on: @existing_mentor_at_school_period.started_on

--- a/spec/features/schools/mentors/register_mentor/edge_cases/find_teacher_using_national_insurance_number_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/find_teacher_using_national_insurance_number_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Registering a mentor" do
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    @ect = FactoryBot.create(:ect_at_school_period, :ongoing, school: @school)
+    @ect = FactoryBot.create(:ect_at_school_period, :unfinished, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/fully_moving_schools_before_reported_leaving_date_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/fully_moving_schools_before_reported_leaving_date_spec.rb
@@ -63,10 +63,10 @@ private
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    @ect = FactoryBot.create(:ect_at_school_period, :ongoing, school: @school)
+    @ect = FactoryBot.create(:ect_at_school_period, :unfinished, school: @school)
     @training_period = FactoryBot.create(
       :training_period,
-      :ongoing,
+      :unfinished,
       :school_led,
       ect_at_school_period: @ect
     )
@@ -91,7 +91,7 @@ private
     )
     other_ect = FactoryBot.create(
       :ect_at_school_period,
-      :ongoing,
+      :unfinished,
       school: another_school
     )
     @existing_mentorship = FactoryBot.create(

--- a/spec/features/schools/mentors/register_mentor/edge_cases/mentor_prohibited_from_teaching_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/mentor_prohibited_from_teaching_spec.rb
@@ -29,13 +29,13 @@ RSpec.describe "Registering a mentor" do
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    @ect = FactoryBot.create(:ect_at_school_period, :ongoing, school: @school)
+    @ect = FactoryBot.create(:ect_at_school_period, :unfinished, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 
   def and_there_is_an_active_mentor_registered_at_the_school
     teacher = FactoryBot.create(:teacher, trs_first_name: "Kirk", trs_last_name: "Van Houten", corrected_name: nil)
-    @mentor = FactoryBot.create(:mentor_at_school_period, :ongoing, school: @school, teacher:)
+    @mentor = FactoryBot.create(:mentor_at_school_period, :unfinished, school: @school, teacher:)
     @mentor_name = Teachers::Name.new(teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/no_trn_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/no_trn_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Registering a mentor" do
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    @ect = FactoryBot.create(:ect_at_school_period, :ongoing, school: @school)
+    @ect = FactoryBot.create(:ect_at_school_period, :unfinished, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/not_found_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/not_found_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Registering a mentor" do
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    @ect = FactoryBot.create(:ect_at_school_period, :ongoing, school: @school)
+    @ect = FactoryBot.create(:ect_at_school_period, :unfinished, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/not_mentoring_at_new_school_only_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/not_mentoring_at_new_school_only_spec.rb
@@ -60,15 +60,15 @@ RSpec.describe "Registering a mentor", :js do
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
     FactoryBot.create(:active_lead_provider, lead_provider: @lead_provider, contract_period: @contract_period)
-    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :ongoing, lead_provider: @lead_provider, school: @school)
-    @training_period = FactoryBot.create(:training_period, :ongoing, :provider_led, school_partnership: @school_partnership, ect_at_school_period: @ect)
+    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :unfinished, lead_provider: @lead_provider, school: @school)
+    @training_period = FactoryBot.create(:training_period, :unfinished, :provider_led, school_partnership: @school_partnership, ect_at_school_period: @ect)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 
   def and_mentor_has_existing_mentorship_at_another_school
     another_school = FactoryBot.create(:school, urn: "7654321")
     @teacher = FactoryBot.create(:teacher, trn:, trs_first_name: "Kirk", trs_last_name: "Van Houten", corrected_name: nil)
-    @existing_mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :ongoing, school: another_school, teacher: @teacher)
+    @existing_mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :unfinished, school: another_school, teacher: @teacher)
   end
 
   def and_i_am_on_the_schools_landing_page

--- a/spec/features/schools/mentors/register_mentor/edge_cases/preserves_contract_period_on_re_registration_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/preserves_contract_period_on_re_registration_spec.rb
@@ -55,8 +55,8 @@ private
     @active_lead_provider = FactoryBot.create(:active_lead_provider,
                                               lead_provider: @lead_provider,
                                               contract_period: @contract_period)
-    @ect = FactoryBot.create(:ect_at_school_period, :ongoing, school: @school)
-    FactoryBot.create(:training_period, :provider_led, :ongoing,
+    @ect = FactoryBot.create(:ect_at_school_period, :unfinished, school: @school)
+    FactoryBot.create(:training_period, :provider_led, :unfinished,
                       ect_at_school_period: @ect,
                       school_partnership: FactoryBot.create(:school_partnership,
                                                             school: @school,

--- a/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_eligible_for_funding_choose_lead_provider_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_eligible_for_funding_choose_lead_provider_spec.rb
@@ -70,9 +70,9 @@ RSpec.describe "Registering a mentor", :js do
     @another_lead_provider = FactoryBot.create(:lead_provider, name: "Another lead provider")
     FactoryBot.create(:active_lead_provider, lead_provider: @another_lead_provider, contract_period: @contract_period)
 
-    @ect_at_school_period = FactoryBot.create(:ect_at_school_period, :ongoing, school: @school)
+    @ect_at_school_period = FactoryBot.create(:ect_at_school_period, :unfinished, school: @school)
     @training_period = FactoryBot.create(
-      :training_period, :ongoing,
+      :training_period, :unfinished,
       ect_at_school_period: @ect_at_school_period,
       school_partnership: school_partnership_for_ect
     )
@@ -83,11 +83,11 @@ RSpec.describe "Registering a mentor", :js do
   def and_mentor_has_existing_mentorship_at_another_school
     another_school = FactoryBot.create(:school, urn: "7654321")
     @teacher = FactoryBot.create(:teacher, trn:, trs_first_name: "Kirk", trs_last_name: "Van Houten", corrected_name: nil)
-    @existing_mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :ongoing, school: another_school, teacher: @teacher)
+    @existing_mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :unfinished, school: another_school, teacher: @teacher)
     school_partnership_for_prev_lp = make_partnership_for(another_school, @contract_period, lead_provider_name: "Mentor Prev LP")
 
     @training_period = FactoryBot.create(
-      :training_period, :for_mentor, :provider_led, :ongoing,
+      :training_period, :for_mentor, :provider_led, :unfinished,
       mentor_at_school_period: @existing_mentor_at_school_period,
       school_partnership: school_partnership_for_prev_lp,
       started_on: @existing_mentor_at_school_period.started_on

--- a/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_eligible_for_funding_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_eligible_for_funding_spec.rb
@@ -67,17 +67,17 @@ RSpec.describe "Registering a mentor", :js do
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
     FactoryBot.create(:active_lead_provider, lead_provider: @lead_provider, contract_period: @contract_period)
-    @ect = FactoryBot.create(:ect_at_school_period, :ongoing, school: @school)
-    @training_period = FactoryBot.create(:training_period, :provider_led, :ongoing, ect_at_school_period: @ect, school_partnership: @school_partnership)
+    @ect = FactoryBot.create(:ect_at_school_period, :unfinished, school: @school)
+    @training_period = FactoryBot.create(:training_period, :provider_led, :unfinished, ect_at_school_period: @ect, school_partnership: @school_partnership)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 
   def and_mentor_has_existing_mentorship_at_another_school
     another_school = FactoryBot.create(:school, urn: "7654321")
     @teacher = FactoryBot.create(:teacher, trn:, trs_first_name: "Kirk", trs_last_name: "Van Houten", corrected_name: nil)
-    @existing_mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :ongoing, school: another_school, teacher: @teacher)
+    @existing_mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :unfinished, school: another_school, teacher: @teacher)
     another_school_partnership = FactoryBot.create(:school_partnership, lead_provider_delivery_partnership: @school_partnership.lead_provider_delivery_partnership, school: another_school)
-    @training_period = FactoryBot.create(:training_period, :for_mentor, :ongoing, started_on: @existing_mentor_at_school_period.started_on, mentor_at_school_period: @existing_mentor_at_school_period, school_partnership: another_school_partnership)
+    @training_period = FactoryBot.create(:training_period, :for_mentor, :unfinished, started_on: @existing_mentor_at_school_period.started_on, mentor_at_school_period: @existing_mentor_at_school_period, school_partnership: another_school_partnership)
   end
 
   def and_i_am_on_the_schools_landing_page

--- a/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_ineligible_for_funding_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_ineligible_for_funding_spec.rb
@@ -54,14 +54,14 @@ RSpec.describe "Registering a mentor", :js do
     @contract_period = FactoryBot.create(:contract_period, :current, :with_schedules)
     @lead_provider = FactoryBot.create(:lead_provider, name: "Xavier's School for Gifted Youngsters")
     FactoryBot.create(:active_lead_provider, lead_provider: @lead_provider, contract_period: @contract_period)
-    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :ongoing, lead_provider: @lead_provider, school: @school)
+    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :unfinished, lead_provider: @lead_provider, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 
   def and_mentor_has_existing_mentorship_at_another_school
     another_school = FactoryBot.create(:school, urn: "7654321")
     @teacher = FactoryBot.create(:teacher, :ineligible_for_mentor_funding, trn:, trs_first_name: "Kirk", trs_last_name: "Van Houten", corrected_name: nil)
-    @existing_mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :ongoing, school: another_school, teacher: @teacher)
+    @existing_mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :unfinished, school: another_school, teacher: @teacher)
   end
 
   def and_i_am_on_the_schools_landing_page

--- a/spec/features/schools/mentors/register_mentor/edge_cases/school_led_ect_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/school_led_ect_spec.rb
@@ -57,15 +57,15 @@ RSpec.describe "Registering a mentor", :js do
   end
 
   def and_there_is_a_school_led_ect_with_no_mentor_registered_at_the_school
-    @ect = FactoryBot.create(:ect_at_school_period, :ongoing, school: @school)
-    @training_period = FactoryBot.create(:training_period, :ongoing, :school_led, ect_at_school_period: @ect)
+    @ect = FactoryBot.create(:ect_at_school_period, :unfinished, school: @school)
+    @training_period = FactoryBot.create(:training_period, :unfinished, :school_led, ect_at_school_period: @ect)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 
   def and_mentor_has_existing_mentorship_at_another_school
     another_school = FactoryBot.create(:school, urn: "7654321")
     @teacher = FactoryBot.create(:teacher, trn:, trs_first_name: "Kirk", trs_last_name: "Van Houten", corrected_name: nil)
-    @existing_mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :ongoing, school: another_school, teacher: @teacher)
+    @existing_mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :unfinished, school: another_school, teacher: @teacher)
   end
 
   def and_i_am_on_the_schools_landing_page

--- a/spec/features/schools/mentors/register_mentor/edge_cases/teacher_with_trn_not_found_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/teacher_with_trn_not_found_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Registering a mentor" do
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    @ect = FactoryBot.create(:ect_at_school_period, :ongoing, school: @school)
+    @ect = FactoryBot.create(:ect_at_school_period, :unfinished, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/trn_not_found_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/trn_not_found_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Registering a mentor" do
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    @ect = FactoryBot.create(:ect_at_school_period, :ongoing, school: @school)
+    @ect = FactoryBot.create(:ect_at_school_period, :unfinished, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/happy_path_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/happy_path_spec.rb
@@ -98,8 +98,8 @@ RSpec.describe "Registering a mentor", :js do
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
     contract_period = @contract_period
-    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :ongoing, lead_provider: @lead_provider, contract_period:, school: @school)
-    @training_period = FactoryBot.create(:training_period, :ongoing, :provider_led, ect_at_school_period: @ect, school_partnership: @school_partnership)
+    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :unfinished, lead_provider: @lead_provider, contract_period:, school: @school)
+    @training_period = FactoryBot.create(:training_period, :unfinished, :provider_led, ect_at_school_period: @ect, school_partnership: @school_partnership)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/selecting_a_different_lead_provider_when_registering_a_new_mentor_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/selecting_a_different_lead_provider_when_registering_a_new_mentor_spec.rb
@@ -58,8 +58,8 @@ RSpec.describe "Selecting a different lead provider" do
     @another_lead_provider = FactoryBot.create(:lead_provider, name: "Another lead provider")
     FactoryBot.create(:active_lead_provider, lead_provider: @another_lead_provider, contract_period:)
 
-    @ect = FactoryBot.create(:ect_at_school_period, :ongoing, school: @school)
-    @training_period = FactoryBot.create(:training_period, :ongoing, :provider_led, ect_at_school_period: @ect, school_partnership: @school_partnership)
+    @ect = FactoryBot.create(:ect_at_school_period, :unfinished, school: @school)
+    @training_period = FactoryBot.create(:training_period, :unfinished, :provider_led, ect_at_school_period: @ect, school_partnership: @school_partnership)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 

--- a/spec/features/schools/mentors/search_spec.rb
+++ b/spec/features/schools/mentors/search_spec.rb
@@ -45,10 +45,10 @@ RSpec.describe "Searching for a mentor" do
     @school = FactoryBot.create(:school)
 
     @matching_teacher = FactoryBot.create(:teacher, trs_first_name: "Jimmy", trs_last_name: "Searchable")
-    FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: @matching_teacher, school: @school)
+    FactoryBot.create(:mentor_at_school_period, :unfinished, teacher: @matching_teacher, school: @school)
 
     @non_matching_teacher = FactoryBot.create(:teacher, trs_first_name: "Bob", trs_last_name: "Invisible")
-    FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: @non_matching_teacher, school: @school)
+    FactoryBot.create(:mentor_at_school_period, :unfinished, teacher: @non_matching_teacher, school: @school)
   end
 
   def and_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/mentors/viewing_a_mentor_spec.rb
+++ b/spec/features/schools/mentors/viewing_a_mentor_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "Viewing a mentor" do
                              started_on: start_date,
                              finished_on: nil)
 
-    FactoryBot.create(:training_period, :ongoing, :provider_led, :for_ect, ect_at_school_period: @ect)
+    FactoryBot.create(:training_period, :unfinished, :provider_led, :for_ect, ect_at_school_period: @ect)
     FactoryBot.create(:mentorship_period, mentor: @mentor, mentee: @ect, started_on: start_date, finished_on: nil)
   end
 

--- a/spec/features/schools/mentorship/add_a_mentor_to_a_provider_led_ect_spec.rb
+++ b/spec/features/schools/mentorship/add_a_mentor_to_a_provider_led_ect_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "Add a mentor to a provider led ECT" do
   def given_the_mentor_already_has_an_ongoing_training_period
     FactoryBot.create(
       :training_period,
-      :ongoing,
+      :unfinished,
       :provider_led,
       :for_mentor,
       mentor_at_school_period: @mentor,
@@ -113,20 +113,20 @@ RSpec.describe "Add a mentor to a provider led ECT" do
 
     @ect = FactoryBot.create(
       :ect_at_school_period,
-      :ongoing,
+      :unfinished,
       school: @school,
       started_on: mid_year
     )
 
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
 
-    FactoryBot.create(:training_period, :ongoing, :provider_led, ect_at_school_period: @ect, school_partnership: @school_partnership)
+    FactoryBot.create(:training_period, :unfinished, :provider_led, ect_at_school_period: @ect, school_partnership: @school_partnership)
   end
 
   def and_the_school_has_a_mentor_eligible_to_mentor_the_ect
     @mentor = FactoryBot.create(
       :mentor_at_school_period,
-      :ongoing,
+      :unfinished,
       school: @school,
       started_on: mid_year
     )

--- a/spec/features/schools/mentorship/add_a_mentor_to_a_school_led_ect_spec.rb
+++ b/spec/features/schools/mentorship/add_a_mentor_to_a_school_led_ect_spec.rb
@@ -25,13 +25,13 @@ RSpec.describe "Add a mentor to a school led ECT" do
   end
 
   def and_there_is_a_school_led_ect_with_no_mentor_registered_at_the_school
-    @ect = FactoryBot.create(:ect_at_school_period, :ongoing, school: @school)
-    @training_period = FactoryBot.create(:training_period, :ongoing, :school_led, ect_at_school_period: @ect)
+    @ect = FactoryBot.create(:ect_at_school_period, :unfinished, school: @school)
+    @training_period = FactoryBot.create(:training_period, :unfinished, :school_led, ect_at_school_period: @ect)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 
   def and_there_is_a_mentor_registered_at_the_school_eligible_to_mentor_the_ect
-    @mentor = FactoryBot.create(:mentor_at_school_period, :ongoing, school: @school, started_on: @ect.started_on)
+    @mentor = FactoryBot.create(:mentor_at_school_period, :unfinished, school: @school, started_on: @ect.started_on)
     @mentor_name = Teachers::Name.new(@mentor.teacher).full_name
   end
 

--- a/spec/features/schools/mentorship/redirect_to_register_a_new_mentor_spec.rb
+++ b/spec/features/schools/mentorship/redirect_to_register_a_new_mentor_spec.rb
@@ -58,14 +58,14 @@ RSpec.describe "Redirect to register a new mentor for an ECT" do
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :ongoing, lead_provider: @lead_provider, school: @school)
+    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :unfinished, lead_provider: @lead_provider, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
 
-    FactoryBot.create(:training_period, :ongoing, school_partnership: @school_partnership, ect_at_school_period: @ect)
+    FactoryBot.create(:training_period, :unfinished, school_partnership: @school_partnership, ect_at_school_period: @ect)
   end
 
   def and_there_is_a_mentor_registered_at_the_school_eligible_to_mentor_the_ect
-    @mentor = FactoryBot.create(:mentor_at_school_period, :ongoing, school: @school)
+    @mentor = FactoryBot.create(:mentor_at_school_period, :unfinished, school: @school)
     @mentor_name = Teachers::Name.new(@mentor.teacher).full_name
   end
 

--- a/spec/helpers/ect_helper_spec.rb
+++ b/spec/helpers/ect_helper_spec.rb
@@ -3,8 +3,8 @@ RSpec.describe ECTHelper, type: :helper do
   let(:school) { FactoryBot.create(:school) }
   let(:trs_induction_status) { nil }
   let(:ect_teacher) { FactoryBot.create(:teacher, trs_induction_status:) }
-  let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: ect_teacher, school:, started_on:) }
-  let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, started_on:) }
+  let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher: ect_teacher, school:, started_on:) }
+  let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, school:, started_on:) }
 
   describe "#ect_mentor_name_or_assign_mentor_link" do
     subject(:mentor_details) { helper.ect_mentor_name_or_assign_mentor_link(ect_at_school_period) }
@@ -15,7 +15,7 @@ RSpec.describe ECTHelper, type: :helper do
 
     context "when the ECT has a mentor assigned" do
       before do
-        FactoryBot.create(:mentorship_period, :ongoing, mentee: ect_at_school_period, mentor: mentor_at_school_period, started_on:)
+        FactoryBot.create(:mentorship_period, :unfinished, mentee: ect_at_school_period, mentor: mentor_at_school_period, started_on:)
       end
 
       it { is_expected.to eq(latest_mentor_name(ect_at_school_period)) }
@@ -30,7 +30,7 @@ RSpec.describe ECTHelper, type: :helper do
         let!(:mentorship_period) do
           FactoryBot.create(
             :mentorship_period,
-            :ongoing,
+            :unfinished,
             mentee: ect_at_school_period,
             mentor: mentor_at_school_period,
             started_on:
@@ -48,7 +48,7 @@ RSpec.describe ECTHelper, type: :helper do
         let!(:current_mentor_at_school_period) do
           FactoryBot.create(
             :mentor_at_school_period,
-            :ongoing,
+            :unfinished,
             teacher: current_mentor_teacher,
             school:,
             started_on:
@@ -57,7 +57,7 @@ RSpec.describe ECTHelper, type: :helper do
         let!(:mentorship_period) do
           FactoryBot.create(
             :mentorship_period,
-            :ongoing,
+            :unfinished,
             mentee: ect_at_school_period,
             mentor: current_mentor_at_school_period,
             started_on:
@@ -115,7 +115,7 @@ RSpec.describe ECTHelper, type: :helper do
 
     context "when the ECT has an empty TRS induction status" do
       context "when the ECT has a current mentor" do
-        let!(:mentorship_period) { FactoryBot.create(:mentorship_period, :ongoing, mentee: ect_at_school_period, mentor: mentor_at_school_period, started_on:) }
+        let!(:mentorship_period) { FactoryBot.create(:mentorship_period, :unfinished, mentee: ect_at_school_period, mentor: mentor_at_school_period, started_on:) }
 
         it "returns a green 'Registered' tag" do
           expect(helper.ect_status(ect_at_school_period)).to have_css("strong.govuk-tag.govuk-tag--green", text: "Registered")

--- a/spec/helpers/induction_helper_spec.rb
+++ b/spec/helpers/induction_helper_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe InductionHelper, type: :helper do
   describe "#claiming_body?" do
     let(:teacher) { FactoryBot.create(:teacher) }
-    let(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:) }
+    let(:induction_period) { FactoryBot.create(:induction_period, :unfinished, teacher:) }
     let(:other_appropriate_body) { FactoryBot.create(:appropriate_body_period) }
 
     it "returns true when the current induction is with the claiming body" do

--- a/spec/helpers/register_ect_helper_spec.rb
+++ b/spec/helpers/register_ect_helper_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe RegisterECTHelper, type: :helper do
     context "when a contract_period exists for the date" do
       it "returns the correct formatted academic year string" do
         contract_period = double("ContractPeriod", year: 2023)
-        allow(ContractPeriod).to receive(:ongoing_on).with(date).and_return([contract_period])
+        allow(ContractPeriod).to receive(:contains_date).with(date).and_return([contract_period])
 
         expect(formatted_year_range_for_registration_date(date)).to eq("2023 to 2024")
       end
@@ -19,7 +19,7 @@ RSpec.describe RegisterECTHelper, type: :helper do
 
     context "when no contract_period exists for the date" do
       it "returns an empty string" do
-        allow(ContractPeriod).to receive(:ongoing_on).with(date).and_return([])
+        allow(ContractPeriod).to receive(:contains_date).with(date).and_return([])
 
         expect(formatted_year_range_for_registration_date(date)).to eq("")
       end

--- a/spec/jobs/appropriate_bodies/process_batch/record_pass_job_spec.rb
+++ b/spec/jobs/appropriate_bodies/process_batch/record_pass_job_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::RecordPassJob, type: :job do
 
   before do
     FactoryBot.create(:teacher, trn: pending_induction_submission.trn)
-    FactoryBot.create(:induction_period, :ongoing, teacher: pending_induction_submission.teacher, appropriate_body_period:)
+    FactoryBot.create(:induction_period, :unfinished, teacher: pending_induction_submission.teacher, appropriate_body_period:)
   end
 
   it "records an outcome for the induction", :aggregate_failures do

--- a/spec/jobs/appropriate_bodies/process_batch/record_release_job_spec.rb
+++ b/spec/jobs/appropriate_bodies/process_batch/record_release_job_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::RecordReleaseJob, type: :job do
 
   before do
     FactoryBot.create(:teacher, trn: pending_induction_submission.trn)
-    FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:)
+    FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:)
   end
 
   it "closes the induction", :aggregate_failures do

--- a/spec/jobs/appropriate_bodies/process_batch/register_ect_job_spec.rb
+++ b/spec/jobs/appropriate_bodies/process_batch/register_ect_job_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::RegisterECTJob, type: :job do
 
     context "and has an ongoing induction" do
       before do
-        FactoryBot.create(:induction_period, :ongoing,
+        FactoryBot.create(:induction_period, :unfinished,
                           teacher: Teacher.find_by(trn: pending_induction_submission.trn))
       end
 

--- a/spec/lib/appropriate_bodies/importers/teacher_induction_importer_spec.rb
+++ b/spec/lib/appropriate_bodies/importers/teacher_induction_importer_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe AppropriateBodies::Importers::TeacherInductionImporter do
       expect { induction_importer.import! }.not_to raise_error
 
       expect(Teacher.count).to eq(5) # 2 already + 3 imported
-      expect(InductionPeriod.ongoing.count).to be_zero
+      expect(InductionPeriod.unfinished.count).to be_zero
       expect(Teacher.induction_status_passed.count).to eq(1)
       expect(Teacher.induction_status_failed.count).to eq(2) # 1 already + 1 imported
       expect(Teacher.induction_status_failed_in_wales.count).to eq(1)
@@ -113,7 +113,7 @@ RSpec.describe AppropriateBodies::Importers::TeacherInductionImporter do
       expect(Teacher.induction_status_passed.count).to eq(589_222)
       expect(Teacher.induction_status_exempt.count).to eq(302)
 
-      expect(InductionPeriod.ongoing.count).to be_zero
+      expect(InductionPeriod.unfinished.count).to be_zero
       expect(InductionPeriod.count).to eq(634_213)
       expect(InductionPeriod.finished.count).to eq(InductionPeriod.count)
       expect(InductionPeriod.released.count).to eq(44_681)

--- a/spec/lib/remove_teacher_spec.rb
+++ b/spec/lib/remove_teacher_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe RemoveTeacher, :aggregate_failures do
     end
 
     let!(:ongoing_induction_period) do
-      FactoryBot.create(:induction_period, :ongoing,
+      FactoryBot.create(:induction_period, :unfinished,
                         teacher:,
                         appropriate_body_period: second_appropriate_body,
                         started_on: 1.week.ago)

--- a/spec/lib/schools/validation/period_boundary_spec.rb
+++ b/spec/lib/schools/validation/period_boundary_spec.rb
@@ -504,9 +504,9 @@ RSpec.shared_examples "period boundary validations" do
   def build_training_period(period:, started_on:, finished_on: nil)
     case period
     when ECTAtSchoolPeriod
-      FactoryBot.create(:training_period, :ongoing, :for_ect, ect_at_school_period: period, started_on:, finished_on:)
+      FactoryBot.create(:training_period, :unfinished, :for_ect, ect_at_school_period: period, started_on:, finished_on:)
     when MentorAtSchoolPeriod
-      FactoryBot.create(:training_period, :ongoing, :for_mentor, mentor_at_school_period: period, started_on:, finished_on:)
+      FactoryBot.create(:training_period, :unfinished, :for_mentor, mentor_at_school_period: period, started_on:, finished_on:)
     end
   end
 end
@@ -520,13 +520,13 @@ RSpec.describe Schools::Validation::PeriodBoundary do
   end
 
   context "when validating an ECT at school period" do
-    let(:input_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: input_period_started_on) }
+    let(:input_period) { FactoryBot.create(:ect_at_school_period, :unfinished, started_on: input_period_started_on) }
 
     it_behaves_like "period boundary validations"
   end
 
   context "when validating a mentor at school period" do
-    let(:input_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, started_on: input_period_started_on) }
+    let(:input_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, started_on: input_period_started_on) }
 
     it_behaves_like "period boundary validations"
   end

--- a/spec/models/concerns/at_school_period_spec.rb
+++ b/spec/models/concerns/at_school_period_spec.rb
@@ -14,7 +14,7 @@ describe AtSchoolPeriod do
 
     describe "covering inner periods" do
       context "for an ECT at school period" do
-        let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 1.year.ago) }
+        let(:ect) { FactoryBot.create(:ect_at_school_period, :unfinished, started_on: 1.year.ago) }
 
         context "with no inner periods" do
           it "is valid" do
@@ -34,7 +34,7 @@ describe AtSchoolPeriod do
 
         context "with an ongoing training period when the ECT is ongoing" do
           before do
-            FactoryBot.create(:training_period, :ongoing, ect_at_school_period: ect, started_on: 6.months.ago)
+            FactoryBot.create(:training_period, :unfinished, ect_at_school_period: ect, started_on: 6.months.ago)
           end
 
           it "is valid" do
@@ -69,10 +69,10 @@ describe AtSchoolPeriod do
         end
 
         context "when finishing an ECT that has an ongoing training period" do
-          let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 2.years.ago) }
+          let(:ect) { FactoryBot.create(:ect_at_school_period, :unfinished, started_on: 2.years.ago) }
 
           before do
-            FactoryBot.create(:training_period, :ongoing, ect_at_school_period: ect, started_on: 2.years.ago)
+            FactoryBot.create(:training_period, :unfinished, ect_at_school_period: ect, started_on: 2.years.ago)
           end
 
           it "is invalid when setting finished_on while a training period is ongoing" do
@@ -84,7 +84,7 @@ describe AtSchoolPeriod do
         end
 
         context "with mentorship periods fully within range" do
-          let(:mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, school: ect.school) }
+          let(:mentor) { FactoryBot.create(:mentor_at_school_period, :unfinished, school: ect.school) }
 
           before do
             FactoryBot.create(:mentorship_period, mentee: ect, mentor:, started_on: 6.months.ago, finished_on: 1.month.ago)
@@ -96,7 +96,7 @@ describe AtSchoolPeriod do
         end
 
         context "when the ECT start is moved after the mentorship period start" do
-          let(:mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, school: ect.school) }
+          let(:mentor) { FactoryBot.create(:mentor_at_school_period, :unfinished, school: ect.school) }
 
           before do
             FactoryBot.create(:mentorship_period, mentee: ect, mentor:, started_on: 6.months.ago, finished_on: 1.month.ago)
@@ -110,7 +110,7 @@ describe AtSchoolPeriod do
         end
 
         context "with multiple inner periods all within range" do
-          let(:mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, school: ect.school) }
+          let(:mentor) { FactoryBot.create(:mentor_at_school_period, :unfinished, school: ect.school) }
 
           before do
             FactoryBot.create(:training_period, ect_at_school_period: ect, started_on: 9.months.ago, finished_on: 6.months.ago)
@@ -123,7 +123,7 @@ describe AtSchoolPeriod do
         end
 
         context "with multiple inner periods where one is outside range" do
-          let(:mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, school: ect.school) }
+          let(:mentor) { FactoryBot.create(:mentor_at_school_period, :unfinished, school: ect.school) }
 
           before do
             FactoryBot.create(:training_period, ect_at_school_period: ect, started_on: 9.months.ago, finished_on: 6.months.ago)
@@ -139,7 +139,7 @@ describe AtSchoolPeriod do
       end
 
       context "for a mentor at school period" do
-        let(:mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, started_on: 1.year.ago) }
+        let(:mentor) { FactoryBot.create(:mentor_at_school_period, :unfinished, started_on: 1.year.ago) }
 
         context "with no inner periods" do
           it "is valid" do
@@ -172,7 +172,7 @@ describe AtSchoolPeriod do
         end
 
         context "with mentorship periods (where this mentor is mentoring) within range" do
-          let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, school: mentor.school) }
+          let(:ect) { FactoryBot.create(:ect_at_school_period, :unfinished, school: mentor.school) }
 
           before do
             FactoryBot.create(:mentorship_period, mentor:, mentee: ect, started_on: 6.months.ago, finished_on: 1.month.ago)
@@ -184,7 +184,7 @@ describe AtSchoolPeriod do
         end
 
         context "when the mentor start is moved after the mentorship period start" do
-          let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, school: mentor.school) }
+          let(:ect) { FactoryBot.create(:ect_at_school_period, :unfinished, school: mentor.school) }
 
           before do
             FactoryBot.create(:mentorship_period, mentor:, mentee: ect, started_on: 6.months.ago, finished_on: 3.months.ago)
@@ -282,9 +282,9 @@ describe AtSchoolPeriod do
 
   describe "#provider_led_training_programme?" do
     context "when there is a current or next training period that is provider-led" do
-      let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 1.year.ago) }
+      let(:ect) { FactoryBot.create(:ect_at_school_period, :unfinished, started_on: 1.year.ago) }
 
-      before { FactoryBot.create(:training_period, :ongoing, :provider_led, ect_at_school_period: ect, started_on: 6.months.ago) }
+      before { FactoryBot.create(:training_period, :unfinished, :provider_led, ect_at_school_period: ect, started_on: 6.months.ago) }
 
       it "returns true" do
         expect(ect.provider_led_training_programme?).to be true
@@ -302,9 +302,9 @@ describe AtSchoolPeriod do
 
   describe "#school_led_training_programme?" do
     context "when there is a current or next training period that is school-led" do
-      let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 1.year.ago) }
+      let(:ect) { FactoryBot.create(:ect_at_school_period, :unfinished, started_on: 1.year.ago) }
 
-      before { FactoryBot.create(:training_period, :ongoing, :school_led, ect_at_school_period: ect, started_on: 6.months.ago) }
+      before { FactoryBot.create(:training_period, :unfinished, :school_led, ect_at_school_period: ect, started_on: 6.months.ago) }
 
       it "returns true" do
         expect(ect.school_led_training_programme?).to be true
@@ -322,7 +322,7 @@ describe AtSchoolPeriod do
 
   describe "#reported_leaving_by?" do
     context "via ECTAtSchoolPeriod" do
-      subject(:period) { FactoryBot.create(:ect_at_school_period, :ongoing, reported_leaving_by_school_id: reporter_id) }
+      subject(:period) { FactoryBot.create(:ect_at_school_period, :unfinished, reported_leaving_by_school_id: reporter_id) }
 
       let(:reporting_school) { FactoryBot.create(:school) }
       let(:other_school) { FactoryBot.create(:school) }
@@ -353,7 +353,7 @@ describe AtSchoolPeriod do
     end
 
     context "via MentorAtSchoolPeriod" do
-      subject(:period) { FactoryBot.create(:mentor_at_school_period, :ongoing, reported_leaving_by_school_id: reporter_id) }
+      subject(:period) { FactoryBot.create(:mentor_at_school_period, :unfinished, reported_leaving_by_school_id: reporter_id) }
 
       let(:reporting_school) { FactoryBot.create(:school) }
       let(:other_school) { FactoryBot.create(:school) }

--- a/spec/models/concerns/interval_spec.rb
+++ b/spec/models/concerns/interval_spec.rb
@@ -79,9 +79,9 @@ describe Interval do
       end
     end
 
-    describe ".ongoing" do
+    describe ".unfinished" do
       it "returns records where the finished_on date is null" do
-        expect(DummyMentor.ongoing.to_sql).to end_with(%("finished_on" IS NULL))
+        expect(DummyMentor.unfinished.to_sql).to end_with(%("finished_on" IS NULL))
       end
     end
 
@@ -136,10 +136,10 @@ describe Interval do
       end
     end
 
-    describe ".ongoing_today" do
+    describe ".contains_today" do
       it "queries for dates within the range field" do
         today = Time.zone.today.to_s
-        expect(DummyMentor.ongoing_today.to_sql).to end_with(%{"range" @> date('#{today}'))})
+        expect(DummyMentor.contains_today.to_sql).to end_with(%{"range" @> date('#{today}'))})
       end
     end
 
@@ -151,13 +151,13 @@ describe Interval do
     end
 
     describe ".current_or_future" do
-      it "chains together .ongoing_today and .starting_tomorrow_or_after" do
-        allow(DummyMentor).to receive(:ongoing_today).and_call_original
+      it "chains together .contains_today and .starting_tomorrow_or_after" do
+        allow(DummyMentor).to receive(:contains_today).and_call_original
         allow(DummyMentor).to receive(:starting_tomorrow_or_after).and_call_original
 
         DummyMentor.current_or_future
 
-        expect(DummyMentor).to have_received(:ongoing_today).once
+        expect(DummyMentor).to have_received(:contains_today).once
         expect(DummyMentor).to have_received(:starting_tomorrow_or_after).once
       end
     end
@@ -190,9 +190,9 @@ describe Interval do
       end
     end
 
-    describe ".ongoing_on" do
+    describe ".contains_date" do
       it "returns records where the `started_on` and `finished_on` cover the date" do
-        ongoing_mentor = DummyMentor.ongoing_on(Date.new(2023, 2, 15))
+        ongoing_mentor = DummyMentor.contains_date(Date.new(2023, 2, 15))
 
         expect(ongoing_mentor).to match_array([period_1, teacher_2_period])
       end
@@ -215,17 +215,17 @@ describe Interval do
     end
   end
 
-  describe "#ongoing?" do
+  describe "#unfinished?" do
     context "without finished_on" do
       subject(:interval) { DummyInterval.new(started_on: 1.week.ago, finished_on: nil) }
 
-      it { is_expected.to be_ongoing }
+      it { is_expected.to be_unfinished }
     end
 
     context "with finished_on" do
       subject(:interval) { DummyInterval.new(started_on: 1.week.ago, finished_on: 1.day.ago) }
 
-      it { is_expected.not_to be_ongoing }
+      it { is_expected.not_to be_unfinished }
     end
   end
 
@@ -382,30 +382,30 @@ describe Interval do
     end
   end
 
-  describe "#ongoing_today?" do
+  describe "#contains_today?" do
     context "without finished_on" do
       subject(:interval) { DummyInterval.new(started_on: 1.week.ago, finished_on: nil) }
 
-      it { is_expected.to be_ongoing_today }
+      it { is_expected.to be_contains_today }
     end
 
     context "with finished_on" do
       context "in the future" do
         subject(:interval) { DummyInterval.new(started_on: 1.week.ago, finished_on: 1.day.from_now) }
 
-        it { is_expected.to be_ongoing_today }
+        it { is_expected.to be_contains_today }
       end
 
       context "in the past" do
         subject(:interval) { DummyInterval.new(started_on: 1.week.ago, finished_on: 1.day.ago) }
 
-        it { is_expected.not_to be_ongoing_today }
+        it { is_expected.not_to be_contains_today }
       end
 
       context "in the present" do
         subject(:interval) { DummyInterval.new(started_on: 1.week.ago, finished_on: Time.zone.today) }
 
-        it { is_expected.not_to be_ongoing_today }
+        it { is_expected.not_to be_contains_today }
       end
     end
   end

--- a/spec/models/ect_at_school_period_spec.rb
+++ b/spec/models/ect_at_school_period_spec.rb
@@ -1,14 +1,14 @@
 describe ECTAtSchoolPeriod do
   describe "declarative updates" do
     describe "school target" do
-      let(:instance) { FactoryBot.create(:ect_at_school_period, :ongoing, school: target) }
+      let(:instance) { FactoryBot.create(:ect_at_school_period, :unfinished, school: target) }
       let!(:target) { FactoryBot.create(:school) }
 
       it_behaves_like "a declarative metadata model", on_event: %i[create destroy update]
     end
 
     describe "teacher target" do
-      let(:instance) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: target) }
+      let(:instance) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher: target) }
       let!(:target) { FactoryBot.create(:teacher) }
 
       it_behaves_like "a declarative metadata model", on_event: %i[create destroy update]
@@ -25,12 +25,12 @@ describe ECTAtSchoolPeriod do
     it { is_expected.to have_many(:events) }
 
     describe ".current_or_next_training_period" do
-      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 1.year.ago) }
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, started_on: 1.year.ago) }
 
       it { is_expected.to have_one(:current_or_next_training_period).class_name("TrainingPeriod") }
 
       context "when there is a current period" do
-        let!(:training_period) { FactoryBot.create(:training_period, :ongoing, ect_at_school_period:) }
+        let!(:training_period) { FactoryBot.create(:training_period, :unfinished, ect_at_school_period:) }
 
         it "returns the current training_period" do
           expect(ect_at_school_period.current_or_next_training_period).to eql(training_period)
@@ -56,7 +56,7 @@ describe ECTAtSchoolPeriod do
     end
 
     describe "#current_or_next_or_latest_training_period" do
-      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 1.year.ago) }
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, started_on: 1.year.ago) }
 
       context "when there is a current period and a future period" do
         let!(:current_training_period) do
@@ -71,7 +71,7 @@ describe ECTAtSchoolPeriod do
         let!(:future_training_period) do
           FactoryBot.create(
             :training_period,
-            :ongoing,
+            :unfinished,
             :provider_led,
             ect_at_school_period:,
             started_on: current_training_period.finished_on.next_day
@@ -96,7 +96,7 @@ describe ECTAtSchoolPeriod do
         let!(:future_training_period) do
           FactoryBot.create(
             :training_period,
-            :ongoing,
+            :unfinished,
             :provider_led,
             ect_at_school_period:,
             started_on: next_training_period.finished_on.next_day
@@ -130,7 +130,7 @@ describe ECTAtSchoolPeriod do
       let(:ect_at_school_period) do
         FactoryBot.create(
           :ect_at_school_period,
-          :ongoing,
+          :unfinished,
           started_on: 2.years.ago
         )
       end
@@ -172,7 +172,7 @@ describe ECTAtSchoolPeriod do
 
     describe ".current_or_next_mentorship_period" do
       let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, started_on: 1.year.ago, finished_on: nil) }
-      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school: ect_at_school_period.school) }
+      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, school: ect_at_school_period.school) }
       let(:mentorship_started_on) { 3.weeks.ago }
       let(:mentorship_finished_on) { nil }
 
@@ -200,7 +200,7 @@ describe ECTAtSchoolPeriod do
         let!(:future_mentorship_period) do
           FactoryBot.create(
             :mentorship_period,
-            :ongoing,
+            :unfinished,
             mentee: ect_at_school_period,
             mentor: mentor_at_school_period,
             started_on: mentorship_finished_on + 1.day,
@@ -225,8 +225,8 @@ describe ECTAtSchoolPeriod do
     describe ".latest_mentorship_period" do
       subject { ect_at_school_period.latest_mentorship_period }
 
-      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 1.year.ago) }
-      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school: ect_at_school_period.school) }
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, started_on: 1.year.ago) }
+      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, school: ect_at_school_period.school) }
       let(:mentorship_started_on) { 3.weeks.ago }
       let(:mentorship_finished_on) { nil }
       let!(:latest_mentorship_period) do
@@ -416,7 +416,7 @@ describe ECTAtSchoolPeriod do
       let!(:ongoing_ect_at_school_period) do
         FactoryBot.create(
           :ect_at_school_period,
-          :ongoing,
+          :unfinished,
           teacher:,
           school:,
           started_on: 1.year.ago
@@ -428,7 +428,7 @@ describe ECTAtSchoolPeriod do
         let(:concurrent_ongoing_period) do
           FactoryBot.build(
             :ect_at_school_period,
-            :ongoing,
+            :unfinished,
             teacher:,
             school: other_school,
             started_on: 1.week.from_now
@@ -445,7 +445,7 @@ describe ECTAtSchoolPeriod do
         let(:concurrent_ongoing_period) do
           FactoryBot.build(
             :ect_at_school_period,
-            :ongoing,
+            :unfinished,
             teacher:,
             school:,
             started_on: 1.week.from_now
@@ -538,16 +538,16 @@ describe ECTAtSchoolPeriod do
       let(:appropriate_body_period) { FactoryBot.create(:appropriate_body_period, :teaching_school_hub) }
       let(:other_appropriate_body) { FactoryBot.create(:appropriate_body_period, :teaching_school_hub) }
 
-      let!(:period_without_induction_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school_reported_appropriate_body: appropriate_body_period) }
-      let!(:period_with_ongoing_induction_period_for_same_appropriate_body) { FactoryBot.create(:ect_at_school_period, :ongoing, school_reported_appropriate_body: appropriate_body_period) }
-      let!(:period_with_ongoing_induction_period_for_different_appropriate_body) { FactoryBot.create(:ect_at_school_period, :ongoing, school_reported_appropriate_body: appropriate_body_period) }
-      let!(:period_with_finished_induction_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school_reported_appropriate_body: appropriate_body_period) }
+      let!(:period_without_induction_period) { FactoryBot.create(:ect_at_school_period, :unfinished, school_reported_appropriate_body: appropriate_body_period) }
+      let!(:period_with_ongoing_induction_period_for_same_appropriate_body) { FactoryBot.create(:ect_at_school_period, :unfinished, school_reported_appropriate_body: appropriate_body_period) }
+      let!(:period_with_ongoing_induction_period_for_different_appropriate_body) { FactoryBot.create(:ect_at_school_period, :unfinished, school_reported_appropriate_body: appropriate_body_period) }
+      let!(:period_with_finished_induction_period) { FactoryBot.create(:ect_at_school_period, :unfinished, school_reported_appropriate_body: appropriate_body_period) }
       let!(:finished_period) { FactoryBot.create(:ect_at_school_period, :finished, school_reported_appropriate_body: appropriate_body_period) }
-      let!(:period_with_different_appropriate_body) { FactoryBot.create(:ect_at_school_period, :ongoing, school_reported_appropriate_body: other_appropriate_body) }
+      let!(:period_with_different_appropriate_body) { FactoryBot.create(:ect_at_school_period, :unfinished, school_reported_appropriate_body: other_appropriate_body) }
 
       before do
-        FactoryBot.create(:induction_period, :ongoing, appropriate_body_period:, teacher: period_with_ongoing_induction_period_for_same_appropriate_body.teacher)
-        FactoryBot.create(:induction_period, :ongoing, appropriate_body_period: other_appropriate_body, teacher: period_with_ongoing_induction_period_for_different_appropriate_body.teacher)
+        FactoryBot.create(:induction_period, :unfinished, appropriate_body_period:, teacher: period_with_ongoing_induction_period_for_same_appropriate_body.teacher)
+        FactoryBot.create(:induction_period, :unfinished, appropriate_body_period: other_appropriate_body, teacher: period_with_ongoing_induction_period_for_different_appropriate_body.teacher)
         FactoryBot.create(:induction_period, started_on: 1.year.ago, finished_on: 1.month.ago, teacher: period_with_finished_induction_period.teacher)
       end
 
@@ -572,7 +572,7 @@ describe ECTAtSchoolPeriod do
       let(:teacher_with_failed_induction) { FactoryBot.create(:teacher, :induction_failed) }
 
       let!(:period_1) { FactoryBot.create(:ect_at_school_period, :finished, teacher: teacher_with_passed_induction) }
-      let!(:period_2) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:) }
+      let!(:period_2) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher:) }
       let!(:period_3) { FactoryBot.create(:ect_at_school_period, :finished, teacher: teacher_with_failed_induction) }
 
       it "returns ect periods where the teacher's induction is not completed" do
@@ -589,17 +589,17 @@ describe ECTAtSchoolPeriod do
       let(:teacher_with_qts_claimed_by_different_ab) { FactoryBot.create(:teacher, trs_qts_awarded_on: 1.year.ago) }
 
       let!(:period_with_qts) do
-        FactoryBot.create(:ect_at_school_period, :ongoing, teacher: teacher_with_qts, school_reported_appropriate_body: appropriate_body_period)
+        FactoryBot.create(:ect_at_school_period, :unfinished, teacher: teacher_with_qts, school_reported_appropriate_body: appropriate_body_period)
       end
       let!(:period_without_qts) do
-        FactoryBot.create(:ect_at_school_period, :ongoing, teacher: teacher_without_qts, school_reported_appropriate_body: appropriate_body_period)
+        FactoryBot.create(:ect_at_school_period, :unfinished, teacher: teacher_without_qts, school_reported_appropriate_body: appropriate_body_period)
       end
       let!(:period_with_qts_claimed_by_different_ab) do
-        FactoryBot.create(:ect_at_school_period, :ongoing, teacher: teacher_with_qts_claimed_by_different_ab, school_reported_appropriate_body: appropriate_body_period)
+        FactoryBot.create(:ect_at_school_period, :unfinished, teacher: teacher_with_qts_claimed_by_different_ab, school_reported_appropriate_body: appropriate_body_period)
       end
 
       before do
-        FactoryBot.create(:induction_period, :ongoing, appropriate_body_period: other_appropriate_body, teacher: teacher_with_qts_claimed_by_different_ab)
+        FactoryBot.create(:induction_period, :unfinished, appropriate_body_period: other_appropriate_body, teacher: teacher_with_qts_claimed_by_different_ab)
       end
 
       describe ".without_qts_award" do
@@ -656,7 +656,7 @@ describe ECTAtSchoolPeriod do
   end
 
   describe "#reported_leaving_by?" do
-    subject(:period) { FactoryBot.create(:ect_at_school_period, :ongoing, reported_leaving_by_school_id: reporter_id) }
+    subject(:period) { FactoryBot.create(:ect_at_school_period, :unfinished, reported_leaving_by_school_id: reporter_id) }
 
     let(:reporting_school) { FactoryBot.create(:school) }
     let(:other_school) { FactoryBot.create(:school) }

--- a/spec/models/induction_period_spec.rb
+++ b/spec/models/induction_period_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe InductionPeriod do
     it { is_expected.not_to validate_absence_of(:outcome).with_message("Outcome cannot be set for ongoing induction periods") }
 
     context "when induction period is ongoing" do
-      subject { FactoryBot.build(:induction_period, :ongoing) }
+      subject { FactoryBot.build(:induction_period, :unfinished) }
 
       it { is_expected.to validate_absence_of(:outcome).with_message("Outcome cannot be set for ongoing induction periods") }
     end
@@ -129,7 +129,7 @@ RSpec.describe InductionPeriod do
           end
 
           it "returns false if it is not the first induction period and outcome has not changed" do
-            second_induction_period = FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:, started_on: "2023-01-01")
+            second_induction_period = FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:, started_on: "2023-01-01")
 
             expect(second_induction_period.send(:touch_teacher?)).to be(false)
           end
@@ -165,7 +165,7 @@ RSpec.describe InductionPeriod do
       it { is_expected.to validate_inclusion_of(:training_programme).in_array(%w[provider_led school_led]).with_message("Choose an induction programme") }
 
       context "when the induction pre-dates School-led and Provider-Led programme types and training_programme is blank" do
-        subject { FactoryBot.create(:induction_period, :ongoing, :pre_2021, :legacy_programme_type) }
+        subject { FactoryBot.create(:induction_period, :unfinished, :pre_2021, :legacy_programme_type) }
 
         it { is_expected.to be_valid }
       end
@@ -190,7 +190,7 @@ RSpec.describe InductionPeriod do
     end
 
     describe "#started_on_not_in_future" do
-      subject { FactoryBot.build(:induction_period, :ongoing, appropriate_body_period:, started_on:) }
+      subject { FactoryBot.build(:induction_period, :unfinished, appropriate_body_period:, started_on:) }
 
       context "when start date is today" do
         let(:started_on) { Date.current }
@@ -290,7 +290,7 @@ RSpec.describe InductionPeriod do
 
     describe "#number_of_terms" do
       context "when finished_on is empty" do
-        subject { FactoryBot.build(:induction_period, :ongoing, appropriate_body_period:) }
+        subject { FactoryBot.build(:induction_period, :unfinished, appropriate_body_period:) }
 
         it { is_expected.not_to validate_presence_of(:number_of_terms) }
       end
@@ -360,7 +360,7 @@ RSpec.describe InductionPeriod do
   end
 
   describe "scopes" do
-    let!(:ongoing) { FactoryBot.create(:induction_period, :ongoing) }
+    let!(:unfinished_period) { FactoryBot.create(:induction_period, :unfinished) }
     let!(:released) { FactoryBot.create(:induction_period) }
     let!(:passed) { FactoryBot.create(:induction_period, :pass) }
     let!(:failed) { FactoryBot.create(:induction_period, :fail) }
@@ -373,13 +373,13 @@ RSpec.describe InductionPeriod do
 
     describe ".without_outcome" do
       it "returns induction periods with no outcome" do
-        expect(described_class.without_outcome).to contain_exactly(ongoing, released)
+        expect(described_class.without_outcome).to contain_exactly(unfinished_period, released)
       end
     end
 
-    describe ".ongoing" do
+    describe ".unfinished" do
       it "returns unfinished induction periods" do
-        expect(described_class.ongoing).to contain_exactly(ongoing)
+        expect(described_class.unfinished).to contain_exactly(unfinished_period)
       end
     end
 
@@ -457,7 +457,7 @@ RSpec.describe InductionPeriod do
       end
 
       let!(:induction_period) do
-        FactoryBot.create(:induction_period, :ongoing,
+        FactoryBot.create(:induction_period, :unfinished,
                           teacher:,
                           started_on: "2025-01-01")
       end
@@ -487,7 +487,7 @@ RSpec.describe InductionPeriod do
       end
 
       let!(:induction_period) do
-        FactoryBot.create(:induction_period, :ongoing,
+        FactoryBot.create(:induction_period, :unfinished,
                           teacher:,
                           started_on: "2025-01-01")
       end

--- a/spec/models/mentor_at_school_period_spec.rb
+++ b/spec/models/mentor_at_school_period_spec.rb
@@ -1,14 +1,14 @@
 describe MentorAtSchoolPeriod do
   describe "declarative updates" do
     describe "school target" do
-      let(:instance) { FactoryBot.create(:mentor_at_school_period, :ongoing, school: target) }
+      let(:instance) { FactoryBot.create(:mentor_at_school_period, :unfinished, school: target) }
       let!(:target) { FactoryBot.create(:school) }
 
       it_behaves_like "a declarative metadata model", on_event: %i[create destroy update]
     end
 
     describe "teacher target" do
-      let(:instance) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: target) }
+      let(:instance) { FactoryBot.create(:mentor_at_school_period, :unfinished, teacher: target) }
       let!(:target) { FactoryBot.create(:teacher) }
 
       it_behaves_like "a declarative metadata model", on_event: %i[create destroy update]
@@ -38,9 +38,9 @@ describe MentorAtSchoolPeriod do
     let(:finishing) { FactoryBot.create(:ect_at_school_period, school:, finished_on: 1.week.from_now) }
     let(:current)   { FactoryBot.create(:ect_at_school_period, school:, finished_on: nil) }
     let(:upcoming)  { FactoryBot.create(:ect_at_school_period, school:, started_on: 1.week.from_now) }
-    let(:passed)    { FactoryBot.create(:ect_at_school_period, :ongoing, school:, teacher: passed_teacher) }
-    let(:failed)    { FactoryBot.create(:ect_at_school_period, :ongoing, school:, teacher: failed_teacher) }
-    let(:previously_mentored) { FactoryBot.create(:ect_at_school_period, :ongoing, school:, started_on: 1.year.ago) }
+    let(:passed)    { FactoryBot.create(:ect_at_school_period, :unfinished, school:, teacher: passed_teacher) }
+    let(:failed)    { FactoryBot.create(:ect_at_school_period, :unfinished, school:, teacher: failed_teacher) }
+    let(:previously_mentored) { FactoryBot.create(:ect_at_school_period, :unfinished, school:, started_on: 1.year.ago) }
 
     before do
       [finished, finishing, current, upcoming, passed, failed].each do |mentee|
@@ -62,12 +62,12 @@ describe MentorAtSchoolPeriod do
   end
 
   describe ".current_or_next_training_period" do
-    let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, started_on: 1.year.ago) }
+    let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, started_on: 1.year.ago) }
 
     it { is_expected.to have_one(:current_or_next_training_period).class_name("TrainingPeriod") }
 
     context "when there is a current period" do
-      let!(:training_period) { FactoryBot.create(:training_period, :ongoing, :for_mentor, mentor_at_school_period:) }
+      let!(:training_period) { FactoryBot.create(:training_period, :unfinished, :for_mentor, mentor_at_school_period:) }
 
       it "returns the current training_period" do
         expect(mentor_at_school_period.current_or_next_training_period).to eql(training_period)
@@ -96,7 +96,7 @@ describe MentorAtSchoolPeriod do
     let(:mentor_at_school_period) do
       FactoryBot.create(
         :mentor_at_school_period,
-        :ongoing,
+        :unfinished,
         started_on: 2.years.ago
       )
     end
@@ -210,7 +210,7 @@ describe MentorAtSchoolPeriod do
     let!(:ongoing_mentor_at_school_period) do
       FactoryBot.create(
         :mentor_at_school_period,
-        :ongoing,
+        :unfinished,
         teacher:,
         school:,
         started_on: 1.year.ago
@@ -222,7 +222,7 @@ describe MentorAtSchoolPeriod do
       let(:concurrent_ongoing_period) do
         FactoryBot.build(
           :mentor_at_school_period,
-          :ongoing,
+          :unfinished,
           teacher:,
           school: other_school,
           started_on: 1.week.from_now
@@ -236,7 +236,7 @@ describe MentorAtSchoolPeriod do
       let(:concurrent_ongoing_period) do
         FactoryBot.build(
           :mentor_at_school_period,
-          :ongoing,
+          :unfinished,
           teacher:,
           school:,
           started_on: 1.week.from_now
@@ -337,7 +337,7 @@ describe MentorAtSchoolPeriod do
 
     describe "#latest_mentor_at_school_period?", :with_touches do
       let(:teacher) { FactoryBot.create(:teacher) }
-      let!(:latest_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:, started_on: 6.months.ago) }
+      let!(:latest_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:, started_on: 6.months.ago) }
       let!(:previous_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher:, started_on: 1.year.ago, finished_on: 6.months.ago) }
       let(:email_change) { "test1@anyexampleemail.com" }
 
@@ -375,7 +375,7 @@ describe MentorAtSchoolPeriod do
   end
 
   describe "#reported_leaving_by?" do
-    subject(:period) { FactoryBot.create(:mentor_at_school_period, :ongoing, reported_leaving_by_school_id: reporter_id) }
+    subject(:period) { FactoryBot.create(:mentor_at_school_period, :unfinished, reported_leaving_by_school_id: reporter_id) }
 
     let(:reporting_school) { FactoryBot.create(:school) }
     let(:other_school) { FactoryBot.create(:school) }

--- a/spec/models/mentorship_period_spec.rb
+++ b/spec/models/mentorship_period_spec.rb
@@ -1,6 +1,6 @@
 describe MentorshipPeriod do
   describe "declarative updates" do
-    let(:instance) { FactoryBot.create(:mentorship_period, :ongoing, mentee:, mentor:, started_on: 1.year.ago, finished_on: nil) }
+    let(:instance) { FactoryBot.create(:mentorship_period, :unfinished, mentee:, mentor:, started_on: 1.year.ago, finished_on: nil) }
     let(:mentee) { FactoryBot.create(:ect_at_school_period, started_on: 5.years.ago, finished_on: nil, teacher: target, school:) }
     let(:mentor) { FactoryBot.create(:mentor_at_school_period, started_on: 5.years.ago, finished_on: nil, school:) }
     let!(:target) { FactoryBot.create(:teacher) }
@@ -27,8 +27,8 @@ describe MentorshipPeriod do
     end
 
     let(:school) { FactoryBot.create(:school) }
-    let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 2.years.ago, school:) }
-    let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, started_on: 2.years.ago, school:) }
+    let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, started_on: 2.years.ago, school:) }
+    let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, started_on: 2.years.ago, school:) }
     let(:started_on) { 2.months.ago }
     let(:finished_on) { nil }
 
@@ -122,7 +122,7 @@ describe MentorshipPeriod do
         let(:mentor_at_school_period) do
           FactoryBot.create(
             :mentor_at_school_period,
-            :ongoing,
+            :unfinished,
             school: ect_at_school_period.school,
             started_on: 1.year.ago
           )
@@ -141,7 +141,7 @@ describe MentorshipPeriod do
         let(:next_ect_at_school_period) do
           FactoryBot.create(
             :ect_at_school_period,
-            :ongoing,
+            :unfinished,
             teacher: mentee_teacher,
             started_on: ect_at_school_period.finished_on.advance(days: 1)
           )
@@ -149,7 +149,7 @@ describe MentorshipPeriod do
         let(:next_mentor_at_school_period) do
           FactoryBot.create(
             :mentor_at_school_period,
-            :ongoing,
+            :unfinished,
             school: next_ect_at_school_period.school,
             started_on: 1.year.ago
           )
@@ -157,7 +157,7 @@ describe MentorshipPeriod do
         let!(:ongoing_mentorship_period) do
           FactoryBot.create(
             :mentorship_period,
-            :ongoing,
+            :unfinished,
             mentee: next_ect_at_school_period,
             mentor: next_mentor_at_school_period,
             started_on: next_ect_at_school_period.started_on
@@ -168,7 +168,7 @@ describe MentorshipPeriod do
         let(:concurrent_ongoing_period) do
           FactoryBot.build(
             :mentorship_period,
-            :ongoing,
+            :unfinished,
             mentee: ect_at_school_period,
             mentor: mentor_at_school_period,
             started_on: mentorship_period.finished_on
@@ -188,7 +188,7 @@ describe MentorshipPeriod do
         let(:ect_at_school_period) do
           FactoryBot.create(
             :ect_at_school_period,
-            :ongoing,
+            :unfinished,
             started_on: 1.year.ago
           )
         end
@@ -215,7 +215,7 @@ describe MentorshipPeriod do
         let(:next_mentor_at_school_period) do
           FactoryBot.create(
             :mentor_at_school_period,
-            :ongoing,
+            :unfinished,
             school: next_ect_at_school_period.school,
             teacher: mentor_teacher,
             started_on: mentor_at_school_period.finished_on.advance(days: 1)
@@ -224,14 +224,14 @@ describe MentorshipPeriod do
         let(:next_ect_at_school_period) do
           FactoryBot.create(
             :ect_at_school_period,
-            :ongoing,
+            :unfinished,
             started_on: mentor_at_school_period.finished_on.advance(days: 1)
           )
         end
         let!(:ongoing_mentorship_period) do
           FactoryBot.create(
             :mentorship_period,
-            :ongoing,
+            :unfinished,
             mentor: next_mentor_at_school_period,
             mentee: next_ect_at_school_period,
             started_on: next_mentor_at_school_period.started_on
@@ -242,7 +242,7 @@ describe MentorshipPeriod do
         let(:other_next_ect_at_school_period) do
           FactoryBot.create(
             :ect_at_school_period,
-            :ongoing,
+            :unfinished,
             school: next_ect_at_school_period.school,
             started_on: next_mentor_at_school_period.started_on.advance(weeks: 1)
           )
@@ -250,7 +250,7 @@ describe MentorshipPeriod do
         let(:concurrent_ongoing_period) do
           FactoryBot.build(
             :mentorship_period,
-            :ongoing,
+            :unfinished,
             mentor: next_mentor_at_school_period,
             mentee: other_next_ect_at_school_period,
             started_on: other_next_ect_at_school_period.started_on
@@ -302,8 +302,8 @@ describe MentorshipPeriod do
         subject { FactoryBot.build(:mentorship_period, mentee: ect_at_school_period, mentor: mentor_at_school_period) }
 
         let!(:teacher) { ect_at_school_period.teacher }
-        let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing) }
-        let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:) }
+        let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished) }
+        let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:) }
 
         it "add a base error" do
           subject.valid?
@@ -315,8 +315,8 @@ describe MentorshipPeriod do
       context "when mentor and mentee are different teachers" do
         subject { FactoryBot.build(:mentorship_period, mentee: ect_at_school_period, mentor: mentor_at_school_period) }
 
-        let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing) }
-        let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing) }
+        let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished) }
+        let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished) }
 
         it "do not add an error" do
           subject.valid?
@@ -328,8 +328,8 @@ describe MentorshipPeriod do
       context "when mentor or mentee are not set yet" do
         subject { FactoryBot.build(:mentorship_period, mentor: mentor_at_school_period) }
 
-        let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing) }
-        let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing) }
+        let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished) }
+        let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished) }
 
         it "do not add an error" do
           subject.valid?
@@ -355,11 +355,11 @@ describe MentorshipPeriod do
         end
 
         let!(:ect_at_school_period) do
-          FactoryBot.create(:ect_at_school_period, :ongoing, school: school_1)
+          FactoryBot.create(:ect_at_school_period, :unfinished, school: school_1)
         end
 
         let!(:mentor_at_school_period) do
-          FactoryBot.create(:mentor_at_school_period, :ongoing, school: school_1)
+          FactoryBot.create(:mentor_at_school_period, :unfinished, school: school_1)
         end
 
         it "is valid" do
@@ -380,11 +380,11 @@ describe MentorshipPeriod do
         end
 
         let!(:ect_at_school_period) do
-          FactoryBot.create(:ect_at_school_period, :ongoing, school: school_1)
+          FactoryBot.create(:ect_at_school_period, :unfinished, school: school_1)
         end
 
         let!(:mentor_at_school_period) do
-          FactoryBot.create(:mentor_at_school_period, :ongoing, school: school_2)
+          FactoryBot.create(:mentor_at_school_period, :unfinished, school: school_2)
         end
 
         it "adds a base error" do
@@ -395,8 +395,8 @@ describe MentorshipPeriod do
       end
 
       context "when mentor or mentee is missing" do
-        let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school: school_1) }
-        let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school: school_2) }
+        let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, school: school_1) }
+        let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, school: school_2) }
 
         it "does not add an error when mentee is missing" do
           period = FactoryBot.build(
@@ -458,12 +458,12 @@ describe MentorshipPeriod do
     subject { period_1.siblings }
 
     let(:school) { FactoryBot.create(:school) }
-    let!(:mentee) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: "2021-01-01", school:) }
-    let!(:mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, started_on: "2021-01-01", school:) }
+    let!(:mentee) { FactoryBot.create(:ect_at_school_period, :unfinished, started_on: "2021-01-01", school:) }
+    let!(:mentor) { FactoryBot.create(:mentor_at_school_period, :unfinished, started_on: "2021-01-01", school:) }
     let!(:period_1) { FactoryBot.create(:mentorship_period, mentee:, mentor:, started_on: "2022-01-01", finished_on: "2022-06-01") }
     let!(:period_2) { FactoryBot.create(:mentorship_period, mentee:, mentor:, started_on: "2022-06-02", finished_on: "2023-01-01") }
 
-    let!(:unrelated_mentee) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: "2021-01-01", school:) }
+    let!(:unrelated_mentee) { FactoryBot.create(:ect_at_school_period, :unfinished, started_on: "2021-01-01", school:) }
     let!(:unrelated_period) { FactoryBot.create(:mentorship_period, mentor:, mentee: unrelated_mentee, started_on: "2022-06-01", finished_on: "2023-01-01") }
 
     it "only returns records that belong to the same mentee" do

--- a/spec/models/school_partnership_spec.rb
+++ b/spec/models/school_partnership_spec.rb
@@ -45,21 +45,21 @@ describe SchoolPartnership do
 
       let(:instance) { FactoryBot.create(:school_partnership) }
       let(:ongoing_training_period) do
-        FactoryBot.create(:training_period, :ongoing,
+        FactoryBot.create(:training_period, :unfinished,
                           school_partnership: instance,
-                          ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing))
+                          ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished))
       end
 
       before do
         # Different lead provider
-        FactoryBot.create(:training_period, :ongoing, :with_school_partnership, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing))
+        FactoryBot.create(:training_period, :unfinished, :with_school_partnership, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished))
         # Not on-going today
         ect_at_school_period = FactoryBot.create(:ect_at_school_period, school: instance.school, started_on: 1.year.ago, finished_on: 1.month.ago)
         FactoryBot.create(:training_period, school_partnership: instance, ect_at_school_period:, started_on: 5.months.ago, finished_on: 2.months.ago)
-        FactoryBot.create(:training_period, :ongoing,
+        FactoryBot.create(:training_period, :unfinished,
                           school_partnership: instance,
                           started_on: 1.week.from_now,
-                          ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing))
+                          ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished))
       end
 
       it { is_expected.to contain_exactly(ongoing_training_period) }

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe School do
 
     context "target ect_teachers" do
       let(:school_partnership) { FactoryBot.create(:school_partnership, school: instance) }
-      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school: instance) }
-      let!(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period:) }
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, school: instance) }
+      let!(:training_period) { FactoryBot.create(:training_period, :for_ect, :unfinished, ect_at_school_period:) }
 
       let(:target) { instance.ect_teachers }
 
@@ -40,8 +40,8 @@ RSpec.describe School do
 
     context "target mentor_teachers" do
       let!(:school_partnership) { FactoryBot.create(:school_partnership, school: instance) }
-      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school: instance) }
-      let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period:) }
+      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, school: instance) }
+      let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, :unfinished, mentor_at_school_period:) }
 
       let(:target) { instance.mentor_teachers }
 
@@ -50,8 +50,8 @@ RSpec.describe School do
 
     context "target training periods" do
       let!(:school_partnership) { FactoryBot.create(:school_partnership, school: instance) }
-      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school: instance) }
-      let!(:training_period) { FactoryBot.create(:training_period, :ongoing, ect_at_school_period:) }
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, school: instance) }
+      let!(:training_period) { FactoryBot.create(:training_period, :unfinished, ect_at_school_period:) }
 
       let(:target) { instance.training_periods }
 
@@ -442,17 +442,17 @@ RSpec.describe School do
         end
 
         context "and has an ongoing ect training period" do
-          let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school:) }
+          let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, school:) }
 
-          before { FactoryBot.create(:training_period, :ongoing, ect_at_school_period:) }
+          before { FactoryBot.create(:training_period, :unfinished, ect_at_school_period:) }
 
           it { is_expected.to be_truthy }
         end
 
         context "and has an ongoing mentor training period" do
-          let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:) }
+          let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, school:) }
 
-          before { FactoryBot.create(:training_period, :ongoing, :for_mentor, mentor_at_school_period:) }
+          before { FactoryBot.create(:training_period, :unfinished, :for_mentor, mentor_at_school_period:) }
 
           it { is_expected.to be_truthy }
         end
@@ -467,9 +467,9 @@ RSpec.describe School do
 
         context "and training is at another school" do
           let(:other_school) { FactoryBot.create(:school, :state_funded) }
-          let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school: other_school) }
+          let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, school: other_school) }
 
-          before { FactoryBot.create(:training_period, :ongoing, ect_at_school_period:) }
+          before { FactoryBot.create(:training_period, :unfinished, ect_at_school_period:) }
 
           it { is_expected.to be_falsey }
         end
@@ -477,9 +477,9 @@ RSpec.describe School do
 
       context "and section 41 is approved" do
         let(:school) { FactoryBot.create(:school, :independent, :section_41) }
-        let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school:) }
+        let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, school:) }
 
-        before { FactoryBot.create(:training_period, :ongoing, ect_at_school_period:) }
+        before { FactoryBot.create(:training_period, :unfinished, ect_at_school_period:) }
 
         it { is_expected.to be_falsey }
       end
@@ -487,9 +487,9 @@ RSpec.describe School do
 
     context "when the school is state-funded" do
       let(:school) { FactoryBot.create(:school, :state_funded) }
-      let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school:) }
+      let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, school:) }
 
-      before { FactoryBot.create(:training_period, :ongoing, ect_at_school_period:) }
+      before { FactoryBot.create(:training_period, :unfinished, ect_at_school_period:) }
 
       it { is_expected.to be_falsey }
     end
@@ -508,17 +508,17 @@ RSpec.describe School do
         end
 
         context "with an ongoing ect training period" do
-          let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school:) }
+          let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, school:) }
 
-          before { FactoryBot.create(:training_period, :ongoing, ect_at_school_period:) }
+          before { FactoryBot.create(:training_period, :unfinished, ect_at_school_period:) }
 
           it { is_expected.to be_falsey }
         end
 
         context "with an ongoing mentor training period" do
-          let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:) }
+          let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, school:) }
 
-          before { FactoryBot.create(:training_period, :ongoing, :for_mentor, mentor_at_school_period:) }
+          before { FactoryBot.create(:training_period, :unfinished, :for_mentor, mentor_at_school_period:) }
 
           it { is_expected.to be_falsey }
         end

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -221,7 +221,7 @@ describe Teacher do
       it { is_expected.to have_one(:current_or_next_ect_at_school_period).class_name("ECTAtSchoolPeriod") }
 
       context "when there is a current period" do
-        let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:) }
+        let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher:) }
         let!(:finished_at_school_period) { FactoryBot.create(:ect_at_school_period, started_on: 10.years.ago, finished_on: 8.years.ago, teacher:) }
 
         it "returns the current ect_at_school_period" do

--- a/spec/models/training_period_spec.rb
+++ b/spec/models/training_period_spec.rb
@@ -360,16 +360,16 @@ describe TrainingPeriod do
       let(:envelope_error) { "Date range is not contained by the period the trainee is at the school" }
 
       context "ongoing training period inside an ongoing at school period" do
-        let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 1.year.ago) }
+        let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, started_on: 1.year.ago) }
 
         it "is valid when the training period starts on or after the at school period" do
-          training_period = FactoryBot.build(:training_period, :ongoing, :for_ect, ect_at_school_period:, started_on: 6.months.ago)
+          training_period = FactoryBot.build(:training_period, :unfinished, :for_ect, ect_at_school_period:, started_on: 6.months.ago)
           training_period.valid?
           expect(training_period.errors[:base]).not_to include(envelope_error)
         end
 
         it "is invalid when the training period starts before the at school period" do
-          training_period = FactoryBot.build(:training_period, :ongoing, :for_ect, ect_at_school_period:, started_on: 2.years.ago)
+          training_period = FactoryBot.build(:training_period, :unfinished, :for_ect, ect_at_school_period:, started_on: 2.years.ago)
           training_period.valid?
           expect(training_period.errors[:base]).to include(envelope_error)
         end
@@ -418,7 +418,7 @@ describe TrainingPeriod do
         let(:next_ect_at_school_period) do
           FactoryBot.create(
             :ect_at_school_period,
-            :ongoing,
+            :unfinished,
             teacher:,
             started_on: ect_at_school_period.finished_on.advance(days: 1)
           )
@@ -426,7 +426,7 @@ describe TrainingPeriod do
         let!(:ongoing_training_period) do
           FactoryBot.create(
             :training_period,
-            :ongoing,
+            :unfinished,
             :for_ect,
             :provider_led,
             ect_at_school_period: next_ect_at_school_period,
@@ -476,7 +476,7 @@ describe TrainingPeriod do
         let(:next_mentor_at_school_period) do
           FactoryBot.create(
             :mentor_at_school_period,
-            :ongoing,
+            :unfinished,
             teacher:,
             started_on: mentor_at_school_period.finished_on.advance(days: 1)
           )
@@ -484,7 +484,7 @@ describe TrainingPeriod do
         let!(:ongoing_training_period) do
           FactoryBot.create(
             :training_period,
-            :ongoing,
+            :unfinished,
             :for_mentor,
             :provider_led,
             mentor_at_school_period: next_mentor_at_school_period,
@@ -495,7 +495,7 @@ describe TrainingPeriod do
         let(:concurrent_ongoing_period) do
           FactoryBot.build(
             :training_period,
-            :ongoing,
+            :unfinished,
             :for_mentor,
             :provider_led,
             mentor_at_school_period: next_mentor_at_school_period,
@@ -605,13 +605,13 @@ describe TrainingPeriod do
 
       context "checking contract period matches with school partnership" do
         context "when contract periods match" do
-          subject { FactoryBot.build(:training_period, :ongoing, schedule:, school_partnership:, ect_at_school_period:) }
+          subject { FactoryBot.build(:training_period, :unfinished, schedule:, school_partnership:, ect_at_school_period:) }
 
           it { is_expected.to be_valid }
         end
 
         context "when contract periods do not match" do
-          subject { FactoryBot.build(:training_period, :ongoing, schedule:, school_partnership: mismatched_school_partnership, ect_at_school_period:) }
+          subject { FactoryBot.build(:training_period, :unfinished, schedule:, school_partnership: mismatched_school_partnership, ect_at_school_period:) }
 
           let(:mismatched_school_partnership) { make_partnership_for(school, FactoryBot.create(:contract_period, year: 2025)) }
 
@@ -628,7 +628,7 @@ describe TrainingPeriod do
             FactoryBot.build(
               :training_period,
               :for_ect,
-              :ongoing,
+              :unfinished,
               :provider_led,
               :with_no_school_partnership,
               expression_of_interest:,
@@ -646,7 +646,7 @@ describe TrainingPeriod do
             FactoryBot.build(
               :training_period,
               :for_ect,
-              :ongoing,
+              :unfinished,
               :provider_led,
               :with_no_school_partnership,
               expression_of_interest: mismatched_expression_of_interest,
@@ -665,7 +665,7 @@ describe TrainingPeriod do
         end
 
         context "when training period is `school-led`" do
-          subject { FactoryBot.build(:training_period, :ongoing, :school_led, schedule:, ect_at_school_period:) }
+          subject { FactoryBot.build(:training_period, :unfinished, :school_led, schedule:, ect_at_school_period:) }
 
           it "adds an error to schedule" do
             expect(subject).to be_invalid
@@ -675,7 +675,7 @@ describe TrainingPeriod do
       end
 
       context "checking contract period matches with declarations" do
-        let(:training_period) { FactoryBot.create(:training_period, :ongoing, schedule:, school_partnership:, ect_at_school_period:) }
+        let(:training_period) { FactoryBot.create(:training_period, :unfinished, schedule:, school_partnership:, ect_at_school_period:) }
 
         before do
           FactoryBot.create(:declaration, :paid, training_period:)
@@ -1195,7 +1195,7 @@ describe TrainingPeriod do
     let!(:other_ect_at_school_period) do
       FactoryBot.create(
         :ect_at_school_period,
-        :ongoing,
+        :unfinished,
         teacher:,
         started_on: "2023-01-02"
       )
@@ -1212,7 +1212,7 @@ describe TrainingPeriod do
     let!(:unrelated_ect_at_school_period) do
       FactoryBot.create(
         :ect_at_school_period,
-        :ongoing,
+        :unfinished,
         started_on: "2021-01-01"
       )
     end

--- a/spec/presenters/admin/teacher_presenter_spec.rb
+++ b/spec/presenters/admin/teacher_presenter_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Admin::TeacherPresenter do
   describe "#most_recent_email" do
     context "when there are ECT and mentor periods" do
       before do
-        FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:, email: "ect@example.com", started_on: 2.months.ago)
-        FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:, school:, email: "mentor@example.com", started_on: 1.month.ago)
+        FactoryBot.create(:ect_at_school_period, :unfinished, teacher:, school:, email: "ect@example.com", started_on: 2.months.ago)
+        FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:, school:, email: "mentor@example.com", started_on: 1.month.ago)
       end
 
       it "returns the email from the most recent period" do
@@ -25,7 +25,7 @@ RSpec.describe Admin::TeacherPresenter do
 
   describe "#current_schools" do
     context "when the teacher has ongoing ECT periods" do
-      before { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:) }
+      before { FactoryBot.create(:ect_at_school_period, :unfinished, teacher:, school:) }
 
       it "includes the school from the ongoing period" do
         expect(presenter.current_schools).to include(school)
@@ -75,8 +75,8 @@ RSpec.describe Admin::TeacherPresenter do
     context "when the teacher is an Early Career Teacher" do
       let(:teacher) do
         FactoryBot.create(:teacher, api_id: SecureRandom.uuid, trs_induction_status: "InProgress").tap do |t|
-          FactoryBot.create(:ect_at_school_period, :ongoing, teacher: t, school:)
-          FactoryBot.create(:induction_period, :ongoing, teacher: t)
+          FactoryBot.create(:ect_at_school_period, :unfinished, teacher: t, school:)
+          FactoryBot.create(:induction_period, :unfinished, teacher: t)
         end
       end
 

--- a/spec/requests/admin/appropriate_bodies/appropriate_bodies/current_ects/index_spec.rb
+++ b/spec/requests/admin/appropriate_bodies/appropriate_bodies/current_ects/index_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe "Listing and searching ECTs belonging to an appropriate body" do
       let!(:teacher_1) { FactoryBot.create(:teacher, trs_first_name: "Pam", trs_last_name: "Ferris") }
       let!(:teacher_2) { FactoryBot.create(:teacher, trs_first_name: "Felicity", trs_last_name: "Kendall") }
 
-      let!(:induction_period_1) { FactoryBot.create(:induction_period, :ongoing, teacher: teacher_1, appropriate_body_period:) }
-      let!(:induction_period_2) { FactoryBot.create(:induction_period, :ongoing, teacher: teacher_2, appropriate_body_period:) }
+      let!(:induction_period_1) { FactoryBot.create(:induction_period, :unfinished, teacher: teacher_1, appropriate_body_period:) }
+      let!(:induction_period_2) { FactoryBot.create(:induction_period, :unfinished, teacher: teacher_2, appropriate_body_period:) }
 
       it "shows lists current ECTs" do
         get "/admin/organisations/appropriate-bodies/#{appropriate_body_period.id}/current-ects"

--- a/spec/requests/admin/finance/statements/statements_spec.rb
+++ b/spec/requests/admin/finance/statements/statements_spec.rb
@@ -174,10 +174,10 @@ RSpec.describe "Admin finance statements index", type: :request do
                                                                                 delivery_partner:))
       end
       let(:training_period) do
-        FactoryBot.create(:training_period, :ongoing,
+        FactoryBot.create(:training_period, :unfinished,
                           school_partnership:,
                           started_on: Date.new(2024, 10, 1),
-                          ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing,
+                          ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished,
                                                                   started_on: Date.new(2024, 10, 1)))
       end
       let!(:declaration) do

--- a/spec/requests/admin/induction_periods_spec.rb
+++ b/spec/requests/admin/induction_periods_spec.rb
@@ -659,7 +659,7 @@ RSpec.describe "Admin::InductionPeriodsController", type: :request do
     let(:note) { "A reason we are deleting this induction period" }
 
     context "when it is the only induction period" do
-      let!(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:, started_on: 6.months.ago, finished_on: 1.month.ago, number_of_terms: 2) }
+      let!(:induction_period) { FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:, started_on: 6.months.ago, finished_on: 1.month.ago, number_of_terms: 2) }
       let(:trs_api_client) { instance_double(TRS::APIClient) }
 
       before do
@@ -691,8 +691,8 @@ RSpec.describe "Admin::InductionPeriodsController", type: :request do
     end
 
     context "when there are multiple induction periods" do
-      let!(:induction_period1) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:, started_on: 1.year.ago, finished_on: 9.months.ago, number_of_terms: 2) }
-      let!(:induction_period2) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:, started_on: 6.months.ago, finished_on: 3.months.ago, number_of_terms: 2) }
+      let!(:induction_period1) { FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:, started_on: 1.year.ago, finished_on: 9.months.ago, number_of_terms: 2) }
+      let!(:induction_period2) { FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:, started_on: 6.months.ago, finished_on: 3.months.ago, number_of_terms: 2) }
       let(:trs_api_client) { instance_double(TRS::APIClient) }
 
       before do
@@ -716,7 +716,7 @@ RSpec.describe "Admin::InductionPeriodsController", type: :request do
     end
 
     context "when deletion fails" do
-      let!(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:, started_on: 6.months.ago, finished_on: 1.month.ago, number_of_terms: 2) }
+      let!(:induction_period) { FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:, started_on: 6.months.ago, finished_on: 1.month.ago, number_of_terms: 2) }
 
       before do
         service = instance_double(InductionPeriods::DeleteInductionPeriod)
@@ -737,7 +737,7 @@ RSpec.describe "Admin::InductionPeriodsController", type: :request do
       let!(:induction_period) do
         FactoryBot.create(
           :induction_period,
-          :ongoing,
+          :unfinished,
           teacher:,
           appropriate_body_period:,
           started_on: 6.months.ago,

--- a/spec/requests/admin/schools_spec.rb
+++ b/spec/requests/admin/schools_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe "Admin::Schools", type: :request do
         let(:teacher) { FactoryBot.create(:teacher) }
 
         before do
-          FactoryBot.create(:ect_at_school_period, :ongoing, school:, teacher:)
+          FactoryBot.create(:ect_at_school_period, :unfinished, school:, teacher:)
         end
 
         it "displays teachers in the teachers section" do

--- a/spec/requests/admin/teachers/index_spec.rb
+++ b/spec/requests/admin/teachers/index_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe "Admin teachers index", type: :request do
         let!(:teacher) { FactoryBot.create(:teacher, trs_first_name: "Naruto", trs_last_name: "Uzumaki") }
         let!(:ect_contract_period) { FactoryBot.create(:contract_period, year: 2024) }
         let!(:mentor_contract_period) { FactoryBot.create(:contract_period, year: 2025) }
-        let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, :with_training_period, teacher:, contract_period: ect_contract_period) }
-        let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, :with_training_period, teacher:, contract_period: mentor_contract_period) }
+        let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, :with_training_period, teacher:, contract_period: ect_contract_period) }
+        let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, :with_training_period, teacher:, contract_period: mentor_contract_period) }
 
         it "renders role based rows with contract periods" do
           get "/admin/teachers"
@@ -87,8 +87,8 @@ RSpec.describe "Admin teachers index", type: :request do
           let!(:other_teacher) { FactoryBot.create(:teacher, api_id: "999e4567-e89b-12d3-a456-426614174999") }
           let!(:teacher_contract_period) { FactoryBot.create(:contract_period, year: 2024) }
           let!(:other_teacher_contract_period) { FactoryBot.create(:contract_period, year: 2024) }
-          let!(:teacher_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, :with_training_period, teacher:, contract_period: teacher_contract_period) }
-          let!(:other_teacher_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, :with_training_period, teacher: other_teacher, contract_period: other_teacher_contract_period) }
+          let!(:teacher_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, :with_training_period, teacher:, contract_period: teacher_contract_period) }
+          let!(:other_teacher_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, :with_training_period, teacher: other_teacher, contract_period: other_teacher_contract_period) }
 
           it "filters teachers by API participant ID" do
             get "/admin/teachers", params: { q: "123e4567-e89b-12d3-a456-426614174000" }
@@ -159,7 +159,7 @@ RSpec.describe "Admin teachers index", type: :request do
 
             ect_at_school_period = FactoryBot.create(
               :ect_at_school_period,
-              :ongoing,
+              :unfinished,
               teacher:
             )
 
@@ -173,7 +173,7 @@ RSpec.describe "Admin teachers index", type: :request do
             FactoryBot.create(
               :training_period,
               :for_ect,
-              :ongoing,
+              :unfinished,
               ect_at_school_period:,
               school_partnership:
             )
@@ -183,7 +183,7 @@ RSpec.describe "Admin teachers index", type: :request do
 
           matching_ect_at_school_period = FactoryBot.create(
             :ect_at_school_period,
-            :ongoing,
+            :unfinished,
             teacher: matching_teacher
           )
 
@@ -197,7 +197,7 @@ RSpec.describe "Admin teachers index", type: :request do
           FactoryBot.create(
             :training_period,
             :for_ect,
-            :ongoing,
+            :unfinished,
             ect_at_school_period: matching_ect_at_school_period,
             school_partnership: matching_school_partnership
           )

--- a/spec/requests/admin/teachers/record_failed_induction_spec.rb
+++ b/spec/requests/admin/teachers/record_failed_induction_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe "Admin recording a failed outcome for a teacher" do
   let(:teacher) { FactoryBot.create(:teacher) }
 
   let!(:induction_period) do
-    FactoryBot.create(:induction_period, :ongoing,
+    FactoryBot.create(:induction_period, :unfinished,
                       teacher:,
                       appropriate_body_period:)
   end

--- a/spec/requests/admin/teachers/record_passed_induction_spec.rb
+++ b/spec/requests/admin/teachers/record_passed_induction_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe "Admin recording a passed outcome for a teacher" do
   let(:teacher) { FactoryBot.create(:teacher) }
 
   let!(:induction_period) do
-    FactoryBot.create(:induction_period, :ongoing,
+    FactoryBot.create(:induction_period, :unfinished,
                       teacher:,
                       appropriate_body_period:)
   end

--- a/spec/requests/admin/teachers/reopen_induction_spec.rb
+++ b/spec/requests/admin/teachers/reopen_induction_spec.rb
@@ -33,7 +33,7 @@ describe "Admin::Teachers::ReopenInductionController" do
 
       context "when the last induction period is ongoing" do
         let!(:induction_period) do
-          FactoryBot.create(:induction_period, :ongoing, teacher:)
+          FactoryBot.create(:induction_period, :unfinished, teacher:)
         end
 
         it "redirects to the teacher page" do
@@ -107,7 +107,7 @@ describe "Admin::Teachers::ReopenInductionController" do
 
       context "when the last induction period is ongoing" do
         let!(:induction_period) do
-          FactoryBot.create(:induction_period, :ongoing, teacher:)
+          FactoryBot.create(:induction_period, :unfinished, teacher:)
         end
 
         it "redirects to the teacher page without reopening the induction period" do

--- a/spec/requests/admin/teachers/show_spec.rb
+++ b/spec/requests/admin/teachers/show_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "Admin::Teachers#show", type: :request do
   include ActionView::Helpers::SanitizeHelper
 
   let(:teacher) { FactoryBot.create(:teacher) }
-  let!(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:) }
+  let!(:induction_period) { FactoryBot.create(:induction_period, :unfinished, teacher:) }
 
   describe "GET /admin/teachers/:id/induction" do
     it "redirects to sign in path" do

--- a/spec/requests/admin/teachers/training_partnerships_spec.rb
+++ b/spec/requests/admin/teachers/training_partnerships_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe "Admin::Teachers::TrainingPartnerships", type: :request do
   let(:other_delivery_partner) { FactoryBot.create(:delivery_partner) }
   let(:school_partnership) { FactoryBot.create(:school_partnership, :for_year, year: contract_period.year, school:, lead_provider:, delivery_partner:) }
   let!(:other_school_partnership) { FactoryBot.create(:school_partnership, :for_year, year: contract_period.year, school:, lead_provider: other_lead_provider, delivery_partner: other_delivery_partner) }
-  let(:ect_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:) }
+  let(:ect_period) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher:, school:) }
   let(:schedule) { FactoryBot.create(:schedule, contract_period: school_partnership.contract_period) }
-  let(:training_period) { FactoryBot.create(:training_period, :ongoing, ect_at_school_period: ect_period, school_partnership:, schedule:) }
+  let(:training_period) { FactoryBot.create(:training_period, :unfinished, ect_at_school_period: ect_period, school_partnership:, schedule:) }
   let(:teacher_name) { Teachers::Name.new(teacher).full_name }
 
   describe "GET /admin/teachers/:teacher_id/training_periods/:training_period_id/partnership/new" do

--- a/spec/requests/admin/teachers/training_periods/change_contract_period_wizard_spec.rb
+++ b/spec/requests/admin/teachers/training_periods/change_contract_period_wizard_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardCont
       school:
     )
   end
-  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:) }
+  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher:, school:) }
   let(:schedule) { FactoryBot.create(:schedule, contract_period: current_contract_period) }
   let(:target_schedule) { FactoryBot.create(:schedule, contract_period: target_contract_period, identifier: schedule.identifier) }
   let(:eoi_lead_provider) { FactoryBot.create(:lead_provider) }
@@ -42,7 +42,7 @@ RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardCont
   let(:eoi_only_training_period) do
     FactoryBot.create(
       :training_period,
-      :ongoing,
+      :unfinished,
       :with_only_expression_of_interest,
       ect_at_school_period:,
       expression_of_interest: active_lead_provider,
@@ -53,7 +53,7 @@ RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardCont
   let(:future_eoi_only_training_period) do
     FactoryBot.create(
       :training_period,
-      :ongoing,
+      :unfinished,
       :with_only_expression_of_interest,
       ect_at_school_period:,
       expression_of_interest: active_lead_provider,
@@ -65,7 +65,7 @@ RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardCont
   let(:training_period) do
     FactoryBot.create(
       :training_period,
-      :ongoing,
+      :unfinished,
       ect_at_school_period:,
       school_partnership:,
       schedule:,
@@ -159,7 +159,7 @@ RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardCont
       let(:training_period) do
         FactoryBot.create(
           :training_period,
-          :ongoing,
+          :unfinished,
           ect_at_school_period: future_ect_at_school_period,
           school_partnership:,
           schedule:,
@@ -559,7 +559,7 @@ RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardCont
       let(:training_period) do
         FactoryBot.create(
           :training_period,
-          :ongoing,
+          :unfinished,
           ect_at_school_period: future_ect_at_school_period,
           school_partnership:,
           schedule:,
@@ -592,7 +592,7 @@ RSpec.describe "Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizardCont
         let(:future_eoi_only_training_period) do
           FactoryBot.create(
             :training_period,
-            :ongoing,
+            :unfinished,
             :with_only_expression_of_interest,
             ect_at_school_period: future_ect_at_school_period,
             expression_of_interest: active_lead_provider,

--- a/spec/requests/api/docs/v3/declarations_spec.rb
+++ b/spec/requests/api/docs/v3/declarations_spec.rb
@@ -15,10 +15,10 @@ RSpec.describe "Declarations endpoint", :with_metadata, openapi_spec: "v3/swagge
     FactoryBot.create(
       :training_period,
       :for_ect,
-      :ongoing,
+      :unfinished,
       :with_school_partnership,
       school_partnership:,
-      ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)
+      ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished)
     )
   end
   let(:declaration) { FactoryBot.create(:declaration, training_period:) }

--- a/spec/requests/api/docs/v3/participants_spec.rb
+++ b/spec/requests/api/docs/v3/participants_spec.rb
@@ -15,7 +15,7 @@ describe "Participants endpoint", :with_metadata, openapi_spec: "v3/swagger.yaml
   let(:ect_at_school_period) do
     FactoryBot.create(
       :ect_at_school_period,
-      :ongoing,
+      :unfinished,
       school: school_partnership.school,
       started_on: 6.months.ago
     )
@@ -24,7 +24,7 @@ describe "Participants endpoint", :with_metadata, openapi_spec: "v3/swagger.yaml
     FactoryBot.create(
       :training_period,
       :for_ect,
-      :ongoing,
+      :unfinished,
       :with_school_partnership,
       school_partnership:,
       ect_at_school_period:,

--- a/spec/requests/api/docs/v3/schools_spec.rb
+++ b/spec/requests/api/docs/v3/schools_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe "Schools endpoint", :with_metadata, openapi_spec: "v3/swagger.yam
   let(:resource) { FactoryBot.create(:school, :eligible, :with_induction_tutor) }
   let!(:school_partnership) { FactoryBot.create(:school_partnership, school: resource, lead_provider_delivery_partnership:) }
   let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
-  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school: resource) }
-  let!(:training_period) { FactoryBot.create(:training_period, :provider_led, :ongoing, ect_at_school_period:, school_partnership:) }
+  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, school: resource) }
+  let!(:training_period) { FactoryBot.create(:training_period, :provider_led, :unfinished, ect_at_school_period:, school_partnership:) }
   let(:"filter[cohort]") { contract_period.year }
 
   before do |example|

--- a/spec/requests/api/v3/schools_spec.rb
+++ b/spec/requests/api/v3/schools_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe "Schools API", :with_metadata, type: :request do
     lead_provider_delivery_partnership = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:)
     school = FactoryBot.create(:school, :ineligible, :with_induction_tutor)
     school_partnership = FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:, school:)
-    ect_at_school_period = FactoryBot.create(:ect_at_school_period, :ongoing, school:)
-    FactoryBot.create(:training_period, :provider_led, :ongoing, ect_at_school_period:, school_partnership:)
+    ect_at_school_period = FactoryBot.create(:ect_at_school_period, :unfinished, school:)
+    FactoryBot.create(:training_period, :provider_led, :unfinished, ect_at_school_period:, school_partnership:)
     school
   end
 

--- a/spec/requests/appropriate_bodies/claim_an_ect/check_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/check_ect_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "Appropriate body claiming an ECT: checking we have the right ECT
 
       context "when the ECT has an ongoing induction period with another appropriate body" do
         let!(:preexisting_teacher) { FactoryBot.create(:teacher, trn: pending_induction_submission.trn) }
-        let!(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher: preexisting_teacher) }
+        let!(:induction_period) { FactoryBot.create(:induction_period, :unfinished, teacher: preexisting_teacher) }
 
         it "redirects to the ECT already claimed by another AB early exit page" do
           patch(

--- a/spec/requests/appropriate_bodies/claim_an_ect/find_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/find_ect_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "Appropriate body claiming an ECT: finding the ECT" do
 
         context "with another AB" do
           let!(:induction_period) do
-            FactoryBot.create(:induction_period, :ongoing, teacher:, started_on: Date.parse("2 October 2022"))
+            FactoryBot.create(:induction_period, :unfinished, teacher:, started_on: Date.parse("2 October 2022"))
           end
 
           before do
@@ -82,7 +82,7 @@ RSpec.describe "Appropriate body claiming an ECT: finding the ECT" do
 
         context "with the current AB" do
           let!(:induction_period) do
-            FactoryBot.create(:induction_period, :ongoing, appropriate_body_period:, teacher:, started_on: Date.parse("2 October 2022"))
+            FactoryBot.create(:induction_period, :unfinished, appropriate_body_period:, teacher:, started_on: Date.parse("2 October 2022"))
           end
 
           before do

--- a/spec/requests/appropriate_bodies/induction_periods_spec.rb
+++ b/spec/requests/appropriate_bodies/induction_periods_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "AppropriateBodies::InductionPeriodsController", type: :request d
   let(:teacher) { FactoryBot.create(:teacher, :with_name, trs_qts_awarded_on: 1.year.ago) }
 
   let!(:induction_period) do
-    FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:, started_on: 9.months.ago)
+    FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:, started_on: 9.months.ago)
   end
 
   describe "GET /appropriate-body/teachers/:teacher_id/induction-periods/:id/edit" do

--- a/spec/requests/appropriate_bodies/teachers/extensions/edit_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/extensions/edit_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe "Appropriate Body teacher extensions edit", type: :request do
 
   let(:appropriate_body_period) { FactoryBot.create(:appropriate_body_period) }
   let(:teacher) { FactoryBot.create(:teacher) }
-  let!(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:) }
+  let!(:induction_period) { FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:) }
   let!(:user) { sign_in_as(:appropriate_body_user, appropriate_body: appropriate_body_period) }
   let(:extension) { FactoryBot.create(:induction_extension, teacher:, number_of_terms: 2) }
 

--- a/spec/requests/appropriate_bodies/teachers/extensions/index_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/extensions/index_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "Appropriate Body teacher extensions index", type: :request do
   let(:appropriate_body_period) { FactoryBot.create(:appropriate_body_period) }
   let(:teacher) { FactoryBot.create(:teacher) }
-  let!(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:) }
+  let!(:induction_period) { FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:) }
 
   describe "when not signed in" do
     it "redirects to the root page" do

--- a/spec/requests/appropriate_bodies/teachers/extensions/new_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/extensions/new_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "Appropriate Body teacher extensions new", type: :request do
   let(:appropriate_body_period) { FactoryBot.create(:appropriate_body_period) }
   let(:teacher) { FactoryBot.create(:teacher) }
-  let!(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:) }
+  let!(:induction_period) { FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:) }
   let!(:user) { sign_in_as(:appropriate_body_user, appropriate_body: appropriate_body_period) }
 
   describe "GET /appropriate-body/teachers/:id/extensions/new" do

--- a/spec/requests/appropriate_bodies/teachers/index_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/index_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Appropriate Body teacher index page", type: :request do
         let!(:additional_teachers) do
           FactoryBot.create_list(:teacher, 51, trs_first_name: "John", trs_last_name: "Smith").tap do |teachers|
             teachers.each do |teacher|
-              FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:)
+              FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:)
             end
           end
         end
@@ -33,19 +33,19 @@ RSpec.describe "Appropriate Body teacher index page", type: :request do
       context "with open and closed induction filtering" do
         let!(:alice_johnson) do
           FactoryBot.create(:teacher, trs_first_name: "Alice", trs_last_name: "Johnson", trn: "1000001", trs_induction_status: "InProgress").tap do |teacher|
-            FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:, started_on: 3.months.ago)
+            FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:, started_on: 3.months.ago)
           end
         end
 
         let!(:bob_williams) do
           FactoryBot.create(:teacher, trs_first_name: "Bob", trs_last_name: "Williams", trn: "1000002", trs_induction_status: "RequiredToComplete").tap do |teacher|
-            FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:, started_on: 2.months.ago)
+            FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:, started_on: 2.months.ago)
           end
         end
 
         let!(:charlie_brown) do
           FactoryBot.create(:teacher, trs_first_name: "Charlie", trs_last_name: "Brown", trn: "1000003", trs_induction_status: "InProgress").tap do |teacher|
-            FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:, started_on: 1.month.ago)
+            FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:, started_on: 1.month.ago)
           end
         end
 

--- a/spec/requests/appropriate_bodies/teachers/record_failed_induction_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/record_failed_induction_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe "Appropriate body recording a failed induction outcome for a teac
   let(:teacher) { FactoryBot.create(:teacher) }
 
   let!(:induction_period) do
-    FactoryBot.create(:induction_period, :ongoing,
+    FactoryBot.create(:induction_period, :unfinished,
                       teacher:,
                       appropriate_body_period:)
   end

--- a/spec/requests/appropriate_bodies/teachers/record_passed_induction_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/record_passed_induction_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe "Appropriate body recording a passed induction outcome for a teac
   let(:teacher) { FactoryBot.create(:teacher) }
 
   let!(:induction_period) do
-    FactoryBot.create(:induction_period, :ongoing,
+    FactoryBot.create(:induction_period, :unfinished,
                       teacher:,
                       appropriate_body_period:)
   end

--- a/spec/requests/appropriate_bodies/teachers/record_released_induction_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/record_released_induction_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe "Appropriate body releasing an ECT" do
   let(:teacher) { FactoryBot.create(:teacher) }
 
   let!(:induction_period) do
-    FactoryBot.create(:induction_period, :ongoing,
+    FactoryBot.create(:induction_period, :unfinished,
                       teacher:,
                       appropriate_body_period:)
   end

--- a/spec/requests/appropriate_bodies/teachers/show_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/show_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "Appropriate Body teacher show page", type: :request do
   let(:appropriate_body_period) { FactoryBot.create(:appropriate_body_period) }
   let(:teacher) { FactoryBot.create(:teacher) }
-  let!(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:) }
+  let!(:induction_period) { FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:) }
 
   describe "GET /appropriate-body/teachers/:id" do
     context "when not signed in" do

--- a/spec/requests/schools/access_spec.rb
+++ b/spec/requests/schools/access_spec.rb
@@ -74,8 +74,8 @@ describe "Schools access guard" do
       let(:school) { gias_school.school }
 
       before do
-        ect_at_school_period = FactoryBot.create(:ect_at_school_period, :ongoing, school:)
-        FactoryBot.create(:training_period, :ongoing, ect_at_school_period:)
+        ect_at_school_period = FactoryBot.create(:ect_at_school_period, :unfinished, school:)
+        FactoryBot.create(:training_period, :unfinished, ect_at_school_period:)
         sign_in_as(:school_user, method: :dfe_sign_in, school:)
       end
 

--- a/spec/requests/schools/assign_existing_mentor_wizard_spec.rb
+++ b/spec/requests/schools/assign_existing_mentor_wizard_spec.rb
@@ -3,8 +3,8 @@ RSpec.describe "Assign existing mentor wizard" do
 
   let(:school) { FactoryBot.create(:school) }
   let(:started_on) { mid_year }
-  let(:ect)    { FactoryBot.create(:ect_at_school_period, :ongoing, school:, started_on:) }
-  let(:mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, started_on:) }
+  let(:ect)    { FactoryBot.create(:ect_at_school_period, :unfinished, school:, started_on:) }
+  let(:mentor) { FactoryBot.create(:mentor_at_school_period, :unfinished, school:, started_on:) }
   let(:contract_period) { FactoryBot.create(:contract_period, :with_schedules, :current) }
 
   before do
@@ -12,7 +12,7 @@ RSpec.describe "Assign existing mentor wizard" do
     school_partnership.lead_provider_delivery_partnership.active_lead_provider.update!(contract_period:)
 
     FactoryBot.create(:training_period,
-                      :ongoing,
+                      :unfinished,
                       :provider_led,
                       ect_at_school_period: ect,
                       started_on:,

--- a/spec/requests/schools/ects/change_email_address_wizard_spec.rb
+++ b/spec/requests/schools/ects/change_email_address_wizard_spec.rb
@@ -4,7 +4,7 @@ describe "Schools::ECTs::ChangeEmailAddressWizardController" do
   let(:ect_at_school_period) do
     FactoryBot.create(
       :ect_at_school_period,
-      :ongoing,
+      :unfinished,
       teacher:,
       school:,
       email: "ect@example.com"

--- a/spec/requests/schools/ects/change_lead_provider_wizard_spec.rb
+++ b/spec/requests/schools/ects/change_lead_provider_wizard_spec.rb
@@ -5,7 +5,7 @@ describe "Schools::ECTs::ChangeLeadProviderWizardController" do
   let(:ect_at_school_period) do
     FactoryBot.create(
       :ect_at_school_period,
-      :ongoing,
+      :unfinished,
       teacher:,
       school:,
       started_on: contract_period.started_on
@@ -20,7 +20,7 @@ describe "Schools::ECTs::ChangeLeadProviderWizardController" do
   let!(:training_period) do
     FactoryBot.create(
       :training_period,
-      :ongoing,
+      :unfinished,
       :for_ect,
       :provider_led,
       :with_only_expression_of_interest,
@@ -85,7 +85,7 @@ describe "Schools::ECTs::ChangeLeadProviderWizardController" do
         let!(:training_period) do
           FactoryBot.create(
             :training_period,
-            :ongoing,
+            :unfinished,
             :provider_led,
             :for_ect,
             :withdrawn,
@@ -222,7 +222,7 @@ describe "Schools::ECTs::ChangeLeadProviderWizardController" do
             let!(:training_period) do
               FactoryBot.create(
                 :training_period,
-                :ongoing,
+                :unfinished,
                 :for_ect,
                 :provider_led,
                 ect_at_school_period:,
@@ -268,7 +268,7 @@ describe "Schools::ECTs::ChangeLeadProviderWizardController" do
         let(:training_period) do
           FactoryBot.create(
             :training_period,
-            :ongoing,
+            :unfinished,
             :school_led,
             ect_at_school_period:,
             started_on: ect_at_school_period.started_on

--- a/spec/requests/schools/ects/change_mentor_wizard_spec.rb
+++ b/spec/requests/schools/ects/change_mentor_wizard_spec.rb
@@ -7,7 +7,7 @@ describe "Schools::ECTs::ChangeMentorWizardController" do
   let(:ect_at_school_period) do
     FactoryBot.create(
       :ect_at_school_period,
-      :ongoing,
+      :unfinished,
       teacher:,
       school:,
       started_on: mid_year - 1.month
@@ -17,7 +17,7 @@ describe "Schools::ECTs::ChangeMentorWizardController" do
   let(:mentor_at_school_period) do
     FactoryBot.create(
       :mentor_at_school_period,
-      :ongoing,
+      :unfinished,
       teacher: mentor_teacher,
       school:,
       started_on: mid_year - 2.months
@@ -26,7 +26,7 @@ describe "Schools::ECTs::ChangeMentorWizardController" do
   let!(:mentorship_period) do
     FactoryBot.create(
       :mentorship_period,
-      :ongoing,
+      :unfinished,
       mentee: ect_at_school_period,
       mentor: mentor_at_school_period,
       started_on: ect_at_school_period.started_on
@@ -93,7 +93,7 @@ describe "Schools::ECTs::ChangeMentorWizardController" do
         let!(:other_mentor_at_school_period) do
           FactoryBot.create(
             :mentor_at_school_period,
-            :ongoing,
+            :unfinished,
             teacher: FactoryBot.create(:teacher),
             school:,
             started_on: mid_year - 3.months
@@ -117,7 +117,7 @@ describe "Schools::ECTs::ChangeMentorWizardController" do
     let(:other_mentor_at_school_period) do
       FactoryBot.create(
         :mentor_at_school_period,
-        :ongoing,
+        :unfinished,
         teacher: other_mentor_teacher,
         school:,
         started_on: ect_at_school_period.started_on - 1.week
@@ -175,7 +175,7 @@ describe "Schools::ECTs::ChangeMentorWizardController" do
         let!(:ect_training_period) do
           FactoryBot.create(
             :training_period,
-            :ongoing,
+            :unfinished,
             :school_led,
             :for_ect,
             ect_at_school_period:,
@@ -223,7 +223,7 @@ describe "Schools::ECTs::ChangeMentorWizardController" do
         let!(:ect_training_period) do
           FactoryBot.create(
             :training_period,
-            :ongoing,
+            :unfinished,
             :provider_led,
             :for_ect,
             ect_at_school_period:,
@@ -239,7 +239,7 @@ describe "Schools::ECTs::ChangeMentorWizardController" do
           let!(:other_mentor_training_period) do
             FactoryBot.create(
               :training_period,
-              :ongoing,
+              :unfinished,
               :provider_led,
               :for_mentor,
               mentor_at_school_period: other_mentor_at_school_period,

--- a/spec/requests/schools/ects/change_training_programme_wizard_spec.rb
+++ b/spec/requests/schools/ects/change_training_programme_wizard_spec.rb
@@ -5,20 +5,20 @@ describe "Schools::ECTs::ChangeTrainingProgrammeWizardController" do
   let(:ect_at_school_period) do
     FactoryBot.create(
       :ect_at_school_period,
-      :ongoing,
+      :unfinished,
       teacher:,
       school:,
       started_on: contract_period.started_on
     )
   end
 
-  let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, started_on: ect_at_school_period.started_on) }
+  let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, school:, started_on: ect_at_school_period.started_on) }
   let!(:mentorship_period) { FactoryBot.create(:mentorship_period, mentee: ect_at_school_period, mentor: mentor_at_school_period) }
 
   let!(:training_period) do
     FactoryBot.create(
       :training_period,
-      :ongoing,
+      :unfinished,
       :for_ect,
       ect_at_school_period:,
       started_on: ect_at_school_period.started_on
@@ -72,7 +72,7 @@ describe "Schools::ECTs::ChangeTrainingProgrammeWizardController" do
         let!(:training_period) do
           FactoryBot.create(
             :training_period,
-            :ongoing,
+            :unfinished,
             :provider_led,
             :for_ect,
             :withdrawn,
@@ -145,7 +145,7 @@ describe "Schools::ECTs::ChangeTrainingProgrammeWizardController" do
         let!(:training_period) do
           FactoryBot.create(
             :training_period,
-            :ongoing,
+            :unfinished,
             :provider_led,
             :for_ect,
             ect_at_school_period:,
@@ -194,7 +194,7 @@ describe "Schools::ECTs::ChangeTrainingProgrammeWizardController" do
         let!(:training_period) do
           FactoryBot.create(
             :training_period,
-            :ongoing,
+            :unfinished,
             :school_led,
             :for_ect,
             ect_at_school_period:,

--- a/spec/requests/schools/ects/change_working_pattern_wizard_spec.rb
+++ b/spec/requests/schools/ects/change_working_pattern_wizard_spec.rb
@@ -4,7 +4,7 @@ describe "Schools::ECTs::ChangeWorkingPatternWizardController" do
   let(:ect_at_school_period) do
     FactoryBot.create(
       :ect_at_school_period,
-      :ongoing,
+      :unfinished,
       teacher:,
       school:,
       working_pattern: "full_time"

--- a/spec/requests/schools/ects_spec.rb
+++ b/spec/requests/schools/ects_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "ECT summary" do
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, school:, started_on: 2.years.ago) }
+  let(:ect) { FactoryBot.create(:ect_at_school_period, :unfinished, school:, started_on: 2.years.ago) }
   let(:school) { FactoryBot.create(:school) }
 
   describe "GET #index" do
@@ -38,7 +38,7 @@ RSpec.describe "ECT summary" do
 
   describe "GET #show" do
     let!(:training_period) do
-      FactoryBot.create(:training_period, :ongoing, ect_at_school_period: ect, started_on: 1.year.ago)
+      FactoryBot.create(:training_period, :unfinished, ect_at_school_period: ect, started_on: 1.year.ago)
     end
 
     describe "finding the ECT at school period" do

--- a/spec/requests/schools/mentors/change_email_address_wizard_spec.rb
+++ b/spec/requests/schools/mentors/change_email_address_wizard_spec.rb
@@ -4,7 +4,7 @@ describe "Schools::Mentors::ChangeEmailAddressWizardController" do
   let(:mentor_at_school_period) do
     FactoryBot.create(
       :mentor_at_school_period,
-      :ongoing,
+      :unfinished,
       teacher:,
       school:,
       email: "mentor@example.com"

--- a/spec/requests/schools/mentors/change_lead_provider_wizard_spec.rb
+++ b/spec/requests/schools/mentors/change_lead_provider_wizard_spec.rb
@@ -6,7 +6,7 @@ describe "Schools::Mentors::ChangeLeadProviderWizard Requests" do
   let(:mentor_at_school_period) do
     FactoryBot.create(
       :mentor_at_school_period,
-      :ongoing,
+      :unfinished,
       teacher:,
       school:,
       started_on:
@@ -15,7 +15,7 @@ describe "Schools::Mentors::ChangeLeadProviderWizard Requests" do
 
   let!(:contract_period) { FactoryBot.create(:contract_period, :with_schedules, :current) }
   let(:lead_provider) { FactoryBot.create(:lead_provider) }
-  let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period:, started_on:, school_partnership:) }
+  let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, :unfinished, mentor_at_school_period:, started_on:, school_partnership:) }
   let(:old_lead_provider) { FactoryBot.create(:lead_provider) }
   let(:new_lead_provider) { lead_provider }
   let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider: old_lead_provider, contract_period:) }
@@ -141,7 +141,7 @@ describe "Schools::Mentors::ChangeLeadProviderWizard Requests" do
 
             post(path_for_step("check-answers"))
 
-            new_training_period = mentor_at_school_period.training_periods.ongoing.first
+            new_training_period = mentor_at_school_period.training_periods.unfinished.first
             expect(new_training_period.schedule).to eq(training_period.schedule)
           end
         end
@@ -151,7 +151,7 @@ describe "Schools::Mentors::ChangeLeadProviderWizard Requests" do
             let!(:training_period) do
               FactoryBot.create(:training_period,
                                 :for_mentor,
-                                :ongoing,
+                                :unfinished,
                                 :with_only_expression_of_interest,
                                 mentor_at_school_period:,
                                 started_on:,
@@ -178,7 +178,7 @@ describe "Schools::Mentors::ChangeLeadProviderWizard Requests" do
 
               post(path_for_step("check-answers"))
 
-              new_training_period = mentor_at_school_period.training_periods.ongoing.first
+              new_training_period = mentor_at_school_period.training_periods.unfinished.first
               expect(new_training_period.schedule.identifier).not_to eq(training_period.schedule.identifier)
             end
           end
@@ -191,7 +191,7 @@ describe "Schools::Mentors::ChangeLeadProviderWizard Requests" do
 
               post(path_for_step("check-answers"))
 
-              new_training_period = mentor_at_school_period.training_periods.ongoing.first
+              new_training_period = mentor_at_school_period.training_periods.unfinished.first
               expect(new_training_period.schedule).to eq(training_period.schedule)
             end
           end
@@ -204,7 +204,7 @@ describe "Schools::Mentors::ChangeLeadProviderWizard Requests" do
 
           post(path_for_step("check-answers"))
 
-          new_training_period = mentor_at_school_period.training_periods.ongoing.first
+          new_training_period = mentor_at_school_period.training_periods.unfinished.first
           expect(new_training_period.expression_of_interest.lead_provider).to eq(lead_provider)
 
           expect(response).to redirect_to(path_for_step("confirmation"))

--- a/spec/requests/schools/mentorships_spec.rb
+++ b/spec/requests/schools/mentorships_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe "Create mentorship of an ECT to a mentor" do
   include ActionView::Helpers::SanitizeHelper
 
-  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school:) }
-  let(:mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:) }
+  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, school:) }
+  let(:mentor) { FactoryBot.create(:mentor_at_school_period, :unfinished, school:) }
   let(:school) { FactoryBot.create(:school, :independent) }
 
   describe "GET /school/ects/:id/mentorship/new" do
@@ -79,11 +79,11 @@ RSpec.describe "Create mentorship of an ECT to a mentor" do
 
       context "when a valid mentor has been selected for the school-led ECT mentorship" do
         before do
-          FactoryBot.create(:training_period, :ongoing, :school_led, ect_at_school_period:)
+          FactoryBot.create(:training_period, :unfinished, :school_led, ect_at_school_period:)
         end
 
         let(:params) { { schools_assign_mentor_form: { mentor_id: mentor.id } } }
-        let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school:) }
+        let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, school:) }
 
         it "creates the mentorship and redirects the user to the confirmation page" do
           allow(Schools::AssignMentorForm).to receive(:new).and_call_original
@@ -98,11 +98,11 @@ RSpec.describe "Create mentorship of an ECT to a mentor" do
 
       context "provider-led ECT mentorship" do
         before do
-          FactoryBot.create(:training_period, :ongoing, :provider_led, ect_at_school_period:)
+          FactoryBot.create(:training_period, :unfinished, :provider_led, ect_at_school_period:)
         end
 
         let(:params) { { schools_assign_mentor_form: { mentor_id: mentor.id } } }
-        let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school:) }
+        let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, school:) }
 
         context "when the mentor is eligible for funding" do
           before do

--- a/spec/requests/schools/register_ect_wizard_spec.rb
+++ b/spec/requests/schools/register_ect_wizard_spec.rb
@@ -21,8 +21,8 @@ describe "Schools::RegisterECTWizardController" do
   describe "section 41 approval lost" do
     let(:gias_school) { FactoryBot.create(:gias_school, :independent_school_type, :not_section_41) }
     let(:school) { FactoryBot.create(:school, urn: gias_school.urn, gias_school:) }
-    let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school:) }
-    let!(:training_period) { FactoryBot.create(:training_period, :ongoing, ect_at_school_period:) }
+    let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, school:) }
+    let!(:training_period) { FactoryBot.create(:training_period, :unfinished, ect_at_school_period:) }
 
     before { sign_in_as(:school_user, method: :dfe_sign_in, school:) }
 

--- a/spec/serializers/api/declaration_serializer_spec.rb
+++ b/spec/serializers/api/declaration_serializer_spec.rb
@@ -110,10 +110,10 @@ describe API::DeclarationSerializer, type: :serializer do
     end
 
     describe "mentor_id" do
-      let(:mentee) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+      let(:mentee) { FactoryBot.create(:ect_at_school_period, :unfinished) }
       let(:training_period) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period: mentee) }
-      let(:mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, school: mentee.school) }
-      let!(:mentorship_period) { FactoryBot.create(:mentorship_period, :ongoing, mentee:, mentor:) }
+      let(:mentor) { FactoryBot.create(:mentor_at_school_period, :unfinished, school: mentee.school) }
+      let!(:mentorship_period) { FactoryBot.create(:mentorship_period, :unfinished, mentee:, mentor:) }
       let(:declaration) { FactoryBot.create(:declaration, mentorship_period:, training_period:) }
 
       it "serializes correctly" do

--- a/spec/serializers/api/school_partnership_serializer_spec.rb
+++ b/spec/serializers/api/school_partnership_serializer_spec.rb
@@ -62,9 +62,9 @@ describe API::SchoolPartnershipSerializer, type: :serializer do
         before do
           3.times do
             FactoryBot.create(:training_period,
-                              :ongoing,
+                              :unfinished,
                               school_partnership: partnership,
-                              ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing))
+                              ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished))
           end
         end
 

--- a/spec/serializers/api/teacher_serializer_spec.rb
+++ b/spec/serializers/api/teacher_serializer_spec.rb
@@ -267,7 +267,7 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
           describe "`most_recent_induction_period_end_date`" do
             context "when the latest induction_period is ongoing" do
               let!(:first_induction_period) { FactoryBot.create(:induction_period, teacher:) }
-              let!(:latest_induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, started_on: 1.day.ago) }
+              let!(:latest_induction_period) { FactoryBot.create(:induction_period, :unfinished, teacher:, started_on: 1.day.ago) }
 
               it "serializes `most_recent_induction_period_end_date` as nil" do
                 expect(ect_enrolment["most_recent_induction_period_end_date"]).to be_nil
@@ -292,7 +292,7 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
 
           describe "`overall_induction_start_date`" do
             context "when a started induction period is present" do
-              let!(:started_induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:) }
+              let!(:started_induction_period) { FactoryBot.create(:induction_period, :unfinished, teacher:) }
 
               it "serializes `overall_induction_start_date` from started induction period" do
                 expect(ect_enrolment["overall_induction_start_date"]).to eq(started_induction_period.started_on.to_fs(:api))
@@ -500,7 +500,7 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
 
           context "when there is an induction period" do
             context "when the latest induction period is ongoing" do
-              let!(:first_induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:) }
+              let!(:first_induction_period) { FactoryBot.create(:induction_period, :unfinished, teacher:) }
 
               it "serializes `most_recent_induction_period_end_date` as nil" do
                 expect(mentor_enrolment["most_recent_induction_period_end_date"]).to be_nil

--- a/spec/services/admin/current_teachers_spec.rb
+++ b/spec/services/admin/current_teachers_spec.rb
@@ -10,7 +10,7 @@ describe Admin::CurrentTeachers do
       before do
         FactoryBot.create(
           :induction_period,
-          :ongoing,
+          :unfinished,
           teacher: teacher_1,
           appropriate_body_period: appropriate_body_1,
           started_on: 1.month.ago.to_date,
@@ -18,7 +18,7 @@ describe Admin::CurrentTeachers do
         )
         FactoryBot.create(
           :induction_period,
-          :ongoing,
+          :unfinished,
           teacher: teacher_2,
           appropriate_body_period: appropriate_body_2,
           started_on: 1.month.ago.to_date,
@@ -47,7 +47,7 @@ describe Admin::CurrentTeachers do
       before do
         FactoryBot.create(
           :induction_period,
-          :ongoing,
+          :unfinished,
           teacher: teacher_1,
           started_on: 1.month.ago.to_date,
           induction_programme: "fip"
@@ -73,7 +73,7 @@ describe Admin::CurrentTeachers do
       before do
         FactoryBot.create(
           :induction_period,
-          :ongoing,
+          :unfinished,
           teacher: teacher_1,
           appropriate_body_period: appropriate_body_1,
           started_on: 1.month.ago.to_date,

--- a/spec/services/admin/record_fail_spec.rb
+++ b/spec/services/admin/record_fail_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Admin::RecordFail do
 
     context "when ongoing induction period only has a mappable legacy programme type" do
       let!(:induction_period) do
-        FactoryBot.create(:induction_period, :ongoing, :legacy_programme_type,
+        FactoryBot.create(:induction_period, :unfinished, :legacy_programme_type,
                           appropriate_body_period:,
                           teacher:)
       end
@@ -103,7 +103,7 @@ RSpec.describe Admin::RecordFail do
 
     context "when ongoing induction period only has an unmappable legacy programme type" do
       let!(:induction_period) do
-        FactoryBot.create(:induction_period, :ongoing, :pre_2021, :legacy_programme_type,
+        FactoryBot.create(:induction_period, :unfinished, :pre_2021, :legacy_programme_type,
                           appropriate_body_period:,
                           teacher:)
       end

--- a/spec/services/admin/record_pass_spec.rb
+++ b/spec/services/admin/record_pass_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Admin::RecordPass do
 
     context "when ongoing induction period only has the legacy programme type" do
       let!(:induction_period) do
-        FactoryBot.create(:induction_period, :ongoing, :legacy_programme_type,
+        FactoryBot.create(:induction_period, :unfinished, :legacy_programme_type,
                           appropriate_body_period:,
                           teacher:)
       end

--- a/spec/services/admin/teachers/rows_spec.rb
+++ b/spec/services/admin/teachers/rows_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe Admin::Teachers::Rows do
   describe "#rows" do
     context "when a teacher has both ECT and mentor roles" do
       let!(:teacher) { FactoryBot.create(:teacher, trs_first_name: "Naruto", trs_last_name: "Uzumaki") }
-      let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:) }
-      let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:) }
+      let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher:) }
+      let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:) }
 
       before do
         ect_contract_period = FactoryBot.create(:contract_period, year: 2024)
@@ -29,7 +29,7 @@ RSpec.describe Admin::Teachers::Rows do
         FactoryBot.create(
           :training_period,
           :for_ect,
-          :ongoing,
+          :unfinished,
           ect_at_school_period:,
           school_partnership: ect_school_partnership
         )
@@ -45,7 +45,7 @@ RSpec.describe Admin::Teachers::Rows do
         FactoryBot.create(
           :training_period,
           :for_mentor,
-          :ongoing,
+          :unfinished,
           mentor_at_school_period:,
           school_partnership: mentor_school_partnership
         )
@@ -73,8 +73,8 @@ RSpec.describe Admin::Teachers::Rows do
     context "when sorting rows" do
       let!(:sasuke) { FactoryBot.create(:teacher, trs_first_name: "Sasuke", trs_last_name: "Uchiha") }
       let!(:naruto) { FactoryBot.create(:teacher, trs_first_name: "Naruto", trs_last_name: "Uzumaki") }
-      let!(:sasuke_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: sasuke) }
-      let!(:naruto_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: naruto) }
+      let!(:sasuke_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher: sasuke) }
+      let!(:naruto_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher: naruto) }
 
       before do
         [sasuke_ect_at_school_period, naruto_ect_at_school_period].each do |ect_at_school_period|
@@ -89,7 +89,7 @@ RSpec.describe Admin::Teachers::Rows do
           FactoryBot.create(
             :training_period,
             :for_ect,
-            :ongoing,
+            :unfinished,
             ect_at_school_period:,
             school_partnership:
           )
@@ -104,7 +104,7 @@ RSpec.describe Admin::Teachers::Rows do
     context "when a teacher has a later ect role period" do
       let!(:teacher) { FactoryBot.create(:teacher, trs_first_name: "Naruto", trs_last_name: "Uzumaki") }
       let!(:older_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher:, started_on: Date.new(2024, 1, 1), finished_on: Date.new(2024, 7, 31)) }
-      let!(:latest_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, started_on: Date.new(2025, 1, 1)) }
+      let!(:latest_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher:, started_on: Date.new(2025, 1, 1)) }
 
       before do
         contract_period_2024 = FactoryBot.create(:contract_period, year: 2024)
@@ -136,7 +136,7 @@ RSpec.describe Admin::Teachers::Rows do
         FactoryBot.create(
           :training_period,
           :for_ect,
-          :ongoing,
+          :unfinished,
           ect_at_school_period: latest_ect_at_school_period,
           school_partnership: latest_school_partnership
         )
@@ -152,7 +152,7 @@ RSpec.describe Admin::Teachers::Rows do
     context "when a teacher has a later mentor role period" do
       let!(:teacher) { FactoryBot.create(:teacher, trs_first_name: "Kakashi", trs_last_name: "Hatake") }
       let!(:older_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher:, started_on: Date.new(2024, 1, 1), finished_on: Date.new(2024, 7, 31)) }
-      let!(:latest_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:, started_on: Date.new(2025, 1, 1)) }
+      let!(:latest_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:, started_on: Date.new(2025, 1, 1)) }
 
       before do
         contract_period_2024 = FactoryBot.create(:contract_period, year: 2024)
@@ -184,7 +184,7 @@ RSpec.describe Admin::Teachers::Rows do
         FactoryBot.create(
           :training_period,
           :for_mentor,
-          :ongoing,
+          :unfinished,
           mentor_at_school_period: latest_mentor_at_school_period,
           school_partnership: latest_school_partnership
         )
@@ -200,8 +200,8 @@ RSpec.describe Admin::Teachers::Rows do
     context "when filtering by role" do
       let(:role) { "mentor" }
       let!(:teacher) { FactoryBot.create(:teacher, trs_first_name: "Naruto", trs_last_name: "Uzumaki") }
-      let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:) }
-      let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:) }
+      let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher:) }
+      let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:) }
 
       before do
         ect_contract_period = FactoryBot.create(:contract_period, year: 2024)
@@ -215,7 +215,7 @@ RSpec.describe Admin::Teachers::Rows do
         FactoryBot.create(
           :training_period,
           :for_ect,
-          :ongoing,
+          :unfinished,
           ect_at_school_period:,
           school_partnership: ect_school_partnership
         )
@@ -231,7 +231,7 @@ RSpec.describe Admin::Teachers::Rows do
         FactoryBot.create(
           :training_period,
           :for_mentor,
-          :ongoing,
+          :unfinished,
           mentor_at_school_period:,
           school_partnership: mentor_school_partnership
         )
@@ -247,14 +247,14 @@ RSpec.describe Admin::Teachers::Rows do
       let(:contract_period) { "not_available" }
       let!(:school_led_teacher) { FactoryBot.create(:teacher, trs_first_name: "Naruto", trs_last_name: "Uzumaki") }
       let!(:provider_led_teacher) { FactoryBot.create(:teacher, trs_first_name: "Sasuke", trs_last_name: "Uchiha") }
-      let!(:school_led_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: school_led_teacher) }
-      let!(:provider_led_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: provider_led_teacher) }
+      let!(:school_led_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher: school_led_teacher) }
+      let!(:provider_led_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher: provider_led_teacher) }
 
       before do
         FactoryBot.create(
           :training_period,
           :for_ect,
-          :ongoing,
+          :unfinished,
           :school_led,
           ect_at_school_period: school_led_ect_at_school_period,
           started_on: school_led_ect_at_school_period.started_on
@@ -271,7 +271,7 @@ RSpec.describe Admin::Teachers::Rows do
         FactoryBot.create(
           :training_period,
           :for_ect,
-          :ongoing,
+          :unfinished,
           ect_at_school_period: provider_led_ect_at_school_period,
           school_partnership:
         )

--- a/spec/services/admin/teachers/search_spec.rb
+++ b/spec/services/admin/teachers/search_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe Admin::Teachers::Search do
       let!(:non_matching_teacher) { FactoryBot.create(:teacher, trs_first_name: "Sasuke", trs_last_name: "Uchiha") }
       let!(:matching_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher: matching_teacher, started_on: Date.new(2025, 1, 1), finished_on: Date.new(2025, 7, 31)) }
       let!(:non_matching_old_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher: non_matching_teacher, started_on: Date.new(2024, 1, 1), finished_on: Date.new(2024, 7, 31)) }
-      let!(:non_matching_latest_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: non_matching_teacher, started_on: Date.new(2025, 1, 1)) }
+      let!(:non_matching_latest_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher: non_matching_teacher, started_on: Date.new(2025, 1, 1)) }
 
       before do
         contract_period_2024 = FactoryBot.create(:contract_period, year: 2024)
@@ -219,7 +219,7 @@ RSpec.describe Admin::Teachers::Search do
         FactoryBot.create(
           :training_period,
           :for_ect,
-          :ongoing,
+          :unfinished,
           ect_at_school_period: non_matching_latest_ect_at_school_period,
           school_partnership: current_school_partnership
         )
@@ -237,7 +237,7 @@ RSpec.describe Admin::Teachers::Search do
       let!(:non_matching_teacher) { FactoryBot.create(:teacher, trs_first_name: "Might", trs_last_name: "Guy") }
       let!(:matching_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher: matching_teacher, started_on: Date.new(2025, 1, 1), finished_on: Date.new(2025, 7, 31)) }
       let!(:non_matching_old_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher: non_matching_teacher, started_on: Date.new(2024, 1, 1), finished_on: Date.new(2024, 7, 31)) }
-      let!(:non_matching_latest_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: non_matching_teacher, started_on: Date.new(2025, 1, 1)) }
+      let!(:non_matching_latest_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, teacher: non_matching_teacher, started_on: Date.new(2025, 1, 1)) }
 
       before do
         contract_period_2024 = FactoryBot.create(:contract_period, year: 2024)
@@ -285,7 +285,7 @@ RSpec.describe Admin::Teachers::Search do
         FactoryBot.create(
           :training_period,
           :for_mentor,
-          :ongoing,
+          :unfinished,
           mentor_at_school_period: non_matching_latest_mentor_at_school_period,
           school_partnership: latest_school_partnership
         )

--- a/spec/services/admin/teachers/training_periods/change_contract_period/available_contract_periods_spec.rb
+++ b/spec/services/admin/teachers/training_periods/change_contract_period/available_contract_periods_spec.rb
@@ -26,12 +26,12 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriod::Available
       delivery_partner:
     )
   end
-  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:) }
+  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher:, school:) }
   let(:schedule) { FactoryBot.create(:schedule, contract_period: current_contract_period) }
   let(:training_period) do
     FactoryBot.create(
       :training_period,
-      :ongoing,
+      :unfinished,
       ect_at_school_period:,
       school_partnership:,
       schedule:
@@ -66,11 +66,11 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriod::Available
     end
 
     context "when the training period is for a mentor with an original frozen contract period" do
-      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:, school:) }
+      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:, school:) }
       let(:training_period) do
         FactoryBot.create(
           :training_period,
-          :ongoing,
+          :unfinished,
           :for_mentor,
           mentor_at_school_period:,
           school_partnership:,
@@ -96,7 +96,7 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriod::Available
       let(:training_period) do
         FactoryBot.create(
           :training_period,
-          :ongoing,
+          :unfinished,
           :with_only_expression_of_interest,
           ect_at_school_period:,
           expression_of_interest: active_lead_provider,

--- a/spec/services/admin/teachers/training_periods/change_contract_period/current_active_period_spec.rb
+++ b/spec/services/admin/teachers/training_periods/change_contract_period/current_active_period_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriod::CurrentAc
   let(:ect_at_school_period) do
     FactoryBot.create(
       :ect_at_school_period,
-      :ongoing,
+      :unfinished,
       teacher:,
       school:,
       started_on: today.prev_year,
@@ -35,7 +35,7 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriod::CurrentAc
   let!(:training_period) do
     FactoryBot.create(
       :training_period,
-      :ongoing,
+      :unfinished,
       ect_at_school_period:,
       school_partnership:,
       schedule:,
@@ -83,7 +83,7 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriod::CurrentAc
     let!(:training_period) do
       FactoryBot.create(
         :training_period,
-        :ongoing,
+        :unfinished,
         :with_only_expression_of_interest,
         ect_at_school_period:,
         expression_of_interest: current_active_lead_provider,
@@ -178,12 +178,12 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriod::CurrentAc
   end
 
   context "for mentor training" do
-    let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:, school:, started_on: today.prev_year) }
+    let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:, school:, started_on: today.prev_year) }
     let!(:training_period) do
       FactoryBot.create(
         :training_period,
         :for_mentor,
-        :ongoing,
+        :unfinished,
         mentor_at_school_period:,
         school_partnership:,
         schedule:,

--- a/spec/services/api/declarations/create_spec.rb
+++ b/spec/services/api/declarations/create_spec.rb
@@ -261,7 +261,7 @@ RSpec.describe API::Declarations::Create, type: :model do
           context "when teacher's latest ongoing training period is in a frozen contract period but declaration targets non-frozen" do
             let(:declaration_date) { Faker::Date.between(from: training_period.started_on, to: training_period.finished_on).rfc3339 }
 
-            let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :ongoing, started_on: 6.months.ago) }
+            let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :unfinished, started_on: 6.months.ago) }
             let!(:training_period) do
               FactoryBot.create(:training_period, :"for_#{trainee_type}", :active,
                                 "#{trainee_type}_at_school_period": at_school_period,
@@ -277,7 +277,7 @@ RSpec.describe API::Declarations::Create, type: :model do
                                 school: at_school_period.school)
             end
             let!(:frozen_training_period) do
-              FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing,
+              FactoryBot.create(:training_period, :"for_#{trainee_type}", :unfinished,
                                 "#{trainee_type}_at_school_period": at_school_period,
                                 school_partnership: frozen_school_partnership,
                                 started_on: training_period.finished_on + 1.day)
@@ -324,7 +324,7 @@ RSpec.describe API::Declarations::Create, type: :model do
         end
 
         describe "training period selection" do
-          let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :ongoing, started_on: 6.months.ago) }
+          let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :unfinished, started_on: 6.months.ago) }
 
           context "when multiple training periods exist for the same lead provider" do
             let!(:training_period) do
@@ -335,7 +335,7 @@ RSpec.describe API::Declarations::Create, type: :model do
             end
 
             let!(:current_training_period) do
-              FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing,
+              FactoryBot.create(:training_period, :"for_#{trainee_type}", :unfinished,
                                 "#{trainee_type}_at_school_period": at_school_period,
                                 school_partnership: training_period.school_partnership,
                                 started_on: 2.months.ago + 1.day)
@@ -363,7 +363,7 @@ RSpec.describe API::Declarations::Create, type: :model do
             end
 
             let!(:future_training_period) do
-              FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing,
+              FactoryBot.create(:training_period, :"for_#{trainee_type}", :unfinished,
                                 "#{trainee_type}_at_school_period": at_school_period,
                                 school_partnership: training_period.school_partnership,
                                 started_on: 1.month.from_now)
@@ -384,7 +384,7 @@ RSpec.describe API::Declarations::Create, type: :model do
 
           context "when only a future training period exists for the same lead provider" do
             let!(:training_period) do
-              FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing,
+              FactoryBot.create(:training_period, :"for_#{trainee_type}", :unfinished,
                                 "#{trainee_type}_at_school_period": at_school_period,
                                 started_on: 1.month.from_now)
             end
@@ -622,9 +622,9 @@ RSpec.describe API::Declarations::Create, type: :model do
         let(:teacher_type) { trainee_type }
 
         context "when invalid" do
-          let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :ongoing) }
+          let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :unfinished) }
           let!(:training_period) do
-            FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing,
+            FactoryBot.create(:training_period, :"for_#{trainee_type}", :unfinished,
                               "#{trainee_type}_at_school_period": at_school_period,
                               started_on: at_school_period.started_on)
           end

--- a/spec/services/api/declarations/query_spec.rb
+++ b/spec/services/api/declarations/query_spec.rb
@@ -9,11 +9,11 @@ RSpec.describe API::Declarations::Query, :with_metadata do
       following_on_from_training_period.update!(finished_on: previous_finished_on)
       school_period = following_on_from_training_period.at_school_period
 
-      FactoryBot.create(:training_period, trait, :ongoing, school_partnership:, started_on: previous_finished_on + 1.day, "#{trainee}_at_school_period": school_period)
+      FactoryBot.create(:training_period, trait, :unfinished, school_partnership:, started_on: previous_finished_on + 1.day, "#{trainee}_at_school_period": school_period)
     else
       teacher ||= FactoryBot.create(:teacher)
-      school_period = FactoryBot.create(:"#{trainee}_at_school_period", :ongoing, teacher:)
-      FactoryBot.create(:training_period, trait, :ongoing, school_partnership:, "#{trainee}_at_school_period": school_period)
+      school_period = FactoryBot.create(:"#{trainee}_at_school_period", :unfinished, teacher:)
+      FactoryBot.create(:training_period, trait, :unfinished, school_partnership:, "#{trainee}_at_school_period": school_period)
     end
   end
 
@@ -90,7 +90,7 @@ RSpec.describe API::Declarations::Query, :with_metadata do
 
     describe "filtering" do
       describe "by `lead_provider_id`" do
-        let(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)) }
+        let(:training_period) { FactoryBot.create(:training_period, :for_ect, :unfinished, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished)) }
         let(:lead_provider_id) { training_period.lead_provider.id }
 
         let!(:declaration1) { FactoryBot.create(:declaration, training_period:) }

--- a/spec/services/api/schools/query_spec.rb
+++ b/spec/services/api/schools/query_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe API::Schools::Query, :with_metadata do
         let!(:school1) { FactoryBot.create(:school, :eligible) }
         let!(:school2) { FactoryBot.create(:school, :eligible) }
 
-        let!(:training_period) { FactoryBot.create(:training_period, :ongoing, :for_ect, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)) }
+        let!(:training_period) { FactoryBot.create(:training_period, :unfinished, :for_ect, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished)) }
         let!(:school3) { training_period.school_partnership.school }
 
         let(:updated_since) { 1.day.ago }

--- a/spec/services/api/teachers/change_schedule_spec.rb
+++ b/spec/services/api/teachers/change_schedule_spec.rb
@@ -209,8 +209,8 @@ RSpec.describe API::Teachers::ChangeSchedule, type: :model do
           let(:teacher_type) { trainee_type }
 
           context "when invalid" do
-            let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :ongoing) }
-            let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
+            let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :unfinished) }
+            let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :unfinished, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
             let(:teacher_api_id) { SecureRandom.uuid }
 
             it { expect(instance.change_schedule).to be(false) }

--- a/spec/services/api/teachers/defer_spec.rb
+++ b/spec/services/api/teachers/defer_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe API::Teachers::Defer, type: :model do
     describe "validations" do
       API::Concerns::Teachers::SharedAction::TEACHER_TYPES.each do |trainee_type|
         context "for #{trainee_type}" do
-          let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :ongoing, started_on: 2.months.ago) }
-          let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
+          let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :unfinished, started_on: 2.months.ago) }
+          let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :unfinished, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
           let(:teacher_type) { trainee_type }
 
           it { is_expected.to be_valid }
@@ -59,7 +59,7 @@ RSpec.describe API::Teachers::Defer, type: :model do
           end
 
           context "when training not started yet" do
-            let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :ongoing, started_on: 3.months.from_now) }
+            let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :unfinished, started_on: 3.months.from_now) }
 
             it { is_expected.to have_one_error_per_attribute }
             it { is_expected.to have_error(:teacher_api_id, "You cannot defer #/teacher_api_id. This is because they have not been training with you for at least one day.") }
@@ -95,7 +95,7 @@ RSpec.describe API::Teachers::Defer, type: :model do
           let(:teacher_type) { trainee_type }
 
           context "when invalid" do
-            let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
+            let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :unfinished, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
             let(:teacher_api_id) { SecureRandom.uuid }
 
             it { expect(instance.defer).to be(false) }
@@ -103,7 +103,7 @@ RSpec.describe API::Teachers::Defer, type: :model do
           end
 
           context "when valid" do
-            let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
+            let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :unfinished, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
 
             it "returns teacher" do
               expect(instance.defer).to eq(teacher)

--- a/spec/services/api/teachers/induction_status_spec.rb
+++ b/spec/services/api/teachers/induction_status_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe API::Teachers::InductionStatus, type: :model do
     end
 
     context "when the teacher has an ongoing induction_period" do
-      let(:teacher) { FactoryBot.create(:induction_period, :ongoing).teacher }
+      let(:teacher) { FactoryBot.create(:induction_period, :unfinished).teacher }
 
       it { is_expected.to be_nil }
     end
@@ -106,7 +106,7 @@ RSpec.describe API::Teachers::InductionStatus, type: :model do
     context "when the teacher has multiple induction periods" do
       let(:teacher) { closed_period.teacher }
       let(:closed_period) { FactoryBot.create(:induction_period, finished_on: 10.days.ago) }
-      let!(:latest_period) { FactoryBot.create(:induction_period, :ongoing, started_on: 9.days.ago, teacher:) }
+      let!(:latest_period) { FactoryBot.create(:induction_period, :unfinished, started_on: 9.days.ago, teacher:) }
 
       it { is_expected.to eq latest_period.finished_on }
     end

--- a/spec/services/api/teachers/query_spec.rb
+++ b/spec/services/api/teachers/query_spec.rb
@@ -86,10 +86,10 @@ RSpec.describe API::Teachers::Query, :with_metadata do
 
     describe "filtering" do
       describe "by `lead_provider`" do
-        let(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)) }
+        let(:training_period) { FactoryBot.create(:training_period, :for_ect, :unfinished, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished)) }
         let!(:teacher1) { training_period.teacher }
-        let!(:teacher2) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)).teacher }
-        let!(:teacher3) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)).teacher }
+        let!(:teacher2) { FactoryBot.create(:training_period, :for_ect, :unfinished, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished)).teacher }
+        let!(:teacher3) { FactoryBot.create(:training_period, :for_ect, :unfinished, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished)).teacher }
 
         context "when `lead_provider` param is omitted" do
           it "returns all teachers" do
@@ -118,18 +118,18 @@ RSpec.describe API::Teachers::Query, :with_metadata do
       end
 
       describe "by `contract_period_years`" do
-        let(:ect_at_school_period_1) { FactoryBot.create(:ect_at_school_period, :ongoing) }
-        let(:ect_at_school_period_2) { FactoryBot.create(:ect_at_school_period, :ongoing) }
-        let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing) }
+        let(:ect_at_school_period_1) { FactoryBot.create(:ect_at_school_period, :unfinished) }
+        let(:ect_at_school_period_2) { FactoryBot.create(:ect_at_school_period, :unfinished) }
+        let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished) }
         let(:contract_period1) { FactoryBot.create(:contract_period) }
         let(:contract_period2) { FactoryBot.create(:contract_period) }
         let(:contract_period3) { FactoryBot.create(:contract_period) }
         let(:school_partnership1) { FactoryBot.create(:school_partnership, active_lead_provider: FactoryBot.create(:active_lead_provider, contract_period: contract_period1)) }
         let(:school_partnership2) { FactoryBot.create(:school_partnership, active_lead_provider: FactoryBot.create(:active_lead_provider, contract_period: contract_period2)) }
         let(:school_partnership3) { FactoryBot.create(:school_partnership, active_lead_provider: FactoryBot.create(:active_lead_provider, contract_period: contract_period3)) }
-        let!(:teacher1) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: ect_at_school_period_1, school_partnership: school_partnership1).teacher }
-        let!(:teacher2) { FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period:, school_partnership: school_partnership2).teacher }
-        let!(:teacher3) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: ect_at_school_period_2, school_partnership: school_partnership3).teacher }
+        let!(:teacher1) { FactoryBot.create(:training_period, :for_ect, :unfinished, ect_at_school_period: ect_at_school_period_1, school_partnership: school_partnership1).teacher }
+        let!(:teacher2) { FactoryBot.create(:training_period, :for_mentor, :unfinished, mentor_at_school_period:, school_partnership: school_partnership2).teacher }
+        let!(:teacher3) { FactoryBot.create(:training_period, :for_ect, :unfinished, ect_at_school_period: ect_at_school_period_2, school_partnership: school_partnership3).teacher }
 
         context "when `contract_period_years` param is omitted" do
           it "returns all teachers" do
@@ -177,9 +177,9 @@ RSpec.describe API::Teachers::Query, :with_metadata do
       end
 
       describe "by `api_from_teacher_id`" do
-        let(:teacher1) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)).teacher }
-        let(:teacher2) { FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period: FactoryBot.create(:mentor_at_school_period, :ongoing)).teacher }
-        let(:teacher3) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)).teacher }
+        let(:teacher1) { FactoryBot.create(:training_period, :for_ect, :unfinished, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished)).teacher }
+        let(:teacher2) { FactoryBot.create(:training_period, :for_mentor, :unfinished, mentor_at_school_period: FactoryBot.create(:mentor_at_school_period, :unfinished)).teacher }
+        let(:teacher3) { FactoryBot.create(:training_period, :for_ect, :unfinished, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished)).teacher }
         let!(:teacher_id_change1) { FactoryBot.create(:teacher_id_change, teacher: teacher1, api_from_teacher_id: teacher2.api_id) }
         let!(:teacher_id_change2) { FactoryBot.create(:teacher_id_change, teacher: teacher2, api_from_teacher_id: teacher3.api_id) }
         let!(:teacher_id_change3) { FactoryBot.create(:teacher_id_change, teacher: teacher3, api_from_teacher_id: teacher1.api_id) }
@@ -211,14 +211,14 @@ RSpec.describe API::Teachers::Query, :with_metadata do
       end
 
       describe "by `training_status`" do
-        let(:ect_at_school_period_1) { FactoryBot.create(:ect_at_school_period, :ongoing) }
-        let(:ect_at_school_period_2) { FactoryBot.create(:ect_at_school_period, :ongoing) }
-        let(:mentor_at_school_period_1) { FactoryBot.create(:mentor_at_school_period, :ongoing) }
+        let(:ect_at_school_period_1) { FactoryBot.create(:ect_at_school_period, :unfinished) }
+        let(:ect_at_school_period_2) { FactoryBot.create(:ect_at_school_period, :unfinished) }
+        let(:mentor_at_school_period_1) { FactoryBot.create(:mentor_at_school_period, :unfinished) }
 
         let(:school_partnership) { FactoryBot.create(:school_partnership) }
-        let!(:deferred_teacher) { FactoryBot.create(:training_period, :for_ect, :ongoing, :deferred, ect_at_school_period: ect_at_school_period_1, school_partnership:).teacher }
-        let!(:withdrawn_teacher) { FactoryBot.create(:training_period, :for_mentor, :ongoing, :withdrawn, mentor_at_school_period: mentor_at_school_period_1, school_partnership:).teacher }
-        let!(:active_teacher) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: ect_at_school_period_2, school_partnership:).teacher }
+        let!(:deferred_teacher) { FactoryBot.create(:training_period, :for_ect, :unfinished, :deferred, ect_at_school_period: ect_at_school_period_1, school_partnership:).teacher }
+        let!(:withdrawn_teacher) { FactoryBot.create(:training_period, :for_mentor, :unfinished, :withdrawn, mentor_at_school_period: mentor_at_school_period_1, school_partnership:).teacher }
+        let!(:active_teacher) { FactoryBot.create(:training_period, :for_ect, :unfinished, ect_at_school_period: ect_at_school_period_2, school_partnership:).teacher }
 
         context "when `training_status` param is omitted" do
           it "returns all teachers" do
@@ -264,8 +264,8 @@ RSpec.describe API::Teachers::Query, :with_metadata do
         let(:school_partnership) { FactoryBot.create(:school_partnership) }
         let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher:, school: school_partnership.school) }
         let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher:, school: school_partnership.school) }
-        let!(:deferred_training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, :deferred, school_partnership:, ect_at_school_period:) }
-        let!(:withdrawn_training_period) { FactoryBot.create(:training_period, :for_mentor, :ongoing, :withdrawn, school_partnership:, mentor_at_school_period:) }
+        let!(:deferred_training_period) { FactoryBot.create(:training_period, :for_ect, :unfinished, :deferred, school_partnership:, ect_at_school_period:) }
+        let!(:withdrawn_training_period) { FactoryBot.create(:training_period, :for_mentor, :unfinished, :withdrawn, school_partnership:, mentor_at_school_period:) }
 
         it "returns the teacher if any of the latest training periods match the filter" do
           query = described_class.new(training_status: :deferred)
@@ -313,8 +313,8 @@ RSpec.describe API::Teachers::Query, :with_metadata do
     end
 
     describe "ordering" do
-      let!(:teacher1) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)).teacher }
-      let!(:teacher2) { travel_to(1.day.ago) { FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period: FactoryBot.create(:mentor_at_school_period, :ongoing)).teacher } }
+      let!(:teacher1) { FactoryBot.create(:training_period, :for_ect, :unfinished, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished)).teacher }
+      let!(:teacher2) { travel_to(1.day.ago) { FactoryBot.create(:training_period, :for_mentor, :unfinished, mentor_at_school_period: FactoryBot.create(:mentor_at_school_period, :unfinished)).teacher } }
 
       describe "default order" do
         it "returns teachers ordered by created_at, in ascending order" do
@@ -363,8 +363,8 @@ RSpec.describe API::Teachers::Query, :with_metadata do
     end
 
     it "raises an error if the teacher is not in the filtered query" do
-      teacher1 = FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)).teacher
-      teacher2 = FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period: FactoryBot.create(:mentor_at_school_period, :ongoing)).teacher
+      teacher1 = FactoryBot.create(:training_period, :for_ect, :unfinished, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished)).teacher
+      teacher2 = FactoryBot.create(:training_period, :for_mentor, :unfinished, mentor_at_school_period: FactoryBot.create(:mentor_at_school_period, :unfinished)).teacher
       lead_provider_id = teacher1.lead_provider_metadata.first.lead_provider_id
 
       query = described_class.new(lead_provider_id:)
@@ -392,8 +392,8 @@ RSpec.describe API::Teachers::Query, :with_metadata do
     end
 
     it "raises an error if the teacher is not in the filtered query" do
-      teacher1 = FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)).teacher
-      teacher2 = FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period: FactoryBot.create(:mentor_at_school_period, :ongoing)).teacher
+      teacher1 = FactoryBot.create(:training_period, :for_ect, :unfinished, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished)).teacher
+      teacher2 = FactoryBot.create(:training_period, :for_mentor, :unfinished, mentor_at_school_period: FactoryBot.create(:mentor_at_school_period, :unfinished)).teacher
       lead_provider_id = teacher1.lead_provider_metadata.first.lead_provider_id
 
       query = described_class.new(lead_provider_id:)

--- a/spec/services/api/teachers/resume_spec.rb
+++ b/spec/services/api/teachers/resume_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe API::Teachers::Resume, type: :model do
           it { is_expected.to be_valid }
 
           context "when training period has finished today" do
-            let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :ongoing, started_on: 2.months.ago, finished_on: Date.current) }
+            let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :unfinished, started_on: 2.months.ago, finished_on: Date.current) }
             let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :deferred, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on, finished_on: at_school_period.finished_on) }
 
             it { is_expected.to have_one_error_per_attribute }
@@ -26,26 +26,26 @@ RSpec.describe API::Teachers::Resume, type: :model do
           end
 
           context "when teacher training period is active/ongoing" do
-            let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :ongoing, started_on: 2.months.ago) }
-            let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
+            let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :unfinished, started_on: 2.months.ago) }
+            let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :unfinished, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
 
             it { is_expected.to have_one_error_per_attribute }
             it { is_expected.to have_error(:teacher_api_id, "The '#/teacher_api_id' is already active.") }
           end
 
           context "when there is another active/ongoing training period for the school period at a different lead provider" do
-            let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :ongoing, started_on: 2.months.ago) }
+            let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :unfinished, started_on: 2.months.ago) }
             let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :deferred, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on, finished_on: 1.month.ago) }
-            let!(:other_training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing, "#{trainee_type}_at_school_period": at_school_period, started_on: 2.weeks.ago) }
+            let!(:other_training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :unfinished, "#{trainee_type}_at_school_period": at_school_period, started_on: 2.weeks.ago) }
 
             it { is_expected.to have_one_error_per_attribute }
             it { is_expected.to have_error(:teacher_api_id, "This participant cannot be resumed because they are already active with another provider.") }
           end
 
           context "when there is another active/ongoing training period that finishes in the future for the school period at a different lead provider" do
-            let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :ongoing, started_on: 2.months.ago) }
+            let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :unfinished, started_on: 2.months.ago) }
             let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :deferred, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on, finished_on: 1.month.ago) }
-            let!(:other_training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing, "#{trainee_type}_at_school_period": at_school_period, started_on: 2.weeks.ago, finished_on: 3.months.from_now) }
+            let!(:other_training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :unfinished, "#{trainee_type}_at_school_period": at_school_period, started_on: 2.weeks.ago, finished_on: 3.months.from_now) }
 
             it { is_expected.to have_one_error_per_attribute }
             it { is_expected.to have_error(:teacher_api_id, "This participant cannot be resumed because they are already active with another provider.") }
@@ -58,7 +58,7 @@ RSpec.describe API::Teachers::Resume, type: :model do
           end
 
           context "when at school period is finished" do
-            let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :ongoing, started_on: 2.months.ago, finished_on: 1.month.ago) }
+            let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :unfinished, started_on: 2.months.ago, finished_on: 1.month.ago) }
 
             it { is_expected.to have_one_error_per_attribute }
             it { is_expected.to have_error(:teacher_api_id, "The participant is no longer at the school. Please contact the induction tutor to resolve.") }
@@ -66,14 +66,14 @@ RSpec.describe API::Teachers::Resume, type: :model do
 
           context "when the school period finishes today, but the training period finished before today" do
             let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :deferred, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on, finished_on: 2.days.ago) }
-            let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :ongoing, started_on: 2.months.ago, finished_on: Date.current) }
+            let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :unfinished, started_on: 2.months.ago, finished_on: Date.current) }
 
             it { is_expected.to have_one_error_per_attribute }
             it { is_expected.to have_error(:teacher_api_id, "The participant is no longer at the school. Please contact the induction tutor to resolve.") }
           end
 
           context "when the school period finishes tomorrow" do
-            let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :ongoing, started_on: 2.months.ago, finished_on: Date.tomorrow) }
+            let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :unfinished, started_on: 2.months.ago, finished_on: Date.tomorrow) }
 
             it { is_expected.to be_valid }
           end
@@ -93,8 +93,8 @@ RSpec.describe API::Teachers::Resume, type: :model do
           let(:teacher_type) { trainee_type }
 
           context "when invalid" do
-            let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :ongoing) }
-            let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
+            let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :unfinished) }
+            let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :unfinished, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
             let(:teacher_api_id) { SecureRandom.uuid }
 
             it { expect(instance.resume).to be(false) }

--- a/spec/services/api/teachers/school_transfers/transfer_spec.rb
+++ b/spec/services/api/teachers/school_transfers/transfer_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe API::Teachers::SchoolTransfers::Transfer do
         FactoryBot.build_stubbed(:training_period, finished_on: 1.day.from_now)
       end
       let(:joining_training_period) do
-        FactoryBot.build_stubbed(:training_period, :ongoing)
+        FactoryBot.build_stubbed(:training_period, :unfinished)
       end
 
       it { is_expected.to eq(:incomplete) }

--- a/spec/services/api/teachers/withdraw_spec.rb
+++ b/spec/services/api/teachers/withdraw_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe API::Teachers::Withdraw, type: :model do
     describe "validations" do
       API::Concerns::Teachers::SharedAction::TEACHER_TYPES.each do |trainee_type|
         context "for #{trainee_type}" do
-          let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :ongoing, started_on: 2.months.ago) }
-          let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
+          let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :unfinished, started_on: 2.months.ago) }
+          let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :unfinished, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
           let(:teacher_type) { trainee_type }
 
           it { is_expected.to be_valid }
@@ -52,7 +52,7 @@ RSpec.describe API::Teachers::Withdraw, type: :model do
           end
 
           context "when training not started yet" do
-            let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :ongoing, started_on: 3.months.from_now) }
+            let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :unfinished, started_on: 3.months.from_now) }
 
             it { is_expected.to have_one_error_per_attribute }
             it { is_expected.to have_error(:teacher_api_id, "You cannot withdraw #/teacher_api_id. This is because they have not been training with you for at least one day.") }
@@ -81,8 +81,8 @@ RSpec.describe API::Teachers::Withdraw, type: :model do
       end
 
       context "for ect with mentor-no-longer-being-mentor reason" do
-        let(:at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 2.months.ago) }
-        let!(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: at_school_period, started_on: at_school_period.started_on) }
+        let(:at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, started_on: 2.months.ago) }
+        let!(:training_period) { FactoryBot.create(:training_period, :for_ect, :unfinished, ect_at_school_period: at_school_period, started_on: at_school_period.started_on) }
         let(:teacher_type) { :ect }
         let(:reason) { described_class::MENTOR_ONLY_WITHDRAWAL_REASONS.sample }
 
@@ -91,8 +91,8 @@ RSpec.describe API::Teachers::Withdraw, type: :model do
       end
 
       context "for mentor with mentor-no-longer-being-mentor reason" do
-        let(:at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, started_on: 2.months.ago) }
-        let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period: at_school_period, started_on: at_school_period.started_on) }
+        let(:at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, started_on: 2.months.ago) }
+        let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, :unfinished, mentor_at_school_period: at_school_period, started_on: at_school_period.started_on) }
         let(:teacher_type) { :mentor }
         let(:reason) { described_class::MENTOR_ONLY_WITHDRAWAL_REASONS.sample }
 
@@ -125,7 +125,7 @@ RSpec.describe API::Teachers::Withdraw, type: :model do
           let(:teacher_type) { trainee_type }
 
           context "when invalid" do
-            let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
+            let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :unfinished, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
             let(:teacher_api_id) { SecureRandom.uuid }
 
             it { expect(instance.withdraw).to be(false) }
@@ -133,7 +133,7 @@ RSpec.describe API::Teachers::Withdraw, type: :model do
           end
 
           context "when valid" do
-            let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
+            let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :unfinished, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
 
             include_context "withdraws the teacher"
 

--- a/spec/services/api/training_periods/teacher_status_spec.rb
+++ b/spec/services/api/training_periods/teacher_status_spec.rb
@@ -6,15 +6,15 @@ RSpec.describe API::TrainingPeriods::TeacherStatus do
     subject { service.status }
 
     context "when training period set to start in the future" do
-      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 1.week.from_now) }
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, started_on: 1.week.from_now) }
       let(:training_period) { FactoryBot.create(:training_period, :not_started_yet, ect_at_school_period:) }
 
       it { is_expected.to eq(:joining) }
     end
 
     context "when training period has started and not finished" do
-      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing) }
-      let(:training_period) { FactoryBot.create(:training_period, :ongoing, ect_at_school_period:) }
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished) }
+      let(:training_period) { FactoryBot.create(:training_period, :unfinished, ect_at_school_period:) }
 
       it { is_expected.to eq(:active) }
       it { expect(service).to be_active }

--- a/spec/services/api_seed_data/ect_declaration_scenarios_spec.rb
+++ b/spec/services/api_seed_data/ect_declaration_scenarios_spec.rb
@@ -54,10 +54,10 @@ RSpec.describe APISeedData::ECTDeclarationScenarios do
       expect(training_period.schedule.identifier).to eq("ecf-standard-september")
 
       expect(training_period.started_on).to eq(Date.new(2025, 9, 2))
-      expect(training_period).to be_ongoing
+      expect(training_period).to be_unfinished
 
       expect(training_period.at_school_period.started_on).to eq(Date.new(2025, 9, 2))
-      expect(training_period.at_school_period).to be_ongoing
+      expect(training_period.at_school_period).to be_unfinished
 
       expect(teacher.induction_periods).to be_present
       expect(teacher.finished_induction_period).to be_nil
@@ -101,10 +101,10 @@ RSpec.describe APISeedData::ECTDeclarationScenarios do
       expect(training_period.schedule.identifier).to eq("ecf-standard-september")
 
       expect(training_period.started_on).to eq(Date.new(2025, 9, 1))
-      expect(training_period).to be_ongoing
+      expect(training_period).to be_unfinished
 
       expect(training_period.at_school_period.started_on).to eq(Date.new(2025, 9, 1))
-      expect(training_period.at_school_period).to be_ongoing
+      expect(training_period.at_school_period).to be_unfinished
 
       expect(teacher.induction_periods).to be_present
       expect(teacher.finished_induction_period).to be_nil

--- a/spec/services/api_seed_data/ect_participant_action_scenarios_spec.rb
+++ b/spec/services/api_seed_data/ect_participant_action_scenarios_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe APISeedData::ECTParticipantActionScenarios do
       Metadata::Manager.new.refresh_metadata!(teacher)
 
       expect(API::TrainingPeriods::TrainingStatus.new(training_period:).status).to eq(:withdrawn)
-      expect(training_period.at_school_period).to be_ongoing
+      expect(training_period.at_school_period).to be_unfinished
       expect(teacher.induction_periods).to be_present
       expect(teacher.finished_induction_period).to be_nil
 
@@ -75,7 +75,7 @@ RSpec.describe APISeedData::ECTParticipantActionScenarios do
 
       expect(API::TrainingPeriods::TrainingStatus.new(training_period:).status).to eq(:withdrawn)
       expect(API::TrainingPeriods::TeacherStatus.new(latest_training_period: training_period, teacher:).status).to eq(:left)
-      expect(training_period.at_school_period).to be_ongoing
+      expect(training_period.at_school_period).to be_unfinished
       expect(teacher.induction_periods).to be_present
       expect(teacher.finished_induction_period).to be_nil
 
@@ -100,7 +100,7 @@ RSpec.describe APISeedData::ECTParticipantActionScenarios do
 
       expect(API::TrainingPeriods::TrainingStatus.new(training_period:).status).to eq(:active)
       expect(API::TrainingPeriods::TeacherStatus.new(latest_training_period: training_period, teacher:).status).to eq(:active)
-      expect(training_period.at_school_period).to be_ongoing
+      expect(training_period.at_school_period).to be_unfinished
       expect(teacher.induction_periods).to be_present
       expect(teacher.finished_induction_period).to be_nil
 

--- a/spec/services/appropriate_bodies/claim_an_ect/find_ect_spec.rb
+++ b/spec/services/appropriate_bodies/claim_an_ect/find_ect_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe AppropriateBodies::ClaimAnECT::FindECT do
           let(:other_appropriate_body_period) { FactoryBot.create(:appropriate_body_period) }
 
           before do
-            FactoryBot.create(:induction_period, :ongoing,
+            FactoryBot.create(:induction_period, :unfinished,
                               teacher:,
                               appropriate_body_period: other_appropriate_body_period,
                               started_on: Date.parse("2 October 2022"))
@@ -62,7 +62,7 @@ RSpec.describe AppropriateBodies::ClaimAnECT::FindECT do
 
         context "with the same AB" do
           before do
-            FactoryBot.create(:induction_period, :ongoing,
+            FactoryBot.create(:induction_period, :unfinished,
                               teacher:,
                               appropriate_body_period:,
                               started_on: Date.parse("2 October 2022"))

--- a/spec/services/appropriate_bodies/process_batch/action_spec.rb
+++ b/spec/services/appropriate_bodies/process_batch/action_spec.rb
@@ -292,7 +292,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Action do
       let(:other_body) { FactoryBot.create(:appropriate_body_period, name: "Acme") }
 
       let!(:induction_period) do
-        FactoryBot.create(:induction_period, :ongoing,
+        FactoryBot.create(:induction_period, :unfinished,
                           appropriate_body_period: other_body,
                           teacher:,
                           started_on: "2024-1-1")
@@ -307,7 +307,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Action do
 
     context "with an ongoing induction" do
       let!(:induction_period) do
-        FactoryBot.create(:induction_period, :ongoing,
+        FactoryBot.create(:induction_period, :unfinished,
                           appropriate_body_period:,
                           teacher:,
                           started_on: "2024-1-1")

--- a/spec/services/appropriate_bodies/process_batch/claim_spec.rb
+++ b/spec/services/appropriate_bodies/process_batch/claim_spec.rb
@@ -496,7 +496,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Claim do
     let(:teacher) { FactoryBot.create(:teacher, trn:) }
 
     before do
-      FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period: other_body)
+      FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period: other_body)
       service.process!
     end
 

--- a/spec/services/appropriate_bodies/record_fail_spec.rb
+++ b/spec/services/appropriate_bodies/record_fail_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe AppropriateBodies::RecordFail do
 
     context "when ongoing induction period only has a mappable legacy programme type" do
       let!(:induction_period) do
-        FactoryBot.create(:induction_period, :ongoing, :legacy_programme_type,
+        FactoryBot.create(:induction_period, :unfinished, :legacy_programme_type,
                           appropriate_body_period:,
                           teacher:)
       end
@@ -136,7 +136,7 @@ RSpec.describe AppropriateBodies::RecordFail do
 
     context "when ongoing induction period only has an unmappable legacy programme type" do
       let!(:induction_period) do
-        FactoryBot.create(:induction_period, :ongoing, :pre_2021, :legacy_programme_type,
+        FactoryBot.create(:induction_period, :unfinished, :pre_2021, :legacy_programme_type,
                           appropriate_body_period:,
                           teacher:)
       end

--- a/spec/services/appropriate_bodies/record_pass_spec.rb
+++ b/spec/services/appropriate_bodies/record_pass_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe AppropriateBodies::RecordPass do
 
     context "when ongoing induction period only has the legacy programme type" do
       let!(:induction_period) do
-        FactoryBot.create(:induction_period, :ongoing, :legacy_programme_type,
+        FactoryBot.create(:induction_period, :unfinished, :legacy_programme_type,
                           appropriate_body_period:,
                           teacher:)
       end

--- a/spec/services/data_corrections/ect_contract_period_correction_spec.rb
+++ b/spec/services/data_corrections/ect_contract_period_correction_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe DataCorrections::ECTContractPeriodCorrection do
   let(:ect_at_school_period) do
     FactoryBot.create(
       :ect_at_school_period,
-      :ongoing,
+      :unfinished,
       teacher:,
       school:
     )
@@ -89,7 +89,7 @@ RSpec.describe DataCorrections::ECTContractPeriodCorrection do
     FactoryBot.create(
       :training_period,
       :provider_led,
-      :ongoing,
+      :unfinished,
       ect_at_school_period:,
       schedule: current_schedule,
       school_partnership: current_school_partnership,
@@ -138,7 +138,7 @@ RSpec.describe DataCorrections::ECTContractPeriodCorrection do
           :training_period,
           :for_ect,
           :provider_led,
-          :ongoing,
+          :unfinished,
           :with_no_school_partnership,
           ect_at_school_period:,
           schedule: current_schedule,
@@ -201,7 +201,7 @@ RSpec.describe DataCorrections::ECTContractPeriodCorrection do
       let(:mentor_at_school_period) do
         FactoryBot.create(
           :mentor_at_school_period,
-          :ongoing,
+          :unfinished,
           started_on: 1.year.ago
         )
       end
@@ -210,7 +210,7 @@ RSpec.describe DataCorrections::ECTContractPeriodCorrection do
         FactoryBot.create(
           :training_period,
           :for_mentor,
-          :ongoing,
+          :unfinished,
           :provider_led,
           mentor_at_school_period:,
           started_on: mentor_at_school_period.started_on
@@ -478,7 +478,7 @@ RSpec.describe DataCorrections::ECTContractPeriodCorrection do
           :training_period,
           :for_ect,
           :provider_led,
-          :ongoing,
+          :unfinished,
           :with_no_school_partnership,
           ect_at_school_period:,
           schedule: current_schedule,
@@ -508,7 +508,7 @@ RSpec.describe DataCorrections::ECTContractPeriodCorrection do
           :training_period,
           :for_ect,
           :provider_led,
-          :ongoing,
+          :unfinished,
           :with_no_school_partnership,
           ect_at_school_period:,
           schedule: current_schedule,

--- a/spec/services/ect_at_school_periods/appropriate_body_spec.rb
+++ b/spec/services/ect_at_school_periods/appropriate_body_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe ECTAtSchoolPeriods::AppropriateBody do
         let!(:induction_period) do
           FactoryBot.create(
             :induction_period,
-            :ongoing,
+            :unfinished,
             teacher: ect_at_school_period.teacher,
             started_on: ect_at_school_period.started_on.prev_day
           )
@@ -56,7 +56,7 @@ RSpec.describe ECTAtSchoolPeriods::AppropriateBody do
         let!(:induction_period) do
           FactoryBot.create(
             :induction_period,
-            :ongoing,
+            :unfinished,
             teacher: ect_at_school_period.teacher,
             started_on: ect_at_school_period.finished_on.next_day
           )
@@ -70,7 +70,7 @@ RSpec.describe ECTAtSchoolPeriods::AppropriateBody do
         let!(:induction_period) do
           FactoryBot.create(
             :induction_period,
-            :ongoing,
+            :unfinished,
             teacher: ect_at_school_period.teacher,
             started_on: ect_at_school_period.started_on
           )
@@ -107,7 +107,7 @@ RSpec.describe ECTAtSchoolPeriods::AppropriateBody do
         let!(:induction_period) do
           FactoryBot.create(
             :induction_period,
-            :ongoing,
+            :unfinished,
             teacher: ect_at_school_period.teacher,
             started_on: ect_at_school_period.started_on.prev_day
           )
@@ -121,7 +121,7 @@ RSpec.describe ECTAtSchoolPeriods::AppropriateBody do
         let!(:induction_period) do
           FactoryBot.create(
             :induction_period,
-            :ongoing,
+            :unfinished,
             teacher: ect_at_school_period.teacher,
             started_on: ect_at_school_period.finished_on.next_day
           )
@@ -135,7 +135,7 @@ RSpec.describe ECTAtSchoolPeriods::AppropriateBody do
         let!(:induction_period) do
           FactoryBot.create(
             :induction_period,
-            :ongoing,
+            :unfinished,
             teacher: ect_at_school_period.teacher,
             started_on: ect_at_school_period.started_on
           )
@@ -173,7 +173,7 @@ RSpec.describe ECTAtSchoolPeriods::AppropriateBody do
       let!(:induction_period) do
         FactoryBot.create(
           :induction_period,
-          :ongoing,
+          :unfinished,
           teacher: ect_at_school_period.teacher,
           started_on: ect_at_school_period.started_on.prev_day
         )
@@ -187,7 +187,7 @@ RSpec.describe ECTAtSchoolPeriods::AppropriateBody do
       let!(:induction_period) do
         FactoryBot.create(
           :induction_period,
-          :ongoing,
+          :unfinished,
           teacher: ect_at_school_period.teacher,
           started_on: ect_at_school_period.finished_on.next_day
         )
@@ -201,7 +201,7 @@ RSpec.describe ECTAtSchoolPeriods::AppropriateBody do
       let!(:induction_period) do
         FactoryBot.create(
           :induction_period,
-          :ongoing,
+          :unfinished,
           teacher: ect_at_school_period.teacher,
           started_on: ect_at_school_period.started_on
         )
@@ -241,7 +241,7 @@ RSpec.describe ECTAtSchoolPeriods::AppropriateBody do
         let!(:induction_period) do
           FactoryBot.create(
             :induction_period,
-            :ongoing,
+            :unfinished,
             teacher: ect_at_school_period.teacher,
             started_on: ect_at_school_period.started_on.prev_day
           )
@@ -255,7 +255,7 @@ RSpec.describe ECTAtSchoolPeriods::AppropriateBody do
         let!(:induction_period) do
           FactoryBot.create(
             :induction_period,
-            :ongoing,
+            :unfinished,
             teacher: ect_at_school_period.teacher,
             started_on: ect_at_school_period.finished_on.next_day
           )
@@ -269,7 +269,7 @@ RSpec.describe ECTAtSchoolPeriods::AppropriateBody do
         let!(:induction_period) do
           FactoryBot.create(
             :induction_period,
-            :ongoing,
+            :unfinished,
             teacher: ect_at_school_period.teacher,
             started_on: ect_at_school_period.started_on
           )
@@ -306,7 +306,7 @@ RSpec.describe ECTAtSchoolPeriods::AppropriateBody do
         let!(:induction_period) do
           FactoryBot.create(
             :induction_period,
-            :ongoing,
+            :unfinished,
             teacher: ect_at_school_period.teacher,
             started_on: ect_at_school_period.started_on.prev_day
           )
@@ -320,7 +320,7 @@ RSpec.describe ECTAtSchoolPeriods::AppropriateBody do
         let!(:induction_period) do
           FactoryBot.create(
             :induction_period,
-            :ongoing,
+            :unfinished,
             teacher: ect_at_school_period.teacher,
             started_on: ect_at_school_period.finished_on.next_day
           )
@@ -334,7 +334,7 @@ RSpec.describe ECTAtSchoolPeriods::AppropriateBody do
         let!(:induction_period) do
           FactoryBot.create(
             :induction_period,
-            :ongoing,
+            :unfinished,
             teacher: ect_at_school_period.teacher,
             started_on: ect_at_school_period.started_on
           )

--- a/spec/services/ect_at_school_periods/change_lead_provider_resolver_spec.rb
+++ b/spec/services/ect_at_school_periods/change_lead_provider_resolver_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ECTAtSchoolPeriods::ChangeLeadProviderResolver do
     let(:ect_at_school_period) do
       FactoryBot.create(
         :ect_at_school_period,
-        :ongoing,
+        :unfinished,
         school:,
         started_on: contract_period.started_on
       )
@@ -27,7 +27,7 @@ RSpec.describe ECTAtSchoolPeriods::ChangeLeadProviderResolver do
     let!(:training_period) do
       FactoryBot.create(
         :training_period,
-        :ongoing,
+        :unfinished,
         :provider_led,
         :with_only_expression_of_interest,
         ect_at_school_period:,

--- a/spec/services/ect_at_school_periods/change_lead_provider_spec.rb
+++ b/spec/services/ect_at_school_periods/change_lead_provider_spec.rb
@@ -17,7 +17,7 @@ module ECTAtSchoolPeriods
     end
 
     let(:ect_at_school_period) do
-      FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 2.weeks.ago)
+      FactoryBot.create(:ect_at_school_period, :unfinished, started_on: 2.weeks.ago)
     end
 
     let(:lead_provider) { FactoryBot.create(:lead_provider) }
@@ -55,7 +55,7 @@ module ECTAtSchoolPeriods
       let!(:training_period) do
         FactoryBot.create(
           :training_period,
-          :ongoing,
+          :unfinished,
           :provider_led,
           :with_school_partnership,
           ect_at_school_period:,
@@ -118,7 +118,7 @@ module ECTAtSchoolPeriods
         let(:ect_at_school_period) do
           FactoryBot.create(
             :ect_at_school_period,
-            :ongoing,
+            :unfinished,
             started_on: Date.current
           )
         end
@@ -138,7 +138,7 @@ module ECTAtSchoolPeriods
         let(:ect_at_school_period) do
           FactoryBot.create(
             :ect_at_school_period,
-            :ongoing,
+            :unfinished,
             started_on: 1.month.from_now
           )
         end
@@ -184,7 +184,7 @@ module ECTAtSchoolPeriods
         let(:ect_at_school_period) do
           FactoryBot.create(
             :ect_at_school_period,
-            :ongoing,
+            :unfinished,
             started_on: Date.new(2021, 9, 1)
           )
         end
@@ -297,7 +297,7 @@ module ECTAtSchoolPeriods
       let!(:training_period) do
         FactoryBot.create(
           :training_period,
-          :ongoing,
+          :unfinished,
           :provider_led,
           :with_only_expression_of_interest,
           ect_at_school_period:,
@@ -350,7 +350,7 @@ module ECTAtSchoolPeriods
         let(:ect_at_school_period) do
           FactoryBot.create(
             :ect_at_school_period,
-            :ongoing,
+            :unfinished,
             started_on: 1.month.from_now
           )
         end
@@ -404,7 +404,7 @@ module ECTAtSchoolPeriods
         let(:ect_at_school_period) do
           FactoryBot.create(
             :ect_at_school_period,
-            :ongoing,
+            :unfinished,
             started_on: Date.new(2021, 9, 1)
           )
         end
@@ -527,7 +527,7 @@ module ECTAtSchoolPeriods
         let!(:training_period) do
           FactoryBot.create(
             :training_period,
-            :ongoing,
+            :unfinished,
             :school_led,
             ect_at_school_period:,
             started_on: ect_at_school_period.started_on

--- a/spec/services/ect_at_school_periods/current_training_spec.rb
+++ b/spec/services/ect_at_school_periods/current_training_spec.rb
@@ -2,7 +2,7 @@ describe ECTAtSchoolPeriods::CurrentTraining do
   describe "#current_or_next_training_period" do
     subject { described_class.new(ect_at_school_period).current_or_next_training_period }
 
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 3.years.ago) }
+    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, started_on: 3.years.ago) }
 
     context "when the ect has had no training ever" do
       it { is_expected.to be_nil }
@@ -18,7 +18,7 @@ describe ECTAtSchoolPeriods::CurrentTraining do
 
     context "when the ect has an ongoing training period at the school" do
       let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
-      let!(:ongoing_training) { FactoryBot.create(:training_period, :ongoing, :for_ect, ect_at_school_period:, period_start_date: old_training.finished_on + 1.day) }
+      let!(:ongoing_training) { FactoryBot.create(:training_period, :unfinished, :for_ect, ect_at_school_period:, period_start_date: old_training.finished_on + 1.day) }
 
       it { is_expected.to eq(ongoing_training) }
     end
@@ -27,12 +27,12 @@ describe ECTAtSchoolPeriods::CurrentTraining do
   describe "#lead_provider_via_school_partnership_or_eoi" do
     subject { ECTAtSchoolPeriods::CurrentTraining.new(ect_at_school_period).lead_provider_via_school_partnership_or_eoi }
 
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 3.years.ago) }
+    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, started_on: 3.years.ago) }
 
     context "when there is a lead provider via school partnership" do
       let(:school_partnership) { FactoryBot.create(:school_partnership, school: ect_at_school_period.school) }
 
-      before { FactoryBot.create(:training_period, :ongoing, school_partnership:, ect_at_school_period:) }
+      before { FactoryBot.create(:training_period, :unfinished, school_partnership:, ect_at_school_period:) }
 
       it "returns the lead provider connected via school partnership" do
         expect(subject).to eql(school_partnership.lead_provider)
@@ -42,7 +42,7 @@ describe ECTAtSchoolPeriods::CurrentTraining do
     context "when there is only a lead provider via expression of interest" do
       let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
 
-      before { FactoryBot.create(:training_period, :ongoing, :with_no_school_partnership, ect_at_school_period:, expression_of_interest: active_lead_provider) }
+      before { FactoryBot.create(:training_period, :unfinished, :with_no_school_partnership, ect_at_school_period:, expression_of_interest: active_lead_provider) }
 
       it "returns the lead provider connected via expression of interest" do
         expect(subject).to eql(active_lead_provider.lead_provider)
@@ -53,7 +53,7 @@ describe ECTAtSchoolPeriods::CurrentTraining do
       let(:school_partnership) { FactoryBot.create(:school_partnership, school: ect_at_school_period.school) }
       let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, contract_period: school_partnership.contract_period) }
 
-      before { FactoryBot.create(:training_period, :ongoing, expression_of_interest: active_lead_provider, school_partnership:, ect_at_school_period:) }
+      before { FactoryBot.create(:training_period, :unfinished, expression_of_interest: active_lead_provider, school_partnership:, ect_at_school_period:) }
 
       it "returns the lead provider connected via school partnership" do
         expect(subject).to eql(school_partnership.lead_provider)
@@ -65,7 +65,7 @@ describe ECTAtSchoolPeriods::CurrentTraining do
   describe "#delivery_partner" do
     subject { described_class.new(ect_at_school_period).delivery_partner }
 
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 3.years.ago) }
+    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, started_on: 3.years.ago) }
 
     context "when the ect has had no training ever" do
       it { is_expected.to be_nil }
@@ -81,7 +81,7 @@ describe ECTAtSchoolPeriods::CurrentTraining do
 
     context "when the ect has an ongoing training period at the school" do
       let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
-      let!(:ongoing_training) { FactoryBot.create(:training_period, :ongoing, :for_ect, ect_at_school_period:, period_start_date: old_training.finished_on + 1.day) }
+      let!(:ongoing_training) { FactoryBot.create(:training_period, :unfinished, :for_ect, ect_at_school_period:, period_start_date: old_training.finished_on + 1.day) }
 
       it { is_expected.to eq(ongoing_training.school_partnership.lead_provider_delivery_partnership.delivery_partner) }
     end
@@ -90,7 +90,7 @@ describe ECTAtSchoolPeriods::CurrentTraining do
   describe "#delivery_partner_name" do
     subject { described_class.new(ect_at_school_period).delivery_partner_name }
 
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 3.years.ago) }
+    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, started_on: 3.years.ago) }
 
     context "when the ect has had no training ever" do
       it { is_expected.to be_nil }
@@ -106,7 +106,7 @@ describe ECTAtSchoolPeriods::CurrentTraining do
 
     context "when the ect has an ongoing training period at the school" do
       let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
-      let!(:ongoing_training) { FactoryBot.create(:training_period, :ongoing, :for_ect, ect_at_school_period:, period_start_date: old_training.finished_on + 1.day) }
+      let!(:ongoing_training) { FactoryBot.create(:training_period, :unfinished, :for_ect, ect_at_school_period:, period_start_date: old_training.finished_on + 1.day) }
 
       it { is_expected.to eq(ongoing_training.school_partnership.lead_provider_delivery_partnership.delivery_partner.name) }
     end
@@ -115,7 +115,7 @@ describe ECTAtSchoolPeriods::CurrentTraining do
   describe "#lead_provider" do
     subject { described_class.new(ect_at_school_period).lead_provider }
 
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 3.years.ago) }
+    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, started_on: 3.years.ago) }
 
     context "when the ect has had no training ever" do
       it { is_expected.to be_nil }
@@ -131,7 +131,7 @@ describe ECTAtSchoolPeriods::CurrentTraining do
 
     context "when the ect has an ongoing training period at the school" do
       let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
-      let!(:ongoing_training) { FactoryBot.create(:training_period, :ongoing, :for_ect, ect_at_school_period:, period_start_date: old_training.finished_on + 1.day) }
+      let!(:ongoing_training) { FactoryBot.create(:training_period, :unfinished, :for_ect, ect_at_school_period:, period_start_date: old_training.finished_on + 1.day) }
 
       it { is_expected.to eq(ongoing_training.school_partnership.lead_provider_delivery_partnership.active_lead_provider.lead_provider) }
     end
@@ -140,7 +140,7 @@ describe ECTAtSchoolPeriods::CurrentTraining do
   describe "#lead_provider_name" do
     subject { described_class.new(ect_at_school_period).lead_provider_name }
 
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 3.years.ago) }
+    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, started_on: 3.years.ago) }
 
     context "when the ect has had no training ever" do
       it { is_expected.to be_nil }
@@ -156,7 +156,7 @@ describe ECTAtSchoolPeriods::CurrentTraining do
 
     context "when the ect has an ongoing training period at the school" do
       let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
-      let!(:ongoing_training) { FactoryBot.create(:training_period, :ongoing, :for_ect, period_start_date: old_training.finished_on + 1.day, ect_at_school_period:) }
+      let!(:ongoing_training) { FactoryBot.create(:training_period, :unfinished, :for_ect, period_start_date: old_training.finished_on + 1.day, ect_at_school_period:) }
 
       it { is_expected.to eq(ongoing_training.school_partnership.lead_provider_delivery_partnership.active_lead_provider.lead_provider.name) }
     end
@@ -165,20 +165,20 @@ describe ECTAtSchoolPeriods::CurrentTraining do
   describe "#school_partnership?" do
     subject { described_class.new(ect_at_school_period).school_partnership? }
 
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 3.years.ago) }
+    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, started_on: 3.years.ago) }
 
     context "when the ect has had no training ever" do
       it { is_expected.to be(false) }
     end
 
     context "when the ect has a training period with a school partnership" do
-      let!(:training_period_with_school_partnership) { FactoryBot.create(:training_period, :ongoing, ect_at_school_period:) }
+      let!(:training_period_with_school_partnership) { FactoryBot.create(:training_period, :unfinished, ect_at_school_period:) }
 
       it { is_expected.to be(true) }
     end
 
     context "when the ect has a training period which is an expression of interest" do
-      let!(:expression_of_interest_training_period) { FactoryBot.create(:training_period, :ongoing, :with_only_expression_of_interest, ect_at_school_period:) }
+      let!(:expression_of_interest_training_period) { FactoryBot.create(:training_period, :unfinished, :with_only_expression_of_interest, ect_at_school_period:) }
 
       it { is_expected.to be(false) }
     end
@@ -187,20 +187,20 @@ describe ECTAtSchoolPeriods::CurrentTraining do
   describe "#expression_of_interest?" do
     subject { described_class.new(ect_at_school_period).expression_of_interest? }
 
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 3.years.ago) }
+    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, started_on: 3.years.ago) }
 
     context "when the ect has had no training ever" do
       it { is_expected.to be(false) }
     end
 
     context "when the ect has a training period which is an expression of interest" do
-      let!(:expression_of_interest_training_period) { FactoryBot.create(:training_period, :ongoing, :with_only_expression_of_interest, ect_at_school_period:) }
+      let!(:expression_of_interest_training_period) { FactoryBot.create(:training_period, :unfinished, :with_only_expression_of_interest, ect_at_school_period:) }
 
       it { is_expected.to be(true) }
     end
 
     context "when the ect has a training period which was an expression of interest but now has a partnership too" do
-      let!(:expression_of_interest_training_period) { FactoryBot.create(:training_period, :ongoing, :with_expression_of_interest, ect_at_school_period:) }
+      let!(:expression_of_interest_training_period) { FactoryBot.create(:training_period, :unfinished, :with_expression_of_interest, ect_at_school_period:) }
 
       it { is_expected.to be(false) }
     end
@@ -209,20 +209,20 @@ describe ECTAtSchoolPeriods::CurrentTraining do
   describe "#expression_of_interest_lead_provider_name" do
     subject { described_class.new(ect_at_school_period).expression_of_interest_lead_provider_name }
 
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 3.years.ago) }
+    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, started_on: 3.years.ago) }
 
     context "when the ect has had no training ever" do
       it { is_expected.to be_nil }
     end
 
     context "when the ect has a training period which is an expression of interest" do
-      let!(:expression_of_interest_training_period) { FactoryBot.create(:training_period, :ongoing, :with_only_expression_of_interest, ect_at_school_period:) }
+      let!(:expression_of_interest_training_period) { FactoryBot.create(:training_period, :unfinished, :with_only_expression_of_interest, ect_at_school_period:) }
 
       it { is_expected.to eql(expression_of_interest_training_period.expression_of_interest.lead_provider.name) }
     end
 
     context "when the ect has a training period which was an expression of interest but now has a partnership too" do
-      let!(:expression_of_interest_training_period) { FactoryBot.create(:training_period, :ongoing, :with_expression_of_interest, ect_at_school_period:) }
+      let!(:expression_of_interest_training_period) { FactoryBot.create(:training_period, :unfinished, :with_expression_of_interest, ect_at_school_period:) }
 
       it { is_expected.to eql(expression_of_interest_training_period.expression_of_interest.lead_provider.name) }
     end

--- a/spec/services/ect_at_school_periods/finish_spec.rb
+++ b/spec/services/ect_at_school_periods/finish_spec.rb
@@ -134,9 +134,9 @@ describe ECTAtSchoolPeriods::Finish do
         end
 
         it "closes the mentorship period" do
-          expect(mentorship_period).to be_ongoing
+          expect(mentorship_period).to be_unfinished
           subject.finish!
-          expect(mentorship_period.reload).not_to be_ongoing
+          expect(mentorship_period.reload).not_to be_unfinished
         end
 
         it "uses MentorshipPeriods::Finish to close it" do
@@ -194,9 +194,9 @@ describe ECTAtSchoolPeriods::Finish do
         end
 
         it "closes the training period" do
-          expect(training_period).to be_ongoing
+          expect(training_period).to be_unfinished
           subject.finish!
-          expect(training_period.reload).not_to be_ongoing
+          expect(training_period.reload).not_to be_unfinished
         end
 
         it "uses TrainingPeriods::Finish to close it" do

--- a/spec/services/ect_at_school_periods/mentorship_spec.rb
+++ b/spec/services/ect_at_school_periods/mentorship_spec.rb
@@ -1,8 +1,8 @@
 describe ECTAtSchoolPeriods::Mentorship do
   let(:school) { FactoryBot.create(:school) }
-  let(:mentee) { FactoryBot.create(:ect_at_school_period, :ongoing, school:, started_on: 3.years.ago) }
-  let(:mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, started_on: 3.years.ago) }
-  let(:old_mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, started_on: 3.years.ago) }
+  let(:mentee) { FactoryBot.create(:ect_at_school_period, :unfinished, school:, started_on: 3.years.ago) }
+  let(:mentor) { FactoryBot.create(:mentor_at_school_period, :unfinished, school:, started_on: 3.years.ago) }
+  let(:old_mentor) { FactoryBot.create(:mentor_at_school_period, :unfinished, school:, started_on: 3.years.ago) }
 
   describe "#current_or_next_mentorship_period" do
     subject { described_class.new(mentee).current_or_next_mentorship_period }
@@ -21,7 +21,7 @@ describe ECTAtSchoolPeriods::Mentorship do
 
     context "when the ect has an ongoing mentorship at a school" do
       let!(:old_mentorship) { FactoryBot.create(:mentorship_period, mentee:, mentor:, started_on: 2.years.ago) }
-      let!(:ongoing_mentorship) { FactoryBot.create(:mentorship_period, :ongoing, mentee:, mentor:, started_on: 1.year.ago) }
+      let!(:ongoing_mentorship) { FactoryBot.create(:mentorship_period, :unfinished, mentee:, mentor:, started_on: 1.year.ago) }
 
       it { is_expected.to eq(ongoing_mentorship) }
     end
@@ -45,7 +45,7 @@ describe ECTAtSchoolPeriods::Mentorship do
     context "when the ect has an ongoing mentorship at a school" do
       before do
         FactoryBot.create(:mentorship_period, mentee:, mentor:, started_on: 2.years.ago)
-        FactoryBot.create(:mentorship_period, :ongoing, mentee:, mentor:, started_on: 1.year.ago)
+        FactoryBot.create(:mentorship_period, :unfinished, mentee:, mentor:, started_on: 1.year.ago)
       end
 
       it { is_expected.to eql(mentor) }
@@ -70,7 +70,7 @@ describe ECTAtSchoolPeriods::Mentorship do
     context "when the ect has an ongoing mentorship at a school" do
       before do
         FactoryBot.create(:mentorship_period, mentee:, mentor:, started_on: 2.years.ago)
-        FactoryBot.create(:mentorship_period, :ongoing, mentee:, mentor:, started_on: 1.year.ago)
+        FactoryBot.create(:mentorship_period, :unfinished, mentee:, mentor:, started_on: 1.year.ago)
       end
 
       it { is_expected.to eql(Teachers::Name.new(mentor.teacher).full_name) }
@@ -92,7 +92,7 @@ describe ECTAtSchoolPeriods::Mentorship do
 
     context "when the ect has an ongoing mentorship at the school" do
       let!(:old_mentorship) { FactoryBot.create(:mentorship_period, mentee:, mentor:, started_on: 2.years.ago) }
-      let!(:ongoing_mentorship) { FactoryBot.create(:mentorship_period, :ongoing, mentee:, mentor:, started_on: 1.year.ago) }
+      let!(:ongoing_mentorship) { FactoryBot.create(:mentorship_period, :unfinished, mentee:, mentor:, started_on: 1.year.ago) }
 
       it { is_expected.to eq(ongoing_mentorship) }
     end
@@ -117,7 +117,7 @@ describe ECTAtSchoolPeriods::Mentorship do
     context "when the ect has an ongoing mentorship at a school" do
       before do
         FactoryBot.create(:mentorship_period, mentee:, mentor: old_mentor, started_on: 2.years.ago)
-        FactoryBot.create(:mentorship_period, :ongoing, mentee:, mentor:, started_on: 1.year.ago)
+        FactoryBot.create(:mentorship_period, :unfinished, mentee:, mentor:, started_on: 1.year.ago)
       end
 
       it { is_expected.to eql(mentor) }
@@ -143,7 +143,7 @@ describe ECTAtSchoolPeriods::Mentorship do
     context "when the ect has an ongoing mentorship at a school" do
       before do
         FactoryBot.create(:mentorship_period, mentee:, mentor: old_mentor, started_on: 2.years.ago)
-        FactoryBot.create(:mentorship_period, :ongoing, mentee:, mentor:, started_on: 1.year.ago)
+        FactoryBot.create(:mentorship_period, :unfinished, mentee:, mentor:, started_on: 1.year.ago)
       end
 
       it { is_expected.to eql(Teachers::Name.new(mentor.teacher).full_name) }

--- a/spec/services/ect_at_school_periods/switch_mentor_spec.rb
+++ b/spec/services/ect_at_school_periods/switch_mentor_spec.rb
@@ -17,29 +17,29 @@ module ECTAtSchoolPeriods
     end
 
     let(:ect_at_school_period) do
-      FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 2.weeks.ago)
+      FactoryBot.create(:ect_at_school_period, :unfinished, started_on: 2.weeks.ago)
     end
 
     let(:selected_mentor_teacher) { FactoryBot.create(:teacher) }
     let(:selected_mentor_at_school_period) do
       FactoryBot.create(
         :mentor_at_school_period,
-        :ongoing,
+        :unfinished,
         school: ect_at_school_period.school,
         teacher: selected_mentor_teacher,
         started_on: ect_at_school_period.started_on - 1.month
       )
     end
 
-    let(:current_mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, started_on: 3.years.ago, school: ect_at_school_period.school) }
-    let!(:current_mentorship) { FactoryBot.create(:mentorship_period, :ongoing, mentee: ect_at_school_period, mentor: current_mentor, started_on: 2.weeks.ago) }
+    let(:current_mentor) { FactoryBot.create(:mentor_at_school_period, :unfinished, started_on: 3.years.ago, school: ect_at_school_period.school) }
+    let!(:current_mentorship) { FactoryBot.create(:mentorship_period, :unfinished, mentee: ect_at_school_period, mentor: current_mentor, started_on: 2.weeks.ago) }
 
     describe ".switch" do
       context "when the ECT is undergoing school-led training" do
         let!(:ect_training_period) do
           FactoryBot.create(
             :training_period,
-            :ongoing,
+            :unfinished,
             :school_led,
             :for_ect,
             ect_at_school_period:,
@@ -92,7 +92,7 @@ module ECTAtSchoolPeriods
         let!(:ect_training_period) do
           FactoryBot.create(
             :training_period,
-            :ongoing,
+            :unfinished,
             :provider_led,
             :for_ect,
             ect_at_school_period:,
@@ -134,7 +134,7 @@ module ECTAtSchoolPeriods
           let!(:selected_mentor_training_period) do
             FactoryBot.create(
               :training_period,
-              :ongoing,
+              :unfinished,
               :provider_led,
               :for_mentor,
               mentor_at_school_period: selected_mentor_at_school_period,
@@ -267,8 +267,8 @@ module ECTAtSchoolPeriods
 
         context "when the mentor is mentoring at another school" do
           let(:other_school) { FactoryBot.create(:school) }
-          let(:other_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school: other_school, teacher: selected_mentor_teacher) }
-          let!(:other_mentor_training_period) { FactoryBot.create(:training_period, :ongoing, :provider_led, :for_mentor, mentor_at_school_period: other_mentor_at_school_period, started_on: 1.month.ago) }
+          let(:other_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, school: other_school, teacher: selected_mentor_teacher) }
+          let!(:other_mentor_training_period) { FactoryBot.create(:training_period, :unfinished, :provider_led, :for_mentor, mentor_at_school_period: other_mentor_at_school_period, started_on: 1.month.ago) }
 
           it "does not create a training period" do
             expect { switch_mentor }.not_to change(TrainingPeriod, :count)

--- a/spec/services/ect_at_school_periods/switch_training_spec.rb
+++ b/spec/services/ect_at_school_periods/switch_training_spec.rb
@@ -1,13 +1,13 @@
 module ECTAtSchoolPeriods
   RSpec.describe SwitchTraining do
     let(:ect_at_school_period) do
-      FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 2.weeks.ago)
+      FactoryBot.create(:ect_at_school_period, :unfinished, started_on: 2.weeks.ago)
     end
 
     let(:mentor_at_school_period) do
       FactoryBot.create(
         :mentor_at_school_period,
-        :ongoing,
+        :unfinished,
         started_on: ect_at_school_period.started_on,
         school: ect_at_school_period.school
       )
@@ -32,7 +32,7 @@ module ECTAtSchoolPeriods
             FactoryBot.create(
               :training_period,
               :for_ect,
-              :ongoing,
+              :unfinished,
               :provider_led,
               :with_school_partnership,
               ect_at_school_period:,
@@ -61,7 +61,7 @@ module ECTAtSchoolPeriods
             FactoryBot.create(
               :training_period,
               :for_ect,
-              :ongoing,
+              :unfinished,
               :provider_led,
               :with_only_expression_of_interest,
               ect_at_school_period:,
@@ -88,7 +88,7 @@ module ECTAtSchoolPeriods
             FactoryBot.create(
               :training_period,
               :for_ect,
-              :ongoing,
+              :unfinished,
               :provider_led,
               :with_school_partnership,
               ect_at_school_period:,
@@ -150,7 +150,7 @@ module ECTAtSchoolPeriods
           FactoryBot.create(
             :training_period,
             :for_ect,
-            :ongoing,
+            :unfinished,
             :school_led,
             ect_at_school_period:,
             started_on: ect_at_school_period.started_on
@@ -192,27 +192,27 @@ module ECTAtSchoolPeriods
           SwitchTraining.to_school_led(ect_at_school_period, author:)
 
           new_training_period = ect_at_school_period.reload.latest_training_period
-          expect(new_training_period).not_to be_ongoing
+          expect(new_training_period).not_to be_unfinished
           expect(new_training_period.finished_on).to eq(ect_at_school_period.finished_on)
         end
       end
 
       context "when the `ECTAtSchoolPeriod` does not have a `finished_on` date" do
         let(:ect_at_school_period) do
-          FactoryBot.create(:ect_at_school_period, :ongoing)
+          FactoryBot.create(:ect_at_school_period, :unfinished)
         end
 
         it "creates an ongoing training period" do
           SwitchTraining.to_school_led(ect_at_school_period, author:)
 
           new_training_period = ect_at_school_period.reload.latest_training_period
-          expect(new_training_period).to be_ongoing
+          expect(new_training_period).to be_unfinished
         end
       end
 
       context "when the record is not a `ECTAtSchoolPeriod`" do
         let(:ect_at_school_period) do
-          FactoryBot.create(:mentor_at_school_period, :ongoing)
+          FactoryBot.create(:mentor_at_school_period, :unfinished)
         end
         let(:mentorship_period) { nil }
 
@@ -239,7 +239,7 @@ module ECTAtSchoolPeriods
           FactoryBot.create(
             :training_period,
             :for_ect,
-            :ongoing,
+            :unfinished,
             :school_led,
             ect_at_school_period:,
             started_on: ect_at_school_period.started_on
@@ -327,7 +327,7 @@ module ECTAtSchoolPeriods
             FactoryBot.create(
               :training_period,
               :for_ect,
-              :ongoing,
+              :unfinished,
               :school_led,
               ect_at_school_period:,
               started_on: Date.current
@@ -403,7 +403,7 @@ module ECTAtSchoolPeriods
             let(:ect_at_school_period) do
               FactoryBot.create(
                 :ect_at_school_period,
-                :ongoing,
+                :unfinished,
                 started_on: upcoming_contract_period.started_on
               )
             end
@@ -433,7 +433,7 @@ module ECTAtSchoolPeriods
           FactoryBot.create(
             :training_period,
             :for_ect,
-            :ongoing,
+            :unfinished,
             :provider_led,
             ect_at_school_period:,
             started_on: ect_at_school_period.started_on
@@ -452,7 +452,7 @@ module ECTAtSchoolPeriods
         let!(:extended_schedule) { FactoryBot.create(:schedule, contract_period: contract_period_2024, identifier: "ecf-extended-september") }
 
         let(:ect_at_school_period) do
-          FactoryBot.create(:ect_at_school_period, :ongoing, started_on:)
+          FactoryBot.create(:ect_at_school_period, :unfinished, started_on:)
         end
 
         context "when there is a confirmed school partnership" do
@@ -481,7 +481,7 @@ module ECTAtSchoolPeriods
             FactoryBot.create(
               :training_period,
               :for_ect,
-              :ongoing,
+              :unfinished,
               :school_led,
               ect_at_school_period:,
               started_on: previous_training_period_finished_on + 1.day
@@ -579,7 +579,7 @@ module ECTAtSchoolPeriods
               FactoryBot.create(
                 :training_period,
                 :for_ect,
-                :ongoing,
+                :unfinished,
                 :school_led,
                 ect_at_school_period:,
                 started_on: second_training_period_finished_on + 1.day
@@ -654,7 +654,7 @@ module ECTAtSchoolPeriods
             FactoryBot.create(
               :training_period,
               :for_ect,
-              :ongoing,
+              :unfinished,
               :school_led,
               ect_at_school_period:,
               started_on:
@@ -776,7 +776,7 @@ module ECTAtSchoolPeriods
             FactoryBot.create(
               :training_period,
               :for_ect,
-              :ongoing,
+              :unfinished,
               :school_led,
               ect_at_school_period:,
               started_on: previous_training_period_finished_on + 1.day
@@ -870,7 +870,7 @@ module ECTAtSchoolPeriods
               FactoryBot.create(
                 :training_period,
                 :for_ect,
-                :ongoing,
+                :unfinished,
                 :school_led,
                 ect_at_school_period:,
                 started_on: second_training_period_finished_on + 1.day
@@ -946,27 +946,27 @@ module ECTAtSchoolPeriods
           SwitchTraining.to_provider_led(ect_at_school_period, lead_provider:, author:)
 
           new_training_period = ect_at_school_period.reload.latest_training_period
-          expect(new_training_period).not_to be_ongoing
+          expect(new_training_period).not_to be_unfinished
           expect(new_training_period.finished_on).to eq(ect_at_school_period.finished_on)
         end
       end
 
       context "when the `ECTAtSchoolPeriod` does not have a `finished_on` date" do
         let(:ect_at_school_period) do
-          FactoryBot.create(:ect_at_school_period, :ongoing)
+          FactoryBot.create(:ect_at_school_period, :unfinished)
         end
 
         it "creates an ongoing training period" do
           SwitchTraining.to_provider_led(ect_at_school_period, lead_provider:, author:)
 
           new_training_period = ect_at_school_period.reload.latest_training_period
-          expect(new_training_period).to be_ongoing
+          expect(new_training_period).to be_unfinished
         end
       end
 
       context "when the record is not a `ECTAtSchoolPeriod`" do
         let(:ect_at_school_period) do
-          FactoryBot.create(:mentor_at_school_period, :ongoing)
+          FactoryBot.create(:mentor_at_school_period, :unfinished)
         end
 
         let(:mentorship_period) { nil }
@@ -982,7 +982,7 @@ module ECTAtSchoolPeriods
           FactoryBot.create(
             :training_period,
             :for_ect,
-            :ongoing,
+            :unfinished,
             :school_led,
             ect_at_school_period:,
             started_on: ect_at_school_period.started_on
@@ -1198,7 +1198,7 @@ module ECTAtSchoolPeriods
           let(:mentor_at_school_period) do
             FactoryBot.create(
               :mentor_at_school_period,
-              :ongoing,
+              :unfinished,
               school: ect_at_school_period.school,
               teacher:,
               started_on: ect_at_school_period.started_on

--- a/spec/services/ect_at_school_periods/text_search_spec.rb
+++ b/spec/services/ect_at_school_periods/text_search_spec.rb
@@ -9,9 +9,9 @@ describe ECTAtSchoolPeriods::TextSearch do
   let!(:bob_squarepants) { FactoryBot.create(:teacher, trn: "3456789", trs_first_name: "Bob", trs_last_name: "Squarepants") }
 
   # And some AtSchoolPeriods..
-  let!(:pat_at_grange_hill) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: postman_pat, school: grange_hill_school) }
-  let!(:bob_builder_at_grange_hill) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: bob_builder, school: grange_hill_school) }
-  let!(:bob_squarepants_at_bash_street) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: bob_squarepants, school: bash_street_school) }
+  let!(:pat_at_grange_hill) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher: postman_pat, school: grange_hill_school) }
+  let!(:bob_builder_at_grange_hill) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher: bob_builder, school: grange_hill_school) }
+  let!(:bob_squarepants_at_bash_street) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher: bob_squarepants, school: bash_street_school) }
 
   describe "#search" do
     subject(:search) { described_class.new(initial_cohort, query_string:).search }

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe Events::Record do
     end
 
     it "assigns and saves attributes correctly" do
-      ect_at_school_period = FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 3.weeks.ago)
-      mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :ongoing, school: ect_at_school_period.school, started_on: 3.weeks.ago)
+      ect_at_school_period = FactoryBot.create(:ect_at_school_period, :unfinished, started_on: 3.weeks.ago)
+      mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :unfinished, school: ect_at_school_period.school, started_on: 3.weeks.ago)
 
       attributes = {
         author:,
@@ -52,7 +52,7 @@ RSpec.describe Events::Record do
         lead_provider: FactoryBot.create(:lead_provider),
         delivery_partner: FactoryBot.create(:delivery_partner),
         user: FactoryBot.create(:user),
-        training_period: FactoryBot.create(:training_period, :ongoing, ect_at_school_period:, started_on: 1.week.ago),
+        training_period: FactoryBot.create(:training_period, :unfinished, ect_at_school_period:, started_on: 1.week.ago),
         mentorship_period: FactoryBot.create(
           :mentorship_period,
           mentor: mentor_at_school_period,
@@ -399,7 +399,7 @@ RSpec.describe Events::Record do
   describe ".record_induction_period_updated_event!" do
     let(:three_weeks_ago) { 3.weeks.ago.to_date }
     let(:two_weeks_ago) { 2.weeks.ago.to_date }
-    let(:induction_period) { FactoryBot.create(:induction_period, :ongoing, started_on: three_weeks_ago) }
+    let(:induction_period) { FactoryBot.create(:induction_period, :unfinished, started_on: three_weeks_ago) }
 
     it "queues a RecordEventJob with the correct values" do
       induction_period.assign_attributes(started_on: two_weeks_ago)
@@ -1163,8 +1163,8 @@ RSpec.describe Events::Record do
     let(:started_on_param) { { started_on: 2.years.ago.to_date } }
     let(:school) { FactoryBot.create(:school) }
     let(:mentee) { FactoryBot.create(:teacher, trs_first_name: "Steffan", trs_last_name: "Rhodri") }
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: mentee, school:, **started_on_param) }
-    let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:, school:, **started_on_param) }
+    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher: mentee, school:, **started_on_param) }
+    let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:, school:, **started_on_param) }
     let(:mentorship_period) { FactoryBot.create(:mentorship_period, mentee: ect_at_school_period, mentor: mentor_at_school_period, started_on: 2.days.ago.to_date) }
 
     it "queues a RecordEventJob with the correct values" do
@@ -1190,8 +1190,8 @@ RSpec.describe Events::Record do
     let(:started_on_param) { { started_on: 2.years.ago.to_date } }
     let(:school) { FactoryBot.create(:school) }
     let(:mentor) { FactoryBot.create(:teacher, trs_first_name: "Steffan", trs_last_name: "Rhodri") }
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:, **started_on_param) }
-    let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: mentor, school:, **started_on_param) }
+    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher:, school:, **started_on_param) }
+    let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, teacher: mentor, school:, **started_on_param) }
     let(:mentorship_period) { FactoryBot.create(:mentorship_period, mentee: ect_at_school_period, mentor: mentor_at_school_period, started_on: 2.days.ago.to_date) }
 
     it "queues a RecordEventJob with the correct values" do
@@ -1219,8 +1219,8 @@ RSpec.describe Events::Record do
     let(:finished_on_param) { { finished_on: } }
     let(:school) { FactoryBot.create(:school) }
     let(:mentee) { FactoryBot.create(:teacher, trs_first_name: "Steffan", trs_last_name: "Rhodri") }
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: mentee, school:, **started_on_param) }
-    let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:, school:, **started_on_param, **finished_on_param) }
+    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher: mentee, school:, **started_on_param) }
+    let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:, school:, **started_on_param, **finished_on_param) }
     let(:mentorship_period) { FactoryBot.create(:mentorship_period, mentee: ect_at_school_period, mentor: mentor_at_school_period, started_on: 2.months.ago.to_date) }
 
     it "queues a RecordEventJob with the correct values" do
@@ -1248,8 +1248,8 @@ RSpec.describe Events::Record do
     let(:finished_on_param) { { finished_on: } }
     let(:school) { FactoryBot.create(:school) }
     let(:mentor) { FactoryBot.create(:teacher, trs_first_name: "Steffan", trs_last_name: "Rhodri") }
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:, **started_on_param) }
-    let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: mentor, school:, **started_on_param) }
+    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher:, school:, **started_on_param) }
+    let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, teacher: mentor, school:, **started_on_param) }
     let(:mentorship_period) { FactoryBot.create(:mentorship_period, mentee: ect_at_school_period, mentor: mentor_at_school_period, started_on: 2.months.ago.to_date) }
 
     it "queues a RecordEventJob with the correct values" do
@@ -1397,7 +1397,7 @@ RSpec.describe Events::Record do
   describe ".record_teacher_left_school_as_mentor!" do
     let(:finished_on) { 1.month.ago.to_date }
     let(:school) { FactoryBot.create(:school) }
-    let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:, school:, started_on: 2.years.ago.to_date) }
+    let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:, school:, started_on: 2.years.ago.to_date) }
 
     it "queues a RecordEventJob with the correct values" do
       freeze_time do
@@ -1439,7 +1439,7 @@ RSpec.describe Events::Record do
     end
 
     context "when ECT training" do
-      let(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)) }
+      let(:training_period) { FactoryBot.create(:training_period, :for_ect, :unfinished, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished)) }
       let(:course_identifier) { "ecf-induction" }
 
       it "queues a RecordEventJob with the correct values" do
@@ -1462,7 +1462,7 @@ RSpec.describe Events::Record do
     end
 
     context "when Mentor training" do
-      let(:training_period) { FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period: FactoryBot.create(:mentor_at_school_period, :ongoing)) }
+      let(:training_period) { FactoryBot.create(:training_period, :for_mentor, :unfinished, mentor_at_school_period: FactoryBot.create(:mentor_at_school_period, :unfinished)) }
       let(:course_identifier) { "ecf-mentor" }
 
       it "queues a RecordEventJob with the correct values" do
@@ -2226,14 +2226,14 @@ RSpec.describe Events::Record do
 
     context "when ECT training" do
       let(:ect_at_school_period) do
-        FactoryBot.create(:ect_at_school_period, :ongoing,
+        FactoryBot.create(:ect_at_school_period, :unfinished,
                           teacher:,
                           school:,
                           started_on:)
       end
 
       let!(:training_period) do
-        FactoryBot.create(:training_period, :for_ect, :ongoing,
+        FactoryBot.create(:training_period, :for_ect, :unfinished,
                           ect_at_school_period:,
                           started_on:,
                           school_partnership:)
@@ -2261,14 +2261,14 @@ RSpec.describe Events::Record do
 
     context "when Mentor training" do
       let(:mentor_at_school_period) do
-        FactoryBot.create(:mentor_at_school_period, :ongoing,
+        FactoryBot.create(:mentor_at_school_period, :unfinished,
                           teacher:,
                           school:,
                           started_on:)
       end
 
       let!(:training_period) do
-        FactoryBot.create(:training_period, :for_mentor, :ongoing,
+        FactoryBot.create(:training_period, :for_mentor, :unfinished,
                           mentor_at_school_period:,
                           started_on:,
                           school_partnership:)

--- a/spec/services/gias/schools/close_spec.rb
+++ b/spec/services/gias/schools/close_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe GIAS::Schools::Close do
     let(:closed_on) { Date.current }
     let(:can_be_closed) { true }
     let(:school) { gias_school.school }
-    let!(:mentors) { FactoryBot.create_list(:mentor_at_school_period, 3, :ongoing, :with_training_period, school:) }
-    let!(:ects) { FactoryBot.create_list(:ect_at_school_period, 3, :ongoing, :with_training_period, school:) }
+    let!(:mentors) { FactoryBot.create_list(:mentor_at_school_period, 3, :unfinished, :with_training_period, school:) }
+    let!(:ects) { FactoryBot.create_list(:ect_at_school_period, 3, :unfinished, :with_training_period, school:) }
     let!(:unstarted_mentors) { FactoryBot.create_list(:mentor_at_school_period, 2, :with_training_period, school:, started_on: closed_on + 1.day) }
     let!(:unstarted_ects) { FactoryBot.create_list(:ect_at_school_period, 2, :with_training_period, school:, started_on: closed_on + 1.day) }
     let(:mentor_finish_service) { instance_double(MentorAtSchoolPeriods::Finish) }

--- a/spec/services/induction_periods/delete_induction_period_spec.rb
+++ b/spec/services/induction_periods/delete_induction_period_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe InductionPeriods::DeleteInductionPeriod do
   let(:trs_client) { instance_double(TRS::APIClient) }
 
   let!(:induction_period) do
-    FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:)
+    FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:)
   end
 
   before do
@@ -91,7 +91,7 @@ RSpec.describe InductionPeriods::DeleteInductionPeriod do
     let!(:earliest_period) do
       FactoryBot.create(
         :induction_period,
-        :ongoing,
+        :unfinished,
         teacher:,
         appropriate_body_period:,
         started_on: Date.new(2020, 1, 1),
@@ -103,7 +103,7 @@ RSpec.describe InductionPeriods::DeleteInductionPeriod do
     let!(:later_period) do
       FactoryBot.create(
         :induction_period,
-        :ongoing,
+        :unfinished,
         teacher:,
         appropriate_body_period:,
         started_on: Date.new(2021, 1, 1),

--- a/spec/services/mentor_at_school_periods/assignment/eligibility_spec.rb
+++ b/spec/services/mentor_at_school_periods/assignment/eligibility_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe MentorAtSchoolPeriods::Assignment::Eligibility, type: :service do
     end
 
     context "when mentor is eligible for funding, ECT is provider-led, and the mentor has no ongoing training periods" do
-      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, teacher:) }
-      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school:) }
+      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, school:, teacher:) }
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, school:) }
 
-      before { FactoryBot.create(:training_period, :for_ect, :ongoing, :provider_led, ect_at_school_period:) }
+      before { FactoryBot.create(:training_period, :for_ect, :unfinished, :provider_led, ect_at_school_period:) }
 
       it "returns true" do
         expect(result).to be(true)
@@ -22,12 +22,12 @@ RSpec.describe MentorAtSchoolPeriods::Assignment::Eligibility, type: :service do
     end
 
     context "when mentor already has an ongoing training period" do
-      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, teacher:) }
-      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school:) }
+      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, school:, teacher:) }
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, school:) }
 
       before do
-        FactoryBot.create(:training_period, :for_ect, :ongoing, :provider_led, ect_at_school_period:)
-        FactoryBot.create(:training_period, :for_mentor, :ongoing, :provider_led, mentor_at_school_period:)
+        FactoryBot.create(:training_period, :for_ect, :unfinished, :provider_led, ect_at_school_period:)
+        FactoryBot.create(:training_period, :for_mentor, :unfinished, :provider_led, mentor_at_school_period:)
       end
 
       it "returns false" do
@@ -36,11 +36,11 @@ RSpec.describe MentorAtSchoolPeriods::Assignment::Eligibility, type: :service do
     end
 
     context "when mentor has a training period that ends in the future" do
-      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, teacher:) }
-      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school:) }
+      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, school:, teacher:) }
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, school:) }
 
       before do
-        FactoryBot.create(:training_period, :for_ect, :ongoing, :provider_led, ect_at_school_period:)
+        FactoryBot.create(:training_period, :for_ect, :unfinished, :provider_led, ect_at_school_period:)
         FactoryBot.create(:training_period, :for_mentor, :provider_led, mentor_at_school_period:, started_on: 1.week.ago, finished_on: 1.day.from_now)
       end
 
@@ -50,11 +50,11 @@ RSpec.describe MentorAtSchoolPeriods::Assignment::Eligibility, type: :service do
     end
 
     context "when mentor has a finished training period at the same school" do
-      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, teacher:) }
-      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school:) }
+      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, school:, teacher:) }
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, school:) }
 
       before do
-        FactoryBot.create(:training_period, :for_ect, :ongoing, :provider_led, ect_at_school_period:)
+        FactoryBot.create(:training_period, :for_ect, :unfinished, :provider_led, ect_at_school_period:)
         FactoryBot.create(:training_period, :for_mentor, :finished, :provider_led, mentor_at_school_period:)
       end
 
@@ -64,12 +64,12 @@ RSpec.describe MentorAtSchoolPeriods::Assignment::Eligibility, type: :service do
     end
 
     context "when mentor has a finished training period at another school" do
-      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, teacher:) }
-      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school:) }
-      let(:other_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school: other_school, teacher:) }
+      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, school:, teacher:) }
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, school:) }
+      let(:other_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, school: other_school, teacher:) }
 
       before do
-        FactoryBot.create(:training_period, :for_ect, :ongoing, :provider_led, ect_at_school_period:)
+        FactoryBot.create(:training_period, :for_ect, :unfinished, :provider_led, ect_at_school_period:)
         FactoryBot.create(:training_period, :for_mentor, :finished, :provider_led, mentor_at_school_period: other_mentor_at_school_period)
       end
 
@@ -79,13 +79,13 @@ RSpec.describe MentorAtSchoolPeriods::Assignment::Eligibility, type: :service do
     end
 
     context "when the mentor is mentoring at another school" do
-      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, teacher:) }
-      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school:) }
-      let(:other_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school: other_school, teacher:) }
+      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, school:, teacher:) }
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, school:) }
+      let(:other_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, school: other_school, teacher:) }
 
       before do
-        FactoryBot.create(:training_period, :for_ect, :ongoing, :provider_led, ect_at_school_period:)
-        FactoryBot.create(:training_period, :for_mentor, :ongoing, :provider_led, mentor_at_school_period: other_mentor_at_school_period)
+        FactoryBot.create(:training_period, :for_ect, :unfinished, :provider_led, ect_at_school_period:)
+        FactoryBot.create(:training_period, :for_mentor, :unfinished, :provider_led, mentor_at_school_period: other_mentor_at_school_period)
       end
 
       it "returns false" do
@@ -94,12 +94,12 @@ RSpec.describe MentorAtSchoolPeriods::Assignment::Eligibility, type: :service do
     end
 
     context "when the mentor is mentoring at another school and the mentor's training period ends in the future" do
-      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, teacher:) }
-      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school:) }
-      let(:other_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school: other_school, teacher:) }
+      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, school:, teacher:) }
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, school:) }
+      let(:other_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, school: other_school, teacher:) }
 
       before do
-        FactoryBot.create(:training_period, :for_ect, :ongoing, :provider_led, ect_at_school_period:)
+        FactoryBot.create(:training_period, :for_ect, :unfinished, :provider_led, ect_at_school_period:)
         FactoryBot.create(:training_period, :for_mentor, :provider_led, mentor_at_school_period: other_mentor_at_school_period, started_on: 1.week.ago, finished_on: 1.day.from_now)
       end
 
@@ -110,10 +110,10 @@ RSpec.describe MentorAtSchoolPeriods::Assignment::Eligibility, type: :service do
 
     context "when mentor is ineligible for funding" do
       let(:teacher) { FactoryBot.create(:teacher, :ineligible_for_mentor_funding) }
-      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, teacher:) }
-      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school:) }
+      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, school:, teacher:) }
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, school:) }
 
-      before { FactoryBot.create(:training_period, :for_ect, :ongoing, :provider_led, ect_at_school_period:) }
+      before { FactoryBot.create(:training_period, :for_ect, :unfinished, :provider_led, ect_at_school_period:) }
 
       it "returns false" do
         expect(result).to be(false)
@@ -121,10 +121,10 @@ RSpec.describe MentorAtSchoolPeriods::Assignment::Eligibility, type: :service do
     end
 
     context "when ECT is school-led" do
-      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, teacher:) }
-      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school:) }
+      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, school:, teacher:) }
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, school:) }
 
-      before { FactoryBot.create(:training_period, :for_ect, :ongoing, :school_led, ect_at_school_period:) }
+      before { FactoryBot.create(:training_period, :for_ect, :unfinished, :school_led, ect_at_school_period:) }
 
       it "returns false" do
         expect(result).to be(false)
@@ -133,7 +133,7 @@ RSpec.describe MentorAtSchoolPeriods::Assignment::Eligibility, type: :service do
 
     context "when mentor_at_school_period is nil" do
       let(:mentor_at_school_period) { nil }
-      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school:) }
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, school:) }
 
       it "returns false" do
         expect(result).to be(false)
@@ -141,7 +141,7 @@ RSpec.describe MentorAtSchoolPeriods::Assignment::Eligibility, type: :service do
     end
 
     context "when ect_at_school_period is nil" do
-      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, teacher:) }
+      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, school:, teacher:) }
       let(:ect_at_school_period) { nil }
 
       it "returns false" do

--- a/spec/services/mentor_at_school_periods/change_lead_provider_spec.rb
+++ b/spec/services/mentor_at_school_periods/change_lead_provider_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe MentorAtSchoolPeriods::ChangeLeadProvider, type: :service do
 
   include_context "safe_schedules"
 
-  let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:, started_on:) }
+  let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:, started_on:) }
   let(:teacher) { FactoryBot.create(:teacher) }
   let(:school) { mentor_at_school_period.school }
 
@@ -20,7 +20,7 @@ RSpec.describe MentorAtSchoolPeriods::ChangeLeadProvider, type: :service do
   let(:old_lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: old_active_lead_provider, contract_period:) }
   let(:old_school_partnership) { FactoryBot.create(:school_partnership, school:, lead_provider_delivery_partnership: old_lead_provider_delivery_partnership) }
 
-  let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period:, started_on:, school_partnership: old_school_partnership) }
+  let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, :unfinished, mentor_at_school_period:, started_on:, school_partnership: old_school_partnership) }
 
   let(:new_lead_provider) { lead_provider }
 
@@ -43,7 +43,7 @@ RSpec.describe MentorAtSchoolPeriods::ChangeLeadProvider, type: :service do
         expect(new_active_lead_provider.lead_provider).to eq(lead_provider)
         expect(new_active_lead_provider.contract_period).to eq(contract_period)
 
-        new_training_period = mentor_at_school_period.training_periods.ongoing.first
+        new_training_period = mentor_at_school_period.training_periods.unfinished.first
         expect(new_training_period.school_partnership).to be_nil
         expect(new_training_period.training_programme).to eq("provider_led")
 
@@ -58,7 +58,7 @@ RSpec.describe MentorAtSchoolPeriods::ChangeLeadProvider, type: :service do
       it "uses the existing school partnership" do
         expect { subject }.not_to change(ActiveLeadProvider, :count)
 
-        new_training_period = mentor_at_school_period.training_periods.ongoing.first
+        new_training_period = mentor_at_school_period.training_periods.unfinished.first
         expect(new_training_period.school_partnership).to eq(school_partnership)
         expect(new_training_period.training_programme).to eq("provider_led")
       end
@@ -67,7 +67,7 @@ RSpec.describe MentorAtSchoolPeriods::ChangeLeadProvider, type: :service do
         it "opens a new training period with the previous schedule" do
           expect { subject }.to change(TrainingPeriod, :count).by(1)
 
-          new_training_period = mentor_at_school_period.training_periods.ongoing.first
+          new_training_period = mentor_at_school_period.training_periods.unfinished.first
           expect(new_training_period.schedule).to eq(training_period.schedule)
         end
 
@@ -103,7 +103,7 @@ RSpec.describe MentorAtSchoolPeriods::ChangeLeadProvider, type: :service do
         it "assigns the correct schedule for the new training period" do
           subject
 
-          new_training_period = mentor_at_school_period.training_periods.ongoing.first
+          new_training_period = mentor_at_school_period.training_periods.unfinished.first
           expect(new_training_period.schedule.identifier).to eq("ecf-standard-september")
           expect(new_training_period.schedule.contract_period_year).to eq(Time.zone.now.year)
         end
@@ -115,7 +115,7 @@ RSpec.describe MentorAtSchoolPeriods::ChangeLeadProvider, type: :service do
         it "opens a new training period with the previous schedule" do
           expect { subject }.to change(TrainingPeriod, :count).by(1)
 
-          new_training_period = mentor_at_school_period.training_periods.ongoing.first
+          new_training_period = mentor_at_school_period.training_periods.unfinished.first
           expect(new_training_period.schedule).to eq(training_period.schedule)
         end
       end
@@ -131,7 +131,7 @@ RSpec.describe MentorAtSchoolPeriods::ChangeLeadProvider, type: :service do
         it "does not reassign the contract period and leaves it in the closed contract period" do
           subject
 
-          new_training_period = mentor_at_school_period.training_periods.ongoing.first
+          new_training_period = mentor_at_school_period.training_periods.unfinished.first
           expect(new_training_period.schedule.identifier).not_to include("extended")
           expect(new_training_period.schedule.contract_period_year).to eq(2021)
         end
@@ -147,7 +147,7 @@ RSpec.describe MentorAtSchoolPeriods::ChangeLeadProvider, type: :service do
         it "opens a new training period with the previous schedule" do
           expect { subject }.to change(TrainingPeriod, :count).by(1)
 
-          new_training_period = mentor_at_school_period.training_periods.ongoing.first
+          new_training_period = mentor_at_school_period.training_periods.unfinished.first
           expect(new_training_period.schedule).to eq(training_period.schedule)
           expect(new_training_period.schedule.contract_period_year).to eq(training_period.schedule.contract_period_year)
         end
@@ -159,7 +159,7 @@ RSpec.describe MentorAtSchoolPeriods::ChangeLeadProvider, type: :service do
         it "opens a new training period with the previous schedule" do
           expect { subject }.to change(TrainingPeriod, :count).by(1)
 
-          new_training_period = mentor_at_school_period.training_periods.ongoing.first
+          new_training_period = mentor_at_school_period.training_periods.unfinished.first
           expect(new_training_period.schedule).to eq(training_period.schedule)
           expect(new_training_period.schedule.contract_period_year).to eq(training_period.schedule.contract_period_year)
         end
@@ -176,7 +176,7 @@ RSpec.describe MentorAtSchoolPeriods::ChangeLeadProvider, type: :service do
       let!(:training_period) do
         FactoryBot.create(:training_period,
                           :for_mentor,
-                          :ongoing,
+                          :unfinished,
                           :with_no_school_partnership,
                           expression_of_interest: old_active_lead_provider,
                           schedule:,

--- a/spec/services/mentor_at_school_periods/finish_spec.rb
+++ b/spec/services/mentor_at_school_periods/finish_spec.rb
@@ -7,10 +7,10 @@ describe MentorAtSchoolPeriods::Finish do
   let(:author) { FactoryBot.create(:school_user, school_urn: mentor_at_school_period.school.urn) }
   let(:reported_by_school_id) { nil }
 
-  let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:, started_on:) }
-  let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period:, started_on:) }
-  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on:, school: mentor_at_school_period.school) }
-  let!(:mentorship_period) { FactoryBot.create(:mentorship_period, :ongoing, mentor: mentor_at_school_period, mentee: ect_at_school_period, started_on:) }
+  let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:, started_on:) }
+  let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, :unfinished, mentor_at_school_period:, started_on:) }
+  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, started_on:, school: mentor_at_school_period.school) }
+  let!(:mentorship_period) { FactoryBot.create(:mentorship_period, :unfinished, mentor: mentor_at_school_period, mentee: ect_at_school_period, started_on:) }
 
   describe "#finish_periods_at_all_schools!" do
     context "when finished_on is already set" do
@@ -112,8 +112,8 @@ describe MentorAtSchoolPeriods::Finish do
       let(:mentor_finished_on) { finished_on + 1.month }
       let(:ect_finished_on) { finished_on + 2.months }
 
-      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on:, school: mentor_at_school_period.school) }
-      let!(:mentorship_period) { FactoryBot.create(:mentorship_period, :ongoing, mentor: mentor_at_school_period, mentee: ect_at_school_period, started_on:) }
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, started_on:, school: mentor_at_school_period.school) }
+      let!(:mentorship_period) { FactoryBot.create(:mentorship_period, :unfinished, mentor: mentor_at_school_period, mentee: ect_at_school_period, started_on:) }
 
       before do
         ect_at_school_period.update_column(:finished_on, ect_finished_on)
@@ -132,8 +132,8 @@ describe MentorAtSchoolPeriods::Finish do
       let(:mentor_finished_on) { finished_on + 2.months }
       let(:ect_finished_on) { finished_on + 1.month }
 
-      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on:, school: mentor_at_school_period.school) }
-      let!(:mentorship_period) { FactoryBot.create(:mentorship_period, :ongoing, mentor: mentor_at_school_period, mentee: ect_at_school_period, started_on:) }
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, started_on:, school: mentor_at_school_period.school) }
+      let!(:mentorship_period) { FactoryBot.create(:mentorship_period, :unfinished, mentor: mentor_at_school_period, mentee: ect_at_school_period, started_on:) }
 
       before do
         ect_at_school_period.update_column(:finished_on, ect_finished_on)
@@ -223,11 +223,11 @@ describe MentorAtSchoolPeriods::Finish do
     context "when there are ongoing mentor at school periods at other schools" do
       let(:other_school) { FactoryBot.create(:school) }
       let(:other_mentor_at_school_period) do
-        FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:, school: other_school, started_on:)
+        FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:, school: other_school, started_on:)
       end
 
-      let(:other_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on:, school: other_school) }
-      let!(:other_mentorship_period) { FactoryBot.create(:mentorship_period, :ongoing, mentor: other_mentor_at_school_period, mentee: other_ect_at_school_period, started_on:) }
+      let(:other_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, started_on:, school: other_school) }
+      let!(:other_mentorship_period) { FactoryBot.create(:mentorship_period, :unfinished, mentor: other_mentor_at_school_period, mentee: other_ect_at_school_period, started_on:) }
 
       it "finishes the periods at other schools" do
         subject.finish_periods_at_all_schools!
@@ -290,11 +290,11 @@ describe MentorAtSchoolPeriods::Finish do
     context "when there are ongoing mentor at school periods at other schools" do
       let(:other_school) { FactoryBot.create(:school) }
       let(:other_mentor_at_school_period) do
-        FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:, school: other_school, started_on:)
+        FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:, school: other_school, started_on:)
       end
 
-      let(:other_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on:, school: other_school) }
-      let!(:other_mentorship_period) { FactoryBot.create(:mentorship_period, :ongoing, mentor: other_mentor_at_school_period, mentee: other_ect_at_school_period, started_on:) }
+      let(:other_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, started_on:, school: other_school) }
+      let!(:other_mentorship_period) { FactoryBot.create(:mentorship_period, :unfinished, mentor: other_mentor_at_school_period, mentee: other_ect_at_school_period, started_on:) }
 
       let(:reported_by_school_id) { mentor_at_school_period.school_id }
 
@@ -325,7 +325,7 @@ describe MentorAtSchoolPeriods::Finish do
 
       context "when the mentor is training at another school" do
         let(:training_period) { nil }
-        let!(:other_training_period) { FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period: other_mentor_at_school_period, started_on:) }
+        let!(:other_training_period) { FactoryBot.create(:training_period, :for_mentor, :unfinished, mentor_at_school_period: other_mentor_at_school_period, started_on:) }
 
         it "does not finish the training period at the other school" do
           subject.finish_periods_at_reported_school!

--- a/spec/services/mentor_at_school_periods/latest_registration_choices_spec.rb
+++ b/spec/services/mentor_at_school_periods/latest_registration_choices_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe MentorAtSchoolPeriods::LatestRegistrationChoices do
 
   context "when the latest training period has a confirmed partnership" do
     let(:school_partnership) { FactoryBot.create(:school_partnership) }
-    let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:) }
+    let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:) }
 
     let!(:training_period) do
       FactoryBot.create(
         :training_period,
         :for_mentor,
-        :ongoing,
+        :unfinished,
         school_partnership:,
         started_on: mentor_at_school_period.started_on,
         mentor_at_school_period:
@@ -54,7 +54,7 @@ RSpec.describe MentorAtSchoolPeriods::LatestRegistrationChoices do
     let(:mentor_at_school_period) do
       FactoryBot.create(
         :mentor_at_school_period,
-        :ongoing,
+        :unfinished,
         teacher:,
         school:
       )
@@ -67,7 +67,7 @@ RSpec.describe MentorAtSchoolPeriods::LatestRegistrationChoices do
       FactoryBot.create(
         :training_period,
         :for_mentor,
-        :ongoing,
+        :unfinished,
         :with_no_school_partnership,
         mentor_at_school_period:,
         expression_of_interest:,

--- a/spec/services/migration_fixes/defer_training_period_spec.rb
+++ b/spec/services/migration_fixes/defer_training_period_spec.rb
@@ -2,7 +2,7 @@ describe MigrationFixes::DeferTrainingPeriod do
   subject(:service) { described_class.new(training_period:, deferred_at:, deferral_reason:) }
 
   let(:teacher) { FactoryBot.create(:teacher, api_updated_at:) }
-  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, started_on:) }
+  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher:, started_on:) }
   let!(:training_period) { FactoryBot.create(:training_period, :for_ect, started_on:, finished_on:, ect_at_school_period:, updated_at:) }
   let(:deferred_at) { 1.week.ago.round }
   let(:deferral_reason) { "career_break" }

--- a/spec/services/schedules/find_spec.rb
+++ b/spec/services/schedules/find_spec.rb
@@ -37,8 +37,8 @@ RSpec.describe Schedules::Find do
 
   let(:teacher) { FactoryBot.create(:teacher) }
   let(:school) { FactoryBot.create(:school) }
-  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, :with_training_period, teacher:, school:) }
-  let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, :with_training_period, teacher:, school:) }
+  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, :with_training_period, teacher:, school:) }
+  let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, :with_training_period, teacher:, school:) }
   let(:mentee) {}
 
   let(:lead_provider) { FactoryBot.create(:lead_provider) }
@@ -163,7 +163,7 @@ RSpec.describe Schedules::Find do
               it "assigns the schedule based on the start date of the current training period" do
                 first_training_period = nil
                 travel_to(registered_on) do
-                  first_training_period = FactoryBot.create(:training_period, :school_led, :ongoing, started_on: previous_start_date, ect_at_school_period:)
+                  first_training_period = FactoryBot.create(:training_period, :school_led, :unfinished, started_on: previous_start_date, ect_at_school_period:)
                 end
 
                 travel_to(provider_led_start_date) do
@@ -178,7 +178,7 @@ RSpec.describe Schedules::Find do
               it "uses the identifier from the previous provider-led training period" do
                 first_training_period = nil
                 travel_to(registered_on) do
-                  first_training_period = FactoryBot.create(:training_period, :provider_led, :ongoing,
+                  first_training_period = FactoryBot.create(:training_period, :provider_led, :unfinished,
                                                             started_on: previous_start_date,
                                                             ect_at_school_period:,
                                                             schedule:,
@@ -214,7 +214,7 @@ RSpec.describe Schedules::Find do
 
                 second_training_period = nil
                 travel_to(registered_on + 60.days) do
-                  second_training_period = FactoryBot.create(:training_period, :school_led, :ongoing,
+                  second_training_period = FactoryBot.create(:training_period, :school_led, :unfinished,
                                                              started_on: previous_start_date + 60.days,
                                                              ect_at_school_period:)
                 end
@@ -235,7 +235,7 @@ RSpec.describe Schedules::Find do
             let(:started_on) { new_school_start_date }
             let(:old_school) { FactoryBot.create(:school) }
             let(:ect_at_old_school_period) { FactoryBot.create(:ect_at_school_period, :finished, teacher:, school: old_school, started_on: old_school_start_date, finished_on: old_school_end_date) }
-            let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, :with_training_period, teacher:, school:, started_on:) }
+            let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, :with_training_period, teacher:, school:, started_on:) }
 
             let(:school_partnership) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:, school: old_school) }
 
@@ -272,7 +272,7 @@ RSpec.describe Schedules::Find do
       let(:provider_led_start_date) { Date.new(year, 12, 1) }
       let(:previous_start_date) { Date.new(year, 7, 1) }
 
-      let(:mentee) { FactoryBot.create(:ect_at_school_period, :ongoing, school:, started_on: previous_start_date) }
+      let(:mentee) { FactoryBot.create(:ect_at_school_period, :unfinished, school:, started_on: previous_start_date) }
       let(:schedule) { FactoryBot.create(:schedule, contract_period: previous_contract_period, identifier: "ecf-standard-september") }
 
       before do
@@ -290,14 +290,14 @@ RSpec.describe Schedules::Find do
       end
 
       context "when the mentee has previously received school-led training" do
-        let!(:mentee_training_period) { FactoryBot.create(:training_period, :school_led, :ongoing, started_on: previous_start_date, ect_at_school_period: mentee) }
+        let!(:mentee_training_period) { FactoryBot.create(:training_period, :school_led, :unfinished, started_on: previous_start_date, ect_at_school_period: mentee) }
 
         it_behaves_like "no replacement schedule assigned"
       end
 
       context "when the mentee has previously received provider-led training" do
         context "when there is one previous mentor with a training period" do
-          let!(:mentee_training_period) { FactoryBot.create(:training_period, :provider_led, :ongoing, started_on: previous_start_date, ect_at_school_period: mentee) }
+          let!(:mentee_training_period) { FactoryBot.create(:training_period, :provider_led, :unfinished, started_on: previous_start_date, ect_at_school_period: mentee) }
           let(:previous_mentor) { FactoryBot.create(:mentor_at_school_period, school:, started_on: previous_start_date, finished_on: 1.day.ago) }
           let!(:mentorship_period) { FactoryBot.create(:mentorship_period, started_on: previous_start_date, finished_on: 1.day.ago, mentee:, mentor: previous_mentor) }
           let!(:mentor_training_period) { FactoryBot.create(:training_period, :provider_led, :for_mentor, started_on: previous_start_date, finished_on: 1.day.ago, mentor_at_school_period: previous_mentor) }
@@ -356,7 +356,7 @@ RSpec.describe Schedules::Find do
           let!(:second_mentor_training_period) { FactoryBot.create(:training_period, :provider_led, :for_mentor, started_on: second_date, finished_on: 1.day.ago, mentor_at_school_period: second_mentor) }
 
           before do
-            FactoryBot.create(:training_period, :provider_led, :ongoing, started_on: first_date, ect_at_school_period: mentee)
+            FactoryBot.create(:training_period, :provider_led, :unfinished, started_on: first_date, ect_at_school_period: mentee)
             FactoryBot.create(:mentorship_period, started_on: first_date, finished_on: second_date - 1.day, mentee:, mentor: first_mentor)
             FactoryBot.create(:mentorship_period, started_on: second_date, finished_on: 1.day.ago, mentee:, mentor: second_mentor)
           end
@@ -390,7 +390,7 @@ RSpec.describe Schedules::Find do
           let(:previous_school_start) { Date.new(year - 1, 9, 1) }
           let(:previous_school_end) { Date.new(year - 1, 12, 31) }
 
-          let!(:mentee_training_period) { FactoryBot.create(:training_period, :provider_led, :ongoing, started_on: previous_start_date, ect_at_school_period: mentee) }
+          let!(:mentee_training_period) { FactoryBot.create(:training_period, :provider_led, :unfinished, started_on: previous_start_date, ect_at_school_period: mentee) }
 
           let!(:mentee_at_previous_school) do
             FactoryBot.create(:ect_at_school_period,
@@ -447,13 +447,13 @@ RSpec.describe Schedules::Find do
       before { travel_to provider_led_start_date }
 
       context "when the ECT started training in the 2021 contract period" do
-        let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, :with_training_period, teacher:, school:, started_on: Date.new(2021, 7, 1)) }
+        let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, :with_training_period, teacher:, school:, started_on: Date.new(2021, 7, 1)) }
         let(:contract_period_2021) { FactoryBot.create(:contract_period, :with_schedules, :with_payments_frozen, year: 2021) }
         let(:old_active_lead_provider) { FactoryBot.create(:active_lead_provider, contract_period: contract_period_2021) }
         let!(:old_training_period) do
           FactoryBot.create(:training_period,
                             :provider_led,
-                            :ongoing,
+                            :unfinished,
                             :with_active_lead_provider,
                             started_on: Date.new(2021, 7, 1),
                             ect_at_school_period:,
@@ -477,7 +477,7 @@ RSpec.describe Schedules::Find do
 
       before do
         travel_to started_on
-        FactoryBot.create(:training_period, :provider_led, :ongoing,
+        FactoryBot.create(:training_period, :provider_led, :unfinished,
                           ect_at_school_period:,
                           started_on: previous_start_date,
                           schedule: old_schedule,
@@ -498,7 +498,7 @@ RSpec.describe Schedules::Find do
 
       before do
         travel_to started_on
-        FactoryBot.create(:training_period, :provider_led, :ongoing,
+        FactoryBot.create(:training_period, :provider_led, :unfinished,
                           :for_mentor,
                           mentor_at_school_period:,
                           started_on: previous_start_date,

--- a/spec/services/schools/access_blocker_spec.rb
+++ b/spec/services/schools/access_blocker_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Schools::AccessBlocker do
       let(:school_urn) { school.urn }
 
       before do
-        FactoryBot.create(:training_period, :ongoing, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, school:))
+        FactoryBot.create(:training_period, :unfinished, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished, school:))
       end
 
       it "does not block access" do

--- a/spec/services/schools/assign_mentor_form_spec.rb
+++ b/spec/services/schools/assign_mentor_form_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe Schools::AssignMentorForm, type: :model do
       context "when the mentor is not registered at the ect's school" do
         subject { described_class.new(ect:, mentor_id: mentor.id) }
 
-        let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing) }
-        let(:mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing) }
+        let(:ect) { FactoryBot.create(:ect_at_school_period, :unfinished) }
+        let(:mentor) { FactoryBot.create(:mentor_at_school_period, :unfinished) }
 
         before do
           subject.valid?
@@ -36,8 +36,8 @@ RSpec.describe Schools::AssignMentorForm, type: :model do
       context "when the mentor is not eligible for the ect" do
         subject { described_class.new(ect:, mentor_id: mentor.id) }
 
-        let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing) }
-        let(:mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, school: ect.school, teacher: ect.teacher) }
+        let(:ect) { FactoryBot.create(:ect_at_school_period, :unfinished) }
+        let(:mentor) { FactoryBot.create(:mentor_at_school_period, :unfinished, school: ect.school, teacher: ect.teacher) }
 
         before do
           subject.valid?
@@ -57,14 +57,14 @@ RSpec.describe Schools::AssignMentorForm, type: :model do
       let(:ect) do
         FactoryBot.create(
           :ect_at_school_period,
-          :ongoing,
+          :unfinished,
           started_on: 3.days.ago
         )
       end
       let(:mentor) do
         FactoryBot.create(
           :mentor_at_school_period,
-          :ongoing,
+          :unfinished,
           school: ect.school,
           started_on: 4.weeks.ago
         )

--- a/spec/services/schools/assign_mentor_spec.rb
+++ b/spec/services/schools/assign_mentor_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Schools::AssignMentor do
         let(:current_mentor) do
           FactoryBot.create(
             :mentor_at_school_period,
-            :ongoing,
+            :unfinished,
             started_on: 6.months.ago,
             school: mentee.school
           )
@@ -56,7 +56,7 @@ RSpec.describe Schools::AssignMentor do
         let!(:current_mentorship_period) do
           FactoryBot.create(
             :mentorship_period,
-            :ongoing,
+            :unfinished,
             started_on: current_mentor.started_on,
             mentee:,
             mentor: current_mentor

--- a/spec/services/schools/eligible_mentors_spec.rb
+++ b/spec/services/schools/eligible_mentors_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Schools::EligibleMentors do
   end
 
   let(:school) { FactoryBot.create(:school) }
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 2.years.ago) }
+  let(:ect) { FactoryBot.create(:ect_at_school_period, :unfinished, started_on: 2.years.ago) }
 
   describe "#for_ect" do
     context "when the school has no active mentors" do
@@ -12,7 +12,7 @@ RSpec.describe Schools::EligibleMentors do
     end
 
     context "when the school has ongoing mentors registered" do
-      let!(:ongoing_mentors) { FactoryBot.create_list(:mentor_at_school_period, 2, :ongoing, school:, started_on: 2.years.ago) }
+      let!(:ongoing_mentors) { FactoryBot.create_list(:mentor_at_school_period, 2, :unfinished, school:, started_on: 2.years.ago) }
 
       it "returns those mentors" do
         expect(subject.to_a).to match_array(ongoing_mentors)
@@ -20,10 +20,10 @@ RSpec.describe Schools::EligibleMentors do
     end
 
     context "when the ect is also a mentor at the school" do
-      let!(:mentors_excluding_ect) { FactoryBot.create_list(:mentor_at_school_period, 2, :ongoing, school:, started_on: 2.years.ago) }
+      let!(:mentors_excluding_ect) { FactoryBot.create_list(:mentor_at_school_period, 2, :unfinished, school:, started_on: 2.years.ago) }
 
       before do
-        FactoryBot.create(:mentor_at_school_period, :ongoing, school:, teacher: ect.teacher, started_on: 2.years.ago)
+        FactoryBot.create(:mentor_at_school_period, :unfinished, school:, teacher: ect.teacher, started_on: 2.years.ago)
       end
 
       it "returns those mentors excluding themself" do

--- a/spec/services/schools/home_spec.rb
+++ b/spec/services/schools/home_spec.rb
@@ -6,21 +6,21 @@ RSpec.describe Schools::Home do
   let(:mentor) { FactoryBot.create(:teacher, corrected_name: nil) }
 
   let(:mentor_period) do
-    FactoryBot.create(:mentor_at_school_period, :ongoing,
+    FactoryBot.create(:mentor_at_school_period, :unfinished,
                       school:,
                       teacher: mentor,
                       started_on: 2.years.ago)
   end
 
   let(:ect_period) do
-    FactoryBot.create(:ect_at_school_period, :ongoing,
+    FactoryBot.create(:ect_at_school_period, :unfinished,
                       school:,
                       teacher: ect,
                       started_on: 2.years.ago)
   end
 
   before do
-    FactoryBot.create(:training_period, :ongoing,
+    FactoryBot.create(:training_period, :unfinished,
                       mentor_at_school_period: mentor_period,
                       ect_at_school_period: nil,
                       started_on: 1.year.ago)
@@ -30,7 +30,7 @@ RSpec.describe Schools::Home do
                       mentee: ect_period,
                       started_on: 2.years.ago,
                       finished_on: 1.year.ago)
-    FactoryBot.create(:mentorship_period, :ongoing,
+    FactoryBot.create(:mentorship_period, :unfinished,
                       mentor: mentor_period,
                       mentee: ect_period,
                       started_on: 1.year.ago + 1.day)

--- a/spec/services/schools/mentor_assignment/mentorship_periods/dates_resolver_spec.rb
+++ b/spec/services/schools/mentor_assignment/mentorship_periods/dates_resolver_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Schools::MentorAssignment::MentorshipPeriods::DatesResolver do
         let(:previous_mentor_at_school_period) do
           FactoryBot.create(
             :mentor_at_school_period,
-            :ongoing,
+            :unfinished,
             started_on: previous_mentorship_started_on,
             school: ect_at_school_period.school
           )

--- a/spec/services/schools/register_ect_spec.rb
+++ b/spec/services/schools/register_ect_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe Schools::RegisterECT do
           before do
             FactoryBot.create(
               :ect_at_school_period,
-              :ongoing,
+              :unfinished,
               teacher:,
               school: other_school,
               started_on: Date.new(2024, 1, 1)
@@ -171,7 +171,7 @@ RSpec.describe Schools::RegisterECT do
           before do
             FactoryBot.create(
               :ect_at_school_period,
-              :ongoing,
+              :unfinished,
               teacher:,
               school:,
               started_on: Date.new(2024, 1, 1)
@@ -225,7 +225,7 @@ RSpec.describe Schools::RegisterECT do
             # Finished at current school (previous period)
             FactoryBot.create(:ect_at_school_period, :finished, teacher:, school:, started_on: Date.new(2023, 9, 1), finished_on: Date.new(2023, 12, 31))
             # Ongoing at other school (started after the finished period)
-            FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school: other_school, started_on: Date.new(2024, 1, 1))
+            FactoryBot.create(:ect_at_school_period, :unfinished, teacher:, school: other_school, started_on: Date.new(2024, 1, 1))
           end
 
           it "closes the ongoing period and allows registration at the current school" do
@@ -275,7 +275,7 @@ RSpec.describe Schools::RegisterECT do
           before do
             FactoryBot.create(
               :ect_at_school_period,
-              :ongoing,
+              :unfinished,
               teacher:,
               school: other_school,
               started_on: started_on.advance(weeks: 2)

--- a/spec/services/schools/register_mentor_spec.rb
+++ b/spec/services/schools/register_mentor_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Schools::RegisterMentor do
         end
 
         context "with MentorATSchoolPeriod records" do
-          let!(:existing_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:, started_on: 2.years.ago) }
+          let!(:existing_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:, started_on: 2.years.ago) }
           let!(:existing_training_period) do
             FactoryBot.create(
               :training_period,

--- a/spec/services/schools/teacher_email_spec.rb
+++ b/spec/services/schools/teacher_email_spec.rb
@@ -2,10 +2,10 @@ describe Schools::TeacherEmail do
   subject { described_class.new(email:, trn:) }
 
   let(:finished_ect_at_school_period) { FactoryBot.create(:ect_at_school_period) }
-  let(:ongoing_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+  let(:ongoing_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished) }
 
   let(:finished_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period) }
-  let(:ongoing_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing) }
+  let(:ongoing_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished) }
 
   let(:trn) { "123456" }
 

--- a/spec/services/schools/training_programme_spec.rb
+++ b/spec/services/schools/training_programme_spec.rb
@@ -20,7 +20,7 @@ describe Schools::TrainingProgramme do
       context "when school has at least one mentor in training" do
         let(:mentor_at_school_period) do
           FactoryBot.create(:mentor_at_school_period,
-                            :ongoing,
+                            :unfinished,
                             school:,
                             started_on: "2021-01-01")
         end
@@ -38,19 +38,19 @@ describe Schools::TrainingProgramme do
       context "when school has mentors not in training (only mentoring)" do
         let(:mentor_at_school_period) do
           FactoryBot.create(:mentor_at_school_period,
-                            :ongoing,
+                            :unfinished,
                             school:,
                             started_on: "2021-01-01")
         end
         let(:ect_at_school_period) do
           FactoryBot.create(:ect_at_school_period,
-                            :ongoing,
+                            :unfinished,
                             school:,
                             started_on: "2021-01-01")
         end
         let!(:mentorship_period) do
           FactoryBot.create(:mentorship_period,
-                            :ongoing,
+                            :unfinished,
                             started_on: mentor_at_school_period.started_on,
                             mentor: mentor_at_school_period,
                             mentee: ect_at_school_period)
@@ -62,7 +62,7 @@ describe Schools::TrainingProgramme do
       context "when school has at least one expression of interest for training from a mentor" do
         let(:mentor_at_school_period) do
           FactoryBot.create(:mentor_at_school_period,
-                            :ongoing,
+                            :unfinished,
                             school:,
                             started_on: "2021-01-01")
         end
@@ -82,7 +82,7 @@ describe Schools::TrainingProgramme do
         context "when there is only `provider_led` as the ects training programmes" do
           let(:ect_at_school_period) do
             FactoryBot.create(:ect_at_school_period,
-                              :ongoing,
+                              :unfinished,
                               school:,
                               started_on: "2021-01-01")
           end
@@ -101,7 +101,7 @@ describe Schools::TrainingProgramme do
         context "when there is only `school_led` as the ects training programmes" do
           let(:ect_at_school_period) do
             FactoryBot.create(:ect_at_school_period,
-                              :ongoing,
+                              :unfinished,
                               school:,
                               started_on: "2021-01-01")
           end
@@ -119,7 +119,7 @@ describe Schools::TrainingProgramme do
         context "when the only `school_led` ect training was created for a different contract period" do
           let(:ect_at_school_period) do
             FactoryBot.create(:ect_at_school_period,
-                              :ongoing,
+                              :unfinished,
                               school:,
                               started_on: "2021-01-01")
           end
@@ -137,7 +137,7 @@ describe Schools::TrainingProgramme do
         context "when there is a mix of `provider_led` and `school_led` as the ects training programmes" do
           let(:ect_at_school_period_1) do
             FactoryBot.create(:ect_at_school_period,
-                              :ongoing,
+                              :unfinished,
                               school:,
                               started_on: "2021-01-01")
           end
@@ -152,7 +152,7 @@ describe Schools::TrainingProgramme do
 
           let(:ect_at_school_period_2) do
             FactoryBot.create(:ect_at_school_period,
-                              :ongoing,
+                              :unfinished,
                               school:,
                               started_on: "2021-01-01")
           end
@@ -170,7 +170,7 @@ describe Schools::TrainingProgramme do
         context "when the same ect at school period has both provider-led and school-led training periods" do
           let(:ect_at_school_period) do
             FactoryBot.create(:ect_at_school_period,
-                              :ongoing,
+                              :unfinished,
                               school:,
                               started_on: "2021-01-01")
           end
@@ -199,7 +199,7 @@ describe Schools::TrainingProgramme do
       context "when school has at least one expression of interest for training from an ect" do
         let(:ect_at_school_period) do
           FactoryBot.create(:ect_at_school_period,
-                            :ongoing,
+                            :unfinished,
                             school:,
                             started_on: contract_period.started_on)
         end

--- a/spec/services/statements/declaration_selection_spec.rb
+++ b/spec/services/statements/declaration_selection_spec.rb
@@ -84,8 +84,8 @@ RSpec.describe Statements::DeclarationSelection do
         **default_declaration_attrs.merge(payment_statement: statement),
         training_period: FactoryBot.create(:training_period,
                                            :for_ect,
-                                           :ongoing,
-                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           :unfinished,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished, started_on:),
                                            **default_training_period_attrs)
       )
     end
@@ -99,8 +99,8 @@ RSpec.describe Statements::DeclarationSelection do
         ),
         training_period: FactoryBot.create(:training_period,
                                            :for_ect,
-                                           :ongoing,
-                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           :unfinished,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished, started_on:),
                                            **default_training_period_attrs)
       )
     end
@@ -122,8 +122,8 @@ RSpec.describe Statements::DeclarationSelection do
         **default_declaration_attrs.merge(payment_statement: statement),
         training_period: FactoryBot.create(:training_period,
                                            :for_ect,
-                                           :ongoing,
-                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           :unfinished,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished, started_on:),
                                            **default_training_period_attrs)
       )
     end
@@ -137,8 +137,8 @@ RSpec.describe Statements::DeclarationSelection do
         ),
         training_period: FactoryBot.create(:training_period,
                                            :for_ect,
-                                           :ongoing,
-                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           :unfinished,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished, started_on:),
                                            **default_training_period_attrs)
       )
     end
@@ -152,8 +152,8 @@ RSpec.describe Statements::DeclarationSelection do
         ),
         training_period: FactoryBot.create(:training_period,
                                            :for_ect,
-                                           :ongoing,
-                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           :unfinished,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished, started_on:),
                                            **default_training_period_attrs)
       )
     end
@@ -172,8 +172,8 @@ RSpec.describe Statements::DeclarationSelection do
         **default_declaration_attrs.merge(payment_statement: statement),
         training_period: FactoryBot.create(:training_period,
                                            :for_ect,
-                                           :ongoing,
-                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           :unfinished,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished, started_on:),
                                            **default_training_period_attrs)
       )
     end
@@ -183,8 +183,8 @@ RSpec.describe Statements::DeclarationSelection do
         **default_declaration_attrs.merge(payment_statement: statement),
         training_period: FactoryBot.create(:training_period,
                                            :for_ect,
-                                           :ongoing,
-                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           :unfinished,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished, started_on:),
                                            **default_training_period_attrs)
       )
     end
@@ -194,8 +194,8 @@ RSpec.describe Statements::DeclarationSelection do
         **default_declaration_attrs.merge(payment_statement: statement),
         training_period: FactoryBot.create(:training_period,
                                            :for_ect,
-                                           :ongoing,
-                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           :unfinished,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished, started_on:),
                                            **default_training_period_attrs)
       )
     end
@@ -231,8 +231,8 @@ RSpec.describe Statements::DeclarationSelection do
         ),
         training_period: FactoryBot.create(:training_period,
                                            :for_ect,
-                                           :ongoing,
-                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           :unfinished,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished, started_on:),
                                            **default_training_period_attrs)
       )
     end
@@ -252,8 +252,8 @@ RSpec.describe Statements::DeclarationSelection do
         ),
         training_period: FactoryBot.create(:training_period,
                                            :for_ect,
-                                           :ongoing,
-                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           :unfinished,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished, started_on:),
                                            **default_training_period_attrs)
       )
     end
@@ -300,8 +300,8 @@ RSpec.describe Statements::DeclarationSelection do
         ),
         training_period: FactoryBot.create(:training_period,
                                            :for_ect,
-                                           :ongoing,
-                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           :unfinished,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished, started_on:),
                                            **default_training_period_attrs)
       )
     end
@@ -316,8 +316,8 @@ RSpec.describe Statements::DeclarationSelection do
         ),
         training_period: FactoryBot.create(:training_period,
                                            :for_ect,
-                                           :ongoing,
-                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           :unfinished,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished, started_on:),
                                            **default_training_period_attrs)
       )
     end
@@ -332,8 +332,8 @@ RSpec.describe Statements::DeclarationSelection do
         ),
         training_period: FactoryBot.create(:training_period,
                                            :for_ect,
-                                           :ongoing,
-                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           :unfinished,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished, started_on:),
                                            **default_training_period_attrs)
       )
     end
@@ -350,8 +350,8 @@ RSpec.describe Statements::DeclarationSelection do
         ),
         training_period: FactoryBot.create(:training_period,
                                            :for_ect,
-                                           :ongoing,
-                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           :unfinished,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished, started_on:),
                                            **default_training_period_attrs)
       )
     end
@@ -366,8 +366,8 @@ RSpec.describe Statements::DeclarationSelection do
         ),
         training_period: FactoryBot.create(:training_period,
                                            :for_ect,
-                                           :ongoing,
-                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           :unfinished,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished, started_on:),
                                            **default_training_period_attrs)
       )
     end
@@ -408,8 +408,8 @@ RSpec.describe Statements::DeclarationSelection do
         **default_declaration_attrs.merge(payment_statement: statement),
         training_period: FactoryBot.create(:training_period,
                                            :for_ect,
-                                           :ongoing,
-                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           :unfinished,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished, started_on:),
                                            **default_training_period_attrs)
       )
     end
@@ -445,8 +445,8 @@ RSpec.describe Statements::DeclarationSelection do
         ),
         training_period: FactoryBot.create(:training_period,
                                            :for_ect,
-                                           :ongoing,
-                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           :unfinished,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished, started_on:),
                                            **default_training_period_attrs)
       )
     end
@@ -460,8 +460,8 @@ RSpec.describe Statements::DeclarationSelection do
         ),
         training_period: FactoryBot.create(:training_period,
                                            :for_ect,
-                                           :ongoing,
-                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           :unfinished,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished, started_on:),
                                            **default_training_period_attrs)
       )
     end
@@ -475,8 +475,8 @@ RSpec.describe Statements::DeclarationSelection do
         ),
         training_period: FactoryBot.create(:training_period,
                                            :for_ect,
-                                           :ongoing,
-                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           :unfinished,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished, started_on:),
                                            **default_training_period_attrs)
       )
     end
@@ -520,8 +520,8 @@ RSpec.describe Statements::DeclarationSelection do
         **default_declaration_attrs.merge(payment_statement: qualifying_previous_statement),
         training_period: FactoryBot.create(:training_period,
                                            :for_ect,
-                                           :ongoing,
-                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           :unfinished,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished, started_on:),
                                            **default_training_period_attrs)
       )
     end
@@ -531,8 +531,8 @@ RSpec.describe Statements::DeclarationSelection do
         **default_declaration_attrs.merge(payment_statement: same_payment_date_statement),
         training_period: FactoryBot.create(:training_period,
                                            :for_ect,
-                                           :ongoing,
-                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           :unfinished,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished, started_on:),
                                            **default_training_period_attrs)
       )
     end
@@ -546,8 +546,8 @@ RSpec.describe Statements::DeclarationSelection do
         ),
         training_period: FactoryBot.create(:training_period,
                                            :for_ect,
-                                           :ongoing,
-                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           :unfinished,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished, started_on:),
                                            **default_training_period_attrs)
       )
     end
@@ -602,10 +602,10 @@ RSpec.describe Statements::DeclarationSelection do
       FactoryBot.create(
         :training_period,
         :for_ect,
-        :ongoing,
+        :unfinished,
         school_partnership: other_school_partnership,
         started_on:,
-        ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:)
+        ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished, started_on:)
       )
     end
 
@@ -615,8 +615,8 @@ RSpec.describe Statements::DeclarationSelection do
         **default_declaration_attrs.merge(payment_statement: qualifying_previous_statement),
         training_period: FactoryBot.create(:training_period,
                                            :for_ect,
-                                           :ongoing,
-                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           :unfinished,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished, started_on:),
                                            **default_training_period_attrs)
       )
     end
@@ -637,8 +637,8 @@ RSpec.describe Statements::DeclarationSelection do
         ),
         training_period: FactoryBot.create(:training_period,
                                            :for_ect,
-                                           :ongoing,
-                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           :unfinished,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :unfinished, started_on:),
                                            **default_training_period_attrs)
       )
     end

--- a/spec/services/statements/declarations_csv_spec.rb
+++ b/spec/services/statements/declarations_csv_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Statements::DeclarationsCSV do
       withdrawal_reason: "moved_school"
     )
   end
-  let(:mentorship_period) { FactoryBot.create(:mentorship_period, :ongoing, mentee: ect, mentor:) }
+  let(:mentorship_period) { FactoryBot.create(:mentorship_period, :unfinished, mentee: ect, mentor:) }
   let(:declaration) do
     FactoryBot.create(
       :declaration,

--- a/spec/services/teachers/anonymise_spec.rb
+++ b/spec/services/teachers/anonymise_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe Teachers::Anonymise do
     end
 
     context "when the teacher has an ECT at school period" do
-      before { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:) }
+      before { FactoryBot.create(:ect_at_school_period, :unfinished, teacher:) }
 
       it { is_expected.not_to be_permitted }
     end
 
     context "when the teacher has a mentor at school period" do
-      before { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:) }
+      before { FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:) }
 
       it { is_expected.not_to be_permitted }
     end
@@ -69,7 +69,7 @@ RSpec.describe Teachers::Anonymise do
     end
 
     context "when not permitted" do
-      before { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:) }
+      before { FactoryBot.create(:ect_at_school_period, :unfinished, teacher:) }
 
       it "raises NotPermittedError" do
         expect { service.anonymise! }.to raise_error(Teachers::Anonymise::NotPermittedError)

--- a/spec/services/teachers/change_schedule_spec.rb
+++ b/spec/services/teachers/change_schedule_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe Teachers::ChangeSchedule do
   describe "#change_schedule" do
     %i[ect mentor].each do |trainee_type|
       context "for #{trainee_type}" do
-        let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :ongoing, started_on: school_period_started_on, finished_on: school_period_finished_on) }
-        let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing, :with_expression_of_interest, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on, finished_on: training_period_finished_on) }
+        let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :unfinished, started_on: school_period_started_on, finished_on: school_period_finished_on) }
+        let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :unfinished, :with_expression_of_interest, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on, finished_on: training_period_finished_on) }
         let!(:school_period_started_on) { 6.months.ago }
         let(:school_period_finished_on) { nil }
         let(:training_period_finished_on) { nil }

--- a/spec/services/teachers/defer_spec.rb
+++ b/spec/services/teachers/defer_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Teachers::Defer do
         let(:teacher_type) { trainee_type }
 
         context "when training period is ongoing" do
-          let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
+          let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :unfinished, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
 
           it "defers the training period" do
             freeze_time
@@ -40,7 +40,7 @@ RSpec.describe Teachers::Defer do
             FactoryBot.create(
               :training_period,
               :"for_#{trainee_type}",
-              :ongoing,
+              :unfinished,
               "#{trainee_type}_at_school_period": at_school_period,
               started_on: at_school_period.started_on,
               finished_on: 1.month.ago
@@ -64,7 +64,7 @@ RSpec.describe Teachers::Defer do
             FactoryBot.create(
               :training_period,
               :"for_#{trainee_type}",
-              :ongoing,
+              :unfinished,
               "#{trainee_type}_at_school_period": at_school_period,
               started_on: at_school_period.started_on,
               finished_on: 3.months.from_now
@@ -84,7 +84,7 @@ RSpec.describe Teachers::Defer do
         end
 
         context "event recording" do
-          let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
+          let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :unfinished, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
 
           it "records a teacher defers training period event" do
             freeze_time do

--- a/spec/services/teachers/induction_period_spec.rb
+++ b/spec/services/teachers/induction_period_spec.rb
@@ -36,7 +36,7 @@ describe Teachers::InductionPeriod do
 
     context "with ongoing induction period" do
       let!(:ongoing_induction_period) do
-        FactoryBot.create(:induction_period, :ongoing, teacher:, started_on: "2023-10-3")
+        FactoryBot.create(:induction_period, :unfinished, teacher:, started_on: "2023-10-3")
       end
 
       it "returns the ongoing induction period" do

--- a/spec/services/teachers/induction_spec.rb
+++ b/spec/services/teachers/induction_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Teachers::Induction do
   let(:teacher) { FactoryBot.create(:teacher) }
 
   let(:induction_period_unfinished) do
-    FactoryBot.create(:induction_period, :ongoing, teacher:, started_on: 6.months.ago)
+    FactoryBot.create(:induction_period, :unfinished, teacher:, started_on: 6.months.ago)
   end
 
   let(:induction_period_finished_one_year_ago) do
@@ -92,7 +92,7 @@ RSpec.describe Teachers::Induction do
 
   describe "#with_appropriate_body?" do
     let(:other_appropriate_body) { FactoryBot.create(:appropriate_body_period) }
-    let(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:) }
+    let(:induction_period) { FactoryBot.create(:induction_period, :unfinished, teacher:) }
 
     it "returns true when the current induction is with the body" do
       expect(service.with_appropriate_body?(induction_period.appropriate_body_period)).to be true

--- a/spec/services/teachers/induction_status_spec.rb
+++ b/spec/services/teachers/induction_status_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Teachers::InductionStatus do
 
       context "with an ongoing induction period" do
         before do
-          FactoryBot.create(:induction_period, :ongoing,
+          FactoryBot.create(:induction_period, :unfinished,
                             teacher:)
         end
 

--- a/spec/services/teachers/merge_spec.rb
+++ b/spec/services/teachers/merge_spec.rb
@@ -9,11 +9,11 @@ RSpec.describe Teachers::Merge do
 
   describe "#merge!" do
     context "when the destination has no conflicting records (clean merge)" do
-      let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: source) }
+      let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher: source) }
       let!(:ect_training_period) { FactoryBot.create(:training_period, :for_ect, :with_active_lead_provider, ect_at_school_period:, started_on: ect_at_school_period.started_on, finished_on: nil) }
       let!(:ect_declaration) { FactoryBot.create(:declaration, training_period: ect_training_period) }
 
-      let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: source) }
+      let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, teacher: source) }
       let!(:mentor_training_period) { FactoryBot.create(:training_period, :for_mentor, :with_active_lead_provider, mentor_at_school_period:, started_on: mentor_at_school_period.started_on, finished_on: nil) }
       let!(:mentor_declaration) { FactoryBot.create(:declaration, training_period: mentor_training_period) }
 
@@ -115,8 +115,8 @@ RSpec.describe Teachers::Merge do
     end
 
     context "when the destination already has an overlapping period" do
-      let!(:source_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: source) }
-      let!(:destination_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: destination) }
+      let!(:source_period) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher: source) }
+      let!(:destination_period) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher: destination) }
 
       it "raises and rolls back the whole merge" do
         expect { service.merge! }.to raise_error(ActiveRecord::RecordInvalid)
@@ -136,7 +136,7 @@ RSpec.describe Teachers::Merge do
     end
 
     describe "declaration participant identity via the API serializer" do
-      let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: source) }
+      let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher: source) }
       let!(:ect_training_period) { FactoryBot.create(:training_period, :for_ect, :with_active_lead_provider, ect_at_school_period:, started_on: ect_at_school_period.started_on, finished_on: nil) }
       let!(:declaration) { FactoryBot.create(:declaration, training_period: ect_training_period) }
 

--- a/spec/services/teachers/refresh_trs_attributes_spec.rb
+++ b/spec/services/teachers/refresh_trs_attributes_spec.rb
@@ -265,7 +265,7 @@ describe Teachers::RefreshTRSAttributes do
 
       context "and the teacher has an ongoing induction" do
         before do
-          FactoryBot.create(:induction_period, :ongoing, teacher:)
+          FactoryBot.create(:induction_period, :unfinished, teacher:)
           service.refresh!
           teacher.reload
         end

--- a/spec/services/teachers/resume_spec.rb
+++ b/spec/services/teachers/resume_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe Teachers::Resume do
   describe "#resume" do
     %i[ect mentor].each do |trainee_type|
       context "for #{trainee_type}" do
-        let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :ongoing, started_on: 6.months.ago) }
+        let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :unfinished, started_on: 6.months.ago) }
         let(:course_identifier) { trainee_type == :ect ? "ecf-induction" : "ecf-mentor" }
 
         context "when training period is active" do
-          let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
+          let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :unfinished, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
 
           it "raises an error" do
             expect {
@@ -31,9 +31,9 @@ RSpec.describe Teachers::Resume do
         context "when teacher has moved to a new Lead provider" do
           let(:teacher) { FactoryBot.create(:teacher) }
           let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", started_on: 6.months.ago, finished_on: 5.months.ago, teacher:) }
-          let(:at_school_period_new) { FactoryBot.create(:"#{trainee_type}_at_school_period", :ongoing, started_on: 4.months.ago, finished_on: nil, teacher:) }
+          let(:at_school_period_new) { FactoryBot.create(:"#{trainee_type}_at_school_period", :unfinished, started_on: 4.months.ago, finished_on: nil, teacher:) }
           let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :deferred, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on, finished_on: at_school_period.finished_on) }
-          let!(:training_period_new) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing, "#{trainee_type}_at_school_period": at_school_period_new, started_on: at_school_period_new.started_on, finished_on: nil) }
+          let!(:training_period_new) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :unfinished, "#{trainee_type}_at_school_period": at_school_period_new, started_on: at_school_period_new.started_on, finished_on: nil) }
 
           it "raises an error" do
             expect {
@@ -53,7 +53,7 @@ RSpec.describe Teachers::Resume do
             }.to change(TrainingPeriod, :count).by(1)
 
             created_training_period = TrainingPeriod.last
-            expect(created_training_period).to be_ongoing
+            expect(created_training_period).to be_unfinished
             expect(created_training_period.deferred_at).to be_nil
             expect(created_training_period.at_school_period).to eq(training_period.at_school_period)
             expect(created_training_period.started_on).to eq(Time.zone.today)
@@ -96,7 +96,7 @@ RSpec.describe Teachers::Resume do
             }.to change(TrainingPeriod, :count).by(1)
 
             created_training_period = TrainingPeriod.last
-            expect(created_training_period).to be_ongoing
+            expect(created_training_period).to be_unfinished
             expect(created_training_period.withdrawn_at).to be_nil
             expect(created_training_period.at_school_period).to eq(training_period.at_school_period)
             expect(created_training_period.started_on).to eq(Time.zone.today)
@@ -131,9 +131,9 @@ RSpec.describe Teachers::Resume do
         context "when teacher is moving to a new Lead provider" do
           let(:teacher) { FactoryBot.create(:teacher) }
           let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", started_on: 6.months.ago, finished_on: 60.days.from_now, teacher:) }
-          let(:at_school_period_new) { FactoryBot.create(:"#{trainee_type}_at_school_period", :ongoing, started_on: 61.days.from_now, finished_on: nil, teacher:) }
+          let(:at_school_period_new) { FactoryBot.create(:"#{trainee_type}_at_school_period", :unfinished, started_on: 61.days.from_now, finished_on: nil, teacher:) }
           let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :deferred, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on, finished_on: 1.month.ago) }
-          let!(:training_period_new) { FactoryBot.build(:training_period, :"for_#{trainee_type}", :ongoing, "#{trainee_type}_at_school_period": at_school_period_new, started_on: at_school_period_new.started_on, finished_on: nil) }
+          let!(:training_period_new) { FactoryBot.build(:training_period, :"for_#{trainee_type}", :unfinished, "#{trainee_type}_at_school_period": at_school_period_new, started_on: at_school_period_new.started_on, finished_on: nil) }
 
           it "resumes training period" do
             freeze_time

--- a/spec/services/teachers/role_spec.rb
+++ b/spec/services/teachers/role_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Teachers::Role do
 
       context "when teacher has ongoing ECT period at any school" do
         before do
-          FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:)
+          FactoryBot.create(:ect_at_school_period, :unfinished, teacher:, school:)
         end
 
         it "returns ECT role" do
@@ -49,7 +49,7 @@ RSpec.describe Teachers::Role do
 
       context "when teacher has ongoing mentor period at any school" do
         before do
-          FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:, school:)
+          FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:, school:)
         end
 
         it "returns Mentor role" do
@@ -69,8 +69,8 @@ RSpec.describe Teachers::Role do
 
       context "when teacher has both ECT and mentor roles" do
         before do
-          FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:)
-          FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:, school: other_school)
+          FactoryBot.create(:ect_at_school_period, :unfinished, teacher:, school:)
+          FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:, school: other_school)
         end
 
         it "returns both roles" do
@@ -98,9 +98,9 @@ RSpec.describe Teachers::Role do
 
       context "when teacher has ongoing ECT period at the specified school" do
         before do
-          FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:)
+          FactoryBot.create(:ect_at_school_period, :unfinished, teacher:, school:)
           # Add mentor period at other school to test filtering
-          FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:, school: other_school)
+          FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:, school: other_school)
         end
 
         it "returns ECT role for the specified school only" do
@@ -110,7 +110,7 @@ RSpec.describe Teachers::Role do
 
       context "when teacher has ECT period at other school but not specified school" do
         before do
-          FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school: other_school)
+          FactoryBot.create(:ect_at_school_period, :unfinished, teacher:, school: other_school)
         end
 
         it "returns empty array" do
@@ -132,8 +132,8 @@ RSpec.describe Teachers::Role do
 
       context "when teacher has ongoing mentor period at the specified school" do
         before do
-          FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:, school:)
-          FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:, school: other_school)
+          FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:, school:)
+          FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:, school: other_school)
         end
 
         it "returns Mentor role for the specified school only" do
@@ -143,7 +143,7 @@ RSpec.describe Teachers::Role do
 
       context "when teacher has mentor period at other school but not specified school" do
         before do
-          FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:, school: other_school)
+          FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:, school: other_school)
         end
 
         it "returns empty array" do
@@ -154,7 +154,7 @@ RSpec.describe Teachers::Role do
       context "when teacher has inactive mentor period at the specified school" do
         before do
           FactoryBot.create(:mentor_at_school_period, teacher:, school:, finished_on: 1.month.ago)
-          FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:, school: other_school)
+          FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:, school: other_school)
         end
 
         it "returns Mentor (Inactive) role for the specified school" do
@@ -164,8 +164,8 @@ RSpec.describe Teachers::Role do
 
       context "when teacher has both ECT and mentor roles at the specified school" do
         before do
-          FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:)
-          FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:, school:)
+          FactoryBot.create(:ect_at_school_period, :unfinished, teacher:, school:)
+          FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:, school:)
           # Add periods at other school with different dates to ensure we're filtering correctly
           FactoryBot.create(:ect_at_school_period, teacher:, school: other_school, started_on: 3.years.ago, finished_on: 2.years.ago)
         end
@@ -177,7 +177,7 @@ RSpec.describe Teachers::Role do
 
       context "when teacher has mixed active/inactive roles at the specified school" do
         before do
-          FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:)
+          FactoryBot.create(:ect_at_school_period, :unfinished, teacher:, school:)
           FactoryBot.create(:mentor_at_school_period, teacher:, school:, finished_on: 1.month.ago)
         end
 
@@ -189,8 +189,8 @@ RSpec.describe Teachers::Role do
       context "when teacher has no periods at the specified school" do
         before do
           # Add periods at other schools to ensure we're filtering correctly
-          FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school: other_school)
-          FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:, school: other_school)
+          FactoryBot.create(:ect_at_school_period, :unfinished, teacher:, school: other_school)
+          FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:, school: other_school)
         end
 
         it "returns empty array" do
@@ -214,7 +214,7 @@ RSpec.describe Teachers::Role do
 
       context "with single role" do
         before do
-          FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:)
+          FactoryBot.create(:ect_at_school_period, :unfinished, teacher:, school:)
         end
 
         it "returns the role as string" do
@@ -224,8 +224,8 @@ RSpec.describe Teachers::Role do
 
       context "with multiple roles" do
         before do
-          FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:)
-          FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:, school: other_school)
+          FactoryBot.create(:ect_at_school_period, :unfinished, teacher:, school:)
+          FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:, school: other_school)
         end
 
         it "joins roles with ampersand" do
@@ -245,7 +245,7 @@ RSpec.describe Teachers::Role do
 
       context "with roles at the specified school" do
         before do
-          FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:)
+          FactoryBot.create(:ect_at_school_period, :unfinished, teacher:, school:)
           FactoryBot.create(:mentor_at_school_period, teacher:, school:, finished_on: 1.month.ago)
         end
 
@@ -256,7 +256,7 @@ RSpec.describe Teachers::Role do
 
       context "with no roles at the specified school" do
         before do
-          FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school: other_school)
+          FactoryBot.create(:ect_at_school_period, :unfinished, teacher:, school: other_school)
         end
 
         it "returns empty string" do
@@ -271,8 +271,8 @@ RSpec.describe Teachers::Role do
       let(:role_service) { described_class.new(teacher:) }
 
       before do
-        FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:)
-        FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:, school: other_school)
+        FactoryBot.create(:ect_at_school_period, :unfinished, teacher:, school:)
+        FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:, school: other_school)
       end
 
       it "works as before, checking all schools" do

--- a/spec/services/teachers/search_spec.rb
+++ b/spec/services/teachers/search_spec.rb
@@ -24,8 +24,8 @@ describe Teachers::Search do
     let(:teacher2) { FactoryBot.create(:teacher) }
     let(:teacher3) { FactoryBot.create(:teacher) }
 
-    let!(:induction_period1) { FactoryBot.create(:induction_period, :ongoing, teacher: teacher1, appropriate_body_period: ab1) }
-    let!(:induction_period2) { FactoryBot.create(:induction_period, :ongoing, teacher: teacher2, appropriate_body_period: ab2) }
+    let!(:induction_period1) { FactoryBot.create(:induction_period, :unfinished, teacher: teacher1, appropriate_body_period: ab1) }
+    let!(:induction_period2) { FactoryBot.create(:induction_period, :unfinished, teacher: teacher2, appropriate_body_period: ab2) }
 
     describe "belonging to appropriate bodies" do
       context "when one appropriate body is provided" do
@@ -43,7 +43,7 @@ describe Teachers::Search do
       context "when multiple appropriate bodies are provided" do
         subject { Teachers::Search.new(appropriate_bodies: [ab1, ab3]) }
 
-        let!(:induction_period3) { FactoryBot.create(:induction_period, :ongoing, teacher: teacher3, appropriate_body_period: ab3) }
+        let!(:induction_period3) { FactoryBot.create(:induction_period, :unfinished, teacher: teacher3, appropriate_body_period: ab3) }
 
         it "includes teachers with ongoing induction periods with the specified appropriate bodies" do
           expect(subject.search).to include(teacher1, teacher3)
@@ -76,7 +76,7 @@ describe Teachers::Search do
       let(:teacher_with_completed_induction) { FactoryBot.create(:teacher) }
       let(:teacher_with_no_induction) { FactoryBot.create(:teacher) }
 
-      let!(:open_induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher: teacher_with_open_induction, appropriate_body_period: ab1) }
+      let!(:open_induction_period) { FactoryBot.create(:induction_period, :unfinished, teacher: teacher_with_open_induction, appropriate_body_period: ab1) }
       let!(:completed_induction_period) { FactoryBot.create(:induction_period, :pass, teacher: teacher_with_completed_induction, appropriate_body_period: ab1) }
 
       context 'when status is "open"' do
@@ -237,7 +237,7 @@ describe Teachers::Search do
           end
 
           context "when currently an ECT at the school" do
-            let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school:, teacher:) }
+            let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, school:, teacher:) }
 
             it "returns the teacher" do
               expect(Teachers::Search.new(ect_at_school: school).search).to include(teacher)
@@ -279,16 +279,16 @@ describe Teachers::Search do
         let(:mentored_teacher2) { FactoryBot.create(:teacher) }
 
         # unmentored
-        let!(:ect_at_school_period1) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: teacher1, school: school1, started_on: earlier_start_date) }
-        let!(:ect_at_school_period2) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: teacher2, school: school1, started_on: later_start_date) }
+        let!(:ect_at_school_period1) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher: teacher1, school: school1, started_on: earlier_start_date) }
+        let!(:ect_at_school_period2) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher: teacher2, school: school1, started_on: later_start_date) }
 
         # mentored
-        let!(:mentor_at_school_period1) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: teacher3, school: school1, started_on: earlier_start_date) }
-        let!(:ect_at_school_period3) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: mentored_teacher1, school: school1, started_on: earlier_start_date) }
-        let!(:ect_at_school_period4) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: mentored_teacher2, school: school1, started_on: later_start_date) }
+        let!(:mentor_at_school_period1) { FactoryBot.create(:mentor_at_school_period, :unfinished, teacher: teacher3, school: school1, started_on: earlier_start_date) }
+        let!(:ect_at_school_period3) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher: mentored_teacher1, school: school1, started_on: earlier_start_date) }
+        let!(:ect_at_school_period4) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher: mentored_teacher2, school: school1, started_on: later_start_date) }
 
-        let!(:mentorship_period1) { FactoryBot.create(:mentorship_period, :ongoing, mentee: ect_at_school_period3, mentor: mentor_at_school_period1, started_on: earlier_start_date) }
-        let!(:mentorship_period2) { FactoryBot.create(:mentorship_period, :ongoing, mentee: ect_at_school_period4, mentor: mentor_at_school_period1, started_on: later_start_date) }
+        let!(:mentorship_period1) { FactoryBot.create(:mentorship_period, :unfinished, mentee: ect_at_school_period3, mentor: mentor_at_school_period1, started_on: earlier_start_date) }
+        let!(:mentorship_period2) { FactoryBot.create(:mentorship_period, :unfinished, mentee: ect_at_school_period4, mentor: mentor_at_school_period1, started_on: later_start_date) }
 
         it "orders with unmentored teachers first, then by started_on (newest first)" do
           results = Teachers::Search.new(ect_at_school: school1).search
@@ -298,7 +298,7 @@ describe Teachers::Search do
 
         context "when an ECT only has a past mentorship" do
           let(:previously_mentored_teacher) { FactoryBot.create(:teacher) }
-          let!(:previously_mentored_ect) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: previously_mentored_teacher, school: school1, started_on: later_start_date + 1.day) }
+          let!(:previously_mentored_ect) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher: previously_mentored_teacher, school: school1, started_on: later_start_date + 1.day) }
           let!(:past_mentorship_period) { FactoryBot.create(:mentorship_period, mentee: previously_mentored_ect, mentor: mentor_at_school_period1, started_on: previously_mentored_ect.started_on, finished_on: previously_mentored_ect.started_on + 1.week) }
 
           it "orders them with unmentored ECTs" do
@@ -312,10 +312,10 @@ describe Teachers::Search do
       describe "preloaded current mentorships" do
         let(:school) { FactoryBot.create(:school) }
         let(:teacher) { FactoryBot.create(:teacher) }
-        let(:mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, started_on: 1.year.ago) }
-        let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:, started_on: 1.year.ago) }
+        let(:mentor) { FactoryBot.create(:mentor_at_school_period, :unfinished, school:, started_on: 1.year.ago) }
+        let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher:, school:, started_on: 1.year.ago) }
         let!(:past_mentorship_period) { FactoryBot.create(:mentorship_period, mentee: ect_at_school_period, mentor:, started_on: 1.year.ago, finished_on: 1.month.ago) }
-        let!(:current_mentorship_period) { FactoryBot.create(:mentorship_period, :ongoing, mentee: ect_at_school_period, mentor:, started_on: 1.month.ago + 1.day) }
+        let!(:current_mentorship_period) { FactoryBot.create(:mentorship_period, :unfinished, mentee: ect_at_school_period, mentor:, started_on: 1.month.ago + 1.day) }
 
         it "does not cache current_or_next_mentorship_period as nil" do
           result = Teachers::Search.new(ect_at_school: school).search.find_by!(id: teacher.id)
@@ -366,7 +366,7 @@ describe Teachers::Search do
       let(:future_teacher) { FactoryBot.create(:teacher) }
       let(:past_teacher) { FactoryBot.create(:teacher) }
 
-      let!(:current_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: current_teacher, school:) }
+      let!(:current_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, teacher: current_teacher, school:) }
       let!(:future_period)  { FactoryBot.create(:mentor_at_school_period, teacher: future_teacher, school:, started_on: 1.month.from_now.to_date, finished_on: nil) }
       let!(:past_period)    { FactoryBot.create(:mentor_at_school_period, teacher: past_teacher, school:, started_on: 6.months.ago.to_date, finished_on: 1.month.ago.to_date) }
 

--- a/spec/services/teachers/set_ect_funding_eligibility_spec.rb
+++ b/spec/services/teachers/set_ect_funding_eligibility_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Teachers::SetECTFundingEligibility do
   describe "#set!" do
     context "when teacher is eligible for ECT training" do
       before do
-        FactoryBot.create(:induction_period, :ongoing, teacher:)
-        FactoryBot.create(:ect_at_school_period, :ongoing, teacher:)
+        FactoryBot.create(:induction_period, :unfinished, teacher:)
+        FactoryBot.create(:ect_at_school_period, :unfinished, teacher:)
       end
 
       context "when `ect_first_became_eligible_for_training_at` is not already set" do
@@ -30,7 +30,7 @@ RSpec.describe Teachers::SetECTFundingEligibility do
 
       context "with no-payment and eligible ECT declarations" do
         let(:ect_at_school_period) { teacher.ect_at_school_periods.first }
-        let(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period:) }
+        let(:training_period) { FactoryBot.create(:training_period, :for_ect, :unfinished, ect_at_school_period:) }
         let!(:no_payment_declaration) { FactoryBot.create(:declaration, training_period:, declaration_type: "started") }
         let!(:eligible_declaration) { FactoryBot.create(:declaration, :payable, training_period:, declaration_type: "retained-1") }
 
@@ -48,7 +48,7 @@ RSpec.describe Teachers::SetECTFundingEligibility do
 
     context "when teacher has an ongoing induction but only a future-dated ECT at school period" do
       before do
-        FactoryBot.create(:induction_period, :ongoing, teacher:)
+        FactoryBot.create(:induction_period, :unfinished, teacher:)
         FactoryBot.create(:ect_at_school_period,
                           teacher:,
                           started_on: 1.month.from_now,
@@ -64,7 +64,7 @@ RSpec.describe Teachers::SetECTFundingEligibility do
 
     context "when teacher has an ongoing induction but only a finished ECT at school period" do
       before do
-        FactoryBot.create(:induction_period, :ongoing, teacher:)
+        FactoryBot.create(:induction_period, :unfinished, teacher:)
         FactoryBot.create(:ect_at_school_period,
                           teacher:,
                           started_on: 6.months.ago,
@@ -80,7 +80,7 @@ RSpec.describe Teachers::SetECTFundingEligibility do
 
     context "when teacher has an ongoing induction but no ECT at school periods" do
       before do
-        FactoryBot.create(:induction_period, :ongoing, teacher:)
+        FactoryBot.create(:induction_period, :unfinished, teacher:)
       end
 
       it "does not set `ect_first_became_eligible_for_training_at`" do
@@ -102,10 +102,10 @@ RSpec.describe Teachers::SetECTFundingEligibility do
 
     context "does not touch mentor eligibility" do
       before do
-        FactoryBot.create(:induction_period, :ongoing, teacher:)
-        FactoryBot.create(:ect_at_school_period, :ongoing, teacher:)
-        mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:)
-        FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period:)
+        FactoryBot.create(:induction_period, :unfinished, teacher:)
+        FactoryBot.create(:ect_at_school_period, :unfinished, teacher:)
+        mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:)
+        FactoryBot.create(:training_period, :for_mentor, :unfinished, mentor_at_school_period:)
       end
 
       it "does not set `mentor_first_became_eligible_for_training_at`" do
@@ -116,8 +116,8 @@ RSpec.describe Teachers::SetECTFundingEligibility do
     context "when teacher attributes are changed" do
       it "records a teacher set funding eligibility event" do
         freeze_time do
-          FactoryBot.create(:induction_period, :ongoing, teacher:)
-          FactoryBot.create(:ect_at_school_period, :ongoing, teacher:)
+          FactoryBot.create(:induction_period, :unfinished, teacher:)
+          FactoryBot.create(:ect_at_school_period, :unfinished, teacher:)
 
           expect(Events::Record).to receive(:record_teacher_set_funding_eligibility_event!)
             .with(author:,
@@ -145,8 +145,8 @@ RSpec.describe Teachers::SetECTFundingEligibility do
 
     context "when an error is raised during the eligibility setting" do
       it "rolls back any changes" do
-        FactoryBot.create(:induction_period, :ongoing, teacher:)
-        FactoryBot.create(:ect_at_school_period, :ongoing, teacher:)
+        FactoryBot.create(:induction_period, :unfinished, teacher:)
+        FactoryBot.create(:ect_at_school_period, :unfinished, teacher:)
         original_ect_eligible_at = teacher.ect_first_became_eligible_for_training_at
 
         allow(teacher).to receive(:touch).and_raise(ActiveRecord::RecordInvalid)

--- a/spec/services/teachers/set_mentor_funding_eligibility_spec.rb
+++ b/spec/services/teachers/set_mentor_funding_eligibility_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Teachers::SetMentorFundingEligibility do
 
   describe "#set!" do
     context "when teacher is eligible for mentor training" do
-      let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:) }
-      let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period:) }
+      let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:) }
+      let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, :unfinished, mentor_at_school_period:) }
 
       context "when `mentor_first_became_eligible_for_training_at` is not already set" do
         it "sets `mentor_first_became_eligible_for_training_at`" do
@@ -71,7 +71,7 @@ RSpec.describe Teachers::SetMentorFundingEligibility do
 
       context "when the teacher has a mentor at school period but no training period" do
         before do
-          FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:)
+          FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:)
         end
 
         it "does not set mentor_first_became_eligible_for_training_at" do
@@ -81,8 +81,8 @@ RSpec.describe Teachers::SetMentorFundingEligibility do
 
       context "when the teacher also has an ongoing induction period and an ECT at school period" do
         before do
-          FactoryBot.create(:induction_period, :ongoing, teacher:)
-          FactoryBot.create(:ect_at_school_period, :ongoing, teacher:)
+          FactoryBot.create(:induction_period, :unfinished, teacher:)
+          FactoryBot.create(:ect_at_school_period, :unfinished, teacher:)
         end
 
         it "does not set mentor_first_became_eligible_for_training_at" do
@@ -93,10 +93,10 @@ RSpec.describe Teachers::SetMentorFundingEligibility do
 
     context "does not touch ECT eligibility" do
       before do
-        FactoryBot.create(:induction_period, :ongoing, teacher:)
-        FactoryBot.create(:ect_at_school_period, :ongoing, teacher:)
-        mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:)
-        FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period:)
+        FactoryBot.create(:induction_period, :unfinished, teacher:)
+        FactoryBot.create(:ect_at_school_period, :unfinished, teacher:)
+        mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:)
+        FactoryBot.create(:training_period, :for_mentor, :unfinished, mentor_at_school_period:)
       end
 
       it "does not set `ect_first_became_eligible_for_training_at`" do
@@ -107,8 +107,8 @@ RSpec.describe Teachers::SetMentorFundingEligibility do
     context "when teacher attributes are changed" do
       it "records a teacher set funding eligibility event" do
         freeze_time do
-          mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:)
-          FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period:)
+          mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:)
+          FactoryBot.create(:training_period, :for_mentor, :unfinished, mentor_at_school_period:)
 
           expect(Events::Record).to receive(:record_teacher_set_funding_eligibility_event!)
             .with(author:,
@@ -136,8 +136,8 @@ RSpec.describe Teachers::SetMentorFundingEligibility do
 
     context "when an error is raised during the eligibility setting" do
       it "rolls back any changes" do
-        mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:)
-        FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period:)
+        mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:)
+        FactoryBot.create(:training_period, :for_mentor, :unfinished, mentor_at_school_period:)
         original_mentor_eligible_at = teacher.mentor_first_became_eligible_for_training_at
 
         allow(teacher).to receive(:touch).and_raise(ActiveRecord::RecordInvalid)

--- a/spec/services/teachers/undo_registration_spec.rb
+++ b/spec/services/teachers/undo_registration_spec.rb
@@ -30,10 +30,10 @@ RSpec.describe Teachers::UndoRegistration do
     end
 
     context "when the participant has billable declarations" do
-      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished) }
       let(:at_school_period) { ect_at_school_period }
-      let!(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period:) }
-      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, started_on: ect_at_school_period.started_on, school: ect_at_school_period.school) }
+      let!(:training_period) { FactoryBot.create(:training_period, :for_ect, :unfinished, ect_at_school_period:) }
+      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, started_on: ect_at_school_period.started_on, school: ect_at_school_period.school) }
       let!(:mentorship_period) { FactoryBot.create(:mentorship_period, mentee: ect_at_school_period, mentor: mentor_at_school_period, started_on: ect_at_school_period.started_on, finished_on: nil) }
 
       context "with an eligible declaration" do
@@ -105,7 +105,7 @@ RSpec.describe Teachers::UndoRegistration do
           FactoryBot.create(
             :training_period,
             :for_ect,
-            :ongoing,
+            :unfinished,
             ect_at_school_period:,
             started_on: 6.months.ago.to_date
           )
@@ -134,10 +134,10 @@ RSpec.describe Teachers::UndoRegistration do
     end
 
     context "when the participant has refundable declarations" do
-      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished) }
       let(:at_school_period) { ect_at_school_period }
-      let!(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period:) }
-      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, started_on: ect_at_school_period.started_on, school: ect_at_school_period.school) }
+      let!(:training_period) { FactoryBot.create(:training_period, :for_ect, :unfinished, ect_at_school_period:) }
+      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, started_on: ect_at_school_period.started_on, school: ect_at_school_period.school) }
       let!(:mentorship_period) { FactoryBot.create(:mentorship_period, mentee: ect_at_school_period, mentor: mentor_at_school_period, started_on: ect_at_school_period.started_on, finished_on: nil) }
 
       context "with an awaiting_clawback declaration" do
@@ -170,10 +170,10 @@ RSpec.describe Teachers::UndoRegistration do
     end
 
     context "when the participant has no billable or refundable declarations" do
-      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished) }
       let(:at_school_period) { ect_at_school_period }
-      let!(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period:) }
-      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, started_on: ect_at_school_period.started_on, school: ect_at_school_period.school) }
+      let!(:training_period) { FactoryBot.create(:training_period, :for_ect, :unfinished, ect_at_school_period:) }
+      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, started_on: ect_at_school_period.started_on, school: ect_at_school_period.school) }
       let!(:mentorship_period) { FactoryBot.create(:mentorship_period, mentee: ect_at_school_period, mentor: mentor_at_school_period, started_on: ect_at_school_period.started_on, finished_on: nil) }
 
       context "with no declarations" do
@@ -225,7 +225,7 @@ RSpec.describe Teachers::UndoRegistration do
 
       context "when the teacher has another mentor registration" do
         let!(:other_mentor_at_school_period) do
-          FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: ect_at_school_period.teacher)
+          FactoryBot.create(:mentor_at_school_period, :unfinished, teacher: ect_at_school_period.teacher)
         end
 
         it "deletes only the targeted ECT registration" do
@@ -295,9 +295,9 @@ RSpec.describe Teachers::UndoRegistration do
     end
 
     context "when undoing a mentor registration" do
-      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing) }
+      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished) }
       let(:at_school_period) { mentor_at_school_period }
-      let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period:) }
+      let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, :unfinished, mentor_at_school_period:) }
 
       context "with no declarations" do
         it "only undoes the targeted registration" do
@@ -330,7 +330,7 @@ RSpec.describe Teachers::UndoRegistration do
 
       context "when the teacher has another ECT registration" do
         let!(:other_ect_at_school_period) do
-          FactoryBot.create(:ect_at_school_period, :ongoing, teacher: mentor_at_school_period.teacher)
+          FactoryBot.create(:ect_at_school_period, :unfinished, teacher: mentor_at_school_period.teacher)
         end
 
         it "deletes only the targeted mentor registration" do
@@ -401,8 +401,8 @@ RSpec.describe Teachers::UndoRegistration do
       let(:teacher) { FactoryBot.create(:teacher) }
       let(:legitimate_period) { FactoryBot.create(:ect_at_school_period, :finished, teacher:) }
       let!(:legitimate_training_period) { FactoryBot.create(:training_period, :for_ect, :finished, ect_at_school_period: legitimate_period) }
-      let(:erroneous_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, started_on: legitimate_period.finished_on + 1.day) }
-      let!(:erroneous_training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: erroneous_period) }
+      let(:erroneous_period) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher:, started_on: legitimate_period.finished_on + 1.day) }
+      let!(:erroneous_training_period) { FactoryBot.create(:training_period, :for_ect, :unfinished, ect_at_school_period: erroneous_period) }
       let(:at_school_period) { erroneous_period }
 
       it "only undoes the targeted registration" do
@@ -415,9 +415,9 @@ RSpec.describe Teachers::UndoRegistration do
     end
 
     context "when an error occurs during undoing the registration" do
-      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished) }
       let(:at_school_period) { ect_at_school_period }
-      let!(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period:) }
+      let!(:training_period) { FactoryBot.create(:training_period, :for_ect, :unfinished, ect_at_school_period:) }
 
       it "rolls back all changes" do
         allow(Events::Record).to receive(:record_undo_registration_event!).and_raise(StandardError)

--- a/spec/services/teachers/withdraw_spec.rb
+++ b/spec/services/teachers/withdraw_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Teachers::Withdraw do
         let(:teacher_type) { trainee_type }
 
         context "when training period is ongoing" do
-          let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
+          let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :unfinished, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
 
           it "withdraws training period" do
             freeze_time
@@ -40,7 +40,7 @@ RSpec.describe Teachers::Withdraw do
             FactoryBot.create(
               :training_period,
               :"for_#{trainee_type}",
-              :ongoing,
+              :unfinished,
               "#{trainee_type}_at_school_period": at_school_period,
               started_on: at_school_period.started_on,
               finished_on: 1.month.ago
@@ -64,7 +64,7 @@ RSpec.describe Teachers::Withdraw do
             FactoryBot.create(
               :training_period,
               :"for_#{trainee_type}",
-              :ongoing,
+              :unfinished,
               "#{trainee_type}_at_school_period": at_school_period,
               started_on: at_school_period.started_on,
               finished_on: 3.months.from_now
@@ -84,7 +84,7 @@ RSpec.describe Teachers::Withdraw do
         end
 
         context "event recording" do
-          let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
+          let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :unfinished, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
 
           it "records a teacher withdraws training period event" do
             freeze_time do

--- a/spec/services/training_periods/finish_spec.rb
+++ b/spec/services/training_periods/finish_spec.rb
@@ -7,8 +7,8 @@ describe "TrainingPeriods::Finish" do
     subject { TrainingPeriods::Finish.ect_training(training_period:, finished_on:, author:, ect_at_school_period:) }
 
     let(:author) { FactoryBot.build(:school_user, school_urn: ect_at_school_period.school.urn) }
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing) }
-    let(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period:) }
+    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished) }
+    let(:training_period) { FactoryBot.create(:training_period, :for_ect, :unfinished, ect_at_school_period:) }
 
     it "assigns the training_period" do
       expect(subject.training_period).to eql(training_period)
@@ -35,8 +35,8 @@ describe "TrainingPeriods::Finish" do
     subject { TrainingPeriods::Finish.mentor_training(training_period:, finished_on:, author:, mentor_at_school_period:) }
 
     let(:author) { FactoryBot.build(:school_user, school_urn: mentor_at_school_period.school.urn) }
-    let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing) }
-    let(:training_period) { FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period:) }
+    let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished) }
+    let(:training_period) { FactoryBot.create(:training_period, :for_mentor, :unfinished, mentor_at_school_period:) }
 
     it "assigns the training_period" do
       expect(subject.training_period).to eql(training_period)

--- a/spec/support/features/changes_before_reported_leaving_date_helpers.rb
+++ b/spec/support/features/changes_before_reported_leaving_date_helpers.rb
@@ -32,7 +32,7 @@ private
     @teacher = FactoryBot.create(:teacher, corrected_name: "Mr Teacher")
     @ect_at_school_period = FactoryBot.create(
       :ect_at_school_period,
-      :ongoing,
+      :unfinished,
       school: @school,
       teacher: @teacher,
       started_on: 2.months.ago

--- a/spec/support/shared_contexts/csv_file.rb
+++ b/spec/support/shared_contexts/csv_file.rb
@@ -16,7 +16,7 @@ RSpec.shared_context "1 valid and 1 invalid claim" do
 
   before do
     already_claimed_teacher = FactoryBot.create(:teacher, trn: "1234567")
-    FactoryBot.create(:induction_period, :ongoing, teacher: already_claimed_teacher)
+    FactoryBot.create(:induction_period, :unfinished, teacher: already_claimed_teacher)
   end
 end
 
@@ -33,7 +33,7 @@ RSpec.shared_context "2 valid actions" do
   before do
     data.map do |row|
       teacher = FactoryBot.create(:teacher, trn: row[:trn])
-      FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:, started_on: "2024-12-01")
+      FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:, started_on: "2024-12-01")
     end
   end
 end
@@ -51,9 +51,9 @@ RSpec.shared_context "1 valid and 2 invalid actions" do
 
   before do
     valid_teacher = FactoryBot.create(:teacher, trn: "1234567")
-    FactoryBot.create(:induction_period, :ongoing, teacher: valid_teacher, appropriate_body_period:, started_on: "2024-12-01")
+    FactoryBot.create(:induction_period, :unfinished, teacher: valid_teacher, appropriate_body_period:, started_on: "2024-12-01")
     teacher_at_another_body = FactoryBot.create(:teacher, trn: "7654321")
-    FactoryBot.create(:induction_period, :ongoing, teacher: teacher_at_another_body, started_on: "2024-12-01")
+    FactoryBot.create(:induction_period, :unfinished, teacher: teacher_at_another_body, started_on: "2024-12-01")
     FactoryBot.create(:teacher, trn: "0000007")
   end
 end

--- a/spec/support/shared_examples/api_teacher_shared_action_support.rb
+++ b/spec/support/shared_examples/api_teacher_shared_action_support.rb
@@ -9,8 +9,8 @@ RSpec.shared_examples "an API teacher shared action", :with_metadata do
 
     API::Concerns::Teachers::SharedAction::TEACHER_TYPES.each do |trainee_type|
       context "for #{trainee_type}" do
-        let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :ongoing, started_on: 2.months.ago) }
-        let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
+        let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :unfinished, started_on: 2.months.ago) }
+        let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :unfinished, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
         let(:teacher_type) { trainee_type }
 
         it { is_expected.to validate_presence_of(:lead_provider_id).with_message("Enter a '#/lead_provider_id'.") }

--- a/spec/support/shared_examples/close_induction.rb
+++ b/spec/support/shared_examples/close_induction.rb
@@ -19,7 +19,7 @@ RSpec.shared_context "it closes an induction" do
   end
 
   let!(:induction_period) do
-    FactoryBot.create(:induction_period, :ongoing,
+    FactoryBot.create(:induction_period, :unfinished,
                       appropriate_body_period:,
                       teacher:)
   end

--- a/spec/support/shared_examples/transfer_induction.rb
+++ b/spec/support/shared_examples/transfer_induction.rb
@@ -36,7 +36,7 @@ RSpec.shared_context "it transfers an induction" do
                       teacher: partial_completed_induction.teacher,
                       heading: "partial_completed_induction: #{current_appropriate_body.name}")
 
-    partial_in_progress_induction = FactoryBot.create(:induction_period, :ongoing,
+    partial_in_progress_induction = FactoryBot.create(:induction_period, :unfinished,
                                                       appropriate_body_period: current_appropriate_body,
                                                       started_on: 10.months.before(cut_off_date))
 
@@ -60,7 +60,7 @@ RSpec.shared_context "it transfers an induction" do
                       teacher: full_completed_induction.teacher,
                       heading: "full_completed_induction: #{current_appropriate_body.name}")
 
-    full_in_progress_induction = FactoryBot.create(:induction_period, :ongoing,
+    full_in_progress_induction = FactoryBot.create(:induction_period, :unfinished,
                                                    appropriate_body_period: current_appropriate_body,
                                                    started_on: 1.week.after(cut_off_date))
 

--- a/spec/views/admin/induction_period/edit.html.erb_spec.rb
+++ b/spec/views/admin/induction_period/edit.html.erb_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "admin/induction_periods/edit.html.erb" do
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+  let(:ect) { FactoryBot.create(:ect_at_school_period, :unfinished) }
   let(:back_path) { admin_teacher_induction_path(ect.teacher) }
   let(:induction_period) { FactoryBot.create(:induction_period, teacher: ect.teacher) }
 

--- a/spec/views/admin/induction_period/new.html.erb_spec.rb
+++ b/spec/views/admin/induction_period/new.html.erb_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "admin/induction_periods/new.html.erb" do
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+  let(:ect) { FactoryBot.create(:ect_at_school_period, :unfinished) }
   let(:back_path) { admin_teacher_induction_path(ect.teacher) }
   let(:induction_period) { FactoryBot.build(:induction_period, teacher: ect.teacher) }
 

--- a/spec/views/admin/schools/teachers/show.html.erb_spec.rb
+++ b/spec/views/admin/schools/teachers/show.html.erb_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe "admin/schools/teachers/show.html.erb", type: :view do
     ])
     allow(view).to receive_messages(params: { urn: school.urn }, request: double(fullpath: "/admin/schools/#{school.urn}/teachers"))
 
-    FactoryBot.create(:ect_at_school_period, :ongoing, teacher: ect_teacher, school:)
-    FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: mentor_teacher, school:)
+    FactoryBot.create(:ect_at_school_period, :unfinished, teacher: ect_teacher, school:)
+    FactoryBot.create(:mentor_at_school_period, :unfinished, teacher: mentor_teacher, school:)
   end
 
   it "sets up breadcrumbs in page data" do

--- a/spec/views/admin/teachers/inductions/show.html.erb_spec.rb
+++ b/spec/views/admin/teachers/inductions/show.html.erb_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "admin/teachers/inductions/show.html.erb" do
   end
 
   let!(:induction_period) do
-    FactoryBot.create(:induction_period, :ongoing, teacher:)
+    FactoryBot.create(:induction_period, :unfinished, teacher:)
   end
 
   before do
@@ -78,7 +78,7 @@ RSpec.describe "admin/teachers/inductions/show.html.erb" do
 
   context "when the latest induction period is not complete" do
     let!(:induction_period) do
-      FactoryBot.create(:induction_period, :ongoing, teacher:)
+      FactoryBot.create(:induction_period, :unfinished, teacher:)
     end
 
     it "does not display a link to reopen induction" do

--- a/spec/views/appropriate_bodies/claim_an_ect/check_ect/edit.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/claim_an_ect/check_ect/edit.html.erb_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "appropriate_bodies/claim_an_ect/check_ect/edit.html.erb" do
     end
 
     context "when the ECT has an ongoing induction period with another appropriate body" do
-      let!(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:) }
+      let!(:induction_period) { FactoryBot.create(:induction_period, :unfinished, teacher:) }
 
       before { assign(:current_appropriate_body, appropriate_body_period) }
 
@@ -62,7 +62,7 @@ RSpec.describe "appropriate_bodies/claim_an_ect/check_ect/edit.html.erb" do
 
   describe "induction periods" do
     context "when the ECT has past induction periods" do
-      let!(:current_induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:) }
+      let!(:current_induction_period) { FactoryBot.create(:induction_period, :unfinished, teacher:) }
 
       it "shows the current induction period" do
         render

--- a/spec/views/appropriate_bodies/induction_period/edit.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/induction_period/edit.html.erb_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "appropriate_bodies/induction_periods/edit.html.erb" do
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+  let(:ect) { FactoryBot.create(:ect_at_school_period, :unfinished) }
   let(:back_path) { ab_teacher_path(ect.teacher) }
   let(:induction_period) { FactoryBot.create(:induction_period, teacher: ect.teacher) }
 

--- a/spec/views/appropriate_bodies/teachers/record_failed_induction/confirm.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/teachers/record_failed_induction/confirm.html.erb_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "appropriate_bodies/teachers/record_failed_induction/confirm.html
   end
 
   before do
-    FactoryBot.create(:induction_period, :ongoing,
+    FactoryBot.create(:induction_period, :unfinished,
                       appropriate_body_period:,
                       teacher:)
 

--- a/spec/views/appropriate_bodies/teachers/record_failed_induction/new.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/teachers/record_failed_induction/new.html.erb_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "appropriate_bodies/teachers/record_failed_induction/new.html.erb
   end
 
   before do
-    FactoryBot.create(:induction_period, :ongoing,
+    FactoryBot.create(:induction_period, :unfinished,
                       appropriate_body_period:,
                       teacher:)
 

--- a/spec/views/appropriate_bodies/teachers/record_passed_induction/new.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/teachers/record_passed_induction/new.html.erb_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "appropriate_bodies/teachers/record_passed_induction/new.html.erb
   end
 
   before do
-    FactoryBot.create(:induction_period, :ongoing,
+    FactoryBot.create(:induction_period, :unfinished,
                       appropriate_body_period:,
                       teacher:)
 

--- a/spec/views/appropriate_bodies/teachers/record_released_induction/new.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/teachers/record_released_induction/new.html.erb_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "appropriate_bodies/teachers/record_released_induction/new.html.e
   end
 
   before do
-    FactoryBot.create(:induction_period, :ongoing,
+    FactoryBot.create(:induction_period, :unfinished,
                       appropriate_body_period:,
                       teacher:)
 

--- a/spec/views/schools/ects/index.html.erb_spec.rb
+++ b/spec/views/schools/ects/index.html.erb_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe "schools/ects/index.html.erb" do
 
   context "when there are teachers" do
     let(:teacher) { FactoryBot.create(:teacher, trs_first_name: "Johnnie", trs_last_name: "Walker") }
-    let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:) }
-    let!(:training_period) { FactoryBot.create(:training_period, :ongoing, ect_at_school_period:) }
+    let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher:, school:) }
+    let!(:training_period) { FactoryBot.create(:training_period, :unfinished, ect_at_school_period:) }
 
     before do
       assign(:teachers, [teacher])

--- a/spec/views/schools/ects/show.html.erb_spec.rb
+++ b/spec/views/schools/ects/show.html.erb_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "schools/ects/show.html.erb" do
                                                       school: current_school,
                                                       teacher: mentor)
 
-          FactoryBot.create(:mentorship_period, :ongoing,
+          FactoryBot.create(:mentorship_period, :unfinished,
                             started_on: current_ect_period.started_on,
                             mentee: current_ect_period,
                             mentor: mentor_at_school_period)
@@ -114,7 +114,7 @@ RSpec.describe "schools/ects/show.html.erb" do
 
   describe "Induction details" do
     before do
-      FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:)
+      FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:)
       teacher.reload # Reload to pick up the new induction period
     end
 

--- a/spec/views/schools/mentorships/new.html.erb_spec.rb
+++ b/spec/views/schools/mentorships/new.html.erb_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "schools/mentorships/new.html.erb" do
-  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished) }
   let(:ect_name) { Teachers::Name.new(ect_at_school_period.teacher).full_name }
   let(:mentor) { double("mentor_at_school_period", full_name: "Peter Times", id: 7) }
   let(:mentor_id) { mentor.id }

--- a/spec/views/schools/register_mentor_wizard/check_answers.html.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/check_answers.html.erb_spec.rb
@@ -9,11 +9,11 @@ RSpec.describe "schools/register_mentor_wizard/check_answers.html.erb" do
   end
 
   let(:ect) do
-    FactoryBot.create(:ect_at_school_period, :ongoing, teacher:)
+    FactoryBot.create(:ect_at_school_period, :unfinished, teacher:)
   end
 
   let!(:training_period) do
-    FactoryBot.create(:training_period, :ongoing, ect_at_school_period: ect, school_partnership:)
+    FactoryBot.create(:training_period, :unfinished, ect_at_school_period: ect, school_partnership:)
   end
 
   let(:store) do
@@ -84,11 +84,11 @@ RSpec.describe "schools/register_mentor_wizard/check_answers.html.erb" do
   describe "summary" do
     context "with school led ect" do
       let(:ect) do
-        FactoryBot.create(:ect_at_school_period, :ongoing, teacher:)
+        FactoryBot.create(:ect_at_school_period, :unfinished, teacher:)
       end
 
       let!(:training_period) do
-        FactoryBot.create(:training_period, :ongoing, ect_at_school_period: ect)
+        FactoryBot.create(:training_period, :unfinished, ect_at_school_period: ect)
       end
 
       it "hides lead provider" do

--- a/spec/views/schools/register_mentor_wizard/confirmation.md.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/confirmation.md.erb_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "schools/register_mentor_wizard/confirmation.md.erb" do
 
   let(:teacher) { FactoryBot.create(:teacher, trn: "1234568") }
 
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school: school_partnership.school) }
+  let(:ect) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher:, school: school_partnership.school) }
 
   let(:store) do
     FactoryBot.build(:session_repository,
@@ -67,7 +67,7 @@ RSpec.describe "schools/register_mentor_wizard/confirmation.md.erb" do
   describe "mentor funding" do
     context "when eligible" do
       context "when the ect is provider_led" do
-        let!(:training_period) { FactoryBot.create(:training_period, :provider_led, :ongoing, ect_at_school_period: ect, school_partnership:) }
+        let!(:training_period) { FactoryBot.create(:training_period, :provider_led, :unfinished, ect_at_school_period: ect, school_partnership:) }
 
         it do
           assign(:wizard, wizard)
@@ -131,7 +131,7 @@ RSpec.describe "schools/register_mentor_wizard/confirmation.md.erb" do
 
   context "when the mentor is already active at the school" do
     let(:already_active_at_school) { true }
-    let!(:training_period) { FactoryBot.create(:training_period, :provider_led, :ongoing, ect_at_school_period: ect, school_partnership:) }
+    let!(:training_period) { FactoryBot.create(:training_period, :provider_led, :unfinished, ect_at_school_period: ect, school_partnership:) }
 
     before do
       assign(:wizard, wizard)
@@ -153,7 +153,7 @@ RSpec.describe "schools/register_mentor_wizard/confirmation.md.erb" do
 
   context "when the mentor is not active at the school" do
     let(:already_active_at_school) { false }
-    let!(:training_period) { FactoryBot.create(:training_period, :provider_led, :ongoing, ect_at_school_period: ect, school_partnership:) }
+    let!(:training_period) { FactoryBot.create(:training_period, :provider_led, :unfinished, ect_at_school_period: ect, school_partnership:) }
 
     before do
       assign(:wizard, wizard)
@@ -175,7 +175,7 @@ RSpec.describe "schools/register_mentor_wizard/confirmation.md.erb" do
 
   context "when the mentor is continuing to mentor at another school" do
     let(:mentoring_at_new_school_only) { "no" }
-    let!(:training_period) { FactoryBot.create(:training_period, :provider_led, :ongoing, ect_at_school_period: ect, school_partnership:) }
+    let!(:training_period) { FactoryBot.create(:training_period, :provider_led, :unfinished, ect_at_school_period: ect, school_partnership:) }
 
     before do
       assign(:wizard, wizard)
@@ -196,7 +196,7 @@ RSpec.describe "schools/register_mentor_wizard/confirmation.md.erb" do
 
   context "when the mentor is mentoring at the new school only" do
     let(:mentoring_at_new_school_only) { "yes" }
-    let!(:training_period) { FactoryBot.create(:training_period, :provider_led, :ongoing, ect_at_school_period: ect, school_partnership:) }
+    let!(:training_period) { FactoryBot.create(:training_period, :provider_led, :unfinished, ect_at_school_period: ect, school_partnership:) }
 
     it "mentions passing on details to the lead provider for mentor training" do
       assign(:wizard, wizard)

--- a/spec/views/schools/register_mentor_wizard/find_mentor.html.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/find_mentor.html.erb_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "schools/register_mentor_wizard/find_mentor.html.erb" do
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+  let(:ect) { FactoryBot.create(:ect_at_school_period, :unfinished) }
   let(:back_path) { schools_register_mentor_wizard_start_path(ect_id: ect.id) }
   let(:continue_path) { schools_register_mentor_wizard_find_mentor_path }
   let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :find_mentor, ect_id: ect.id) }

--- a/spec/views/schools/register_mentor_wizard/previous_training_period_details.html.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/previous_training_period_details.html.erb_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "schools/register_mentor_wizard/previous_training_period_details.
   let(:current_school) { FactoryBot.create(:school) }
   let(:mentor_teacher) { FactoryBot.create(:teacher) }
 
-  let(:ect_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school: current_school) }
+  let(:ect_period) { FactoryBot.create(:ect_at_school_period, :unfinished, school: current_school) }
 
   let(:wizard_store) do
     FactoryBot.build(
@@ -108,7 +108,7 @@ RSpec.describe "schools/register_mentor_wizard/previous_training_period_details.
     let!(:mentor_period) do
       FactoryBot.create(
         :mentor_at_school_period,
-        :ongoing,
+        :unfinished,
         teacher: mentor_teacher,
         school: previous_school
       )
@@ -122,7 +122,7 @@ RSpec.describe "schools/register_mentor_wizard/previous_training_period_details.
         :training_period,
         :for_mentor,
         :provider_led,
-        :ongoing,
+        :unfinished,
         mentor_at_school_period: mentor_period,
         school_partnership: nil,
         expression_of_interest:

--- a/spec/views/schools/register_mentor_wizard/programme_choices.html.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/programme_choices.html.erb_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe "schools/register_mentor_wizard/programme_choices.html.erb" do
     make_partnership_for(school, contract_period, lead_provider_name: "Naruto Ninja Academy", delivery_partner_name: "Shinobi Training Co")
   end
 
-  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:) }
+  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher:, school:) }
 
   let!(:training_period) do
     FactoryBot.create(:training_period,
                       :provider_led,
-                      :ongoing,
+                      :unfinished,
                       ect_at_school_period:,
                       school_partnership:)
   end

--- a/spec/views/schools/register_mentor_wizard/start.html.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/start.html.erb_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "schools/register_mentor_wizard/start.html.erb" do
   let(:continue_path) { schools_register_mentor_wizard_find_mentor_path }
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+  let(:ect) { FactoryBot.create(:ect_at_school_period, :unfinished) }
   let(:ect_name) { Teachers::Name.new(ect.teacher).full_name }
 
   before do
@@ -29,7 +29,7 @@ RSpec.describe "schools/register_mentor_wizard/start.html.erb" do
       let(:back_path) { new_schools_ect_mentorship_path(ect) }
 
       before do
-        FactoryBot.create(:mentor_at_school_period, :ongoing, school: ect.school)
+        FactoryBot.create(:mentor_at_school_period, :unfinished, school: ect.school)
         render
       end
 
@@ -46,9 +46,9 @@ RSpec.describe "schools/register_mentor_wizard/start.html.erb" do
   end
 
   context "when the ect has chosen a provider led training programme" do
-    let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+    let(:ect) { FactoryBot.create(:ect_at_school_period, :unfinished) }
 
-    before { FactoryBot.create(:training_period, :ongoing, :provider_led, ect_at_school_period: ect) }
+    before { FactoryBot.create(:training_period, :unfinished, :provider_led, ect_at_school_period: ect) }
 
     it "informs the user about the mentor training programme requirements" do
       render
@@ -58,9 +58,9 @@ RSpec.describe "schools/register_mentor_wizard/start.html.erb" do
   end
 
   context "when the ect has chosen a school led training programme" do
-    let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+    let(:ect) { FactoryBot.create(:ect_at_school_period, :unfinished) }
 
-    before { FactoryBot.create(:training_period, :ongoing, :school_led, ect_at_school_period: ect) }
+    before { FactoryBot.create(:training_period, :unfinished, :school_led, ect_at_school_period: ect) }
 
     it "does not inform the user about the mentor training programme requirements" do
       render

--- a/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard_spec.rb
+++ b/spec/wizards/admin/teachers/training_periods/change_contract_period_wizard/wizard_spec.rb
@@ -28,12 +28,12 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Wiz
       delivery_partner:
     )
   end
-  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:) }
+  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher:, school:) }
   let(:schedule) { FactoryBot.create(:schedule, contract_period: current_contract_period) }
   let(:training_period) do
     FactoryBot.create(
       :training_period,
-      :ongoing,
+      :unfinished,
       ect_at_school_period:,
       school_partnership:,
       schedule:
@@ -97,7 +97,7 @@ RSpec.describe Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Wiz
       let(:training_period) do
         FactoryBot.create(
           :training_period,
-          :ongoing,
+          :unfinished,
           :with_only_expression_of_interest,
           ect_at_school_period:,
           expression_of_interest: active_lead_provider,

--- a/spec/wizards/schools/assign_existing_mentor_wizard/lead_provider_step_spec.rb
+++ b/spec/wizards/schools/assign_existing_mentor_wizard/lead_provider_step_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Schools::AssignExistingMentorWizard::LeadProviderStep do
   let(:lead_provider_id) { lead_provider.id }
   let(:school) { FactoryBot.create(:school) }
   let(:started_on) { mid_year - 2.days }
-  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school:, started_on:) }
-  let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, started_on:) }
+  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, school:, started_on:) }
+  let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, school:, started_on:) }
   let(:user) { FactoryBot.create(:user) }
   let(:author) { Sessions::Users::DfEPersona.new(email: user.email) }
 
@@ -109,7 +109,7 @@ RSpec.describe Schools::AssignExistingMentorWizard::LeadProviderStep do
     context "when the mentee has previously started training with another mentor" do
       let(:previous_mentor) { FactoryBot.create(:mentor_at_school_period, school:, started_on:, finished_on: started_on + 2.months) }
       let(:previous_mentor_training_period) { FactoryBot.create(:training_period, :provider_led, :for_mentor, started_on:, finished_on: started_on + 2.months, mentor_at_school_period: previous_mentor) }
-      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, started_on: Date.current) }
+      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, school:, started_on: Date.current) }
 
       before do
         FactoryBot.create(:schedule, contract_period:, identifier: "ecf-replacement-january")
@@ -117,7 +117,7 @@ RSpec.describe Schools::AssignExistingMentorWizard::LeadProviderStep do
         FactoryBot.create(:schedule, contract_period:, identifier: "ecf-replacement-september")
 
         FactoryBot.create(:training_period,
-                          :ongoing,
+                          :unfinished,
                           :provider_led,
                           :with_no_school_partnership,
                           ect_at_school_period:,

--- a/spec/wizards/schools/assign_existing_mentor_wizard/review_mentor_eligibility_step_spec.rb
+++ b/spec/wizards/schools/assign_existing_mentor_wizard/review_mentor_eligibility_step_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Schools::AssignExistingMentorWizard::ReviewMentorEligibilityStep 
   let(:lead_provider) { FactoryBot.create(:lead_provider) }
   let(:school) { FactoryBot.create(:school) }
   let(:started_on) { mid_year - 2.days }
-  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school:, started_on:) }
-  let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, started_on:) }
+  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, school:, started_on:) }
+  let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, school:, started_on:) }
   let(:user) { FactoryBot.create(:user) }
   let(:author) { Sessions::Users::DfEPersona.new(email: user.email) }
 
@@ -59,7 +59,7 @@ RSpec.describe Schools::AssignExistingMentorWizard::ReviewMentorEligibilityStep 
         school:,
         lead_provider_delivery_partnership: FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:)
       )
-      FactoryBot.create(:training_period, :ongoing, :provider_led,
+      FactoryBot.create(:training_period, :unfinished, :provider_led,
                         ect_at_school_period:,
                         started_on:,
                         school_partnership:)

--- a/spec/wizards/schools/ects/change_lead_provider_wizard/check_answers_step_spec.rb
+++ b/spec/wizards/schools/ects/change_lead_provider_wizard/check_answers_step_spec.rb
@@ -17,7 +17,7 @@ describe Schools::ECTs::ChangeLeadProviderWizard::CheckAnswersStep do
   let(:ect_at_school_period) do
     FactoryBot.create(
       :ect_at_school_period,
-      :ongoing,
+      :unfinished,
       school:,
       started_on: contract_period.started_on
     )
@@ -41,7 +41,7 @@ describe Schools::ECTs::ChangeLeadProviderWizard::CheckAnswersStep do
   let!(:training_period) do
     FactoryBot.create(
       :training_period,
-      :ongoing,
+      :unfinished,
       :provider_led,
       :with_only_expression_of_interest,
       ect_at_school_period:,
@@ -82,7 +82,7 @@ describe Schools::ECTs::ChangeLeadProviderWizard::CheckAnswersStep do
       let!(:training_period) do
         FactoryBot.create(
           :training_period,
-          :ongoing,
+          :unfinished,
           :provider_led,
           :withdrawn,
           :with_only_expression_of_interest,
@@ -121,7 +121,7 @@ describe Schools::ECTs::ChangeLeadProviderWizard::CheckAnswersStep do
       let!(:training_period) do
         training_period = FactoryBot.create(
           :training_period,
-          :ongoing,
+          :unfinished,
           :provider_led,
           :with_only_expression_of_interest,
           ect_at_school_period:,
@@ -158,7 +158,7 @@ describe Schools::ECTs::ChangeLeadProviderWizard::CheckAnswersStep do
       let!(:training_period) do
         training_period = FactoryBot.create(
           :training_period,
-          :ongoing,
+          :unfinished,
           :school_led,
           ect_at_school_period:,
           started_on: ect_at_school_period.started_on

--- a/spec/wizards/schools/ects/change_lead_provider_wizard/confirmation_step_spec.rb
+++ b/spec/wizards/schools/ects/change_lead_provider_wizard/confirmation_step_spec.rb
@@ -14,7 +14,7 @@ describe Schools::ECTs::ChangeLeadProviderWizard::ConfirmationStep, type: :model
   let(:author) { FactoryBot.build(:school_user, school_urn: school.urn) }
   let(:school) { FactoryBot.create(:school) }
   let(:ect_at_school_period) do
-    FactoryBot.create(:ect_at_school_period, :ongoing, school:)
+    FactoryBot.create(:ect_at_school_period, :unfinished, school:)
   end
   let(:params) { {} }
 

--- a/spec/wizards/schools/ects/change_lead_provider_wizard/edit_step_spec.rb
+++ b/spec/wizards/schools/ects/change_lead_provider_wizard/edit_step_spec.rb
@@ -102,7 +102,7 @@ describe Schools::ECTs::ChangeLeadProviderWizard::EditStep do
       FactoryBot.create(:contract_period, :current)
     end
     let(:ect_at_school_period) do
-      FactoryBot.create(:ect_at_school_period, :ongoing, school:, started_on:)
+      FactoryBot.create(:ect_at_school_period, :unfinished, school:, started_on:)
     end
     let!(:current_lead_provider) do
       FactoryBot.create(:active_lead_provider, contract_period: current_contract_period)
@@ -111,7 +111,7 @@ describe Schools::ECTs::ChangeLeadProviderWizard::EditStep do
       FactoryBot.create(
         :training_period,
         :for_ect,
-        :ongoing,
+        :unfinished,
         :with_active_lead_provider,
         ect_at_school_period:,
         started_on: training_period_started_on,

--- a/spec/wizards/schools/ects/change_mentor_wizard/check_answers_step_spec.rb
+++ b/spec/wizards/schools/ects/change_mentor_wizard/check_answers_step_spec.rb
@@ -22,7 +22,7 @@ describe Schools::ECTs::ChangeMentorWizard::CheckAnswersStep do
   let(:ect_at_school_period) do
     FactoryBot.create(
       :ect_at_school_period,
-      :ongoing,
+      :unfinished,
       school:,
       started_on: 1.week.ago
     )
@@ -30,7 +30,7 @@ describe Schools::ECTs::ChangeMentorWizard::CheckAnswersStep do
   let(:mentor_at_school_period) do
     FactoryBot.create(
       :mentor_at_school_period,
-      :ongoing,
+      :unfinished,
       school:,
       started_on: ect_at_school_period.started_on - 1.month
     )
@@ -84,7 +84,7 @@ describe Schools::ECTs::ChangeMentorWizard::CheckAnswersStep do
     let(:current_mentor_at_school_period) do
       FactoryBot.create(
         :mentor_at_school_period,
-        :ongoing,
+        :unfinished,
         school:,
         started_on: ect_at_school_period.started_on - 2.months
       )
@@ -92,7 +92,7 @@ describe Schools::ECTs::ChangeMentorWizard::CheckAnswersStep do
     let!(:mentorship_period) do
       FactoryBot.create(
         :mentorship_period,
-        :ongoing,
+        :unfinished,
         mentee: ect_at_school_period,
         mentor: current_mentor_at_school_period,
         started_on: ect_at_school_period.started_on
@@ -116,7 +116,7 @@ describe Schools::ECTs::ChangeMentorWizard::CheckAnswersStep do
     let(:current_mentor_at_school_period) do
       FactoryBot.create(
         :mentor_at_school_period,
-        :ongoing,
+        :unfinished,
         school:,
         started_on: ect_at_school_period.started_on - 2.months
       )
@@ -124,7 +124,7 @@ describe Schools::ECTs::ChangeMentorWizard::CheckAnswersStep do
     let!(:mentorship_period) do
       FactoryBot.create(
         :mentorship_period,
-        :ongoing,
+        :unfinished,
         mentee: ect_at_school_period,
         mentor: current_mentor_at_school_period,
         started_on: ect_at_school_period.started_on

--- a/spec/wizards/schools/ects/change_mentor_wizard/confirmation_step_spec.rb
+++ b/spec/wizards/schools/ects/change_mentor_wizard/confirmation_step_spec.rb
@@ -14,12 +14,12 @@ describe Schools::ECTs::ChangeMentorWizard::ConfirmationStep, type: :model do
   let(:author) { FactoryBot.build(:school_user, school_urn: school.urn) }
   let(:school) { FactoryBot.create(:school) }
   let(:ect_at_school_period) do
-    FactoryBot.create(:ect_at_school_period, :ongoing, school:)
+    FactoryBot.create(:ect_at_school_period, :unfinished, school:)
   end
   let(:mentor_at_school_period) do
     FactoryBot.create(
       :mentor_at_school_period,
-      :ongoing,
+      :unfinished,
       school:,
       started_on: ect_at_school_period.started_on - 1.month
     )
@@ -27,7 +27,7 @@ describe Schools::ECTs::ChangeMentorWizard::ConfirmationStep, type: :model do
   let!(:mentorship_period) do
     FactoryBot.create(
       :mentorship_period,
-      :ongoing,
+      :unfinished,
       mentee: ect_at_school_period,
       mentor: mentor_at_school_period,
       started_on: ect_at_school_period.started_on

--- a/spec/wizards/schools/ects/change_mentor_wizard/edit_step_spec.rb
+++ b/spec/wizards/schools/ects/change_mentor_wizard/edit_step_spec.rb
@@ -14,12 +14,12 @@ describe Schools::ECTs::ChangeMentorWizard::EditStep do
   let(:author) { FactoryBot.build(:school_user, school_urn: school.urn) }
   let(:school) { FactoryBot.create(:school) }
   let(:ect_at_school_period) do
-    FactoryBot.create(:ect_at_school_period, :ongoing, school:)
+    FactoryBot.create(:ect_at_school_period, :unfinished, school:)
   end
   let(:current_mentor_at_school_period) do
     FactoryBot.create(
       :mentor_at_school_period,
-      :ongoing,
+      :unfinished,
       school:,
       started_on: ect_at_school_period.started_on - 1.month
     )
@@ -27,7 +27,7 @@ describe Schools::ECTs::ChangeMentorWizard::EditStep do
   let!(:current_mentorship_period) do
     FactoryBot.create(
       :mentorship_period,
-      :ongoing,
+      :unfinished,
       mentee: ect_at_school_period,
       mentor: current_mentor_at_school_period,
       started_on: ect_at_school_period.started_on + 1.week
@@ -36,7 +36,7 @@ describe Schools::ECTs::ChangeMentorWizard::EditStep do
   let(:mentor_at_school_period) do
     FactoryBot.create(
       :mentor_at_school_period,
-      :ongoing,
+      :unfinished,
       school:,
       started_on: ect_at_school_period.started_on - 1.month
     )
@@ -161,11 +161,11 @@ describe Schools::ECTs::ChangeMentorWizard::EditStep do
 
       # Two ongoing mentors at the same school -> both are eligible
       let!(:mentor_at_school_period_1) do
-        FactoryBot.create(:mentor_at_school_period, :ongoing, school:, started_on: envelope_start)
+        FactoryBot.create(:mentor_at_school_period, :unfinished, school:, started_on: envelope_start)
       end
 
       let!(:mentor_at_school_period_2) do
-        FactoryBot.create(:mentor_at_school_period, :ongoing, school:, started_on: envelope_start)
+        FactoryBot.create(:mentor_at_school_period, :unfinished, school:, started_on: envelope_start)
       end
 
       it "returns all eligible mentors" do
@@ -174,7 +174,7 @@ describe Schools::ECTs::ChangeMentorWizard::EditStep do
     end
 
     context "when there is a current mentorship period (current mentor not eligible)" do
-      let!(:mentor_at_school_period_1) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, started_on: envelope_start) }
+      let!(:mentor_at_school_period_1) { FactoryBot.create(:mentor_at_school_period, :unfinished, school:, started_on: envelope_start) }
 
       # mentor 2 is the current mentor but is (not ongoing) -> not eligible
       let!(:mentor_at_school_period_2) { FactoryBot.create(:mentor_at_school_period, school:, started_on: envelope_start, finished_on: envelope_end) }

--- a/spec/wizards/schools/ects/change_mentor_wizard/lead_provider_step_spec.rb
+++ b/spec/wizards/schools/ects/change_mentor_wizard/lead_provider_step_spec.rb
@@ -23,7 +23,7 @@ describe Schools::ECTs::ChangeMentorWizard::LeadProviderStep do
   let(:mentor_at_school_period) do
     FactoryBot.create(
       :mentor_at_school_period,
-      :ongoing,
+      :unfinished,
       school:,
       started_on: ect_at_school_period.started_on - 1.month
     )

--- a/spec/wizards/schools/ects/change_mentor_wizard/review_mentor_eligibility_step_spec.rb
+++ b/spec/wizards/schools/ects/change_mentor_wizard/review_mentor_eligibility_step_spec.rb
@@ -19,12 +19,12 @@ describe Schools::ECTs::ChangeMentorWizard::ReviewMentorEligibilityStep do
   let(:author) { FactoryBot.build(:school_user, school_urn: school.urn) }
   let(:school) { FactoryBot.create(:school) }
   let(:ect_at_school_period) do
-    FactoryBot.create(:ect_at_school_period, :ongoing, school:)
+    FactoryBot.create(:ect_at_school_period, :unfinished, school:)
   end
   let(:mentor_at_school_period) do
     FactoryBot.create(
       :mentor_at_school_period,
-      :ongoing,
+      :unfinished,
       school:,
       started_on: ect_at_school_period.started_on - 1.month
     )
@@ -54,7 +54,7 @@ describe Schools::ECTs::ChangeMentorWizard::ReviewMentorEligibilityStep do
     let!(:training_period) do
       FactoryBot.create(
         :training_period,
-        :ongoing,
+        :unfinished,
         :with_school_partnership,
         ect_at_school_period:,
         started_on: ect_at_school_period.started_on

--- a/spec/wizards/schools/ects/change_training_programme_wizard/check_answers_step_spec.rb
+++ b/spec/wizards/schools/ects/change_training_programme_wizard/check_answers_step_spec.rb
@@ -24,7 +24,7 @@ describe Schools::ECTs::ChangeTrainingProgrammeWizard::CheckAnswersStep do
   let(:ect_at_school_period) do
     FactoryBot.create(
       :ect_at_school_period,
-      :ongoing,
+      :unfinished,
       school:,
       started_on: 1.week.ago
     )

--- a/spec/wizards/schools/ects/change_training_programme_wizard/confirmation_step_spec.rb
+++ b/spec/wizards/schools/ects/change_training_programme_wizard/confirmation_step_spec.rb
@@ -13,7 +13,7 @@ describe Schools::ECTs::ChangeTrainingProgrammeWizard::ConfirmationStep do
   let(:store) { FactoryBot.build(:session_repository, training_programme: "provider_led") }
   let(:author) { FactoryBot.build(:school_user, school_urn: school.urn) }
   let(:school) { FactoryBot.create(:school) }
-  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school:) }
+  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, school:) }
   let(:params) { {} }
 
   describe "#previous_step" do
@@ -45,7 +45,7 @@ describe Schools::ECTs::ChangeTrainingProgrammeWizard::ConfirmationStep do
       let!(:training_period) do
         FactoryBot.create(
           :training_period,
-          :ongoing,
+          :unfinished,
           :for_ect,
           :with_school_partnership,
           ect_at_school_period:,
@@ -63,7 +63,7 @@ describe Schools::ECTs::ChangeTrainingProgrammeWizard::ConfirmationStep do
       let!(:training_period) do
         FactoryBot.create(
           :training_period,
-          :ongoing,
+          :unfinished,
           :for_ect,
           :with_only_expression_of_interest,
           ect_at_school_period:,

--- a/spec/wizards/schools/ects/change_training_programme_wizard/lead_provider_step_spec.rb
+++ b/spec/wizards/schools/ects/change_training_programme_wizard/lead_provider_step_spec.rb
@@ -116,7 +116,7 @@ describe Schools::ECTs::ChangeTrainingProgrammeWizard::LeadProviderStep do
       FactoryBot.create(:active_lead_provider, contract_period: upcoming_contract_period)
     end
     let(:ect_at_school_period) do
-      FactoryBot.create(:ect_at_school_period, :ongoing, school:, started_on:)
+      FactoryBot.create(:ect_at_school_period, :unfinished, school:, started_on:)
     end
 
     context "when there are no active lead providers in contract period containing the ect's start date" do

--- a/spec/wizards/schools/ects/teacher_leaving_wizard/edit_step_spec.rb
+++ b/spec/wizards/schools/ects/teacher_leaving_wizard/edit_step_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Schools::ECTs::TeacherLeavingWizard::EditStep do
   subject(:step) { described_class.new(wizard:, leaving_on:) }
 
   let(:wizard) { instance_double(Schools::ECTs::TeacherLeavingWizard::Wizard, store:, ect_at_school_period:) }
-  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: Date.new(2025, 1, 1)) }
+  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, started_on: Date.new(2025, 1, 1)) }
   let(:teacher_name) { Teachers::Name.new(ect_at_school_period.teacher).full_name }
   let(:store) { FactoryBot.build(:session_repository, form_key: :teacher_leaving_wizard) }
   let(:leaving_on) { { "day" => "1", "month" => "3", "year" => "2025" } }
@@ -98,7 +98,7 @@ RSpec.describe Schools::ECTs::TeacherLeavingWizard::EditStep do
     end
 
     context "when the date clashes with the latest training period" do
-      let(:training_period) { FactoryBot.create(:training_period, :ongoing, ect_at_school_period:, started_on: Date.new(2025, 1, 1)) }
+      let(:training_period) { FactoryBot.create(:training_period, :unfinished, ect_at_school_period:, started_on: Date.new(2025, 1, 1)) }
 
       before do
         allow(Schools::Validation::PeriodBoundary)

--- a/spec/wizards/schools/mentors/change_lead_provider_wizard/check_answers_step_spec.rb
+++ b/spec/wizards/schools/mentors/change_lead_provider_wizard/check_answers_step_spec.rb
@@ -25,7 +25,7 @@ describe Schools::Mentors::ChangeLeadProviderWizard::CheckAnswersStep, type: :mo
   let(:mentor_at_school_period) do
     FactoryBot.create(
       :mentor_at_school_period,
-      :ongoing,
+      :unfinished,
       teacher:,
       school:,
       email: "mentor@example.com"
@@ -37,7 +37,7 @@ describe Schools::Mentors::ChangeLeadProviderWizard::CheckAnswersStep, type: :mo
   let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:, contract_period:) }
   let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:, contract_period:) }
 
-  let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period:, started_on:) }
+  let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, :unfinished, mentor_at_school_period:, started_on:) }
   let(:old_lead_provider) { training_period.lead_provider }
   let(:new_lead_provider) { lead_provider }
 

--- a/spec/wizards/schools/mentors/change_lead_provider_wizard/confirmation_step_spec.rb
+++ b/spec/wizards/schools/mentors/change_lead_provider_wizard/confirmation_step_spec.rb
@@ -12,8 +12,8 @@ describe Schools::Mentors::ChangeLeadProviderWizard::ConfirmationStep, type: :mo
   end
   let(:store) { FactoryBot.build(:session_repository) }
   let(:school) { FactoryBot.create(:school) }
-  let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:) }
-  let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period:, started_on: Time.zone.today) }
+  let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, school:) }
+  let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, :unfinished, mentor_at_school_period:, started_on: Time.zone.today) }
 
   let(:author) { FactoryBot.build(:school_user, school_urn: school.urn) }
   let(:lead_provider) { training_period.lead_provider }

--- a/spec/wizards/schools/mentors/change_lead_provider_wizard/edit_step_spec.rb
+++ b/spec/wizards/schools/mentors/change_lead_provider_wizard/edit_step_spec.rb
@@ -13,9 +13,9 @@ describe Schools::Mentors::ChangeLeadProviderWizard::EditStep, type: :model do
   let(:store) { FactoryBot.build(:session_repository) }
   let(:author) { FactoryBot.build(:school_user, school_urn: school.urn) }
   let(:school) { FactoryBot.create(:school) }
-  let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:) }
+  let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, school:) }
   let(:lead_provider) { FactoryBot.create(:lead_provider) }
-  let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, :ongoing, :with_school_partnership, mentor_at_school_period:, started_on: mentor_at_school_period.started_on) }
+  let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, :unfinished, :with_school_partnership, mentor_at_school_period:, started_on: mentor_at_school_period.started_on) }
 
   let(:params) { { lead_provider_id: lead_provider.id } }
 
@@ -100,7 +100,7 @@ describe Schools::Mentors::ChangeLeadProviderWizard::EditStep, type: :model do
       FactoryBot.create(:contract_period, :current)
     end
     let(:mentor_at_school_period) do
-      FactoryBot.create(:mentor_at_school_period, :ongoing, school:, started_on:)
+      FactoryBot.create(:mentor_at_school_period, :unfinished, school:, started_on:)
     end
     let!(:current_lead_provider) do
       FactoryBot.create(:active_lead_provider, contract_period: current_contract_period)
@@ -109,7 +109,7 @@ describe Schools::Mentors::ChangeLeadProviderWizard::EditStep, type: :model do
       FactoryBot.create(
         :training_period,
         :for_mentor,
-        :ongoing,
+        :unfinished,
         :with_active_lead_provider,
         mentor_at_school_period:,
         started_on: training_started_on,

--- a/spec/wizards/schools/mentors/teacher_leaving_wizard/edit_step_spec.rb
+++ b/spec/wizards/schools/mentors/teacher_leaving_wizard/edit_step_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Schools::Mentors::TeacherLeavingWizard::EditStep do
   subject(:step) { described_class.new(wizard:, leaving_on:) }
 
   let(:wizard) { instance_double(Schools::Mentors::TeacherLeavingWizard::Wizard, store:, mentor_at_school_period:) }
-  let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, started_on: Date.new(2025, 1, 1)) }
+  let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, started_on: Date.new(2025, 1, 1)) }
   let(:teacher_name) { Teachers::Name.new(mentor_at_school_period.teacher).full_name }
   let(:store) { FactoryBot.build(:session_repository, form_key: :teacher_leaving_wizard) }
   let(:leaving_on) { { "day" => "1", "month" => "3", "year" => "2025" } }
@@ -100,7 +100,7 @@ RSpec.describe Schools::Mentors::TeacherLeavingWizard::EditStep do
     end
 
     context "when the date clashes with the latest training period" do
-      let(:training_period) { FactoryBot.create(:training_period, :ongoing, :for_mentor, mentor_at_school_period:, started_on: Date.new(2025, 1, 1)) }
+      let(:training_period) { FactoryBot.create(:training_period, :unfinished, :for_mentor, mentor_at_school_period:, started_on: Date.new(2025, 1, 1)) }
 
       before do
         allow(Schools::Validation::PeriodBoundary)

--- a/spec/wizards/schools/register_ect_wizard/find_ect_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/find_ect_step_spec.rb
@@ -110,7 +110,7 @@ describe Schools::RegisterECTWizard::FindECTStep, type: :model do
 
     context "when the ect is already active at the school" do
       let(:teacher) { FactoryBot.create(:teacher, trn: "1234568") }
-      let(:ongoing_ect_period) { FactoryBot.create(:ect_at_school_period, :teaching_school_hub_ab, :ongoing, teacher:, school:) }
+      let(:ongoing_ect_period) { FactoryBot.create(:ect_at_school_period, :teaching_school_hub_ab, :unfinished, teacher:, school:) }
 
       before do
         wizard.store.update!(school_urn: ongoing_ect_period.school.urn)

--- a/spec/wizards/schools/register_ect_wizard/registration_store/queries_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/registration_store/queries_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
 
   describe "#active_record_at_school" do
     let(:school) { FactoryBot.create(:school) }
-    let!(:ongoing_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:) }
+    let!(:ongoing_period) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher:, school:) }
 
     it "returns the ongoing period for the given urn" do
       expect(queries.active_record_at_school(school.urn)).to eq(ongoing_period)

--- a/spec/wizards/schools/register_ect_wizard/registration_store_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/registration_store_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore do
     let(:teacher) { FactoryBot.create(:teacher, trn: "3002586") }
 
     context "when the ECT has an ongoing ECT record at the school" do
-      let!(:existing_ect_record) { FactoryBot.create(:ect_at_school_period, :ongoing, school:, teacher:) }
+      let!(:existing_ect_record) { FactoryBot.create(:ect_at_school_period, :unfinished, school:, teacher:) }
 
       it "returns the ECT record" do
         expect(registration_store.active_record_at_school(school.urn)).to eq(existing_ect_record)
@@ -49,7 +49,7 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore do
     let(:teacher) { FactoryBot.create(:teacher, trn: registration_store.trn) }
 
     it "returns true if the ECT is active at the given school" do
-      FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:)
+      FactoryBot.create(:ect_at_school_period, :unfinished, teacher:, school:)
 
       expect(registration_store).to be_active_at_school(school.urn)
     end

--- a/spec/wizards/schools/register_ect_wizard/start_date_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/start_date_step_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Schools::RegisterECTWizard::StartDateStep, type: :model do
         end
 
         context "and the previous registration is ongoing" do
-          let(:previous_period) { :ongoing }
+          let(:previous_period) { :unfinished }
 
           it "is valid up to 4 months from today" do
             subject.start_date = start_date - 1.day

--- a/spec/wizards/schools/register_mentor_wizard/check_answers_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/check_answers_step_spec.rb
@@ -1,7 +1,7 @@
 describe Schools::RegisterMentorWizard::CheckAnswersStep, type: :model do
   subject { wizard.current_step }
 
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+  let(:ect) { FactoryBot.create(:ect_at_school_period, :unfinished) }
   let(:training_programme) { "provider_led" }
   let(:use_previous_ect_choices) { true }
   let(:store) { FactoryBot.build(:session_repository) }
@@ -15,20 +15,20 @@ describe Schools::RegisterMentorWizard::CheckAnswersStep, type: :model do
 
     describe "#previous_step" do
       context "when the mentor is available for funding" do
-        let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+        let(:ect) { FactoryBot.create(:ect_at_school_period, :unfinished) }
 
         before do
           allow(wizard.mentor).to receive_messages(eligible_for_funding?: true, ect_lead_provider_invalid?: false)
         end
 
         context "when the ect is provider led" do
-          let!(:training_period) { FactoryBot.create(:training_period, :provider_led, :ongoing, ect_at_school_period: ect) }
+          let!(:training_period) { FactoryBot.create(:training_period, :provider_led, :unfinished, ect_at_school_period: ect) }
 
           it { expect(subject.previous_step).to eq(:review_mentor_eligibility) }
         end
 
         context "when the ect is not provider led" do
-          let!(:training_period) { FactoryBot.create(:training_period, :school_led, :ongoing, ect_at_school_period: ect) }
+          let!(:training_period) { FactoryBot.create(:training_period, :school_led, :unfinished, ect_at_school_period: ect) }
 
           it { expect(subject.previous_step).to eq(:email_address) }
         end

--- a/spec/wizards/schools/register_mentor_wizard/email_address_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/email_address_step_spec.rb
@@ -69,7 +69,7 @@ describe Schools::RegisterMentorWizard::EmailAddressStep, type: :model do
   end
 
   context "previously registered with unexpected mentorship_status" do
-    let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+    let(:ect) { FactoryBot.create(:ect_at_school_period, :unfinished) }
     let(:store) do
       FactoryBot.build(:session_repository,
                        trn: "1234567",
@@ -82,7 +82,7 @@ describe Schools::RegisterMentorWizard::EmailAddressStep, type: :model do
     let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :email_address, store:, ect_id: ect.id) }
 
     before do
-      FactoryBot.create(:training_period, :provider_led, :ongoing, ect_at_school_period: ect)
+      FactoryBot.create(:training_period, :provider_led, :unfinished, ect_at_school_period: ect)
       allow(wizard.mentor).to receive_messages(
         email_taken?: false,
         previously_registered_as_mentor?: true,

--- a/spec/wizards/schools/register_mentor_wizard/find_mentor_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/find_mentor_step_spec.rb
@@ -62,7 +62,7 @@ describe Schools::RegisterMentorWizard::FindMentorStep, type: :model do
   describe "#next_step" do
     subject { wizard.current_step }
 
-    let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+    let(:ect) { FactoryBot.create(:ect_at_school_period, :unfinished) }
     let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :find_mentor, step_params:, ect_id: ect.id) }
     let(:step_params) do
       ActionController::Parameters.new(
@@ -110,7 +110,7 @@ describe Schools::RegisterMentorWizard::FindMentorStep, type: :model do
 
     context "when the mentor trn matches that of the ECT" do
       let(:teacher) { FactoryBot.create(:teacher, trn: "1234568") }
-      let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:) }
+      let(:ect) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher:) }
 
       before do
         allow(::TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new)
@@ -146,7 +146,7 @@ describe Schools::RegisterMentorWizard::FindMentorStep, type: :model do
 
     context "when the mentor is already active at the school" do
       let(:teacher) { FactoryBot.create(:teacher, trn: "1234568") }
-      let(:ongoing_mentor_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:) }
+      let(:ongoing_mentor_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:) }
 
       before do
         wizard.store.update!(school_urn: ongoing_mentor_period.school.urn)

--- a/spec/wizards/schools/register_mentor_wizard/lead_provider_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/lead_provider_step_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Schools::RegisterMentorWizard::LeadProviderStep, type: :model do
   subject { wizard.current_step }
 
-  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished) }
   let(:store) { FactoryBot.build(:session_repository) }
   let(:author) { FactoryBot.create(:school_user, school_urn: ect_at_school_period.school.urn) }
   let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :lead_provider, store:, author:, ect_id: ect_at_school_period.id) }

--- a/spec/wizards/schools/register_mentor_wizard/national_insurance_number_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/national_insurance_number_step_spec.rb
@@ -82,7 +82,7 @@ describe Schools::RegisterMentorWizard::NationalInsuranceNumberStep, type: :mode
 
     context "when the mentor is already active at the school" do
       let(:teacher) { FactoryBot.create(:teacher, trn: "1234568") }
-      let(:ongoing_mentor_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:) }
+      let(:ongoing_mentor_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:) }
 
       before do
         wizard.store.update!(trn: "1234568", school_urn: ongoing_mentor_period.school.urn)
@@ -97,7 +97,7 @@ describe Schools::RegisterMentorWizard::NationalInsuranceNumberStep, type: :mode
 
     context "when the mentor is already active at the school" do
       let(:teacher) { FactoryBot.create(:teacher, trn: "1234568") }
-      let(:ongoing_mentor_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:) }
+      let(:ongoing_mentor_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:) }
 
       before do
         wizard.store.update!(trn: "1234568", school_urn: ongoing_mentor_period.school.urn)

--- a/spec/wizards/schools/register_mentor_wizard/previous_training_period_details_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/previous_training_period_details_step_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Schools::RegisterMentorWizard::PreviousTrainingPeriodDetailsStep, type: :model do
   subject { wizard.current_step }
 
-  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished) }
   let(:store) { FactoryBot.build(:session_repository) }
   let(:author) { FactoryBot.create(:school_user, school_urn: ect_at_school_period.school.urn) }
   let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :previous_training_period_details, store:, author:, ect_id: ect_at_school_period.id) }

--- a/spec/wizards/schools/register_mentor_wizard/registration_store/queries_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/registration_store/queries_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Schools::RegisterMentorWizard::RegistrationStore::Queries do
   let(:started_on) { nil }
 
   describe "#active_record_at_school" do
-    let!(:ongoing_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:, school:) }
+    let!(:ongoing_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:, school:) }
 
     it "returns the ongoing mentor period for the school" do
       expect(queries.active_record_at_school).to eq(ongoing_period)
@@ -55,7 +55,7 @@ RSpec.describe Schools::RegisterMentorWizard::RegistrationStore::Queries do
   end
 
   describe "#previous_training_period" do
-    let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, started_on: 1.year.ago, teacher:) }
+    let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, started_on: 1.year.ago, teacher:) }
     let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, mentor_at_school_period:, started_on: 9.months.ago) }
 
     it "returns the latest training period for the mentor" do
@@ -101,7 +101,7 @@ RSpec.describe Schools::RegisterMentorWizard::RegistrationStore::Queries do
   describe "#previous_school_mentor_at_school_periods" do
     let(:other_school) { FactoryBot.create(:school) }
     let(:other_teacher) { FactoryBot.create(:teacher) }
-    let!(:current_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:, school:) }
+    let!(:current_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:, school:) }
     let!(:finished_recently) do
       FactoryBot.create(:mentor_at_school_period,
                         teacher:,
@@ -111,14 +111,14 @@ RSpec.describe Schools::RegisterMentorWizard::RegistrationStore::Queries do
     end
     let!(:ongoing_other_school) do
       FactoryBot.create(:mentor_at_school_period,
-                        :ongoing,
+                        :unfinished,
                         teacher:,
                         school: other_school,
                         started_on: finished_recently.finished_on + 1.day)
     end
     let!(:other_teacher_finishes_in_the_future) do
       FactoryBot.create(:mentor_at_school_period,
-                        :ongoing,
+                        :unfinished,
                         teacher: other_teacher,
                         school: other_school,
                         started_on: 2.years.ago,

--- a/spec/wizards/schools/register_mentor_wizard/registration_store/status_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/registration_store/status_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe Schools::RegisterMentorWizard::RegistrationStore::Status do
 
   describe "#currently_mentor_at_another_school?" do
     context "when there is an ongoing periods at another school" do
-      let(:previous_school_periods_relation) { MentorAtSchoolPeriod.where(id: FactoryBot.create(:mentor_at_school_period, :ongoing).id) }
+      let(:previous_school_periods_relation) { MentorAtSchoolPeriod.where(id: FactoryBot.create(:mentor_at_school_period, :unfinished).id) }
 
       it "returns true" do
         expect(status.currently_mentor_at_another_school?).to be(true)
@@ -234,7 +234,7 @@ RSpec.describe Schools::RegisterMentorWizard::RegistrationStore::Status do
 
   describe "#mentorship_status" do
     context "when there is an ongoing mentor period" do
-      let(:mentor_periods_relation) { MentorAtSchoolPeriod.where(id: FactoryBot.create(:mentor_at_school_period, :ongoing).id) }
+      let(:mentor_periods_relation) { MentorAtSchoolPeriod.where(id: FactoryBot.create(:mentor_at_school_period, :unfinished).id) }
 
       it "returns :currently_a_mentor" do
         expect(status.mentorship_status).to eq(:currently_a_mentor)

--- a/spec/wizards/schools/register_mentor_wizard/registration_store_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/registration_store_spec.rb
@@ -22,7 +22,7 @@ describe Schools::RegisterMentorWizard::RegistrationStore do
 
     context "when the mentor has an ongoing mentor record at the school" do
       let!(:ongoing_mentor_record) do
-        FactoryBot.create(:mentor_at_school_period, :ongoing, school:, teacher:)
+        FactoryBot.create(:mentor_at_school_period, :unfinished, school:, teacher:)
       end
 
       it "returns true" do
@@ -46,7 +46,7 @@ describe Schools::RegisterMentorWizard::RegistrationStore do
 
     context "when the mentor has an ongoing mentor record at the school" do
       let!(:ongoing_mentor_record) do
-        FactoryBot.create(:mentor_at_school_period, :ongoing, school:, teacher:)
+        FactoryBot.create(:mentor_at_school_period, :unfinished, school:, teacher:)
       end
 
       it "returns the mentor record" do
@@ -190,7 +190,7 @@ describe Schools::RegisterMentorWizard::RegistrationStore do
     let!(:mentor_at_school_period) do
       FactoryBot.create(
         :mentor_at_school_period,
-        :ongoing,
+        :unfinished,
         teacher:,
         started_on: Date.new(2025, 1, 1)
       )
@@ -228,11 +228,11 @@ describe Schools::RegisterMentorWizard::RegistrationStore do
     end
 
     context "when there is an associated mentee on provider-led training who has previously been trained" do
-      let(:mentee) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 2.weeks.ago) }
+      let(:mentee) { FactoryBot.create(:ect_at_school_period, :unfinished, started_on: 2.weeks.ago) }
       let!(:mentee_training_period) do
         FactoryBot.create(
           :training_period,
-          :ongoing,
+          :unfinished,
           :provider_led,
           :for_ect,
           ect_at_school_period: mentee,
@@ -372,7 +372,7 @@ describe Schools::RegisterMentorWizard::RegistrationStore do
 
     context "when there is an ongoing mentor_at_school_period" do
       let!(:ongoing_period) do
-        FactoryBot.create(:mentor_at_school_period, :ongoing, school:, teacher:)
+        FactoryBot.create(:mentor_at_school_period, :unfinished, school:, teacher:)
       end
 
       it "returns :currently_a_mentor" do
@@ -395,7 +395,7 @@ describe Schools::RegisterMentorWizard::RegistrationStore do
         FactoryBot.create(:mentor_at_school_period, school:, teacher:, started_on: 3.years.ago)
       end
       let!(:ongoing_period) do
-        FactoryBot.create(:mentor_at_school_period, :ongoing, school:, teacher:)
+        FactoryBot.create(:mentor_at_school_period, :unfinished, school:, teacher:)
       end
 
       it "returns :currently_a_mentor" do
@@ -419,7 +419,7 @@ describe Schools::RegisterMentorWizard::RegistrationStore do
 
     context "when there is an ongoing record at another school" do
       before do
-        FactoryBot.create(:mentor_at_school_period, :ongoing, school: other_school, teacher:)
+        FactoryBot.create(:mentor_at_school_period, :unfinished, school: other_school, teacher:)
       end
 
       it "returns true" do
@@ -458,7 +458,7 @@ describe Schools::RegisterMentorWizard::RegistrationStore do
 
     context "when all previous periods are ongoing" do
       before do
-        FactoryBot.create(:mentor_at_school_period, :ongoing, school: other_school, teacher:)
+        FactoryBot.create(:mentor_at_school_period, :unfinished, school: other_school, teacher:)
       end
 
       it { is_expected.to be_falsey }

--- a/spec/wizards/schools/register_mentor_wizard/shared_examples/email_step.rb
+++ b/spec/wizards/schools/register_mentor_wizard/shared_examples/email_step.rb
@@ -1,7 +1,7 @@
 RSpec.shared_examples "an email step" do |current_step:, previous_step:, next_step:, training_programme: :provider_led|
   subject { described_class.new(wizard:) }
 
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+  let(:ect) { FactoryBot.create(:ect_at_school_period, :unfinished) }
   let(:store) do
     FactoryBot.build(:session_repository,
                      trn: "1234567",
@@ -13,7 +13,7 @@ RSpec.shared_examples "an email step" do |current_step:, previous_step:, next_st
   end
   let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step:, store:, ect_id: ect.id) }
 
-  before { FactoryBot.create(:training_period, training_programme, :ongoing, ect_at_school_period: ect) }
+  before { FactoryBot.create(:training_period, training_programme, :unfinished, ect_at_school_period: ect) }
 
   describe "#initialize" do
     subject { described_class.new(wizard:, **params) }

--- a/spec/wizards/schools/register_mentor_wizard/wizard_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/wizard_spec.rb
@@ -1,7 +1,7 @@
 describe Schools::RegisterMentorWizard::Wizard do
   let(:current_step) { :find_mentor }
   let(:ect_teacher) { FactoryBot.create(:teacher, trn: "7654321") }
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: ect_teacher, school:) }
+  let(:ect) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher: ect_teacher, school:) }
   let(:school) { FactoryBot.create(:school, create_contract_period: false, urn: school_urn) }
   let(:ect_id) { ect.id }
   let(:mentor_trn) { "1234567" }
@@ -71,7 +71,7 @@ describe Schools::RegisterMentorWizard::Wizard do
 
       context "when the mentor is already active at the school" do
         let(:mentor_teacher) { FactoryBot.create(:teacher, trn: mentor_trn) }
-        let(:ongoing_mentor_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: mentor_teacher) }
+        let(:ongoing_mentor_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, teacher: mentor_teacher) }
         let(:school_urn) { ongoing_mentor_period.school.urn }
 
         it { is_expected.to eq(%i[find_mentor already_active_at_school]) }
@@ -113,7 +113,7 @@ describe Schools::RegisterMentorWizard::Wizard do
 
       context "when the mentor is already active at the school" do
         let(:mentor_teacher) { FactoryBot.create(:teacher, trn: mentor_trn) }
-        let(:ongoing_mentor_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: mentor_teacher) }
+        let(:ongoing_mentor_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, teacher: mentor_teacher) }
         let(:school_urn) { ongoing_mentor_period.school.urn }
 
         it { is_expected.to eq(%i[find_mentor national_insurance_number already_active_at_school]) }
@@ -132,7 +132,7 @@ describe Schools::RegisterMentorWizard::Wizard do
 
     context "when only TRN, DoB and already active at school have been set" do
       let(:mentor_teacher) { FactoryBot.create(:teacher, trn: mentor_trn) }
-      let(:ongoing_mentor_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: mentor_teacher) }
+      let(:ongoing_mentor_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, teacher: mentor_teacher) }
       let(:school_urn) { ongoing_mentor_period.school.urn }
       let(:already_active_at_school) { true }
       let(:store) do
@@ -153,7 +153,7 @@ describe Schools::RegisterMentorWizard::Wizard do
     context "when only TRN, DoB, Nino and already active at school have been set" do
       let(:mentor_date_of_birth) { "2000-01-01" }
       let(:mentor_teacher) { FactoryBot.create(:teacher, trn: mentor_trn) }
-      let(:ongoing_mentor_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: mentor_teacher) }
+      let(:ongoing_mentor_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, teacher: mentor_teacher) }
       let(:school_urn) { ongoing_mentor_period.school.urn }
       let(:already_active_at_school) { true }
       let(:store) do

--- a/spec/wizards/schools/shared/mentor_assignment_context_spec.rb
+++ b/spec/wizards/schools/shared/mentor_assignment_context_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Schools::Shared::MentorAssignmentContext do
   let(:mentor_teacher) { FactoryBot.create(:teacher, trn: "1234567", trs_first_name: "Goku", trs_last_name: "Saiyan", mentor_became_ineligible_for_funding_reason: nil) }
   let(:ect_teacher) { FactoryBot.create(:teacher, trs_first_name: "King", trs_last_name: "Vegeta") }
 
-  let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, teacher: mentor_teacher) }
+  let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, school:, teacher: mentor_teacher) }
   let(:ect_at_school_period) do
     FactoryBot.create(:ect_at_school_period, school:, teacher: ect_teacher, started_on: Date.new(2025, 5, 1))
   end
@@ -38,7 +38,7 @@ RSpec.describe Schools::Shared::MentorAssignmentContext do
         FactoryBot.create(
           :training_period,
           :provider_led,
-          :ongoing,
+          :unfinished,
           ect_at_school_period:,
           started_on:,
           finished_on:,
@@ -95,7 +95,7 @@ RSpec.describe Schools::Shared::MentorAssignmentContext do
       FactoryBot.create(
         :training_period,
         :provider_led,
-        :ongoing,
+        :unfinished,
         ect_at_school_period:,
         started_on:,
         finished_on:,


### PR DESCRIPTION
### Context

Resolves https://github.com/DFE-Digital/register-ects-project-board/issues/3765

The issue is confusing naming where:
```
ongoing returns if finished_on is nil
ongoing_today returns if the start/finish cover the current date (with nil treated as future)
```
In practice, this means:
```
when started_on: 1.week.ago, finished_on: nil - 'ongoing' and 'ongoing today'
when started_on: 1.week.from_now, finished_on: 2.weeks.from_now - neither 'ongoing' nor 'ongoing today'
when started_on: 1.week.ago, finished_on: 1.week.from_now - not 'ongoing', but is 'ongoing today' ⚠️
when started_on: 1.week.from_now, finished_on: nil - 'ongoing' but is not 'ongoing today' ⚠️
```

### Changes proposed in this pull request

* Renames `ongoing_today`=> `contains_today` and renames  `ongoing`=> `unfinished`.

### Guidance to review

> [!Note]
> This is a straight simple rename refactoring, but unfortunately with quite a large blast radius.

> [!Warning]
> `contains_today?` currently and continues to ignore the `start_date`. So any Interval with a `start_date` in the future would still have `contains_today?` returning true. 

Changing the implementation of `contains_today?` would no longer be a _behaviour preserving change_, with the PR already being unacceptably large. I have left this as out of scope - to be covered in a subsequent PR.  

Concretely In **Interval** `in app/models/concerns/interval.rb`, contains_today? is implemented as.
```
  def contains_today? = finished_on.nil? || finished_on.future?
```



