### PR TITLE
Fix semantic headings in teacher registration forms

### DIFF
--- a/app/views/schools/register_ect_wizard/_review_ect_details.html.erb
+++ b/app/views/schools/register_ect_wizard/_review_ect_details.html.erb
@@ -34,7 +34,7 @@ end %>
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
   <%= content_for(:error_summary) { f.govuk_error_summary } %>
 
-  <%= f.govuk_radio_buttons_fieldset :change_name, legend: { text: "Are these details correct for the ECT?" } do %>
+  <%= f.govuk_radio_buttons_fieldset :change_name, legend: { text: "Are these details correct for the ECT?", tag: "h2" } do %>
     <%= f.govuk_radio_button :change_name, :no, label: { text: "Yes" }, link_errors: true %>
     <%= f.govuk_radio_button :change_name, :yes, label: { text: "No, they changed their name or it's spelt wrong" } do %>
       <%= f.govuk_text_field :corrected_name,

--- a/app/views/schools/register_ect_wizard/_use_previous_ect_choices.html.erb
+++ b/app/views/schools/register_ect_wizard/_use_previous_ect_choices.html.erb
@@ -21,7 +21,7 @@
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
   <%= content_for(:error_summary) { f.govuk_error_summary } %>
   <%= f.govuk_radio_buttons_fieldset :use_previous_ect_choices,
-                                     legend: { text: "Do you want to use the same choices for #{@ect.full_name}?" },
+                                     legend: { text: "Do you want to use the same choices for #{@ect.full_name}?", tag: "h2" },
                                      inline: true do %>
     <%= f.govuk_radio_button :use_previous_ect_choices,
                              :true,

--- a/app/views/schools/register_mentor_wizard/_review_mentor_details.html.erb
+++ b/app/views/schools/register_mentor_wizard/_review_mentor_details.html.erb
@@ -31,7 +31,7 @@ end %>
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
   <%= content_for(:error_summary) { f.govuk_error_summary } %>
 
-  <%= f.govuk_radio_buttons_fieldset :change_name, legend: { text: "Are these details correct for the mentor?" } do %>
+  <%= f.govuk_radio_buttons_fieldset :change_name, legend: { text: "Are these details correct for the mentor?", tag: "h2" } do %>
     <%= f.govuk_radio_button :change_name, :yes, label: { text: "Yes" }, link_errors: true %>
     <%= f.govuk_radio_button :change_name, :no, label: { text: "No, they changed their name or it's spelt wrong" } do %>
       <%= f.govuk_text_field :corrected_name,

--- a/app/views/schools/register_mentor_wizard/programme_choices.html.erb
+++ b/app/views/schools/register_mentor_wizard/programme_choices.html.erb
@@ -38,7 +38,7 @@ end %>
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
   <%= content_for(:error_summary) { f.govuk_error_summary } %>
 
-  <%= f.govuk_radio_buttons_fieldset :use_same_programme_choices, legend: { text: "Do you want to use the same programme choices for #{@mentor.full_name}’s mentor training?" }, inline: true do %>
+  <%= f.govuk_radio_buttons_fieldset :use_same_programme_choices, legend: { text: "Do you want to use the same programme choices for #{@mentor.full_name}’s mentor training?", tag: "h2", }, inline: true do %>
     <%= f.govuk_radio_button :use_same_programme_choices,
                          :yes,
                          label: {

--- a/app/views/shared/_find_teacher_fields.html.erb
+++ b/app/views/shared/_find_teacher_fields.html.erb
@@ -2,7 +2,7 @@
   f.govuk_text_field(
     :trn,
     width: 10,
-    label: { text: "Teacher reference number (TRN)", size: "m" },
+    label: { text: "Teacher reference number (TRN)", size: "m", tag: "h2" },
     hint: {
       text: "
         This unique ID is usually 7 digits long, for example 4567814. It may

--- a/app/views/shared/_find_teacher_fields.html.erb
+++ b/app/views/shared/_find_teacher_fields.html.erb
@@ -20,7 +20,7 @@
   f.govuk_date_field(
     :date_of_birth,
     width: "two-thirds",
-    legend: { text: "Date of birth", size: "m", tag: "h3" },
+    legend: { text: "Date of birth", size: "m", tag: "h2" },
     hint: { text: "For example, 31 3 1980" }
   )
 %>


### PR DESCRIPTION
Ticket [here](https://github.com/DFE-Digital/register-ects-project-board/issues/4085) 

### Context
Some form questions in the ECT and mentor registration journeys were styled visually as headings but were not marked up with the correct semantic heading levels.

### Changes proposed in this pull request
This PR changes the heading semantics identified in the accessibility review while retaining the existing visual styling and form behaviour.

- Adds semantic h2 headings to form questions in the ECT and mentor registration journeys.
- Updates the shared teacher lookup fields so “Teacher reference number (TRN)” is an h2 and dob is an h2
- Adds h2 semantics to the ECT details confirmation and previous programme choices questions.
- The shared TRN partial also applies this improvement to the appropriate body and admin ECT lookup journeys.


### Guidance to review
- No new specs added, as agreed during sizing; these are markup-only changes to existing GOV.UK form-builder components.