### PR TITLE
Fixes to API touch model

### DIFF
--- a/app/models/concerns/declarative_updates.rb
+++ b/app/models/concerns/declarative_updates.rb
@@ -19,10 +19,9 @@ module DeclarativeUpdates
       end
     end
 
-    def touch(target, when_changing: [], on_event: %i[update], timestamp_attribute: :updated_at, if: nil)
-      condition = binding.local_variable_get(:if)
+    def touch(target, when_changing: [], on_event: %i[update], timestamp_attribute: :updated_at)
       events = Array(on_event)
-      options = { target:, when_changing:, condition:, timestamp_attribute: }
+      options = { target:, when_changing:, timestamp_attribute: }
 
       after_create { DeclarativeUpdates.perform_touch(self, **options) } if events.include?(:create)
       after_update { DeclarativeUpdates.perform_touch(self, **options) } if events.include?(:update)
@@ -30,16 +29,14 @@ module DeclarativeUpdates
     end
   end
 
-  def self.perform_touch(record, target:, when_changing:, condition:, timestamp_attribute:)
+  def self.perform_touch(record, target:, when_changing:, timestamp_attribute:)
     return if skip?(:touch)
 
     should_touch_based_on_changes = record.destroyed? || when_changing.blank? || when_changing.any? do |attr|
       record.saved_change_to_attribute?(attr)
     end
 
-    should_touch_based_on_condition = condition.nil? || record.send(:evaluate_condition, condition)
-
-    return unless should_touch_based_on_changes && should_touch_based_on_condition
+    return unless should_touch_based_on_changes
 
     evaluated_target = record.instance_exec(&target)
 
@@ -69,18 +66,5 @@ module DeclarativeUpdates
     key = SKIP_THREAD_KEY.fetch(type) { raise ArgumentError, "Unknown declarative type: #{type}" }
 
     Thread.current[key]
-  end
-
-private
-
-  def evaluate_condition(condition)
-    case condition
-    when Symbol, String
-      send(condition)
-    when Proc
-      instance_exec(&condition)
-    else
-      condition
-    end
   end
 end

--- a/app/models/gias/school.rb
+++ b/app/models/gias/school.rb
@@ -4,7 +4,8 @@ class GIAS::School < ApplicationRecord
 
   include DeclarativeUpdates
 
-  touch -> { contract_period_metadata }, when_changing: %i[name], timestamp_attribute: :api_updated_at
+  touch -> { contract_period_metadata }, when_changing: %i[name primary_contact_email secondary_contact_email], timestamp_attribute: :api_updated_at
+  touch -> { school_partnerships }, when_changing: %i[primary_contact_email secondary_contact_email], timestamp_attribute: :api_updated_at
 
   # Enums
   enum :status,
@@ -17,6 +18,7 @@ class GIAS::School < ApplicationRecord
 
   # Associations
   has_one :school, foreign_key: :urn, primary_key: :urn, inverse_of: :gias_school
+  has_many :school_partnerships, through: :school
   has_many :school_funding_eligibilities, foreign_key: :gias_school_urn, primary_key: :urn, inverse_of: :gias_school
   has_many :contract_period_metadata, class_name: "Metadata::SchoolContractPeriod", through: :school
   has_many :gias_school_links, class_name: "GIAS::SchoolLink", foreign_key: :urn, dependent: :destroy, inverse_of: :from_gias_school

--- a/app/models/induction_period.rb
+++ b/app/models/induction_period.rb
@@ -110,9 +110,8 @@ private
 
   def touch_teacher?
     first_period = saved_change_to_id? && teacher.induction_periods.count == 1
-    outcome_changed = saved_change_to_outcome?
 
-    first_period || outcome_changed
+    first_period || saved_change_to_outcome? || saved_change_to_finished_on?
   end
 
   def at_most_one_outcome_per_teacher

--- a/app/models/induction_period.rb
+++ b/app/models/induction_period.rb
@@ -17,7 +17,7 @@ class InductionPeriod < ApplicationRecord
   belongs_to :teacher
   has_many :events
 
