### PR TITLE
[4030] Remove opened_on conditions

### DIFF
--- a/app/models/gias/school.rb
+++ b/app/models/gias/school.rb
@@ -82,7 +82,7 @@ class GIAS::School < ApplicationRecord
   end
 
   def can_be_opened?
-    open_status? && opened_on_or_before_today? && school_not_yet_opened? && predecessors.empty? && successors.empty?
+    open_status? && school_not_yet_opened? && predecessors.empty? && successors.empty?
   end
 
   def can_be_replaced?
@@ -90,7 +90,6 @@ class GIAS::School < ApplicationRecord
       closed_on_or_before_today? &&
       successors.one? &&
       successor.open_status? &&
-      successor.opened_on_or_before_today? &&
       successor.school_not_yet_opened? &&
       school_being_replaced?
   end
@@ -101,7 +100,6 @@ class GIAS::School < ApplicationRecord
       no_school_merged_event_recorded? &&
       successors.one? &&
       successor.open_status? &&
-      successor.opened_on_or_before_today? &&
       successor.school.present? &&
       school_being_merged?
   end
@@ -114,12 +112,6 @@ class GIAS::School < ApplicationRecord
     return false if closed_on.blank?
 
     closed_on <= Date.current
-  end
-
-  def opened_on_or_before_today?
-    return false if opened_on.blank?
-
-    opened_on <= Date.current
   end
 
 private

--- a/app/services/gias/schools/open.rb
+++ b/app/services/gias/schools/open.rb
@@ -27,11 +27,12 @@ module GIAS::Schools
       Events::Record.record_school_opened_event!(
         school: gias_school.school,
         gias_school:,
-        happened_at: gias_school.opened_on,
+        happened_at:,
         author:
       )
     end
 
+    def happened_at = gias_school.opened_on || Date.current
     def author = Events::SystemAuthor.new
   end
 end

--- a/app/services/gias/schools/replace.rb
+++ b/app/services/gias/schools/replace.rb
@@ -41,7 +41,7 @@ module GIAS::Schools
           ect_at_school_period:,
           new_school: successor.school,
           old_school_name_and_urn:,
-          happened_at: successor.opened_on,
+          happened_at:,
           author:
         )
       end
@@ -54,7 +54,7 @@ module GIAS::Schools
           mentor_at_school_period:,
           new_school: successor.school,
           old_school_name_and_urn:,
-          happened_at: successor.opened_on,
+          happened_at:,
           author:
         )
       end
@@ -65,7 +65,7 @@ module GIAS::Schools
         school:,
         new_gias_school: successor,
         old_gias_school: gias_school,
-        happened_at: successor.opened_on,
+        happened_at:,
         author:
       )
     end
@@ -75,6 +75,7 @@ module GIAS::Schools
     delegate :successor, to: :gias_school
     delegate :school, to: :gias_school
 
+    def happened_at = gias_school.closed_on
     def author = Events::SystemAuthor.new
   end
 end

--- a/spec/models/gias/school_spec.rb
+++ b/spec/models/gias/school_spec.rb
@@ -224,8 +224,7 @@ describe GIAS::School do
     describe "#can_be_opened?" do
       subject { gias_school.can_be_opened? }
 
-      let(:gias_school) { FactoryBot.create(:gias_school, status: :open, opened_on:) }
-      let(:opened_on) { Date.current }
+      let(:gias_school) { FactoryBot.create(:gias_school, status: :open) }
 
       context "when the school is open, has no predecessors or successors and no associated school" do
         it { is_expected.to be_truthy }
@@ -258,18 +257,6 @@ describe GIAS::School do
 
         it { is_expected.to be_falsy }
       end
-
-      context "when the school opens in the future" do
-        let(:opened_on) { Date.tomorrow }
-
-        it { is_expected.to be_falsy }
-      end
-
-      context "when the school opened in the past but it has not yet been associated with a school record" do
-        let(:opened_on) { Date.yesterday }
-
-        it { is_expected.to be_truthy }
-      end
     end
 
     describe "#can_be_replaced?" do
@@ -282,8 +269,7 @@ describe GIAS::School do
         it { is_expected.to be_falsy }
 
         context "when there is a unique successor" do
-          let(:successor) { FactoryBot.create(:gias_school, status: :open, opened_on:) }
-          let(:opened_on) { Date.current }
+          let(:successor) { FactoryBot.create(:gias_school, status: :open) }
 
           before do
             FactoryBot.create(:gias_school_link, :successor_unique, from_gias_school: gias_school, to_gias_school: successor)
