### PR TITLE
[4030] Rename namespace

### DIFF
--- a/app/services/gias/reconciliation/close.rb
+++ b/app/services/gias/reconciliation/close.rb
@@ -1,4 +1,4 @@
-module GIAS::Schools
+module GIAS::Reconciliation
   class Close
     def initialize(gias_school)
       @gias_school = gias_school

--- a/app/services/gias/reconciliation/ect_at_school_periods/transfer.rb
+++ b/app/services/gias/reconciliation/ect_at_school_periods/transfer.rb
@@ -1,4 +1,4 @@
-module GIAS::Schools
+module GIAS::Reconciliation
   module ECTAtSchoolPeriods
     class Transfer
       def self.call(...) = new(...).call
@@ -48,7 +48,7 @@ module GIAS::Schools
       end
 
       def successor_partnership(predecessor_school_partnership)
-        GIAS::Schools::SchoolPartnerships::Transfer.call(predecessor_school_partnership:, successor_school:)
+        GIAS::Reconciliation::SchoolPartnerships::Transfer.call(predecessor_school_partnership:, successor_school:)
       end
 
       def record_event!

--- a/app/services/gias/reconciliation/ect_at_school_periods/transfer.rb
+++ b/app/services/gias/reconciliation/ect_at_school_periods/transfer.rb
@@ -48,7 +48,7 @@ module GIAS::Reconciliation
       end
 
       def successor_partnership(predecessor_school_partnership)
-        GIAS::Reconciliation::SchoolPartnerships::Transfer.call(predecessor_school_partnership:, successor_school:)
+        SchoolPartnerships::Transfer.call(predecessor_school_partnership:, successor_school:)
       end
 
       def record_event!

--- a/app/services/gias/reconciliation/mentor_at_school_periods/merge.rb
+++ b/app/services/gias/reconciliation/mentor_at_school_periods/merge.rb
@@ -1,4 +1,4 @@
-module GIAS::Schools
+module GIAS::Reconciliation
   module MentorAtSchoolPeriods
     class Merge
       def self.call(...) = new(...).call
@@ -68,7 +68,7 @@ module GIAS::Schools
 
       def update_mentorship_periods!
         mentorship_periods.each do |mentorship_period|
-          GIAS::Schools::ECTAtSchoolPeriods::Transfer.call(ect_at_school_period: mentorship_period.mentee, predecessor_school:, successor_school:)
+          GIAS::Reconciliation::ECTAtSchoolPeriods::Transfer.call(ect_at_school_period: mentorship_period.mentee, predecessor_school:, successor_school:)
           mentorship_period.mentor = successor_period
           mentorship_period.save!
         end
@@ -86,7 +86,7 @@ module GIAS::Schools
       end
 
       def successor_partnership(predecessor_school_partnership)
-        GIAS::Schools::SchoolPartnerships::Transfer.call(predecessor_school_partnership:, successor_school:)
+        GIAS::Reconciliation::SchoolPartnerships::Transfer.call(predecessor_school_partnership:, successor_school:)
       end
 
       def finished_on

--- a/app/services/gias/reconciliation/mentor_at_school_periods/merge.rb
+++ b/app/services/gias/reconciliation/mentor_at_school_periods/merge.rb
@@ -68,7 +68,7 @@ module GIAS::Reconciliation
 
       def update_mentorship_periods!
         mentorship_periods.each do |mentorship_period|
-          GIAS::Reconciliation::ECTAtSchoolPeriods::Transfer.call(ect_at_school_period: mentorship_period.mentee, predecessor_school:, successor_school:)
+          ECTAtSchoolPeriods::Transfer.call(ect_at_school_period: mentorship_period.mentee, predecessor_school:, successor_school:)
           mentorship_period.mentor = successor_period
           mentorship_period.save!
         end
@@ -86,7 +86,7 @@ module GIAS::Reconciliation
       end
 
       def successor_partnership(predecessor_school_partnership)
-        GIAS::Reconciliation::SchoolPartnerships::Transfer.call(predecessor_school_partnership:, successor_school:)
+        SchoolPartnerships::Transfer.call(predecessor_school_partnership:, successor_school:)
       end
 
       def finished_on

