### PR TITLE
Set autocomplete attributes on OTP signin pages

### DIFF
--- a/app/views/otp_sessions/new.html.erb
+++ b/app/views/otp_sessions/new.html.erb
@@ -7,7 +7,7 @@
     You need to request an email with a code to sign in.
   </p>
 
-  <%= f.govuk_text_field :email, type: :email, width: 'two-thirds', label: { text: "Email address", size: "s" } %>
+  <%= f.govuk_email_field :email, width: 'two-thirds', label: { text: "Email address", size: "s" }, autocomplete: "email" %>
 
   <%= f.govuk_submit "Request code to sign in" %>
 <% end %>

--- a/app/views/otp_sessions/request_code.html.erb
+++ b/app/views/otp_sessions/request_code.html.erb
@@ -7,7 +7,7 @@
     We’ve sent you an email with a sign in code.
   </p>
 
-  <%= f.govuk_text_field :code, width: 'one-quarter', label: { text: "Sign in code", size: "s" }, inputmode: "numeric", autocomplete:"off" %>
+  <%= f.govuk_text_field :code, width: 'one-quarter', label: { text: "Sign in code", size: "s" }, inputmode: "numeric" %>
 
   <%= f.govuk_submit "Sign in" %>
 <% end %>

--- a/spec/views/otp_sessions/new_spec.html.erb_spec.rb
+++ b/spec/views/otp_sessions/new_spec.html.erb_spec.rb
@@ -1,0 +1,21 @@
+describe "otp_sessions/new.html.erb" do
+  before { assign(:otp_form, Sessions::OTPSignInForm.new) }
+
+  it "sets the page title to 'Sign in'" do
+    render
+
+    expect(view.content_for(:page_title)).to eql("Sign in")
+  end
+
+  it "renders an email field with autocomplete='email'" do
+    render
+
+    expect(rendered).to have_css("form input[type='email'][autocomplete='email']")
+  end
+
+  it "renders a 'Request code to sign in' button" do
+    render
+
+    expect(rendered).to have_css("form button", text: "Request code to sign in")
+  end
+end

--- a/spec/views/otp_sessions/request_code.html.erb_spec.rb
+++ b/spec/views/otp_sessions/request_code.html.erb_spec.rb
@@ -1,0 +1,21 @@
+describe "otp_sessions/request_code.html.erb" do
+  before { assign(:otp_form, Sessions::OTPSignInForm.new(email: "hello@example.com")) }
+
+  it "sets the page title to 'Enter your code'" do
+    render
+
+    expect(view.content_for(:page_title)).to eql("Enter your code")
+  end
+
+  it "renders a text field with inputmode='numeric' and autocomplete='one-time-code'" do
+    render
+
+    expect(rendered).to have_css("form input[inputmode='numeric']")
+  end
+
+  it "renders a 'Sign in' button" do
+    render
+
+    expect(rendered).to have_css("form button", text: "Sign in")
+  end
+end


### PR DESCRIPTION
These pages are used by DfE staff to log in.

There have been reports that autocompletion isn't working in Microsoft Edge on Windows (DfE-provisioned devices).

This commit sets the autocomplete attributes for the [email](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/autocomplete#email) field in an attempt to make it work.
