### PR TITLE
Remove debug screenshot from spec

### DIFF
--- a/spec/features/schools/mentors/register_mentor/edge_cases/changing_start_date_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/changing_start_date_spec.rb
@@ -271,7 +271,6 @@ RSpec.describe "Registering a mentor", :js do
   end
 
   def then_i_should_be_taken_to_lead_provider_page
-    page.screenshot(path: "tmp/lead_provider_page.png")
     expect(page).to have_path("/school/register-mentor/lead-provider")
   end
 


### PR DESCRIPTION
### Summary

Remove the unnecessary screenshot capture from the mentor registration feature spec.