--- a/app/services/gias/reconciliation/mentor_at_school_periods/overlapping.rb
+++ b/app/services/gias/reconciliation/mentor_at_school_periods/overlapping.rb
@@ -1,4 +1,4 @@
-module GIAS::Schools
+module GIAS::Reconciliation
   module MentorAtSchoolPeriods
     class Overlapping
       def self.find(...) = new(...).find

--- a/app/services/gias/reconciliation/mentor_at_school_periods/transfer.rb
+++ b/app/services/gias/reconciliation/mentor_at_school_periods/transfer.rb
@@ -1,4 +1,4 @@
-module GIAS::Schools
+module GIAS::Reconciliation
   module MentorAtSchoolPeriods
     class Transfer
       def self.call(...) = new(...).call
@@ -50,12 +50,12 @@ module GIAS::Schools
 
       def update_mentorship_periods!
         mentorship_periods.each do |mentorship_period|
-          GIAS::Schools::ECTAtSchoolPeriods::Transfer.call(ect_at_school_period: mentorship_period.mentee, predecessor_school:, successor_school:)
+          GIAS::Reconciliation::ECTAtSchoolPeriods::Transfer.call(ect_at_school_period: mentorship_period.mentee, predecessor_school:, successor_school:)
         end
       end
 
       def successor_partnership(predecessor_school_partnership)
-        GIAS::Schools::SchoolPartnerships::Transfer.call(predecessor_school_partnership:, successor_school:)
+        GIAS::Reconciliation::SchoolPartnerships::Transfer.call(predecessor_school_partnership:, successor_school:)
       end
 
       def record_event!

--- a/app/services/gias/reconciliation/mentor_at_school_periods/transfer.rb
+++ b/app/services/gias/reconciliation/mentor_at_school_periods/transfer.rb
@@ -50,12 +50,12 @@ module GIAS::Reconciliation
 
       def update_mentorship_periods!
         mentorship_periods.each do |mentorship_period|
-          GIAS::Reconciliation::ECTAtSchoolPeriods::Transfer.call(ect_at_school_period: mentorship_period.mentee, predecessor_school:, successor_school:)
+          ECTAtSchoolPeriods::Transfer.call(ect_at_school_period: mentorship_period.mentee, predecessor_school:, successor_school:)
         end
       end
 
       def successor_partnership(predecessor_school_partnership)
-        GIAS::Reconciliation::SchoolPartnerships::Transfer.call(predecessor_school_partnership:, successor_school:)
+        SchoolPartnerships::Transfer.call(predecessor_school_partnership:, successor_school:)
       end
 
       def record_event!

--- a/app/services/gias/reconciliation/merge.rb
+++ b/app/services/gias/reconciliation/merge.rb
@@ -20,20 +20,20 @@ module GIAS::Reconciliation
       ActiveRecord::Base.transaction do
         mentor_teachers.each do |teacher|
           overlapping_mentor_at_school_periods(teacher).each do |periods|
-            GIAS::Reconciliation::MentorAtSchoolPeriods::Merge.call(periods:, predecessor_school:, successor_school:)
+            MentorAtSchoolPeriods::Merge.call(periods:, predecessor_school:, successor_school:)
           end
         end
 
         remaining_mentor_periods = predecessor_school.mentor_at_school_periods.reload
 
         remaining_mentor_periods.each do |mentor_at_school_period|
-          GIAS::Reconciliation::MentorAtSchoolPeriods::Transfer.call(mentor_at_school_period:, predecessor_school:, successor_school:)
+          MentorAtSchoolPeriods::Transfer.call(mentor_at_school_period:, predecessor_school:, successor_school:)
         end
 
         remaining_ect_periods = predecessor_school.ect_at_school_periods.reload
 
         remaining_ect_periods.each do |ect_at_school_period|
-          GIAS::Reconciliation::ECTAtSchoolPeriods::Transfer.call(ect_at_school_period:, predecessor_school:, successor_school:)
+          ECTAtSchoolPeriods::Transfer.call(ect_at_school_period:, predecessor_school:, successor_school:)
         end
 
         record_school_merged_event!
@@ -41,7 +41,7 @@ module GIAS::Reconciliation
     end
 
     def overlapping_mentor_at_school_periods(teacher)
