### PR TITLE
[4270] Fix Change LP journey when no current/next training period

### DIFF
--- a/app/services/ect_at_school_periods/change_lead_provider_resolver.rb
+++ b/app/services/ect_at_school_periods/change_lead_provider_resolver.rb
@@ -5,7 +5,7 @@ module ECTAtSchoolPeriods
     end
 
     def call
-      current_training_lead_provider || withdrawn_or_deferred_lead_provider
+      current_training_lead_provider || latest_training_lead_provider
     end
 
   private
@@ -20,9 +20,9 @@ module ECTAtSchoolPeriods
       nil
     end
 
-    def withdrawn_or_deferred_lead_provider
+    def latest_training_lead_provider
       training_period = ect_at_school_period.latest_training_period
-      return unless training_period.status.in?(%i[withdrawn deferred])
+      return if training_period.blank?
 
       if training_period.only_expression_of_interest?
         training_period.expression_of_interest&.lead_provider

--- a/spec/requests/schools/ects/change_lead_provider_wizard_spec.rb
+++ b/spec/requests/schools/ects/change_lead_provider_wizard_spec.rb
@@ -39,6 +39,12 @@ describe "Schools::ECTs::ChangeLeadProviderWizardController" do
       lead_provider: other_lead_provider
     )
   end
+  let(:lead_provider_delivery_partnership) do
+    FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:, contract_period:)
+  end
+  let(:school_partnership) do
+    FactoryBot.create(:school_partnership, school:, lead_provider_delivery_partnership:)
+  end
 
   describe "GET #new" do
     subject { get path_for_step("edit") }
@@ -97,6 +103,28 @@ describe "Schools::ECTs::ChangeLeadProviderWizardController" do
         it "returns ok" do
           subject
           expect(response).to have_http_status(:ok)
+        end
+      end
+
+      context "when the latest training period has finished" do
+        let!(:training_period) do
+          FactoryBot.create(
+            :training_period,
+            :for_ect,
+            :provider_led,
+            ect_at_school_period:,
+            started_on: ect_at_school_period.started_on,
+            finished_on: 1.month.ago.to_date,
+            school_partnership:
+          )
+        end
+
+        it "offers the other lead providers, excluding the one they were training with" do
+          subject
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include(other_lead_provider.name)
+          expect(response.body).not_to include(lead_provider.name)
         end
       end
     end
@@ -261,6 +289,49 @@ describe "Schools::ECTs::ChangeLeadProviderWizardController" do
 
           expect(Events::Record).to have_received(:record_teacher_training_lead_provider_updated_event!)
           expect(response).to redirect_to(path_for_step("confirmation"))
+        end
+      end
+
+      context "when the latest training period has finished" do
+        let!(:training_period) do
+          FactoryBot.create(
+            :training_period,
+            :for_ect,
+            :provider_led,
+            ect_at_school_period:,
+            started_on: ect_at_school_period.started_on,
+            finished_on: 1.month.ago.to_date,
+            school_partnership:
+          )
+        end
+
+        it "shows the previous lead provider and completes the change" do
+          subject
+
+          follow_redirect!
+
+          expect(response.body).to include(lead_provider.name)
+
+          post(path_for_step("check-answers"))
+
+          expect(response).to redirect_to(path_for_step("confirmation"))
+
+          training = current_training_for(ect_at_school_period.reload)
+          expect(training.lead_provider_via_school_partnership_or_eoi).to eq(other_lead_provider)
+        end
+
+        it "records the previous lead provider on the event" do
+          allow(Events::Record).to receive(:record_teacher_training_lead_provider_updated_event!)
+
+          subject
+          follow_redirect!
+          post(path_for_step("check-answers"))
+
+          expect(Events::Record).to have_received(:record_teacher_training_lead_provider_updated_event!)
+            .with(hash_including(
+                    old_lead_provider_name: lead_provider.name,
+                    new_lead_provider_name: other_lead_provider.name
+                  ))
         end
       end
 

--- a/spec/services/ect_at_school_periods/change_lead_provider_resolver_spec.rb
+++ b/spec/services/ect_at_school_periods/change_lead_provider_resolver_spec.rb
@@ -90,6 +90,45 @@ RSpec.describe ECTAtSchoolPeriods::ChangeLeadProviderResolver do
           expect(resolver.call).to eq(lead_provider)
         end
       end
+
+      context "and latest TP has finished without being withdrawn or deferred" do
+        before do
+          training_period.update!(finished_on: 1.month.ago.to_date)
+        end
+
+        it "falls back to the lead provider of the latest training period" do
+          expect(resolver.call).to eq(lead_provider)
+        end
+      end
+
+      context "and the latest TP is confirmed by a school partnership rather than an EOI" do
+        let(:lead_provider_delivery_partnership) do
+          FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:, contract_period:)
+        end
+        let(:school_partnership) do
+          FactoryBot.create(:school_partnership, school:, lead_provider_delivery_partnership:)
+        end
+
+        before do
+          training_period.update!(
+            expression_of_interest: nil,
+            school_partnership:,
+            finished_on: 1.month.ago.to_date
+          )
+        end
+
+        it "falls back to the school partnership's lead provider" do
+          expect(resolver.call).to eq(lead_provider)
+        end
+      end
+    end
+
+    context "when the ECT has no training periods at all" do
+      let!(:training_period) { nil }
+
+      it "returns nil rather than raising" do
+        expect(resolver.call).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/4270#issuecomment-5176404565 (second, separate issue discovered during product review)

### Changes proposed in this pull request

Similar to #3308 (but in a totally different code path), if an ECT has no current/next training period, the Change LP resolver would fail as documented in @mason-emily comment in that ticket. This PR changes the resolver to consider any past training period within the same AtSchoolPeriod, rather than only withdrawn/deferred ones.

This makes it work the same way as the fix in #3308 to display a current lead provider.