### PR TITLE
Change schedule api refactoring

### DIFF
--- a/app/services/api/teachers/change_schedule.rb
+++ b/app/services/api/teachers/change_schedule.rb
@@ -6,21 +6,10 @@ module API::Teachers
     attribute :schedule_identifier
 
     validates :schedule_identifier, presence: { message: "The property '#/schedule_identifier' must be present and correspond to a valid schedule." }
-    validates :schedule_identifier, inclusion: {
-      in: Schedule.identifiers.keys,
-      message: "Enter a valid schedule identifier."
-    }, allow_blank: true
-    validate :schedule_exists
-    validate :change_to_different_schedule
-    validate :schedule_applicable_for_ect
-    validate :schedule_applicable_for_mentor
-    validate :school_partnership_exists_if_changing_contract_period
-    validate :trainee_not_completed
-    validate :lead_provider_is_currently_training_teacher
-    validate :training_period_not_withdrawn
-    validate :no_future_training_periods_exist
-    validate :can_move_to_frozen_contract_period
-    validate :schedule_does_not_invalidate_declarations
+    validates :schedule_identifier, inclusion: { in: Schedule.identifiers.keys, message: "Enter a valid schedule identifier." }, allow_blank: true
+    validate :schedule_acceptable_for_change, if: -> { errors[:schedule_identifier].empty? }
+    validate :contract_period_acceptable_for_change, if: -> { training_period && errors[:contract_period_year].empty? }
+    validate :teacher_can_change_schedule, if: -> { training_period && errors[:teacher_api_id].empty? }
 
     def change_schedule
       return false unless valid?
@@ -37,72 +26,60 @@ module API::Teachers
 
   private
 
-    def contract_period
-      @contract_period ||= ContractPeriod.find_by(year: contract_period_year) || fallback_contract_period
+    def schedule_acceptable_for_change
+      return errors.add(:schedule_identifier, "The property '#/schedule_identifier' must be present and correspond to a valid schedule.") unless schedule
+      return unless training_period
+      return errors.add(:schedule_identifier, "Selected schedule is already on the profile") if schedule == training_period.schedule
+      return errors.add(:schedule_identifier, "Selected schedule is not valid for the teacher_type") if training_period.for_ect? && schedule.replacement_schedule?
+      return errors.add(:schedule_identifier, "Mentors cannot be placed on a reduced schedule. Assign them to a different schedule.") if training_period.for_mentor? && schedule.reduced_schedule?
+      return if training_period.started_on.past?
+      return unless declarations_would_become_invalid?
+
+      errors.add(:schedule_identifier, "The change of schedule cannot be applied because a previous change of schedule and a declaration were made on the same day. Applying another change of schedule would invalidate existing declarations. Please contact DfE for assistance.")
     end
 
-    def fallback_contract_period
-      training_period&.contract_period
+    def contract_period_acceptable_for_change
+      return errors.add(:contract_period_year, "You cannot change a participant to this contract_period as you do not have a partnership with the school for the contract_period. Contact the DfE for assistance.") if contract_period_changing? && school_partnership.nil?
+      return unless contract_period&.payments_frozen?
+
+      original_frozen_year = training_period.for_ect? ? teacher.ect_payments_frozen_year : teacher.mentor_payments_frozen_year
+      return if original_frozen_year == contract_period.year
+
+      errors.add(:contract_period_year, "You cannot move a participant to a payments frozen contract period unless they previously belonged to that contract period.")
+    end
+
+    def teacher_can_change_schedule
+      return errors.add(:teacher_api_id, "You cannot change this participant's schedule as they have completed their training or induction.") if training_period.teacher_completed_training? && !ect_moving_to_reduced_schedule?
+      return errors.add(:teacher_api_id, "You cannot change this participant's schedule. This is because the participant has a 'left' participant_status, so they are not training with you currently.") if participant_status.left?
+      return errors.add(:teacher_api_id, "Cannot perform actions on a withdrawn participant") if training_status.withdrawn?
+      return unless future_training_periods.exists?
+
+      errors.add(:teacher_api_id, "You cannot change this participant's schedule as they are due to start with another lead provider in the future.")
+    end
+
+    def contract_period
+      @contract_period ||= ContractPeriod.find_by(year: contract_period_year) || training_period&.contract_period
     end
 
     def schedule