@@ -300,32 +286,20 @@ describe GIAS::School do
           end
 
           context "when the successor is not open" do
-            let(:successor) { FactoryBot.create(:gias_school, status: :proposed_to_open, opened_on:) }
+            let(:successor) { FactoryBot.create(:gias_school, status: :proposed_to_open) }
 
             it { is_expected.to be_falsy }
           end
 
           context "when the successor already has an associated school" do
-            let(:successor) { FactoryBot.create(:gias_school, :with_school, status: :open, opened_on:) }
+            let(:successor) { FactoryBot.create(:gias_school, :with_school, status: :open) }
 
             it { is_expected.to be_falsy }
-          end
-
-          context "when the successor opens in the future" do
-            let(:opened_on) { Date.tomorrow }
-
-            it { is_expected.to be_falsy }
-          end
-
-          context "when the successor opened in the past but it has not yet been associated with a school record" do
-            let(:opened_on) { Date.yesterday }
-
-            it { is_expected.to be_truthy }
           end
         end
 
         context "when there is a non-unique successor" do
-          let(:successor) { FactoryBot.create(:gias_school, status: :open, opened_on: Date.current) }
+          let(:successor) { FactoryBot.create(:gias_school, status: :open) }
 
           context "when the school is being merged" do
             before do
@@ -385,8 +359,7 @@ describe GIAS::School do
         it { is_expected.to be_falsy }
 
         context "when there is a unique successor" do
-          let(:successor) { FactoryBot.create(:gias_school, :with_school, status: :open, opened_on:) }
-          let(:opened_on) { Date.current }
+          let(:successor) { FactoryBot.create(:gias_school, :with_school, status: :open) }
           let(:link_type) { :successor_merged }
 
           before do
@@ -398,19 +371,13 @@ describe GIAS::School do
           end
 
           context "when the successor is not open" do
-            let(:successor) { FactoryBot.create(:gias_school, :with_school, status: :proposed_to_open, opened_on:) }
+            let(:successor) { FactoryBot.create(:gias_school, :with_school, status: :proposed_to_open) }
 
             it { is_expected.to be_falsy }
           end
 
           context "when the successor does not have a school record" do
-            let(:successor) { FactoryBot.create(:gias_school, status: :open, opened_on:) }
-
-            it { is_expected.to be_falsy }
-          end
-
-          context "when the successor opens in the future" do
-            let(:opened_on) { Date.tomorrow }
+            let(:successor) { FactoryBot.create(:gias_school, status: :open) }
 
             it { is_expected.to be_falsy }
           end
@@ -437,8 +404,8 @@ describe GIAS::School do
         end
 
         context "when there are multiple successors" do
-          let(:successor) { FactoryBot.create(:gias_school, :with_school, status: :open, opened_on: Date.current) }
-          let(:other_successor) { FactoryBot.create(:gias_school, :with_school, status: :open, opened_on: Date.current) }
+          let(:successor) { FactoryBot.create(:gias_school, :with_school, status: :open) }
+          let(:other_successor) { FactoryBot.create(:gias_school, :with_school, status: :open) }
 
           before do
             FactoryBot.create(:gias_school_link, :successor_merged, from_gias_school: gias_school, to_gias_school: other_successor)
@@ -451,7 +418,7 @@ describe GIAS::School do
 
       context "when the school is not closed" do
         let(:gias_school) { FactoryBot.create(:gias_school, status: :proposed_to_close) }
-        let(:successor) { FactoryBot.create(:gias_school, :with_school, status: :open, opened_on: Date.current) }
+        let(:successor) { FactoryBot.create(:gias_school, :with_school, status: :open) }
 
         before do
           FactoryBot.create(:gias_school_link, :successor_merged, from_gias_school: gias_school, to_gias_school: successor)
@@ -502,36 +469,6 @@ describe GIAS::School do
 
       context "when the school closes tomorrow" do
         let(:closed_on) { Date.tomorrow }
-
-        it { is_expected.to be_falsy }
-      end
-    end
-
-    describe "#opened_on_or_before_today?" do
-      subject { gias_school.opened_on_or_before_today? }
-
-      let(:gias_school) { FactoryBot.create(:gias_school, opened_on:) }
-
-      context "when the school does not have an opened_on date" do
-        let(:opened_on) { nil }
-
-        it { is_expected.to be_falsy }
-      end
-
-      context "when the school opened yesterday" do
-        let(:opened_on) { Date.yesterday }
-
-        it { is_expected.to be_truthy }
-      end
-
-      context "when the school opens today" do
-        let(:opened_on) { Date.current }
-
-        it { is_expected.to be_truthy }
-      end
-
-      context "when the school opens tomorrow" do
-        let(:opened_on) { Date.tomorrow }
 
         it { is_expected.to be_falsy }
       end