-  touch -> { teacher }, when_changing: %i[started_on finished_on], timestamp_attribute: :api_updated_at, if: :touch_teacher?
+  touch -> { teacher }, on_event: %i[create update], when_changing: %i[started_on finished_on outcome], timestamp_attribute: :api_updated_at
 
   refresh_metadata -> { teacher },
                    on_event: %i[create destroy update],
@@ -106,12 +106,6 @@ private
 
   def teacher_distinct_period
     overlap_validation(name: "induction")
-  end
-
-  def touch_teacher?
-    first_period = saved_change_to_id? && teacher.induction_periods.count == 1
-
-    first_period || saved_change_to_outcome? || saved_change_to_finished_on?
   end
 
   def at_most_one_outcome_per_teacher

--- a/app/models/induction_period.rb
+++ b/app/models/induction_period.rb
@@ -17,7 +17,7 @@ class InductionPeriod < ApplicationRecord
   belongs_to :teacher
   has_many :events
 
-  touch -> { teacher }, on_event: %i[create update], when_changing: %i[started_on finished_on outcome], timestamp_attribute: :api_updated_at
+  touch -> { teacher }, on_event: %i[create update destroy], when_changing: %i[started_on finished_on outcome], timestamp_attribute: :api_updated_at
 
   refresh_metadata -> { teacher },
                    on_event: %i[create destroy update],

--- a/app/models/mentor_at_school_period.rb
+++ b/app/models/mentor_at_school_period.rb
@@ -21,7 +21,7 @@ class MentorAtSchoolPeriod < ApplicationRecord
            through: :current_or_future_mentorship_periods,
            source: :mentee
 
-  touch -> { teacher }, on_event: %i[create destroy update], when_changing: %i[email], timestamp_attribute: :api_unfunded_mentor_updated_at, if: :latest_mentor_at_school_period?
+  touch -> { teacher }, on_event: %i[create destroy update], when_changing: %i[email], timestamp_attribute: :api_unfunded_mentor_updated_at
 
   # Validations
   validate :teacher_school_distinct_period
@@ -39,9 +39,5 @@ private
 
   def teacher_school_distinct_period
     overlap_validation(name: "Teacher School Mentor")
-  end
-
-  def latest_mentor_at_school_period?
-    teacher.latest_mentor_at_school_period == self
   end
 end

--- a/app/models/school_partnership.rb
+++ b/app/models/school_partnership.rb
@@ -44,13 +44,6 @@ class SchoolPartnership < ApplicationRecord
   }
 
   def teachers
-    # We can't use a has-many through association here because a TrainingPeriod
-    # can have a Teacher via the ECTAtSchoolPeriod or MentorAtSchoolPeriod.
-    teacher_ids = training_periods
-        .left_joins(:ect_at_school_period, :mentor_at_school_period)
-        .select("COALESCE(ect_at_school_periods.teacher_id, mentor_at_school_periods.teacher_id)")
-        .distinct
-
-    Teacher.where(id: teacher_ids)
+    Teacher.with_training_periods(training_periods)
   end
 end

--- a/app/models/school_partnership.rb
+++ b/app/models/school_partnership.rb
@@ -15,6 +15,7 @@ class SchoolPartnership < ApplicationRecord
 
   touch -> { self }, when_changing: %i[lead_provider_delivery_partnership_id], timestamp_attribute: :api_updated_at
   touch -> { declarations }, when_changing: %i[lead_provider_delivery_partnership_id], timestamp_attribute: :api_updated_at
+  touch -> { teachers }, when_changing: %i[lead_provider_delivery_partnership_id], timestamp_attribute: :api_updated_at
   refresh_metadata -> { school }, on_event: %i[create destroy update]
 
   # Validations
@@ -41,4 +42,15 @@ class SchoolPartnership < ApplicationRecord
     joins(lead_provider_delivery_partnership: :active_lead_provider)
       .order("active_lead_providers.contract_period_year DESC, school_partnerships.created_at DESC")
   }
+
+  def teachers
+    # We can't use a has-many through association here because a TrainingPeriod
+    # can have a Teacher via the ECTAtSchoolPeriod or MentorAtSchoolPeriod.
+    teacher_ids = training_periods
+        .left_joins(:ect_at_school_period, :mentor_at_school_period)
+        .select("COALESCE(ect_at_school_periods.teacher_id, mentor_at_school_periods.teacher_id)")
+        .distinct
+
+    Teacher.where(id: teacher_ids)
+  end
 end

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -69,6 +69,8 @@ class Teacher < ApplicationRecord
           mentor_first_became_eligible_for_training_at
           ect_payments_frozen_year
           mentor_payments_frozen_year
