### PR TITLE
Introduce `Schools::ECTs::TeachersQuery` object

### DIFF
--- a/app/controllers/schools/ects_controller.rb
+++ b/app/controllers/schools/ects_controller.rb
@@ -5,33 +5,12 @@ module Schools
     include Schools::InductionRedirectable
 
     def index
-      search = Teachers::Search
-        .new(
-          ect_at_school: school,
-          in_progress: true,
-          query_string: params[:q]
-        )
-        .search
-        .includes(
-          ongoing_induction_period: :appropriate_body_period,
-          ect_at_school_periods: %i[latest_training_period mentorship_periods],
-          current_or_next_ect_at_school_period: [
-            { current_or_next_training_period: %i[
-              lead_provider
-              delivery_partner
-              expression_of_interest_lead_provider
-            ] },
-            { latest_training_period: %i[
-              lead_provider
-              delivery_partner
-              expression_of_interest_lead_provider
-            ] },
-            { current_or_next_mentorship_period: { mentor: :teacher } }
-          ]
-        )
-      @pagy, @teachers = pagy(search)
-
-      @number_of_teachers = Teachers::Search.new(ect_at_school: school, in_progress: true).count
+      teachers_query = ECTs::TeachersQuery.new(
+        school: @school,
+        query_string: params[:q]
+      )
+      @pagy, @teachers = pagy(teachers_query.teachers)
+      @number_of_teachers = teachers_query.total_teachers_count
     end
 
     def show

--- a/app/services/schools/ects/teachers_query.rb
+++ b/app/services/schools/ects/teachers_query.rb
@@ -1,0 +1,46 @@
+module Schools::ECTs
+  class TeachersQuery
+    def initialize(school:, query_string:)
+      @school = school
+      @query_string = query_string
+    end
+
+    def teachers
+      teachers_search
+        .search
+        .strict_loading
+        .preload(
+          ongoing_induction_period: :appropriate_body_period,
+          current_or_next_ect_at_school_period: [
+            :school,
+            :school_reported_appropriate_body,
+            {
+              current_or_next_mentorship_period: { mentor: :teacher },
+              current_or_next_training_period: %i[
+                lead_provider
+                expression_of_interest
+                expression_of_interest_lead_provider
+                delivery_partner
+              ],
+              latest_training_period: %i[
+                lead_provider
+                expression_of_interest
+                expression_of_interest_lead_provider
+                delivery_partner
+              ]
+            }
+          ]
+        )
+    end
+
+    def total_teachers_count
+      Teachers::Search.new(ect_at_school: @school, in_progress: true).count
+    end
+
+  private
+
+    def teachers_search
+      Teachers::Search.new(ect_at_school: @school, in_progress: true, query_string: @query_string)
+    end
+  end
+end