--- a/spec/services/gias/schools/open_spec.rb
+++ b/spec/services/gias/schools/open_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe GIAS::Schools::Open do
       expect(gias_school.school).to be_present
     end
 
-    it "records a school opened event" do
+    it "records a school opened event with the current date" do
       allow(Events::Record).to receive(:record_school_opened_event!)
 
       service
@@ -32,9 +32,28 @@ RSpec.describe GIAS::Schools::Open do
       expect(Events::Record).to have_received(:record_school_opened_event!).with(
         school:,
         gias_school:,
-        happened_at: gias_school.opened_on,
+        happened_at: Date.current,
         author: an_instance_of(Events::SystemAuthor)
       ).once
+    end
+
+    context "when GIAS provides an opening date" do
+      let!(:gias_school) { FactoryBot.create(:gias_school, status: :open, opened_on: Date.yesterday) }
+
+      it "records a school opened event with the provided date" do
+        allow(Events::Record).to receive(:record_school_opened_event!)
+
+        service
+
+        school = gias_school.reload.school
+
+        expect(Events::Record).to have_received(:record_school_opened_event!).with(
+          school:,
+          gias_school:,
+          happened_at: Date.yesterday,
+          author: an_instance_of(Events::SystemAuthor)
+        ).once
+      end
     end
 
     context "when the school cannot be opened" do

--- a/spec/services/gias/schools/replace_spec.rb
+++ b/spec/services/gias/schools/replace_spec.rb
@@ -2,7 +2,8 @@ RSpec.describe GIAS::Schools::Replace do
   describe "#replace!" do
     subject(:service) { described_class.new(gias_school).replace! }
 
-    let(:gias_school) { FactoryBot.create(:gias_school, :with_school, status: :closed) }
+    let(:gias_school) { FactoryBot.create(:gias_school, :with_school, status: :closed, closed_on:) }
+    let(:closed_on) { Date.yesterday }
     let(:successor_gias_school) { FactoryBot.create(:gias_school, status: :open) }
     let(:other_gias_school) { FactoryBot.create(:gias_school) }
     let!(:school_link) { FactoryBot.create(:gias_school_link, link_type, from_gias_school: gias_school, to_gias_school: successor_gias_school) }
@@ -28,7 +29,7 @@ RSpec.describe GIAS::Schools::Replace do
           school: gias_school.school,
           new_gias_school: successor_gias_school,
           old_gias_school: gias_school,
-          happened_at: successor_gias_school.opened_on,
+          happened_at: closed_on,
           author: an_instance_of(Events::SystemAuthor)
         ).once
 
@@ -53,7 +54,7 @@ RSpec.describe GIAS::Schools::Replace do
               ect_at_school_period: ect,
               new_school: successor_gias_school.school,
               old_school_name_and_urn: Schools::Name.new(gias_school).name_and_urn,
-              happened_at: successor_gias_school.opened_on,
+              happened_at: closed_on,
               author: an_instance_of(Events::SystemAuthor)
             ).once
           end
@@ -78,7 +79,7 @@ RSpec.describe GIAS::Schools::Replace do
               mentor_at_school_period: mentor,
               new_school: successor_gias_school.school,
               old_school_name_and_urn: Schools::Name.new(gias_school).name_and_urn,
-              happened_at: successor_gias_school.opened_on,
+              happened_at: closed_on,
               author: an_instance_of(Events::SystemAuthor)
             ).once
           end


### PR DESCRIPTION
### Context
During manual testing of the GIAS services, we discovered that a large number of open schools have no opening date. Since this affects both historical and new schools it seems best to rely on the school's status only. I've spoken to @tonyheadford about this and he thought this best. I considered adding a method to the `GIAS::Schools::Open` service to set the `opened_on` date when it was missing. But we'd also have to backfill old dates, which we might not have appropriate data to do.

### Changes proposed in this pull request
Remove the `opened_on_or_before_today?` condition on `can_be_opened?`, `can_be_replaced?`, and `can_be_merged?`.  The main changes are to the events.  The `GIAS::Schools::Replace` service now uses the date the school being replaced `closed_on`, because that is still a condition on a school being replaced.  From looking at the data I could not find instances of closed schools with `closed_on = nil` 

### Guidance to review