+          trs_induction_completed_date
+          trs_induction_start_date
         ]
 
   touch -> { self },

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -143,6 +143,16 @@ class Teacher < ApplicationRecord
   scope :induction_status_required_to_complete, -> { where(trs_induction_status: "RequiredToComplete") }
   scope :not_failed, -> { where.not(trs_induction_status: %w[Failed FailedInWales]).or(induction_status_missing) }
   scope :not_passed, -> { where.not(trs_induction_status: "Passed").or(induction_status_missing) }
+  scope :with_training_periods, ->(training_periods) {
+    where(
+      id: training_periods
+        .left_joins(:ect_at_school_period, :mentor_at_school_period)
+        .select(
+          "COALESCE(ect_at_school_periods.teacher_id, mentor_at_school_periods.teacher_id)"
+        )
+        .distinct
+    )
+  }
 
   normalizes :trs_first_name, :trs_last_name, with: -> { it&.squish }
   normalizes :corrected_name, with: -> { it&.squish }

--- a/app/serializers/api/school_partnership_serializer.rb
+++ b/app/serializers/api/school_partnership_serializer.rb
@@ -30,6 +30,8 @@ class API::SchoolPartnershipSerializer < Blueprinter::Base
       Schools::InductionTutorEmail.new(school: partnership.school).email_or_gias_contact
     end
 
+    # Changes to this field will be reflected in the `updated_at` via the nightly
+    # TouchSchoolPartnershipForParticipantsCurrentlyTrainingJob.
     field(:participants_currently_training) do |partnership, _options|
       partnership.ongoing_training_periods.size
     end

--- a/app/serializers/api/teacher_serializer.rb
+++ b/app/serializers/api/teacher_serializer.rb
@@ -37,6 +37,10 @@ class API::TeacherSerializer < Blueprinter::Base
         end
       end
       field(:training_status) { |(training_period, _, _)| API::TrainingPeriods::TrainingStatus.new(training_period:).status }
+      # Participant status is partly derived from the current date. As time passes,
+      # the status may change (for example, `joining` → `active` or `leaving` →
+      # `left`) without any database record being updated, so `updated_at` will not
+      # necessarily change.
       field(:participant_status) { |(training_period, teacher, _)| API::TrainingPeriods::TeacherStatus.new(latest_training_period: training_period, teacher:).status }
       field(:eligible_for_funding) do |(training_period, teacher, _)|
         teacher_type = training_period.for_ect? ? :ect : :mentor

--- a/app/serializers/api/teachers/unfunded_mentor_serializer.rb
+++ b/app/serializers/api/teachers/unfunded_mentor_serializer.rb
@@ -3,6 +3,10 @@ class API::Teachers::UnfundedMentorSerializer < Blueprinter::Base
     exclude :id
 
     field(:full_name) { |teacher| Teachers::Name.new(teacher).full_name }
+    # Email is derived from the latest mentor assignment for the requested lead
+    # provider. Consequently, direct email changes on the mentor will result in the
+    # `updated_at` changing, however mentor assignments that result in email changes
+    # will not be reflected in the `updated_at` timestamp.
     field(:email) do |teacher, options|
       lead_provider_id = options[:lead_provider_id]
 

--- a/spec/models/gias/school_spec.rb
+++ b/spec/models/gias/school_spec.rb
@@ -34,11 +34,22 @@ describe GIAS::School do
 
   describe "declarative touch" do
     let(:instance) { FactoryBot.create(:gias_school, :with_school) }
-    let(:target) { instance.contract_period_metadata }
 
     before { Metadata::Handlers::School.new(instance.school).refresh_metadata! }
 