-      @schedule ||= Schedule.find_by(contract_period_year: contract_period.year, identifier: schedule_identifier) if contract_period && schedule_identifier
+      return unless contract_period && schedule_identifier
+
+      @schedule ||= contract_period.schedules.find_by(identifier: schedule_identifier)
     end
 
-    def schedule_exists
-      return if errors[:schedule_identifier].any?
-      return if schedule
-
-      errors.add(:schedule_identifier, "The property '#/schedule_identifier' must be present and correspond to a valid schedule.")
-    end
-
-    def training_period_not_withdrawn
-      return if errors[:teacher_api_id].any?
-      return unless training_period
-      return unless training_status&.withdrawn?
-
-      errors.add(:teacher_api_id, "Cannot perform actions on a withdrawn participant")
-    end
-
-    def change_to_different_schedule
-      return if errors[:schedule_identifier].any?
-      return unless training_period
-      return if schedule != training_period.schedule
-
-      errors.add(:schedule_identifier, "Selected schedule is already on the profile")
-    end
-
-    def schedule_applicable_for_ect
-      return if errors[:schedule_identifier].any?
-      return unless training_period&.for_ect?
-
-      errors.add(:schedule_identifier, "Selected schedule is not valid for the teacher_type") if schedule.replacement_schedule?
-    end
-
-    def schedule_applicable_for_mentor
-      return if errors[:schedule_identifier].any?
-      return unless training_period&.for_mentor?
-
-      errors.add(:schedule_identifier, "Mentors cannot be placed on a reduced schedule. Assign them to a different schedule.") if schedule.reduced_schedule?
-    end
-
-    def school_partnership_exists_if_changing_contract_period
-      return if errors[:contract_period_year].any?
-      return unless training_period
-      return unless contract_period_changing?
-      return if school_partnership
-
-      errors.add(:contract_period_year, "You cannot change a participant to this contract_period as you do not have a partnership with the school for the contract_period. Contact the DfE for assistance.")
+    def contract_period_changing?
+      contract_period != training_period&.contract_period
     end
 
     def school_partnership
-      @school_partnership ||= begin
-        return nil unless existing_school_partnership && active_lead_provider
+      @school_partnership ||= find_school_partnership
+    end
 
-        return existing_school_partnership unless contract_period_changing?
+    def find_school_partnership
+      return unless existing_school_partnership && active_lead_provider
+      return existing_school_partnership unless contract_period_changing?
 
-        school_partnership_with_same_delivery_partner || available_school_partnerships.first
-      end
+      school_partnership_with_same_delivery_partner || available_school_partnerships.first
     end
 
     def existing_school_partnership
@@ -126,74 +103,18 @@ module API::Teachers
       @active_lead_provider ||= lead_provider.active_lead_providers.find_by(contract_period_year: contract_period.year)
     end
 
-    def contract_period_changing?
-      contract_period != training_period&.contract_period
-    end
-
     def participant_status
-      @participant_status ||= API::TrainingPeriods::TeacherStatus.new(
-        latest_training_period: training_period,
-        teacher:
-      )
+      API::TrainingPeriods::TeacherStatus.new(latest_training_period: training_period, teacher:)
     end
 
-    def lead_provider_is_currently_training_teacher
-      return if errors[:teacher_api_id].any?
-      return unless training_period
-      return unless participant_status.left?
-
-      errors.add(:teacher_api_id, "You cannot change this participant's schedule. This is because the participant has a 'left' participant_status, so they are not training with you currently.")
-    end
-
-    def no_future_training_periods_exist
-      return if errors[:teacher_api_id].any?
-      return unless training_period
-
-      if future_training_periods.exists?
-        errors.add(:teacher_api_id, "You cannot change this participant's schedule as they are due to start with another lead provider in the future.")
-      end
+    def ect_moving_to_reduced_schedule?
+      training_period.for_ect? && schedule&.reduced_schedule?
     end
 
     def future_training_periods
-      if training_period.for_mentor?
-        TrainingPeriod
-          .joins(:mentor_at_school_period)
-          .where(mentor_at_school_period: { teacher: })
-          .started_after(training_period.started_on)
-      else
-        TrainingPeriod
-          .joins(:ect_at_school_period)
-          .where(ect_at_school_period: { teacher: })
-          .started_after(training_period.started_on)
-      end
-    end
+      periods = training_period.for_mentor? ? teacher.mentor_training_periods : teacher.ect_training_periods
 
