### PR TITLE
Set `autocomplete="off"` for OTP code field

### DIFF
--- a/app/views/otp_sessions/request_code.html.erb
+++ b/app/views/otp_sessions/request_code.html.erb
@@ -7,7 +7,7 @@
     We’ve sent you an email with a sign in code.
   </p>
 
-  <%= f.govuk_text_field :code, width: 'one-quarter', label: { text: "Sign in code", size: "s" }, inputmode: "numeric", autocomplete: false %>
+  <%= f.govuk_text_field :code, width: 'one-quarter', label: { text: "Sign in code", size: "s" }, inputmode: "numeric", autocomplete: "off" %>
 
   <%= f.govuk_submit "Sign in" %>
 <% end %>

--- a/spec/views/otp_sessions/request_code.html.erb_spec.rb
+++ b/spec/views/otp_sessions/request_code.html.erb_spec.rb
@@ -7,10 +7,10 @@ describe "otp_sessions/request_code.html.erb" do
     expect(view.content_for(:page_title)).to eql("Enter your code")
   end
 
-  it "renders a text field with inputmode='numeric' and autocomplete='false'" do
+  it "renders a text field with inputmode='numeric' and autocomplete='off'" do
     render
 
-    expect(rendered).to have_css("form input[inputmode='numeric'][autocomplete='false']")
+    expect(rendered).to have_css("form input[inputmode='numeric'][autocomplete='off']")
   end
 
   it "renders a 'Sign in' button" do


### PR DESCRIPTION
This should be "off" rather than "false" 🤦‍♂️