-    it_behaves_like "a declarative touch model", when_changing: %i[name], timestamp_attribute: :api_updated_at
+    context "when the target is contract period metadata" do
+      let(:target) { instance.contract_period_metadata }
+
+      it_behaves_like "a declarative touch model", when_changing: %i[name primary_contact_email secondary_contact_email], timestamp_attribute: :api_updated_at
+    end
+
+    context "when the target is school partnerships" do
+      before { FactoryBot.create(:school_partnership, school: instance.school) }
+
+      let(:target) { instance.school_partnerships }
+
+      it_behaves_like "a declarative touch model", when_changing: %i[primary_contact_email secondary_contact_email], timestamp_attribute: :api_updated_at
+    end
   end
 
   describe "db indexes" do
@@ -68,6 +79,7 @@ describe GIAS::School do
     it { is_expected.to have_many(:predecessor_links).class_name("GIAS::SchoolLink").with_foreign_key(:urn).with_primary_key(:urn).conditions(link_type: GIAS::SchoolLink::PREDECESSOR_LINK_TYPES) }
     it { is_expected.to have_many(:successors).through(:successor_links).source(:to_gias_school).class_name("GIAS::School") }
     it { is_expected.to have_many(:predecessors).through(:predecessor_links).source(:from_gias_school).class_name("GIAS::School") }
+    it { is_expected.to have_many(:school_partnerships).through(:school) }
   end
 
   describe "validations" do

--- a/spec/models/induction_period_spec.rb
+++ b/spec/models/induction_period_spec.rb
@@ -106,66 +106,13 @@ RSpec.describe InductionPeriod do
     end
 
     describe "declarative updates" do
-      let(:instance) { FactoryBot.create(:induction_period, :pass) }
+      let(:instance) { FactoryBot.create(:induction_period, teacher: target) }
 
       context "target teacher" do
-        let(:target) { instance.teacher }
+        let(:target) { FactoryBot.create(:teacher) }
 
-        it_behaves_like "a declarative touch model", when_changing: %i[started_on finished_on], timestamp_attribute: :api_updated_at, conditional_method: :touch_teacher?
-
-        it_behaves_like "a declarative metadata model",
-                        on_event: %i[create destroy update],
-                        when_changing: %i[outcome finished_on]
-      end
-
-      describe "#touch_teacher?" do
-        let(:teacher) { FactoryBot.create(:teacher) }
-        let(:appropriate_body_period) { FactoryBot.create(:appropriate_body_period) }
-        let!(:induction_period) { FactoryBot.create(:induction_period, teacher:, appropriate_body_period:, started_on: "2019-01-01", finished_on: "2019-07-01") }
-
-        context "when a new induction period is created" do
-          it "returns true if it is the first induction period for the teacher" do
-            expect(induction_period.send(:touch_teacher?)).to be(true)
-          end
-
-          it "returns false if it is not the first induction period and outcome has not changed" do
-            second_induction_period = FactoryBot.create(:induction_period, :unfinished, teacher:, appropriate_body_period:, started_on: "2023-01-01")
-
-            expect(second_induction_period.send(:touch_teacher?)).to be(false)
-          end
-
-          it "returns true if it is not the first induction period but outcome is set on creation" do
-            second_induction_period = FactoryBot.create(:induction_period, teacher:, appropriate_body_period:, started_on: "2023-01-01", outcome: "pass")
-
-            expect(second_induction_period.send(:touch_teacher?)).to be(true)
-          end
-
-          it "returns true if it is not the first induction period but finished_on is set" do
-            second_induction_period = FactoryBot.create(:induction_period, teacher:, appropriate_body_period:, started_on: "2023-01-01", finished_on: "2023-06-01")
-
-            expect(second_induction_period.send(:touch_teacher?)).to be(true)
-          end
-        end
-
-        context "when an existing induction period is updated" do
-          it "returns true if the outcome is changed" do
-            induction_period.update!(outcome: "fail")
-
-            expect(induction_period.send(:touch_teacher?)).to be(true)
-          end
-
-          it "returns false if the outcome is not changed" do
-            induction_period.update!(started_on: "2018-01-01")
-
-            expect(induction_period.send(:touch_teacher?)).to be(false)
-          end
-
-          it "returns true if the finished_on is changed" do
-            induction_period.update!(finished_on: "2019-01-01")
-
-            expect(induction_period.send(:touch_teacher?)).to be(true)
-          end
-        end
+        it_behaves_like "a declarative touch model", on_event: %i[create update], when_changing: %i[started_on finished_on outcome], timestamp_attribute: :api_updated_at, target_optional: false
+        it_behaves_like "a declarative metadata model", on_event: %i[create destroy update], when_changing: %i[outcome finished_on]
       end
     end
 