-    def can_move_to_frozen_contract_period
-      return unless contract_period&.payments_frozen?
-
-      original_frozen_year = training_period.for_ect? ? teacher.ect_payments_frozen_year : teacher.mentor_payments_frozen_year
-
-      unless original_frozen_year == contract_period.year
-        errors.add(:contract_period_year, "You cannot move a participant to a payments frozen contract period unless they previously belonged to that contract period.")
-      end
-    end
-
-    def trainee_not_completed
-      return if errors[:teacher_api_id].any?
-      return unless training_period&.teacher_completed_training?
-      # allow an ECT that has completed training to move to a reduced schedule
-      return if schedule&.reduced_schedule? && training_period&.for_ect?
-
-      errors.add(:teacher_api_id, "You cannot change this participant's schedule as they have completed their training or induction.")
-    end
-
-    def schedule_does_not_invalidate_declarations
-      return if errors[:schedule_identifier].any?
-      return unless training_period
-      return if training_period.started_on.past?
-      return unless declarations_would_become_invalid?
-
-      errors.add(:schedule_identifier, "The change of schedule cannot be applied because a previous change of schedule and a declaration were made on the same day. Applying another change of schedule would invalidate existing declarations. Please contact DfE for assistance.")
+      periods.started_after(training_period.started_on)
     end
 
     def declarations_would_become_invalid?

--- a/app/services/api/teachers/change_schedule.rb
+++ b/app/services/api/teachers/change_schedule.rb
@@ -5,9 +5,7 @@ module API::Teachers
     attribute :contract_period_year
     attribute :schedule_identifier
 
-    validates :schedule_identifier, presence: { message: "The property '#/schedule_identifier' must be present and correspond to a valid schedule." }
-    validates :schedule_identifier, inclusion: { in: Schedule.identifiers.keys, message: "Enter a valid schedule identifier." }, allow_blank: true
-    validate :schedule_acceptable_for_change, if: -> { errors[:schedule_identifier].empty? }
+    validate :schedule_acceptable_for_change
     validate :contract_period_acceptable_for_change, if: -> { training_period && errors[:contract_period_year].empty? }
     validate :teacher_can_change_schedule, if: -> { training_period && errors[:teacher_api_id].empty? }
 
@@ -27,6 +25,8 @@ module API::Teachers
   private
 
     def schedule_acceptable_for_change
+      return errors.add(:schedule_identifier, "The property '#/schedule_identifier' must be present and correspond to a valid schedule.") if schedule_identifier.blank?
+      return errors.add(:schedule_identifier, "Enter a valid schedule identifier.") if Schedule.identifiers.keys.exclude?(schedule_identifier)
       return errors.add(:schedule_identifier, "The property '#/schedule_identifier' must be present and correspond to a valid schedule.") unless schedule
       return unless training_period
       return errors.add(:schedule_identifier, "Selected schedule is already on the profile") if schedule == training_period.schedule


### PR DESCRIPTION
### Context

Resolves https://github.com/DFE-Digital/register-ects-project-board/issues/4136

### Changes proposed in this pull request

To a large extent our decision to have an anaemic domain model with procedural style service objects means there isn't really much we can do here in terms of DDD elegance. Silk purses, and sows ears as they say.

This PR does make some attempts to improve the clarity:
- It collapses the 10 or 11 custom validations to a single custom validation per attribute. This allows better "at a glance reading",
- It moves validation internal guard conditions up to be conditional validations, allows better "at a glance" reading, so we only need to drill into the detail when it is relevant.
- It now uses the teachers `ect_training_periods`, and `mentor_training_periods` instead of building new queries to do this.

### Guidance to review

There are pretty significant changes to this file, as such it might be easier to read the new file, rather than attempting to decode the diff.

This is a single file refactoring, the following options to improve simplicity are structural and wider ranging and as such have been deemed out of scope:

1. Passing objects into the service than primitives;  thus avoiding primitive obsession and it's issues.  
2. Dealing with "keeping junk in the garage"(API::Concerns::Teachers::SharedAction) 
3. Moving methods to the models, as we have explicitly ruled  that out.           

