### PR TITLE
Fix Staging failure on invalid session handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ECF is a framework of standards to help early career teachers succeed at the start of their careers.
 
+
 ## Workflows
 
 [![App deployment](https://github.com/DFE-Digital/register-early-career-teachers-public/actions/workflows/deploy.yml/badge.svg)](https://github.com/DFE-Digital/register-early-career-teachers/actions/workflows/deploy.yml)

--- a/app/services/sessions/manager.rb
+++ b/app/services/sessions/manager.rb
@@ -30,8 +30,7 @@ module Sessions
     end
 
     # @see Sessions::User
-    # @raise [Sessions::User::UnrecognisedType]
-    # @return [Sessions::User]
+    # @return [Sessions::User, nil]
     def current_user
       @current_user ||= load_from_session
     end
@@ -85,9 +84,10 @@ module Sessions
 
         record_new_activity(session_user)
       end
-    rescue ArgumentError => e
-      Sentry.capture_exception(e)
+    rescue Sessions::User::InvalidSession, ArgumentError => e
+      Sentry.capture_exception(e, level: :info)
       end_session!
+      nil
     end
 
     def record_new_activity(session_user)

--- a/app/services/sessions/manager.rb
+++ b/app/services/sessions/manager.rb
@@ -85,7 +85,9 @@ module Sessions
         record_new_activity(session_user)
       end
     rescue Sessions::User::InvalidSession, ArgumentError => e
-      Sentry.capture_exception(e, level: :info)
+      # This will be expected regularly in Staging, as any push will refresh the data,
+      # so only capture this in production.
+      Sentry.capture_exception(e, level: :info) if Rails.env.production?
       end_session!
       nil
     end

--- a/app/services/sessions/user.rb
+++ b/app/services/sessions/user.rb
@@ -1,7 +1,8 @@
 module Sessions
   # Current user session base class
   class User
-    class UnrecognisedType < StandardError; end
+    class InvalidSession < StandardError; end
+    class UnrecognisedType < InvalidSession; end
 
     # @raise [Sessions::User::UnrecognisedType]
     #
@@ -16,9 +17,11 @@ module Sessions
       return unless (type = user_session&.dig("type"))
 
       user_props = user_session.except("type").symbolize_keys
-      type.constantize.new(**user_props)
-    rescue NameError
-      fail(UnrecognisedType, type)
+      session_user_class = type.safe_constantize
+
+      fail(UnrecognisedType, type) if session_user_class.nil?
+
+      session_user_class.new(**user_props)
     end
 
     attr_reader :email, :last_active_at

--- a/app/services/sessions/users/appropriate_body_persona.rb
+++ b/app/services/sessions/users/appropriate_body_persona.rb
@@ -1,8 +1,8 @@
 module Sessions
   module Users
     class AppropriateBodyPersona < User
-      class AppropriateBodyPersonaDisabledError < StandardError; end
-      class UnknownAppropriateBodyPeriodId < StandardError; end
+      class AppropriateBodyPersonaDisabledError < Sessions::User::InvalidSession; end
+      class UnknownAppropriateBodyPeriodId < Sessions::User::InvalidSession; end
 
       USER_TYPE = :appropriate_body_user
       PROVIDER = :persona

--- a/app/services/sessions/users/appropriate_body_user.rb
+++ b/app/services/sessions/users/appropriate_body_user.rb
@@ -1,7 +1,7 @@
 module Sessions
   module Users
     class AppropriateBodyUser < User
-      class UnknownOrganisationId < StandardError; end
+      class UnknownOrganisationId < Sessions::User::InvalidSession; end
 
       USER_TYPE = :appropriate_body_user
       PROVIDER = :dfe_sign_in

--- a/app/services/sessions/users/dfe_persona.rb
+++ b/app/services/sessions/users/dfe_persona.rb
@@ -1,8 +1,8 @@
 module Sessions
   module Users
     class DfEPersona < User
-      class DfEPersonaDisabledError < StandardError; end
-      class UnknownUserEmail < StandardError; end
+      class DfEPersonaDisabledError < Sessions::User::InvalidSession; end
+      class UnknownUserEmail < Sessions::User::InvalidSession; end
 
       include Sessions::ImpersonateSchoolUser
 

--- a/app/services/sessions/users/dfe_user.rb
+++ b/app/services/sessions/users/dfe_user.rb
@@ -1,7 +1,7 @@
 module Sessions
   module Users
     class DfEUser < User
-      class UnknownUserEmail < StandardError; end
+      class UnknownUserEmail < Sessions::User::InvalidSession; end
 
       include Sessions::ImpersonateSchoolUser
 

--- a/app/services/sessions/users/dfe_user_impersonating_school_user.rb
+++ b/app/services/sessions/users/dfe_user_impersonating_school_user.rb
@@ -1,7 +1,7 @@
 module Sessions
   module Users
     class DfEUserImpersonatingSchoolUser < DfEUser
-      class UnknownOrganisationURN < StandardError; end
+      class UnknownOrganisationURN < Sessions::User::InvalidSession; end
 
       attr_reader :original_type, :school
 

--- a/app/services/sessions/users/otp_school_user.rb
+++ b/app/services/sessions/users/otp_school_user.rb
@@ -1,7 +1,7 @@
 module Sessions
   module Users
     class OTPSchoolUser < User
-      class UnknownOrganisationURN < StandardError; end
+      class UnknownOrganisationURN < Sessions::User::InvalidSession; end
 
       USER_TYPE = :school_user
       PROVIDER = :otp

--- a/app/services/sessions/users/school_persona.rb
+++ b/app/services/sessions/users/school_persona.rb
@@ -1,8 +1,8 @@
 module Sessions
   module Users
     class SchoolPersona < User
-      class SchoolPersonaDisabledError < StandardError; end
-      class UnknownSchoolURN < StandardError; end
+      class SchoolPersonaDisabledError < Sessions::User::InvalidSession; end
+      class UnknownSchoolURN < Sessions::User::InvalidSession; end
 
       USER_TYPE = :school_user
       PROVIDER = :persona

--- a/app/services/sessions/users/school_user.rb
+++ b/app/services/sessions/users/school_user.rb
@@ -1,7 +1,7 @@
 module Sessions
   module Users
     class SchoolUser < User
-      class UnknownOrganisationURN < StandardError; end
+      class UnknownOrganisationURN < Sessions::User::InvalidSession; end
 
       USER_TYPE = :school_user
       PROVIDER = :dfe_sign_in

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -32,6 +32,25 @@ RSpec.describe "Sessions", type: :request do
     end
   end
 
+  describe "requesting a page after the records in the session have been deleted" do
+    let(:user) { FactoryBot.create(:user, :admin) }
+
+    before do
+      sign_in_as(:dfe_user, user:)
+      user.destroy!
+    end
+
+    it "signs the user out and redirects them to sign in" do
+      allow(Sentry).to receive(:capture_exception)
+
+      get("/admin/teachers")
+
+      expect(response).to redirect_to("/sign-in")
+      expect(Sentry).to have_received(:capture_exception)
+        .with(instance_of(Sessions::Users::DfEPersona::UnknownUserEmail), level: :info)
+    end
+  end
+
   describe "POST /auth/:provider/callback" do
     let(:first_name) { Faker::Name.first_name }
     let(:last_name) { Faker::Name.last_name }

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -41,13 +41,9 @@ RSpec.describe "Sessions", type: :request do
     end
 
     it "signs the user out and redirects them to sign in" do
-      allow(Sentry).to receive(:capture_exception)
-
       get("/admin/teachers")
 
       expect(response).to redirect_to("/sign-in")
-      expect(Sentry).to have_received(:capture_exception)
-        .with(instance_of(Sessions::Users::DfEPersona::UnknownUserEmail), level: :info)
     end
   end
 

--- a/spec/services/sessions/session_manager_spec.rb
+++ b/spec/services/sessions/session_manager_spec.rb
@@ -153,6 +153,24 @@ RSpec.describe Sessions::Manager do
         expect { service.current_user }.not_to raise_error
       end
     end
+
+    context "when the records the session refers to no longer exist" do
+      let(:session) { ActionController::TestSession.new }
+
+      before do
+        cookies["id_token"] = "stale_token"
+        session["user_session"]["school_urn"] = "999999"
+        allow(Sentry).to receive(:capture_exception)
+      end
+
+      it "signs the user out, clears the id_token and reports to Sentry" do
+        expect(service.current_user).to be_nil
+        expect(session["user_session"]).to be_nil
+        expect(cookies["id_token"]).to be_nil
+        expect(Sentry).to have_received(:capture_exception)
+          .with(instance_of(Sessions::Users::SchoolUser::UnknownOrganisationURN), level: :info)
+      end
+    end
   end
 
   describe "#end_session!" do

--- a/spec/services/sessions/session_manager_spec.rb
+++ b/spec/services/sessions/session_manager_spec.rb
@@ -163,12 +163,31 @@ RSpec.describe Sessions::Manager do
         allow(Sentry).to receive(:capture_exception)
       end
 
-      it "signs the user out, clears the id_token and reports to Sentry" do
+      it "signs the user out and clears the id_token" do
         expect(service.current_user).to be_nil
         expect(session["user_session"]).to be_nil
         expect(cookies["id_token"]).to be_nil
-        expect(Sentry).to have_received(:capture_exception)
-          .with(instance_of(Sessions::Users::SchoolUser::UnknownOrganisationURN), level: :info)
+      end
+
+      describe "Sentry reporting" do
+        subject { Sentry }
+
+        before do
+          allow(Rails.env).to receive(:production?).and_return(production)
+          service.current_user
+        end
+
+        context "in production" do
+          let(:production) { true }
+
+          it { is_expected.to have_received(:capture_exception).with(instance_of(Sessions::Users::SchoolUser::UnknownOrganisationURN), level: :info) }
+        end
+
+        context "not production" do
+          let(:production) { false }
+
+          it { is_expected.not_to have_received(:capture_exception) }
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

After a data refresh, a signed-in user's session points at data that no longer exists. This results in a 500 error instead of signing the user.

### Changes proposed in this pull request

When a user's session points at a deleted user, school, or appropriate body, Sessions::Manager#current_user now:
- logs the issue to Sentry at info level; 
- ends the session; 
- returns nil 

so the user is signed out rather than receiving a 500 error.

### Guidance to review

We introduce the concept of an InvalidSession and use that in place of StandardError. This is actually the bulk of the modifications in this PR.

> [!Note]
> Key question, sending a Sentry notification follows our current approach - but do we want to send it to Sentry at all?

If you want to check behaviour:

1. go to the review app
2. log in as an Appropriate Body leave the page open; 
3. modify the README file, push and wait for the rebuild of the review app;
4. then go back to the page and refresh, where previously this would have been a 500, it not logs out the user.