--- a/spec/models/induction_period_spec.rb
+++ b/spec/models/induction_period_spec.rb
@@ -139,6 +139,12 @@ RSpec.describe InductionPeriod do
 
             expect(second_induction_period.send(:touch_teacher?)).to be(true)
           end
+
+          it "returns true if it is not the first induction period but finished_on is set" do
+            second_induction_period = FactoryBot.create(:induction_period, teacher:, appropriate_body_period:, started_on: "2023-01-01", finished_on: "2023-06-01")
+
+            expect(second_induction_period.send(:touch_teacher?)).to be(true)
+          end
         end
 
         context "when an existing induction period is updated" do
@@ -152,6 +158,12 @@ RSpec.describe InductionPeriod do
             induction_period.update!(started_on: "2018-01-01")
 
             expect(induction_period.send(:touch_teacher?)).to be(false)
+          end
+
+          it "returns true if the finished_on is changed" do
+            induction_period.update!(finished_on: "2019-01-01")
+
+            expect(induction_period.send(:touch_teacher?)).to be(true)
           end
         end
       end

--- a/spec/models/induction_period_spec.rb
+++ b/spec/models/induction_period_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe InductionPeriod do
       context "target teacher" do
         let(:target) { FactoryBot.create(:teacher) }
 
-        it_behaves_like "a declarative touch model", on_event: %i[create update], when_changing: %i[started_on finished_on outcome], timestamp_attribute: :api_updated_at, target_optional: false
+        it_behaves_like "a declarative touch model", on_event: %i[create update destroy], when_changing: %i[started_on finished_on outcome], timestamp_attribute: :api_updated_at, target_optional: false
         it_behaves_like "a declarative metadata model", on_event: %i[create destroy update], when_changing: %i[outcome finished_on]
       end
     end

--- a/spec/models/mentor_at_school_period_spec.rb
+++ b/spec/models/mentor_at_school_period_spec.rb
@@ -326,38 +326,13 @@ describe MentorAtSchoolPeriod do
   end
 
   describe "declarative touch" do
-    let(:instance) { FactoryBot.create(:mentor_at_school_period) }
+    let(:instance) { FactoryBot.create(:mentor_at_school_period, teacher: target) }
 
     context "target teacher" do
-      let(:target) { instance.teacher }
+      let(:target) { FactoryBot.create(:teacher) }
 
-      it_behaves_like "a declarative touch model", when_changing: %i[email], timestamp_attribute: :api_updated_at
-      it_behaves_like "a declarative touch model", when_changing: %i[email], timestamp_attribute: :api_unfunded_mentor_updated_at, conditional_method: :latest_mentor_at_school_period?
-    end
-
-    describe "#latest_mentor_at_school_period?", :with_touches do
-      let(:teacher) { FactoryBot.create(:teacher) }
-      let!(:latest_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :unfinished, teacher:, started_on: 6.months.ago) }
-      let!(:previous_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher:, started_on: 1.year.ago, finished_on: 6.months.ago) }
-      let(:email_change) { "test1@anyexampleemail.com" }
-
-      context "when updating the email for the latest mentor period" do
-        it "touches `api_unfunded_mentor_updated_at`" do
-          expect {
-            latest_mentor_at_school_period.update!(email: email_change)
-            teacher.reload
-          }.to change(teacher, :api_unfunded_mentor_updated_at)
-        end
-      end
-
-      context "when updating the email for a previous mentor period" do
-        it "does not touch `api_unfunded_mentor_updated_at`" do
-          expect {
-            previous_mentor_at_school_period.update!(email: email_change)
-            teacher.reload
-          }.not_to change(teacher, :api_unfunded_mentor_updated_at)
-        end
-      end
+      it_behaves_like "a declarative touch model", when_changing: %i[email], timestamp_attribute: :api_updated_at, target_optional: false
+      it_behaves_like "a declarative touch model", when_changing: %i[email], timestamp_attribute: :api_unfunded_mentor_updated_at, target_optional: false
     end
   end
 

