### PR TITLE
Order teachers by created at on admin page

### DIFF
--- a/app/services/admin/teachers/rows.rb
+++ b/app/services/admin/teachers/rows.rb
@@ -9,8 +9,6 @@ module Admin
         "mentor" => "Mentor",
       }.freeze
 
-      ROLE_SORT_ORDER = ROLE_NAMES.keys.append(NO_ROLE_ASSIGNED).each_with_index.to_h.freeze
-
       Row = Data.define(:teacher, :role, :contract_period) do
         delegate :id, to: :teacher, prefix: true
         delegate :trn, to: :teacher
@@ -31,14 +29,6 @@ module Admin
 
           contract_period
         end
-
-        def sort_key
-          [
-            name.to_s.downcase,
-            Rows::ROLE_SORT_ORDER.fetch(role),
-            teacher.id
-          ]
-        end
       end
 
       def initialize(role: nil, contract_period: nil)
@@ -49,9 +39,7 @@ module Admin
       def rows(teachers)
         rows = teachers.flat_map { |teacher| rows_for_teacher(teacher) }
         rows = filter_by_role(rows)
-        rows = filter_by_contract_period(rows)
-
-        sort_rows(rows)
+        filter_by_contract_period(rows)
       end
 
     private
@@ -112,10 +100,6 @@ module Admin
         return rows if contract_period.blank?
 
         rows.select { |row| row.contract_period == contract_period }
-      end
-
-      def sort_rows(rows)
-        rows.sort_by(&:sort_key)
       end
     end
   end

--- a/app/services/admin/teachers/search.rb
+++ b/app/services/admin/teachers/search.rb
@@ -13,7 +13,7 @@ module Admin
 
       def teacher_scope
         preload_associations(filtered_teacher_scope)
-          .reorder(Arel.sql(display_name_order_sql), :id)
+          .reorder(created_at: :desc)
       end
 
     private
@@ -203,27 +203,6 @@ module Admin
         {
           latest_training_period: :schedule
         }
-      end
-
-      def display_name_order_sql
-        # Mirrors Teachers::Name in SQL so ordering and pagination use the same
-        # display name logic used by the UI.
-        <<~SQL.squish
-          LOWER(
-            COALESCE(
-              NULLIF(TRIM(teachers.corrected_name), ''),
-              NULLIF(
-                CONCAT_WS(
-                  ' ',
-                  NULLIF(NULLIF(TRIM(teachers.trs_first_name), ''), '.'),
-                  NULLIF(NULLIF(TRIM(teachers.trs_last_name), ''), '.')
-                ),
-                ''
-              ),
-              'Unknown'
-            )
-          )
-        SQL
       end
     end
   end

--- a/spec/services/admin/teachers/rows_spec.rb
+++ b/spec/services/admin/teachers/rows_spec.rb
@@ -71,10 +71,11 @@ RSpec.describe Admin::Teachers::Rows do
     end
 
     context "when sorting rows" do
-      let!(:sasuke) { FactoryBot.create(:teacher, trs_first_name: "Sasuke", trs_last_name: "Uchiha") }
-      let!(:naruto) { FactoryBot.create(:teacher, trs_first_name: "Naruto", trs_last_name: "Uzumaki") }
+      let!(:sasuke) { FactoryBot.create(:teacher, trs_first_name: "Sasuke", trs_last_name: "Uchiha", created_at: 1.day.ago) }
+      let!(:naruto) { FactoryBot.create(:teacher, trs_first_name: "Naruto", trs_last_name: "Uzumaki", created_at: 2.days.ago) }
       let!(:sasuke_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher: sasuke) }
       let!(:naruto_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :unfinished, teacher: naruto) }
+      let(:teachers) { Admin::Teachers::Search.new.teacher_scope.where(id: [sasuke, naruto]) }
 
       before do
         [sasuke_ect_at_school_period, naruto_ect_at_school_period].each do |ect_at_school_period|
@@ -96,8 +97,8 @@ RSpec.describe Admin::Teachers::Rows do
         end
       end
 
-      it "orders rows alphabetically by full name" do
-        expect(rows_builder.rows(teachers).map(&:name)).to eq(["Naruto Uzumaki", "Sasuke Uchiha"])
+      it "orders rows by creation time" do
+        expect(rows_builder.rows(teachers).map(&:name)).to eq(["Sasuke Uchiha", "Naruto Uzumaki"])
       end
     end
 

--- a/spec/services/admin/teachers/search_spec.rb
+++ b/spec/services/admin/teachers/search_spec.rb
@@ -15,41 +15,12 @@ RSpec.describe Admin::Teachers::Search do
       it { is_expected.to contain_exactly(teacher, other_teacher) }
     end
 
-    context "when a corrected name changes alphabetical ordering" do
-      let!(:teacher_with_corrected_name) do
-        FactoryBot.create(
-          :teacher,
-          trs_first_name: "Zelda",
-          trs_last_name: "Zimmer",
-          corrected_name: "Aaron Aardvark"
-        )
-      end
-      let!(:other_teacher) { FactoryBot.create(:teacher, trs_first_name: "Bob", trs_last_name: "Builder") }
+    context "when teachers have different creation times" do
+      let!(:older_teacher) { FactoryBot.create(:teacher, created_at: 2.days.ago) }
+      let!(:newer_teacher) { FactoryBot.create(:teacher, created_at: 1.day.ago) }
 
-      it "orders teachers by the displayed full name" do
-        expect(teacher_scope).to eq([teacher_with_corrected_name, other_teacher])
-      end
-    end
-
-    context "when TRS name parts are blank or placeholder values" do
-      let!(:teacher_with_blank_first_name) do
-        FactoryBot.create(:teacher, trs_first_name: "", trs_last_name: "Smith")
-      end
-
-      let!(:teacher_with_placeholder_first_name) do
-        FactoryBot.create(:teacher, trs_first_name: ".", trs_last_name: "Taylor")
-      end
-
-      let!(:teacher_with_no_name) do
-        FactoryBot.create(:teacher, trs_first_name: "", trs_last_name: "")
-      end
-
-      it "orders teachers by the displayed full name fallbacks" do
-        expect(teacher_scope).to eq([
-          teacher_with_blank_first_name,
-          teacher_with_placeholder_first_name,
-          teacher_with_no_name
-        ])
+      it "orders teachers by most recently created" do
+        expect(teacher_scope).to eq([newer_teacher, older_teacher])
       end
     end
 


### PR DESCRIPTION
## Context

The default admin teacher list calculated a display name and sorted every teacher record alphabetically. With around ~280k teachers, this is expensive and becomes more costly as the table grows.

The primary users confirmed that alphabetical ordering isn't needed, they mainly find teachers through search. Ordering the default list by newest first lets postgres use the existing `created_at` index instead.

This follows up on a concern raised by @peteryates in https://github.com/DFE-Digital/register-early-career-teachers-public/pull/3184#discussion_r3512622593

## Performance evidence

Measured locally using synthetic data with 279,894 teachers (matching the current production count).

| Query | Before | After |
| --- | --- | --- |
| Default teacher list | 249ms (scans and sorts all 279,894 teachers by display name) | 0.8ms (reads the `created_at` index backwards and stops after 50 teachers) |
| ECT + 2025 filter | 2.27s (runs latest period checks across all 279,894 teachers) | 279ms (runs those checks for 264 newest teachers to find 50 matches) |