### PR TITLE
[4270] Fix incorrect "Not Available" Lead Provider message

### DIFF
--- a/app/controllers/schools/ects_controller.rb
+++ b/app/controllers/schools/ects_controller.rb
@@ -12,7 +12,7 @@ module Schools
           query_string: params[:q]
         )
         .search
-        .includes(
+        .preload( # .includes folds into search query and breaks when no current/next TP
           ongoing_induction_period: :appropriate_body_period,
           ect_at_school_periods: %i[latest_training_period mentorship_periods],
           current_or_next_ect_at_school_period: [

--- a/spec/requests/schools/ects_spec.rb
+++ b/spec/requests/schools/ects_spec.rb
@@ -34,6 +34,31 @@ RSpec.describe "ECT summary" do
         expect(response).to have_http_status(:ok)
       end
     end
+
+    context "when the ECT has no current or next training period" do
+      let(:lead_provider) { FactoryBot.create(:lead_provider, name: "Ambition Institute") }
+      let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:) }
+
+      let!(:finished_training_period) do
+        FactoryBot.create(
+          :training_period,
+          :with_active_lead_provider,
+          active_lead_provider:,
+          ect_at_school_period: ect,
+          started_on: 2.years.ago,
+          finished_on: 6.months.ago
+        )
+      end
+
+      before { sign_in_as(:school_user, school:) }
+
+      it "shows the lead provider of the latest training period rather than 'Not available'" do
+        subject
+
+        expect(response.body).to include("Ambition Institute")
+        expect(response.body).not_to include(ECTHelper::NOT_AVAILABLE)
+      end
+    end
   end
 
   describe "GET #show" do


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/4270

### Changes proposed in this pull request

`Teachers::Search#where_ect_at` calls `eager_load(current_or_next_ect_at_school_period: …)`, which makes the whole relation eager loading. This meant that the `.includes` the controller chained was folded it into the same `LEFT OUTER JOIN`.

Because `latest_training_period.lead_provider` was resolved through the current/next period's join chain, if an ECT had no current or next period, the joined chain would be all NULL, so the latest period's lead provider comes back NULL, which triggers the "Not available" message. The same collapse would affect `delivery_partner` and `expression_of_interest_lead_provider`.

By changing from `includes` to `preload`, the query doesn't get rolled up, and we get the desired outcome.

### Guidance to review

Check the same record mentioned in the ticket on staging; it should no longer show "Not available".