--- a/spec/models/school_partnership_spec.rb
+++ b/spec/models/school_partnership_spec.rb
@@ -20,6 +20,15 @@ describe SchoolPartnership do
       it_behaves_like "a declarative touch model", when_changing: %i[lead_provider_delivery_partnership_id], timestamp_attribute: :api_updated_at
     end
 
+    describe "declarative touch target teachers" do
+      let(:instance) { FactoryBot.create(:school_partnership) }
+      let(:target) { instance.teachers }
+
+      before { FactoryBot.create(:training_period, school_partnership: instance) }
+
+      it_behaves_like "a declarative touch model", when_changing: %i[lead_provider_delivery_partnership_id], timestamp_attribute: :api_updated_at
+    end
+
     describe "declarative metadata" do
       let(:instance) { FactoryBot.create(:school_partnership, school: target) }
       let!(:target) { FactoryBot.create(:school) }
@@ -76,6 +85,24 @@ describe SchoolPartnership do
       expect(subject).to validate_uniqueness_of(:school_id)
                            .scoped_to(:lead_provider_delivery_partnership_id)
                            .with_message("School and lead provider delivery partnership combination must be unique")
+    end
+  end
+
+  describe "#teachers" do
+    subject { instance.teachers }
+
+    let(:instance) { FactoryBot.create(:school_partnership) }
+    let!(:ect_training_period) { FactoryBot.create(:training_period, :for_ect, school_partnership: instance) }
+    let!(:mentor_training_period) { FactoryBot.create(:training_period, :for_mentor, school_partnership: instance) }
+
+    before do
+      # Teachers with other partnerships should not be included.
+      FactoryBot.create(:training_period, :for_ect, :with_school_partnership)
+      FactoryBot.create(:training_period, :for_mentor, :with_school_partnership)
+    end
+
+    it "returns the teachers associated with the training periods" do
+      expect(subject).to contain_exactly(ect_training_period.teacher, mentor_training_period.teacher)
     end
   end
 

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -25,6 +25,8 @@ describe Teacher do
                       mentor_first_became_eligible_for_training_at
                       ect_payments_frozen_year
                       mentor_payments_frozen_year
+                      trs_induction_completed_date
+                      trs_induction_start_date
                     ],
                     timestamp_attribute: :api_updated_at
 

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -452,6 +452,24 @@ describe Teacher do
   end
 
   describe "scopes" do
+    describe ".with_training_periods" do
+      subject { described_class.with_training_periods(training_periods) }
+
+      let(:ect_training_period) { FactoryBot.create(:training_period, :for_ect) }
+      let(:mentor_training_period) { FactoryBot.create(:training_period, :for_mentor) }
+      let(:ect) { ect_training_period.teacher }
+      let(:mentor) { mentor_training_period.teacher }
+      let(:training_periods) { TrainingPeriod.where(id: [ect_training_period, mentor_training_period]) }
+
+      before do
+        # Teachers with other training periods should not be included.
+        FactoryBot.create(:training_period, :for_ect)
+        FactoryBot.create(:training_period, :for_mentor)
+      end
+
+      it { is_expected.to contain_exactly(ect, mentor) }
+    end
+
     describe ".search" do
       it "searches the 'search' column using a tsquery" do
         expect(Teacher.search("Joey").to_sql).to end_with(%{WHERE (teachers.search @@ to_tsquery('unaccented', 'Joey:*'))})

--- a/spec/support/shared_examples/declarative_updates.rb
+++ b/spec/support/shared_examples/declarative_updates.rb
@@ -27,9 +27,7 @@ def generate_new_value(attribute_to_change:)
   end
 end
 
-RSpec.shared_examples "a declarative touch model", :with_touches do |when_changing: [], on_event: %i[update], timestamp_attribute: :updated_at, target_optional: true, conditional_method: nil|
-  before { allow(instance).to receive(conditional_method).and_return(true) if conditional_method }
-
+RSpec.shared_examples "a declarative touch model", :with_touches do |when_changing: [], on_event: %i[update], timestamp_attribute: :updated_at, target_optional: true|
   if :update.in?(on_event)
     context "when updating" do
       before { instance } # Ensure it's created first.
