### PR TITLE
Add initial `Statement::AuditNote`s for contract managers

### DIFF
--- a/app/components/admin/statements/audit_notes_component.html.erb
+++ b/app/components/admin/statements/audit_notes_component.html.erb
@@ -3,6 +3,6 @@
 
   <% audit_notes.each do |audit_note| %>
     <p class="govuk-hint govuk-!-margin-bottom-1"><%= timestamp(audit_note) %></p>
-    <p class="govuk-body"><%= audit_note.body %></p>
+    <p class="govuk-body"><%= audit_note.body.html_safe %></p>
   <% end %>
 </div>

--- a/app/components/admin/statements/audit_notes_component.html.erb
+++ b/app/components/admin/statements/audit_notes_component.html.erb
@@ -3,6 +3,6 @@
 
   <% audit_notes.each do |audit_note| %>
     <p class="govuk-hint govuk-!-margin-bottom-1"><%= timestamp(audit_note) %></p>
-    <p class="govuk-body"><%= audit_note.body.html_safe %></p>
+    <p class="govuk-body"><%= sanitize audit_note.body %></p>
   <% end %>
 </div>

--- a/db/scripts/add_statement_audit_notes.rb
+++ b/db/scripts/add_statement_audit_notes.rb
@@ -1,0 +1,78 @@
+# Add initial Statement::AuditNote records
+# Thexe are not currently designed to be added or edited in the UI,
+# but are to show some context to contract managers on particular statements
+#
+# NOTE: To best preserve formatting, the son-of-patch tool wasn't used for this
+#
+
+Statement::AuditNote.create!(
+  statement_id: 616,
+  body: <<~NOTE.squish
+    Known discrepancy with what was invoiced following data migration to RECT service in April 2026: +£4,896.54
+    <br/></br/>
+    x1 started declaration (955c45ff-32f3-4f58-8219-5804d7a5de4f) included for payment in ECF1 service but was unable
+    to be represented in the RECT service
+    <br/></br/>
+    x15 started declarations priced at £0 in ECF1 service and priced £272.03+VAT in RECT service because RECT recognises
+    a higher ceiling to Band D than was present at the time of invoicing
+  NOTE
+)
+
+Statement::AuditNote.create!(
+  statement_id: 114,
+  body: <<~NOTE.squish
+    Known discrepancy with what was invoiced following data migration to RECT service in April 2026: +£10,119.52
+    <br/></br/>
+    x31 started declarations priced at £0 in ECF1 service and priced £272.03+VAT in RECT service because RECT recognises
+    a higher ceiling to Band D than was present at the time of invoicing
+  NOTE
+)
+
+Statement::AuditNote.create!(
+  statement_id: 852,
+  body: <<~NOTE.squish
+    Known discrepancy with what was invoiced following data migration to RECT service in April 2026: +£171.40
+    <br/></br/>
+    Retained-1 declaration (0e907957-5c0f-43f4-8604-9a6d9b745d3b) included for payment in ECF1 service but was unable
+    to be represented in the RECT service
+  NOTE
+)
+
+Statement::AuditNote.create!(
+  statement_id: 458,
+  body: <<~NOTE.squish
+    Known discrepancy with what was invoiced following data migration to RECT service in April 2026: -£171.40
+    <br/></br/>
+    Retained-1 declaration (0e907957-5c0f-43f4-8604-9a6d9b745d3b) included for clawback in ECF1 service but was unable
+    to be represented in the RECT service
+  NOTE
+)
+
+Statement::AuditNote.create!(
+  statement_id: 506,
+  body: <<~NOTE.squish
+    Known discrepancy with what was invoiced following data migration to RECT service in April 2026: +£104.33
+    <br/></br/>
+    Retained-1 declaration (ed8fef62-3a53-4b2d-8230-97a64e90847c) included for payment in ECF1 service but was unable
+    to be represented in the RECT service
+  NOTE
+)
+
+Statement::AuditNote.create!(
+  statement_id: 471,
+  body: <<~NOTE.squish
+    Known discrepancy with what was invoiced following data migration to RECT service in April 2026: -£104.33
+    <br/></br/>
+    Retained-1 declaration (ed8fef62-3a53-4b2d-8230-97a64e90847c) included for clawback in ECF1 service but was unable
+    to be represented in the RECT service
+  NOTE
+)
+
+Statement::AuditNote.create!(
+  statement_id: 795,
+  body: <<~NOTE.squish
+    Known discrepancy with what was invoiced following data migration to RECT service in April 2026: -£120.00
+    <br/></br/>
+    x1 additional uplift fee included for payment in ECF1 service but was unable to be represented in the RECT service
+  NOTE
+)


### PR DESCRIPTION
### Context

Add the initial statement audit notes to the database.  These are intended to be view only and attached to a Statement where there is something noteworthy for contract managers to see.

Also to preserve paragraph spacing of the audit notes, I've added HTML `<br/>` elements to the notes and made the content `.html_safe` in the view component.

### Changes proposed in this pull request

Script to add the audit notes
Render note body as HTML-safe

### Guidance to review

Example of note displayed on Statement view:
<img width="1029" height="369" alt="image" src="https://github.com/user-attachments/assets/62734db1-bd67-474d-a42f-4527a4ed98c8" />
