### PR TITLE
[4030] Treat amalgamations as mergers

### DIFF
--- a/app/models/gias/school.rb
+++ b/app/models/gias/school.rb
@@ -101,7 +101,7 @@ class GIAS::School < ApplicationRecord
       successors.one? &&
       successor.open_status? &&
       successor.school.present? &&
-      school_being_merged?
+      school_being_merged_or_amalgamated?
   end
 
   def school_not_yet_opened?
@@ -128,7 +128,9 @@ private
     successor_links.where(link_type: GIAS::SchoolLink::SUCESSOR).exists?
   end
 
-  def school_being_merged?
-    successor_links.where(link_type: GIAS::SchoolLink::SUCCESSOR_MERGED).exists?
+  def school_being_merged_or_amalgamated?
+    successor_links.where(
+      link_type: [GIAS::SchoolLink::SUCCESSOR_MERGED, GIAS::SchoolLink::SUCCESSOR_AMALGAMATED]
+    ).exists?
   end
 end

--- a/db/seeds/gias_data.rb
+++ b/db/seeds/gias_data.rb
@@ -366,7 +366,7 @@ FactoryBot.create(:gias_school_link,
 end
 
 FactoryBot.create(:gias_school_link,
-                  :successor_merged,
+                  :successor_amalgamated,
                   from_gias_school: girls_high_school,
                   to_gias_school: monstropolis_academy).tap do |school_link|
   describe_school_link(school_link)

--- a/spec/models/gias/school_spec.rb
+++ b/spec/models/gias/school_spec.rb
@@ -383,9 +383,15 @@ describe GIAS::School do
           end
 
           context "when the link between the schools is not a merger" do
-            let(:link_type) { :successor_amalgamated }
+            let(:link_type) { :successor_split }
 
             it { is_expected.to be_falsy }
+          end
+
+          context "when the school is being amalgamated" do
+            let(:link_type) { :successor_amalgamated }
+
+            it { is_expected.to be_truthy }
           end
 
           context "when the school closes in the future" do


### PR DESCRIPTION
### Context

From manual testing it would appear that amalgamations can be treated exactly like mergers.  We have a small number of amalgamations which have come through the wrong way round - successors identified as predecessors and vice versa.  But outside of this it would appear that amalgamations can be treated as mergers.  There are a number of proposed mergers where the successor school has not yet opened, and both schools are in `proposed_to_close` status.  The current guards will be able to handle that context.

### Changes proposed in this pull request

Simply widen the criteria we use to identify the `GIAS::SchoolLink` to include `Successor - amalgamation`.

### Guidance to review

Updated the test data so that the following code from the console can test an amalgamation.

```
gias_school = GIAS::School.find(9123502)
GIAS::Schools::Merge.new(gias_school).merge!
```
