### PR TITLE
[4191] Trim previous period on same school re-registration

### DIFF
--- a/app/services/schools/register_ect.rb
+++ b/app/services/schools/register_ect.rb
@@ -66,9 +66,7 @@ module Schools
   private
 
     def already_registered_as_an_ect?
-      # Check if ECT is already registered at THIS school to prevent duplicates
-      # School transfers to different schools are allowed
-      teacher.ect_at_school_periods.where(school:).ongoing_today.exists?
+      teacher.ect_at_school_periods.where(school:).ongoing.exists?
     end
 
     def not_registered_as_an_ect!
@@ -143,7 +141,6 @@ module Schools
 
     def previous_periods
       teacher.ect_at_school_periods
-             .where.not(school:)
              .started_on_or_before(started_on)
     end
 

--- a/spec/services/schools/register_ect_spec.rb
+++ b/spec/services/schools/register_ect_spec.rb
@@ -553,7 +553,7 @@ RSpec.describe Schools::RegisterECT do
       let(:training_programme) { "school_led" }
       let(:lead_provider) { nil }
 
-      before { FactoryBot.create(:teacher, trn:) }
+      let!(:teacher) { FactoryBot.create(:teacher, trn:) }
 
       it "creates a TrainingPeriod" do
         expect { service.register! }.to change(TrainingPeriod, :count).by(1)
@@ -579,6 +579,46 @@ RSpec.describe Schools::RegisterECT do
         training_period = TrainingPeriod.find_by!(started_on:)
 
         expect(training_period.training_programme).to eql("school_led")
+      end
+
+      context "when re-registering an ECT at the same school with a recorded leaving date" do
+        let(:recorded_leaving_date) { Date.new(2026, 9, 20) }
+        let(:expected_finished_on) { started_on.yesterday }
+        let(:overridden_current_date) { Date.new(2026, 9, 1) }
+
+        let!(:existing_period) do
+          FactoryBot.create(
+            :ect_at_school_period,
+            teacher:,
+            school:,
+            started_on: Date.new(2026, 7, 1),
+            finished_on: recorded_leaving_date
+          )
+        end
+
+        shared_examples "successful same-school re-registration" do
+          it "finishes the existing period and allows a new registration at the same school" do
+            expect { service.register! }
+              .to change { existing_period.reload.finished_on }
+                .from(recorded_leaving_date)
+                .to(expected_finished_on)
+              .and change(ECTAtSchoolPeriod, :count).by(1)
+
+            expect(service.ect_at_school_period).to have_attributes(started_on:, finished_on: nil)
+          end
+        end
+
+        context "when the new start is before the recorded leaving date" do
+          let(:started_on) { Date.new(2026, 8, 10) }
+
+          include_examples "successful same-school re-registration"
+        end
+
+        context "when the new start is on the recorded leaving date" do
+          let(:started_on) { recorded_leaving_date }
+
+          include_examples "successful same-school re-registration"
+        end
       end
     end
 

--- a/spec/services/schools/register_ect_spec.rb
+++ b/spec/services/schools/register_ect_spec.rb
@@ -612,6 +612,45 @@ RSpec.describe Schools::RegisterECT do
           let(:started_on) { Date.new(2026, 8, 10) }
 
           include_examples "successful same-school re-registration"
+
+          context "when associated periods span the new start date" do
+            let!(:training_period) do
+              FactoryBot.create(
+                :training_period,
+                :school_led,
+                ect_at_school_period: existing_period,
+                started_on: existing_period.started_on,
+                finished_on: recorded_leaving_date
+              )
+            end
+
+            let!(:mentorship_period) do
+              mentor = FactoryBot.create(
+                :mentor_at_school_period,
+                school:,
+                started_on: existing_period.started_on,
+                finished_on: recorded_leaving_date
+              )
+
+              FactoryBot.create(
+                :mentorship_period,
+                mentee: existing_period,
+                mentor:,
+                started_on: existing_period.started_on,
+                finished_on: recorded_leaving_date
+              )
+            end
+
+            it "trims the associated periods to the day before the new start date" do
+              expect { service.register! }
+                .to change { training_period.reload.finished_on }
+                  .from(recorded_leaving_date)
+                  .to(expected_finished_on)
+                .and change { mentorship_period.reload.finished_on }
+                  .from(recorded_leaving_date)
+                  .to(expected_finished_on)
+            end
+          end
         end
 
         context "when the new start is on the recorded leaving date" do

--- a/spec/wizards/schools/register_ect_wizard/start_date_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/start_date_step_spec.rb
@@ -144,6 +144,25 @@ RSpec.describe Schools::RegisterECTWizard::StartDateStep, type: :model do
       it { is_expected.to have_error(:start_date, "Our records show that Johnnie Walker started teaching at Springfield Primary on 1 September 2024. Enter a start date after 2 September 2024.") }
     end
 
+    context "when re-registering an ECT at the same school before their recorded leaving date" do
+      let(:school) { FactoryBot.create(:school) }
+      let(:start_date) { Date.new(2026, 8, 10) }
+
+      before do
+        store.trn = teacher.trn
+
+        FactoryBot.create(
+          :ect_at_school_period,
+          teacher:,
+          school:,
+          started_on: Date.new(2026, 7, 1),
+          finished_on: Date.new(2026, 9, 20)
+        )
+      end
+
+      it { is_expected.to be_valid }
+    end
+
     context "when the date clashes with the latest training period" do
       let(:training_period) { FactoryBot.create(:training_period, ect_at_school_period: previous_period, started_on: Date.new(2024, 12, 31), finished_on: Date.new(2025, 3, 31)) }
 


### PR DESCRIPTION
## Summary

When a school re-registers an ECT at the same school before or on their recorded leaving date, the inclusive periods would overlap and cause a 500.

This change allows the re-registration and trims the previous ECT period to the day before the new start date, matching the existing behaviour for school transfers. Registrations are still blocked when the ECT has an ongoing period with no recorded leaving date at the same school.