### PR TITLE
[4030] Ensure events logged on both schools

### DIFF
--- a/app/services/gias/schools/merge.rb
+++ b/app/services/gias/schools/merge.rb
@@ -36,7 +36,7 @@ module GIAS::Schools
           GIAS::Schools::ECTAtSchoolPeriods::Transfer.call(ect_at_school_period:, predecessor_school:, successor_school:)
         end
 
-        record_school_merged_event!
+        record_school_merged_events!
       end
     end
 
@@ -47,14 +47,16 @@ module GIAS::Schools
       )
     end
 
-    def record_school_merged_event!
-      Events::Record.record_school_merged_event!(
-        school: predecessor_school,
-        successor_gias_school: successor,
-        predecessor_gias_school: gias_school,
-        happened_at: closed_on,
-        author:
-      )
+    def record_school_merged_events!
+      [predecessor_school, successor_school].each do |affected_school|
+        Events::Record.record_school_merged_event!(
+          school: affected_school,
+          successor_gias_school: successor,
+          predecessor_gias_school: gias_school,
+          happened_at: closed_on,
+          author:
+        )
+      end
     end
 
     def predecessor_school = school

--- a/spec/services/gias/schools/merge_spec.rb
+++ b/spec/services/gias/schools/merge_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe GIAS::Schools::Merge do
   subject(:service) { described_class.new(gias_school) }
 
-  let(:gias_school) { FactoryBot.create(:gias_school, :with_school, :closed) }
+  let(:gias_school) { FactoryBot.create(:gias_school, :with_school, :closed, closed_on: Date.yesterday) }
   let(:successor_gias_school) { FactoryBot.create(:gias_school, :with_school, :open) }
   let!(:school_link) do
     FactoryBot.create(
@@ -145,18 +145,22 @@ RSpec.describe GIAS::Schools::Merge do
           )
       end
 
-      it "records a school merged event" do
+      it "records a school merged event on each school record" do
         merge!
 
-        expect(Events::Record)
-          .to have_received(:record_school_merged_event!)
-          .with(
-            school: predecessor_school,
-            successor_gias_school:,
-            predecessor_gias_school: gias_school,
-            happened_at: gias_school.closed_on,
-            author: an_instance_of(Events::SystemAuthor)
-          )
+        aggregate_failures do
+          [predecessor_school, successor_school].each do |school|
+            expect(Events::Record)
+              .to have_received(:record_school_merged_event!)
+              .with(
+                school:,
+                successor_gias_school:,
+                predecessor_gias_school: gias_school,
+                happened_at: gias_school.closed_on,
+                author: an_instance_of(Events::SystemAuthor)
+              ).once
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

When a school is merged the predecessor school record remains, although all teachers have been moved out of it.  Initially the event was assigned to the successor school because that would remain open, and have all the other data.  This was changed during refactoring. In discussion with @mason-emily, it was decided it was probably best to log an event on both schools.

### Changes proposed in this pull request

Log a `school_merged` event twice, once for each school.

### Guidance to review