-      GIAS::Reconciliation::MentorAtSchoolPeriods::Overlapping.find(
+      MentorAtSchoolPeriods::Overlapping.find(
         teacher:,
         schools: [predecessor_school, successor_school]
       )

--- a/app/services/gias/reconciliation/merge.rb
+++ b/app/services/gias/reconciliation/merge.rb
@@ -1,4 +1,4 @@
-module GIAS::Schools
+module GIAS::Reconciliation
   class Merge
     def initialize(gias_school)
       @gias_school = gias_school
@@ -20,20 +20,20 @@ module GIAS::Schools
       ActiveRecord::Base.transaction do
         mentor_teachers.each do |teacher|
           overlapping_mentor_at_school_periods(teacher).each do |periods|
-            GIAS::Schools::MentorAtSchoolPeriods::Merge.call(periods:, predecessor_school:, successor_school:)
+            GIAS::Reconciliation::MentorAtSchoolPeriods::Merge.call(periods:, predecessor_school:, successor_school:)
           end
         end
 
         remaining_mentor_periods = predecessor_school.mentor_at_school_periods.reload
 
         remaining_mentor_periods.each do |mentor_at_school_period|
-          GIAS::Schools::MentorAtSchoolPeriods::Transfer.call(mentor_at_school_period:, predecessor_school:, successor_school:)
+          GIAS::Reconciliation::MentorAtSchoolPeriods::Transfer.call(mentor_at_school_period:, predecessor_school:, successor_school:)
         end
 
         remaining_ect_periods = predecessor_school.ect_at_school_periods.reload
 
         remaining_ect_periods.each do |ect_at_school_period|
-          GIAS::Schools::ECTAtSchoolPeriods::Transfer.call(ect_at_school_period:, predecessor_school:, successor_school:)
+          GIAS::Reconciliation::ECTAtSchoolPeriods::Transfer.call(ect_at_school_period:, predecessor_school:, successor_school:)
         end
 
         record_school_merged_event!
@@ -41,7 +41,7 @@ module GIAS::Schools
     end
 
     def overlapping_mentor_at_school_periods(teacher)
-      GIAS::Schools::MentorAtSchoolPeriods::Overlapping.find(
+      GIAS::Reconciliation::MentorAtSchoolPeriods::Overlapping.find(
         teacher:,
         schools: [predecessor_school, successor_school]
       )

--- a/app/services/gias/reconciliation/open.rb
+++ b/app/services/gias/reconciliation/open.rb
@@ -1,4 +1,4 @@
-module GIAS::Schools
+module GIAS::Reconciliation
   class Open
     def initialize(gias_school)
       @gias_school = gias_school

--- a/app/services/gias/reconciliation/replace.rb
+++ b/app/services/gias/reconciliation/replace.rb
@@ -1,4 +1,4 @@
-module GIAS::Schools
+module GIAS::Reconciliation
   class Replace
     def initialize(gias_school)
       @gias_school = gias_school

--- a/app/services/gias/reconciliation/school_partnerships/transfer.rb
+++ b/app/services/gias/reconciliation/school_partnerships/transfer.rb
@@ -1,4 +1,4 @@
-module GIAS::Schools
+module GIAS::Reconciliation
   module SchoolPartnerships
     class Transfer
       def self.call(...) = new(...).call

--- a/spec/services/gias/reconciliation/close_spec.rb
+++ b/spec/services/gias/reconciliation/close_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe GIAS::Schools::Close do
+RSpec.describe GIAS::Reconciliation::Close do
   describe "#close" do
     subject(:service) { described_class.new(gias_school).close! }
 

--- a/spec/services/gias/reconciliation/ect_at_school_periods/transfer_spec.rb
+++ b/spec/services/gias/reconciliation/ect_at_school_periods/transfer_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe GIAS::Schools::ECTAtSchoolPeriods::Transfer do
+RSpec.describe GIAS::Reconciliation::ECTAtSchoolPeriods::Transfer do
   let(:author) { Events::SystemAuthor.new }
   let(:predecessor_gias_school) { FactoryBot.create(:gias_school, :with_school) }
   let(:gias_school) { FactoryBot.create(:gias_school, :with_school) }

--- a/spec/services/gias/reconciliation/mentor_at_school_periods/merge_spec.rb
+++ b/spec/services/gias/reconciliation/mentor_at_school_periods/merge_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe GIAS::Schools::MentorAtSchoolPeriods::Merge do
+RSpec.describe GIAS::Reconciliation::MentorAtSchoolPeriods::Merge do
   subject(:service) do
     described_class.call(
       periods:,

--- a/spec/services/gias/reconciliation/mentor_at_school_periods/overlapping_spec.rb
+++ b/spec/services/gias/reconciliation/mentor_at_school_periods/overlapping_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe GIAS::Schools::MentorAtSchoolPeriods::Overlapping do
+RSpec.describe GIAS::Reconciliation::MentorAtSchoolPeriods::Overlapping do
   subject(:groups) { described_class.find(teacher:, schools:) }
 
   let(:teacher) { FactoryBot.create(:teacher) }

--- a/spec/services/gias/reconciliation/mentor_at_school_periods/transfer_spec.rb
+++ b/spec/services/gias/reconciliation/mentor_at_school_periods/transfer_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe GIAS::Schools::MentorAtSchoolPeriods::Transfer do
+RSpec.describe GIAS::Reconciliation::MentorAtSchoolPeriods::Transfer do
   let(:author) { Events::SystemAuthor.new }
   let(:predecessor_gias_school) { FactoryBot.create(:gias_school, :with_school) }
   let(:gias_school) { FactoryBot.create(:gias_school, :with_school) }
@@ -84,15 +84,15 @@ RSpec.describe GIAS::Schools::MentorAtSchoolPeriods::Transfer do
         end
       end
 
-      it "calls GIAS::Schools::ECTAtSchoolPeriods::Transfer for each mentorship_period's mentee" do
+      it "calls GIAS::Reconciliation::ECTAtSchoolPeriods::Transfer for each mentorship_period's mentee" do
         ect_at_school_periods.each do |_mentee|
-          allow(GIAS::Schools::ECTAtSchoolPeriods::Transfer).to receive(:call).and_call_original
+          allow(GIAS::Reconciliation::ECTAtSchoolPeriods::Transfer).to receive(:call).and_call_original
         end
 
         subject
 
         ect_at_school_periods.each do |mentee|
-          expect(GIAS::Schools::ECTAtSchoolPeriods::Transfer).to have_received(:call).with(ect_at_school_period: mentee, predecessor_school:, successor_school:)
+          expect(GIAS::Reconciliation::ECTAtSchoolPeriods::Transfer).to have_received(:call).with(ect_at_school_period: mentee, predecessor_school:, successor_school:)
         end
       end
     end

--- a/spec/services/gias/reconciliation/merge_spec.rb
+++ b/spec/services/gias/reconciliation/merge_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe GIAS::Schools::Merge do
+RSpec.describe GIAS::Reconciliation::Merge do
   subject(:service) { described_class.new(gias_school) }
 
   let(:gias_school) { FactoryBot.create(:gias_school, :with_school, :closed) }
@@ -28,25 +28,25 @@ RSpec.describe GIAS::Schools::Merge do
       it { expect(merge!).to be_falsey }
 
       it "does not find any overlapping `MentorAtSchoolPeriod` records" do
-        expect(GIAS::Schools::MentorAtSchoolPeriods::Overlapping).not_to receive(:find)
+        expect(GIAS::Reconciliation::MentorAtSchoolPeriods::Overlapping).not_to receive(:find)
 
         merge!
       end
 
       it "does not merge any `MentorAtSchoolPeriod` records" do
-        expect(GIAS::Schools::MentorAtSchoolPeriods::Merge).not_to receive(:call)
+        expect(GIAS::Reconciliation::MentorAtSchoolPeriods::Merge).not_to receive(:call)
 
         merge!
       end
 
       it "does not transfer any `MentorAtSchoolPeriod` records" do
-        expect(GIAS::Schools::MentorAtSchoolPeriods::Transfer).not_to receive(:call)
+        expect(GIAS::Reconciliation::MentorAtSchoolPeriods::Transfer).not_to receive(:call)
 
         merge!
       end
 
       it "does not transfer any `ECTAtSchoolPeriod` records" do
-        expect(GIAS::Schools::ECTAtSchoolPeriods::Transfer).not_to receive(:call)
+        expect(GIAS::Reconciliation::ECTAtSchoolPeriods::Transfer).not_to receive(:call)
 
         merge!
       end
@@ -87,12 +87,12 @@ RSpec.describe GIAS::Schools::Merge do
       end
 
       before do
-        allow(GIAS::Schools::MentorAtSchoolPeriods::Overlapping)
+        allow(GIAS::Reconciliation::MentorAtSchoolPeriods::Overlapping)
           .to receive(:find)
           .and_return([[mentor_at_school_period]])
-        allow(GIAS::Schools::MentorAtSchoolPeriods::Merge).to receive(:call)
-        allow(GIAS::Schools::MentorAtSchoolPeriods::Transfer).to receive(:call)
-        allow(GIAS::Schools::ECTAtSchoolPeriods::Transfer).to receive(:call)
+        allow(GIAS::Reconciliation::MentorAtSchoolPeriods::Merge).to receive(:call)
+        allow(GIAS::Reconciliation::MentorAtSchoolPeriods::Transfer).to receive(:call)
+        allow(GIAS::Reconciliation::ECTAtSchoolPeriods::Transfer).to receive(:call)
         allow(Events::Record).to receive(:record_school_merged_event!)
       end
 
@@ -101,7 +101,7 @@ RSpec.describe GIAS::Schools::Merge do
       it "finds overlapping `MentorAtSchoolPeriod` records for each mentor teacher" do
         merge!
 
-        expect(GIAS::Schools::MentorAtSchoolPeriods::Overlapping)
+        expect(GIAS::Reconciliation::MentorAtSchoolPeriods::Overlapping)
           .to have_received(:find)
           .with(
             teacher: mentor_teacher,
@@ -112,7 +112,7 @@ RSpec.describe GIAS::Schools::Merge do
       it "merges overlapping `MentorAtSchoolPeriod` records" do
         merge!
 
-        expect(GIAS::Schools::MentorAtSchoolPeriods::Merge)
+        expect(GIAS::Reconciliation::MentorAtSchoolPeriods::Merge)
           .to have_received(:call)
           .with(
             periods: [mentor_at_school_period],
@@ -124,7 +124,7 @@ RSpec.describe GIAS::Schools::Merge do
       it "transfers remaining `MentorAtSchoolPeriod` records" do
         merge!
 
-        expect(GIAS::Schools::MentorAtSchoolPeriods::Transfer)
+        expect(GIAS::Reconciliation::MentorAtSchoolPeriods::Transfer)
           .to have_received(:call)
           .with(
             mentor_at_school_period:,
@@ -136,7 +136,7 @@ RSpec.describe GIAS::Schools::Merge do
       it "transfers remaining `ECTAtSchoolPeriod` records" do
         merge!
 
-        expect(GIAS::Schools::ECTAtSchoolPeriods::Transfer)
+        expect(GIAS::Reconciliation::ECTAtSchoolPeriods::Transfer)
           .to have_received(:call)
           .with(
             ect_at_school_period:,

--- a/spec/services/gias/reconciliation/open_spec.rb
+++ b/spec/services/gias/reconciliation/open_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe GIAS::Schools::Open do
+RSpec.describe GIAS::Reconciliation::Open do
   describe "#open!" do
     subject(:service) { described_class.new(gias_school).open! }
 

--- a/spec/services/gias/reconciliation/replace_spec.rb
+++ b/spec/services/gias/reconciliation/replace_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe GIAS::Schools::Replace do
+RSpec.describe GIAS::Reconciliation::Replace do
   describe "#replace!" do
     subject(:service) { described_class.new(gias_school).replace! }
 

--- a/spec/services/gias/reconciliation/school_partnerships/transfer_spec.rb
+++ b/spec/services/gias/reconciliation/school_partnerships/transfer_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe GIAS::Schools::SchoolPartnerships::Transfer do
+RSpec.describe GIAS::Reconciliation::SchoolPartnerships::Transfer do
   subject(:service) do
     described_class.call(
       predecessor_school_partnership:,


### PR DESCRIPTION
### Context
Rename the `GIAS::Schools` namespace to `GIAS::Reconciliation`.  We had considered using the `GIAS::Importer` namespace.  But the code which will run this will run in a second service class, which I am planning to called `GIAS::Reconcile` since it runs after the import is completed and performs the necessary changes.  Also `Importer` is a class, not a module.  Whilst nesting these under the `GIAS::Importer` class isn't wrong, it seems a bad smell to use this as a namespace.