--- a/spec/services/schools/ects/teachers_query_spec.rb
+++ b/spec/services/schools/ects/teachers_query_spec.rb
@@ -1,0 +1,114 @@
+RSpec.describe Schools::ECTs::TeachersQuery do
+  subject(:query) { described_class.new(school:, query_string:) }
+
+  let(:school) { FactoryBot.create(:school) }
+  let(:query_string) { nil }
+
+  let(:search_double) { instance_double(Teachers::Search) }
+
+  let!(:ect_at_school_period) do
+    FactoryBot.create(:ect_at_school_period, :unfinished, school:)
+  end
+  let!(:induction_period) do
+    FactoryBot.create(
+      :induction_period,
+      :unfinished,
+      teacher: ect_at_school_period.teacher
+    )
+  end
+  let!(:training_period) do
+    FactoryBot.create(
+      :training_period,
+      :unfinished,
+      :with_expression_of_interest,
+      :with_school_partnership,
+      ect_at_school_period:
+    )
+  end
+  let(:mentor_at_school_period) do
+    FactoryBot.create(:mentor_at_school_period, :unfinished, school:)
+  end
+  let!(:mentorship_period) do
+    FactoryBot.create(
+      :mentorship_period,
+      :unfinished,
+      mentee: ect_at_school_period,
+      mentor: mentor_at_school_period
+    )
+  end
+
+  describe "#teachers" do
+    subject(:teachers) { query.teachers }
+
+    it "calls `#search` on the `Teachers::Search` service with the correct parameters" do
+      allow(Teachers::Search)
+        .to receive(:new)
+        .with(ect_at_school: school, in_progress: true, query_string:)
+        .and_return(search_double)
+      allow(search_double).to receive(:search).and_return(Teacher.all)
+
+      teachers
+
+      expect(search_double).to have_received(:search)
+    end
+
+    describe "preloading associations" do
+      subject(:result) { teachers.first }
+
+      it { expect(result.association(:ongoing_induction_period)).to be_loaded }
+      it { expect(result.ongoing_induction_period.association(:appropriate_body_period)).to be_loaded }
+      it { expect(result.association(:current_or_next_ect_at_school_period)).to be_loaded }
+      it { expect(result.current_or_next_ect_at_school_period.association(:school)).to be_loaded }
+      it { expect(result.current_or_next_ect_at_school_period.association(:school_reported_appropriate_body)).to be_loaded }
+      it { expect(result.current_or_next_ect_at_school_period.association(:current_or_next_mentorship_period)).to be_loaded }
+      it { expect(result.current_or_next_ect_at_school_period.current_or_next_mentorship_period.association(:mentor)).to be_loaded }
+      it { expect(result.current_or_next_ect_at_school_period.current_or_next_mentorship_period.mentor.association(:teacher)).to be_loaded }
+      it { expect(result.current_or_next_ect_at_school_period.association(:current_or_next_training_period)).to be_loaded }
+      it { expect(result.current_or_next_ect_at_school_period.current_or_next_training_period.association(:lead_provider)).to be_loaded }
+      it { expect(result.current_or_next_ect_at_school_period.current_or_next_training_period.association(:expression_of_interest)).to be_loaded }
+      it { expect(result.current_or_next_ect_at_school_period.current_or_next_training_period.association(:expression_of_interest_lead_provider)).to be_loaded }
+      it { expect(result.current_or_next_ect_at_school_period.current_or_next_training_period.association(:delivery_partner)).to be_loaded }
+      it { expect(result.current_or_next_ect_at_school_period.association(:latest_training_period)).to be_loaded }
+      it { expect(result.current_or_next_ect_at_school_period.latest_training_period.association(:lead_provider)).to be_loaded }
+      it { expect(result.current_or_next_ect_at_school_period.latest_training_period.association(:expression_of_interest)).to be_loaded }
+      it { expect(result.current_or_next_ect_at_school_period.latest_training_period.association(:expression_of_interest_lead_provider)).to be_loaded }
+      it { expect(result.current_or_next_ect_at_school_period.latest_training_period.association(:delivery_partner)).to be_loaded }
+
+      describe "lead provider name" do
+        subject(:lead_provider_name) do
+          result.current_or_next_ect_at_school_period.latest_lead_provider_name
+        end
+
+        context "when the teacher has a finished `TrainingPeriod`" do
+          let!(:training_period) do
+            FactoryBot.create(
+              :training_period,
+              :finished,
+              :with_expression_of_interest,
+              :with_school_partnership,
+              ect_at_school_period:
+            )
+          end
+
+          it { is_expected.to eq(training_period.lead_provider_name) }
+        end
+      end
+    end
+  end
+
+  describe "#total_teachers_count" do
+    subject(:total_teachers_count) { query.total_teachers_count }
+
+    it "calls `#count` on the `Teachers::Search` service with the correct parameters" do
+      allow(Teachers::Search)
+        .to receive(:new)
+        .with(ect_at_school: school, in_progress: true)
+        .and_return(search_double)
+      allow(search_double).to receive(:count)
+
+      total_teachers_count
+
+      expect(search_double).to have_received(:count)
+    end
+  end
+end


### PR DESCRIPTION
This adds another layer of abstraction between the `Schools::ECTsController` and
the complex query that filters teachers.

The intention is this will make things easier to test, and allow us to
explicitly preload associations that are relevant for this use case.

This query object also leans on [`preload`][preload] rather than
[`includes`][includes]. This means we use a separate query for each association,
rather than rolling them into a single, complex query with multiple joins.

The benefits of this are two-fold:

1. It means the latest training period associations are loaded even when there
is no current or next training period (as outlined in https://github.com/DFE-Digital/register-early-career-teachers-public/pull/3308)
2. It is more performant in this use-case (as discussed in https://github.com/DFE-Digital/register-early-career-teachers-public/pull/3287)

There is also a specific unit-test that asserts the `lead_provider_name` is
returned correctly from results when an ECT only has a finished training period
(i.e no `current_or_next`, only `latest`). This is fixed by us using `preload`
instead of `include`. See https://github.com/DFE-Digital/register-early-career-teachers-public/pull/3308.

[preload]: https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-preload
[includes]: https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-includes