@@ -44,18 +42,6 @@ RSpec.shared_examples "a declarative touch model", :with_touches do |when_changi
             expect {
               instance.update_attribute(attribute_to_change, new_value)
             }.to(change { Array.wrap(target).map { |t| t.reload.send(timestamp_attribute) } }.to(all(be_within(5.seconds).of(Time.current))))
-          end
-
-          if conditional_method
-            context "when the conditional method is defined and returns false" do
-              before { allow(instance).to receive(conditional_method).and_return(false) if conditional_method }
-
-              it "does not touch the #{timestamp_attribute} of the associated model(s)" do
-                expect {
-                  instance.update_attribute(attribute_to_change, new_value)
-                }.not_to(change { Array.wrap(target).map { |t| t.reload.send(timestamp_attribute) } })
-              end
-            end
           end
 
           context "when wrapped in a skip(:touch) block" do
@@ -150,18 +136,6 @@ RSpec.shared_examples "a declarative touch model", :with_touches do |when_changi
         }.not_to(change { Array.wrap(target).map { |t| t.reload.updated_at } })
       end
 
-      if conditional_method
-        context "when the conditional method is defined and returns false" do
-          before { allow(instance).to receive(conditional_method).and_return(false) if conditional_method }
-
-          it "does not touch the #{timestamp_attribute} of the associated model(s)" do
-            expect {
-              instance
-            }.not_to(change { Array.wrap(target).map { |t| t.reload.send(timestamp_attribute) } })
-          end
-        end
-      end
-
       context "when wrapped in a skip(:touch) block" do
         around { |example| DeclarativeUpdates.skip(:touch) { example.run } }
 
@@ -194,18 +168,6 @@ RSpec.shared_examples "a declarative touch model", :with_touches do |when_changi
         expect {
           instance.destroy!
         }.not_to(change { Array.wrap(target).map { |t| t.reload.updated_at } })
-      end
-
-      if conditional_method
-        context "when the conditional method is defined and returns false" do
-          before { allow(instance).to receive(conditional_method).and_return(false) if conditional_method }
-
-          it "does not touch the #{timestamp_attribute} of the associated model(s)" do
-            expect {
-              instance.destroy!
-            }.not_to(change { Array.wrap(target).map { |t| t.reload.send(timestamp_attribute) } })
-          end
-        end
       end
 
       context "when wrapped in a skip(:touch) block" do


### PR DESCRIPTION
### Context

We have been asked by lead providers to provide a list of fields that, when changed, won't always result in the `updated_at` being touched/updated in the respective serializer.

As part of this we also wanted to audit all serializer fields and ensure the touch model is up to date/consistent in case we were missing any (which we were!).

### Changes proposed in this pull request

- Fixes to API touch model

Include `primary_contact_email` and `secondary_contact_email` so changes from `GIAS::School` touch `contract_period_metadata` (`SchoolSerializer`) and `school_partnerships` (`SchoolPartnershipSerializer`).

Touch `Teacher` when setting `finished_on` of any `InductionPeriod` to reflect changes in `most_recent_induction_period_end_date` for `TeacherSerializer`.

Include `trs_induction_completed_date` and `trs_induction_start_date` in `Teacher` touch model to reflect changes to `induction_end_date` and `overall_induction_start_date` in `TeacherSerializer`.

Touch `Teacher` when a `SchoolPartnership` changes the `lead_provider_delivery_partnership` to reflect changes on `delivery_partner_id` in the `TeacherSerializer`.

Add comments to serializer fields that will _not_ result in the `updated_at` being touched when they change.

- Remove conditional from touch model

We have the ability to only touch a model when it's in a very specific state. We were using this to ensure we only touch the `Teacher#api_updated_at` when the first `InductionPeriod` was created, for example (as this triggers a change
to the overall start date in the API response).

The issue with doing this is it because very hard to test; the way the tests were setup we mocked the conditional before performing a change that should trigger a touch. This worked for updates but not creation (as to mock the
conditional we have to instantate the instance, so we have a chicken/egg situation).

After reviewing how this is used and talking to Nathan we've decided to pull out the conditional updates in order to simplify the touch model and accept that we may over-touch a timestamp when nothing actually changes in the API
response. We will inform lead providers of the potential for this/when it could happen.

### Guidance for review
