### PR TITLE
[4084] Fix duplicate screen reader announcements on question pages

### DIFF
--- a/app/views/admin/schools/add_partnership_wizard/select_contract_period.html.erb
+++ b/app/views/admin/schools/add_partnership_wizard/select_contract_period.html.erb
@@ -1,5 +1,6 @@
 <% page_data(
   title: "Select the contract period",
+  header: nil,
   error: @wizard.current_step.errors.present?,
   backlink_href: admin_school_partnerships_path(@school.urn)
 ) %>
@@ -11,7 +12,7 @@
 
       <%= f.govuk_radio_buttons_fieldset(
         :contract_period_year,
-        legend: { text: "Select the contract period", hidden: true }
+        legend: { text: "Select the contract period", size: "l", tag: "h1" }
       ) do %>
         <% @wizard.contract_periods.each_with_index do |contract_period, index| %>
           <%= f.govuk_radio_button(

--- a/app/views/admin/schools/add_partnership_wizard/select_lead_provider.html.erb
+++ b/app/views/admin/schools/add_partnership_wizard/select_lead_provider.html.erb
@@ -3,6 +3,7 @@
 
   page_data(
     title:,
+    header: nil,
     error: @wizard.current_step.errors.present?,
     backlink_href: @wizard.previous_step_path
   )
@@ -15,7 +16,7 @@
 
       <%= f.govuk_radio_buttons_fieldset(
         :active_lead_provider_id,
-        legend: { text: title, hidden: true }
+        legend: { text: title, size: "l", tag: "h1" }
       ) do %>
         <% @wizard.active_lead_providers.each_with_index do |active_lead_provider, index| %>
           <%= f.govuk_radio_button(

--- a/app/views/admin/teachers/training_periods/change_contract_period_wizard/select_contract_period.html.erb
+++ b/app/views/admin/teachers/training_periods/change_contract_period_wizard/select_contract_period.html.erb
@@ -1,5 +1,6 @@
 <% page_data(
   title: "Select new contract period for #{@wizard.teacher_name}",
+  header: nil,
   error: @wizard.current_step.errors.present?,
   backlink_href: admin_teacher_training_path(@teacher)
 ) %>
@@ -11,7 +12,7 @@
 
       <%= f.govuk_radio_buttons_fieldset(
         :contract_period_year,
-        legend: { text: "Select new contract period for #{@wizard.teacher_name}", hidden: true }
+        legend: { text: "Select new contract period for #{@wizard.teacher_name}", size: "l", tag: "h1" }
       ) do %>
         <% @wizard.contract_periods.each_with_index do |contract_period, index| %>
           <%= f.govuk_radio_button(

--- a/app/views/schools/register_ect_wizard/_training_programme.html.erb
+++ b/app/views/schools/register_ect_wizard/_training_programme.html.erb
@@ -1,5 +1,6 @@
 <% page_data(
     title: "Which training programme will #{@ect.full_name} follow?",
+    header: nil,
     error: @wizard.current_step.errors.present?,
     backlink_href: @wizard.previous_step_path,
 ) %>
@@ -7,7 +8,8 @@
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
   <%= content_for(:error_summary) { f.govuk_error_summary } %>
 
-  <%= f.govuk_radio_buttons_fieldset :training_programme, legend: { text: "Which training programme will #{@ect.full_name} follow?", hidden: true} do %>
+  <%= f.govuk_radio_buttons_fieldset :training_programme,
+                                     legend: { text: "Which training programme will #{@ect.full_name} follow?", size: "l", tag: "h1" } do %>
     <%= f.govuk_radio_button :training_programme,
                              :provider_led,
                              label: { text: "Provider-led" },

--- a/app/views/schools/register_ect_wizard/_working_pattern.html.erb
+++ b/app/views/schools/register_ect_wizard/_working_pattern.html.erb
@@ -1,16 +1,17 @@
 <% page_data(
     title: "Is #{@ect.full_name}’s working pattern as an ECT full or part time?",
+    header: nil,
     error: @wizard.current_step.errors.present?,
     backlink_href: @wizard.previous_step_path,
 ) %>
 
-<p class="govuk-body">We'll pass this information on so adjustments can be made to training if needed.</p>
-
-
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
   <%= content_for(:error_summary) { f.govuk_error_summary } %>
 
-  <%= f.govuk_radio_buttons_fieldset :working_pattern, legend: { text: "Is #{@ect.full_name}’s working pattern as an ECT full or part time?", hidden: true } do %>
+  <%= f.govuk_radio_buttons_fieldset :working_pattern,
+                                     legend: { text: "Is #{@ect.full_name}’s working pattern as an ECT full or part time?", size: "l", tag: "h1" } do %>
+    <p class="govuk-body">We’ll pass this information on so adjustments can be made to training if needed.</p>
+
     <%= f.govuk_radio_button :working_pattern, :full_time, label: { text: "Full time" }, link_errors: true %>
     <%= f.govuk_radio_button :working_pattern, :part_time, label: { text: "Part time" } %>
   <% end %>

--- a/app/views/schools/register_mentor_wizard/mentoring_at_new_school_only.html.erb
+++ b/app/views/schools/register_mentor_wizard/mentoring_at_new_school_only.html.erb
@@ -1,5 +1,6 @@
 <% page_data(
   title: "Will #{@mentor.full_name} be mentoring ECTs at your school only?",
+  header: nil,
   error: @wizard.current_step.errors.present?,
   backlink_href: @wizard.previous_step_path,
 ) %>
@@ -7,17 +8,18 @@
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
   <%= content_for(:error_summary) { f.govuk_error_summary } %>
 
-  <p class="govuk-body">
-    Our records show that
-    <%= @mentor.full_name %>
-    is already registered as a mentor at a different school.
-  </p>
-
   <%= f.govuk_radio_buttons_fieldset :mentoring_at_new_school_only,
         legend: {
           text: "Will #{@mentor.full_name} be mentoring ECTs at your school only?",
-          hidden: true
+          size: "l",
+          tag: "h1"
         } do %>
+    <p class="govuk-body">
+      Our records show that
+      <%= @mentor.full_name %>
+      is already registered as a mentor at a different school.
+    </p>
+
     <%= f.govuk_radio_button :mentoring_at_new_school_only,
                          :yes,
                          label: {

--- a/spec/views/admin/schools/add_partnership_wizard/select_contract_period.html.erb_spec.rb
+++ b/spec/views/admin/schools/add_partnership_wizard/select_contract_period.html.erb_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe "admin/schools/add_partnership_wizard/select_contract_period.html.erb" do
+  let(:school) { FactoryBot.build(:school, create_contract_period: false) }
+  let(:store) { SessionRepository.new(session: {}, form_key: "add_partnership") }
+  let(:wizard) do
+    Admin::Schools::AddPartnershipWizard::Wizard.new(
+      store:,
+      school_urn: school.urn,
+      current_step: :select_contract_period
+    )
+  end
+
+  before do
+    assign(:school, school)
+    assign(:wizard, wizard)
+  end
+
+  it "uses the fieldset legend as the page heading to avoid repeating the question for screen readers" do
+    render
+
+    expect(view.content_for(:page_header)).to be_blank
+    expect(rendered).to have_css("legend h1", text: "Select the contract period")
+  end
+end

--- a/spec/views/admin/schools/add_partnership_wizard/select_lead_provider.html.erb_spec.rb
+++ b/spec/views/admin/schools/add_partnership_wizard/select_lead_provider.html.erb_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe "admin/schools/add_partnership_wizard/select_lead_provider.html.erb" do
+  let(:school) { FactoryBot.build(:school, create_contract_period: false) }
+  let(:contract_period) { FactoryBot.create(:contract_period) }
+  let(:store) do
+    SessionRepository.new(session: {}, form_key: "add_partnership").tap do |repository|
+      repository.contract_period_year = contract_period.year
+    end
+  end
+  let(:wizard) do
+    Admin::Schools::AddPartnershipWizard::Wizard.new(
+      store:,
+      school_urn: school.urn,
+      current_step: :select_lead_provider
+    )
+  end
+
+  before do
+    assign(:school, school)
+    assign(:wizard, wizard)
+  end
+
+  it "uses the fieldset legend as the page heading to avoid repeating the question for screen readers" do
+    render
+
+    expect(view.content_for(:page_header)).to be_blank
+    expect(rendered).to have_css("legend h1", text: "Select the lead provider for #{contract_period.year}")
+  end
+end

--- a/spec/views/admin/teachers/training_periods/change_contract_period_wizard/select_contract_period.html.erb_spec.rb
+++ b/spec/views/admin/teachers/training_periods/change_contract_period_wizard/select_contract_period.html.erb_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe "admin/teachers/training_periods/change_contract_period_wizard/select_contract_period.html.erb" do
+  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished) }
+  let(:training_period) do
+    FactoryBot.create(
+      :training_period,
+      :unfinished,
+      ect_at_school_period:,
+      started_on: ect_at_school_period.started_on
+    )
+  end
+  let(:teacher) { training_period.teacher }
+  let(:store) { SessionRepository.new(session: {}, form_key: "change_contract_period") }
+  let(:wizard) do
+    Admin::Teachers::TrainingPeriods::ChangeContractPeriodWizard::Wizard.new(
+      store:,
+      teacher_id: teacher.id,
+      training_period_id: training_period.id,
+      current_step: :select_contract_period
+    )
+  end
+
+  before do
+    assign(:teacher, teacher)
+    assign(:wizard, wizard)
+  end
+
+  it "uses the fieldset legend as the page heading to avoid repeating the question for screen readers" do
+    render
+
+    expect(view.content_for(:page_header)).to be_blank
+    expect(rendered).to have_css("legend h1", text: "Select new contract period for #{Teachers::Name.new(teacher).full_name}")
+  end
+end

--- a/spec/views/schools/register_ect_wizard/shared_examples/training_programme_view.rb
+++ b/spec/views/schools/register_ect_wizard/shared_examples/training_programme_view.rb
@@ -21,6 +21,13 @@ RSpec.shared_examples "a training programme view" do |current_step:, back_path:,
     expect(sanitize(view.content_for(:page_title))).to eql("Which training programme will John Smith follow?")
   end
 
+  it "uses the fieldset legend as the page heading to avoid repeating the question for screen readers" do
+    render
+
+    expect(view.content_for(:page_header)).to be_blank
+    expect(rendered).to have_css("legend h1", text: "Which training programme will John Smith follow?")
+  end
+
   context "when the training programme is invalid" do
     before do
       wizard.valid_step?

--- a/spec/views/schools/register_ect_wizard/working_pattern.html.erb_spec.rb
+++ b/spec/views/schools/register_ect_wizard/working_pattern.html.erb_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe "schools/register_ect_wizard/working_pattern.html.erb" do
+  let(:ect) { wizard.ect }
+  let(:store) do
+    FactoryBot.build(:session_repository, trs_first_name: "John", trs_last_name: "Smith")
+  end
+  let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :working_pattern, store:) }
+
+  before do
+    assign(:wizard, wizard)
+    assign(:ect, ect)
+  end
+
+  it "uses the fieldset legend as the page heading to avoid repeating the question for screen readers" do
+    render
+
+    question = "Is John Smith’s working pattern as an ECT full or part time?"
+
+    expect(view.content_for(:page_header)).to be_blank
+    expect(rendered).to have_css("legend h1", text: question)
+  end
+end

--- a/spec/views/schools/register_mentor_wizard/mentoring_at_new_school_only.html.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/mentoring_at_new_school_only.html.erb_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe "schools/register_mentor_wizard/mentoring_at_new_school_only.html.erb" do
+  let(:store) do
+    FactoryBot.build(:session_repository, trs_first_name: "John", trs_last_name: "Smith")
+  end
+  let(:wizard) do
+    FactoryBot.build(:register_mentor_wizard, current_step: :mentoring_at_new_school_only, store:)
+  end
+  let(:mentor) { wizard.mentor }
+
+  before do
+    assign(:wizard, wizard)
+    assign(:mentor, mentor)
+  end
+
+  it "uses the fieldset legend as the page heading to avoid repeating the question for screen readers" do
+    render
+
+    expect(view.content_for(:page_header)).to be_blank
+    expect(rendered).to have_css("legend h1", text: "Will John Smith be mentoring ECTs at your school only?")
+  end
+end


### PR DESCRIPTION
## Summary

Fix duplicate screen reader announcements on question pages.

Use the radio fieldset legend as the page `<h1>` instead of rendering a separate heading with identical text. This preserves the radio group label and ensures the question is announced once.