### PR TITLE
[3260] Refine DQT importer for second round- #3332

### DIFF
--- a/db/scripts/export_invalid_records.rb
+++ b/db/scripts/export_invalid_records.rb
@@ -1,0 +1,55 @@
+# 🫠 Wonkiness checker (use on production data but not on the production deployment)
+#
+# Example:
+#   rails runner db/scripts/export_invalid_records.rb induction_periods induction_extensions
+#
+# Run in-service model validations to help triage data
+
+if Rails.env.production?
+  $stdout.puts "Query production data using a database backup."
+  exit 0
+end
+
+if ARGV.empty?
+  $stdout.puts "No tables specified."
+  exit 0
+end
+
+batch_size = 1_000
+headers = %w[table_name record_id errors]
+date = Time.zone.today.iso8601
+filename = Rails.root.join("tmp", "invalid-records-#{date}.csv")
+results = []
+
+def validate(model, batch_size, &block)
+  model.find_in_batches(batch_size:) do |batch|
+    batch.each(&block)
+  end
+end
+
+ARGV.each do |table_name|
+  model = table_name.singularize.camelize.constantize
+
+  validate(model, batch_size) do |record|
+    next if record.valid?
+
+    errors = record.errors.full_messages.join("; ")
+
+    results << {
+      table_name: model.table_name,
+      record_id: record.id,
+      errors:,
+    }
+  end
+end
+
+if results.empty?
+  $stdout.puts "No invalid records found."
+  exit 0
+end
+
+CSV.open(filename, "w", write_headers: true, headers:) do |csv|
+  results.each { |row| csv << row.values }
+end
+
+$stdout.puts "Exported #{results.size} invalid record(s) to #{filename}"

--- a/lib/appropriate_bodies/importers/induction_period_parser.rb
+++ b/lib/appropriate_bodies/importers/induction_period_parser.rb
@@ -226,7 +226,7 @@ module AppropriateBodies::Importers
           if row.trn.nil? || row.legacy_appropriate_body_id.nil?
             log_error("cannot be imported because TRN or AB is missing",
                       trn: row.trn,
-                      dqt_id: row.legacy_appropriate_body_id)
+                      dqt_id: [row.legacy_appropriate_body_id, nil])
           else
             false
           end
@@ -235,7 +235,7 @@ module AppropriateBodies::Importers
           if row.started_on.nil?
             log_error("cannot be imported because started_on is nil",
                       trn: row.trn,
-                      dqt_id: row.legacy_appropriate_body_id)
+                      dqt_id: [row.legacy_appropriate_body_id, nil])
           else
             false
           end
@@ -244,7 +244,7 @@ module AppropriateBodies::Importers
           if row.finished_on.nil?
             log_error("cannot be imported because finished_on is nil",
                       trn: row.trn,
-                      dqt_id: row.legacy_appropriate_body_id)
+                      dqt_id: [row.legacy_appropriate_body_id, nil])
           else
             false
           end
@@ -253,7 +253,7 @@ module AppropriateBodies::Importers
           if row.started_on == Date.new(1, 1, 1)
             log_error("cannot be imported because started_on is 0001-01-01",
                       trn: row.trn,
-                      dqt_id: row.legacy_appropriate_body_id)
+                      dqt_id: [row.legacy_appropriate_body_id, nil])
           else
             false
           end
@@ -262,7 +262,7 @@ module AppropriateBodies::Importers
           if row.finished_on && row.started_on > row.finished_on
             log_error("cannot be imported because started_on is greater than finished_on",
                       trn: row.trn,
-                      dqt_id: row.legacy_appropriate_body_id)
+                      dqt_id: [row.legacy_appropriate_body_id, nil])
           else
             false
           end
@@ -271,7 +271,7 @@ module AppropriateBodies::Importers
           if row.legacy_appropriate_body_id.in?(offshore_dqt_uuids)
             log_error("cannot be imported because AB is offshore",
                       trn: row.trn,
-                      dqt_id: row.legacy_appropriate_body_id)
+                      dqt_id: [row.legacy_appropriate_body_id, nil])
           else
             false
           end
@@ -402,7 +402,7 @@ module AppropriateBodies::Importers
                     log_error(
                       "cannot be imported because two overlapping induction periods with the same appropriate body and programme could not be resolved",
                       trn: current.trn,
-                      dqt_id: current.legacy_appropriate_body_id,
+                      dqt_id: [current.legacy_appropriate_body_id, nil],
                       started_on: [sibling.started_on, current.started_on],
                       finished_on: [sibling.finished_on, current.finished_on]
                     )
@@ -487,7 +487,7 @@ module AppropriateBodies::Importers
             log_error(
               "cannot be imported because the induction period is 1 day or shorter",
               trn: edited_period.trn,
-              dqt_id: edited_period.legacy_appropriate_body_id,
+              dqt_id: [edited_period.legacy_appropriate_body_id, nil],
               started_on: [original[:started_on], edited_period.started_on],
               finished_on: [original[:finished_on], edited_period.finished_on]
             )
@@ -531,17 +531,14 @@ module AppropriateBodies::Importers
 
     # @param message [String]
     # @param trn [String]
-    # @param dqt_id [String, Array<String>]
-    # @param started_on [Date]
-    # @param finished_on [Date]
-    # @return [void]
-    def log_error(message, trn:, dqt_id:, started_on: nil, finished_on: nil)
+    # @param dqt_id [Array<String>]
+    # @param started_on [Array<Date>]
+    # @param finished_on [Array<Date>]
+    def log_error(message, trn:, dqt_id: [nil, nil], started_on: [nil, nil], finished_on: [nil, nil])
       log_error_csv(message, trn:, dqt_id:, started_on:, finished_on:)
 
-      uuids = Array(dqt_id).join(", ")
-      dates = [started_on, finished_on].compact.map(&:to_s).join(" to ")
-      suffix = dates.empty? ? "" : " dates: #{dates}"
-      logger.error("#{message} trn: #{trn} dqt_id: #{uuids}#{suffix}")
+      uuids = dqt_id.join(", ")
+      logger.error("#{message} trn: #{trn} dqt_id: #{uuids}")
     end
 
     # @param datetime [String]
@@ -554,18 +551,21 @@ module AppropriateBodies::Importers
     end
 
     def error_csv_header
-      CSV.generate_line(%w[reason trn dqt_id started_on finished_on])
+      CSV.generate_line(%w[
+        reason
+        trn
+        dqt_id
+        dqt_id_other
+        started_on
+        started_on_other
+        finished_on
+        finished_on_other
+      ])
     end
 
-    def log_error_csv(message, trn:, dqt_id:, started_on: nil, finished_on: nil)
+    def log_error_csv(message, trn:, dqt_id:, started_on:, finished_on:)
       File.open(PARSER_ERROR_CSV, "a") do |f|
-        f.puts(CSV.generate_line([
-          message,
-          trn,
-          Array(dqt_id).join("; "),
-          Array(started_on).map(&:to_s).join("; "),
-          Array(finished_on).map(&:to_s).join("; ")
-        ]))
+        f.puts(CSV.generate_line([message, trn, *dqt_id, *started_on, *finished_on]))
       end
     end
   end

--- a/lib/appropriate_bodies/importers/induction_period_parser.rb
+++ b/lib/appropriate_bodies/importers/induction_period_parser.rb
@@ -1,12 +1,9 @@
-require "csv"
-
 module AppropriateBodies::Importers
   class InductionPeriodParser
     PARSER_ERROR_LOG = "tmp/dqt_induction_period_parser.log"
+    PARSER_ERROR_CSV = "tmp/dqt_induction_period_parser_rejected.csv"
 
-    # 2 legacy teachers with inductions have already been imported manually
-    UNWANTED_TEACHER_IDS = [76_075, 93_314].freeze
-    # Import cut off date
+    # Local Authorities (LAs) lost AB status
     CUTOFF_DATE = Date.new(2024, 8, 31).freeze
 
     InductionEvent = Struct.new(
@@ -198,16 +195,15 @@ module AppropriateBodies::Importers
                   :data_csv,
                   :logger,
                   :offshore_dqt_uuids,
-                  :all_dqt_uuids,
-                  :trns_already_persisted_with_inductions
+                  :la_dqt_uuids
 
     def initialize(data_csv:, logger: nil)
       @data_csv = data_csv
       @offshore_dqt_uuids = OFFSHORE_DQT_UUIDS.to_set
-      @all_dqt_uuids = AppropriateBodyPeriod.pluck(:dqt_id).to_set
-      @trns_already_persisted_with_inductions = Teacher.where(id: UNWANTED_TEACHER_IDS).pluck(:trn).to_set
+      @la_dqt_uuids = AppropriateBodyPeriod.local_authority.pluck(:dqt_id).to_set
 
       File.open(PARSER_ERROR_LOG, "w") { |f| f.truncate(0) }
+      File.write(PARSER_ERROR_CSV, error_csv_header)
       @logger = logger || Logger.new(PARSER_ERROR_LOG, File::CREAT)
     end
 
@@ -280,15 +276,6 @@ module AppropriateBodies::Importers
             false
           end
         }
-        .reject { |row|
-          if row.trn.in?(trns_already_persisted_with_inductions)
-            log_error("cannot be imported because teacher already exists with inductions",
-                      trn: row.trn,
-                      dqt_id: row.legacy_appropriate_body_id)
-          else
-            false
-          end
-        }
         .sort_by(&:trn)
         .group_by(&:trn)
         .transform_values { |periods|
@@ -314,10 +301,10 @@ module AppropriateBodies::Importers
             end
 
             # retard end date (add if missing) if it postdates the initial import
-            if current.legacy_appropriate_body_id.in?(all_dqt_uuids) && current.finished_on > CUTOFF_DATE
+            if current.legacy_appropriate_body_id.in?(la_dqt_uuids) && current.finished_on > CUTOFF_DATE
               current.notes << {
                 heading:,
-                body: "Induction period curtailed because it finished after appropriate body status lost",
+                body: "Induction period curtailed because it finished after LA lost appropriate body status",
                 data: { originals: [current.dup] }
               }
 
@@ -412,7 +399,13 @@ module AppropriateBodies::Importers
                     }
 
                   else
-                    fail
+                    log_error(
+                      "cannot be imported because two overlapping induction periods with the same appropriate body and programme could not be resolved",
+                      trn: current.trn,
+                      dqt_id: current.legacy_appropriate_body_id,
+                      started_on: [sibling.started_on, current.started_on],
+                      finished_on: [sibling.finished_on, current.finished_on]
+                    )
                   end
 
                 # same appropriate body and conflicting programme type
@@ -473,14 +466,33 @@ module AppropriateBodies::Importers
                     }
                     keep << current
                   else
-                    fail
+                    log_error(
+                      "cannot be imported because two overlapping induction periods with different appropriate bodies could not be deconflicted",
+                      trn: current.trn,
+                      dqt_id: [current.legacy_appropriate_body_id, sibling.legacy_appropriate_body_id],
+                      started_on: [sibling.started_on, current.started_on],
+                      finished_on: [sibling.finished_on, current.finished_on]
+                    )
                   end
 
                 end
               end
           end
 
-          keep = keep.reject { |edited_period| edited_period.length <= 1 }
+          keep = keep.reject do |edited_period|
+            next false if edited_period.length > 1
+
+            original = edited_period.notes.dig(0, :data, :originals)&.first.to_h
+
+            log_error(
+              "cannot be imported because the induction period is 1 day or shorter",
+              trn: edited_period.trn,
+              dqt_id: edited_period.legacy_appropriate_body_id,
+              started_on: [original[:started_on], edited_period.started_on],
+              finished_on: [original[:finished_on], edited_period.finished_on]
+            )
+            true
+          end
 
           next if keep.empty?
 
@@ -520,10 +532,16 @@ module AppropriateBodies::Importers
     # @param message [String]
     # @param trn [String]
     # @param dqt_id [String, Array<String>]
+    # @param started_on [Date]
+    # @param finished_on [Date]
     # @return [void]
-    def log_error(message, trn:, dqt_id:)
+    def log_error(message, trn:, dqt_id:, started_on: nil, finished_on: nil)
+      log_error_csv(message, trn:, dqt_id:, started_on:, finished_on:)
+
       uuids = Array(dqt_id).join(", ")
-      logger.error("#{message} trn: #{trn} dqt_id: #{uuids}")
+      dates = [started_on, finished_on].compact.map(&:to_s).join(" to ")
+      suffix = dates.empty? ? "" : " dates: #{dates}"
+      logger.error("#{message} trn: #{trn} dqt_id: #{uuids}#{suffix}")
     end
 
     # @param datetime [String]
@@ -533,6 +551,22 @@ module AppropriateBodies::Importers
 
       date = datetime.first(10)
       Date.strptime(date, "%m/%d/%Y")
+    end
+
+    def error_csv_header
+      CSV.generate_line(%w[reason trn dqt_id started_on finished_on])
+    end
+
+    def log_error_csv(message, trn:, dqt_id:, started_on: nil, finished_on: nil)
+      File.open(PARSER_ERROR_CSV, "a") do |f|
+        f.puts(CSV.generate_line([
+          message,
+          trn,
+          Array(dqt_id).join("; "),
+          Array(started_on).map(&:to_s).join("; "),
+          Array(finished_on).map(&:to_s).join("; ")
+        ]))
+      end
     end
   end
 end

--- a/lib/appropriate_bodies/importers/teacher_induction_importer.rb
+++ b/lib/appropriate_bodies/importers/teacher_induction_importer.rb
@@ -23,7 +23,7 @@ module AppropriateBodies::Importers
       where e.heading = 'placeholder'
       and e.event_type = 'induction_period_opened'
       and e.teacher_id = t.id
-      and e.appropriate_body_period_id = ab.id;
+      and e.appropriate_body_period_id = ab.id
     CLAIMED
       update events e
       set heading = t.trs_first_name || ' ' || t.trs_last_name || ' was released by ' || ab.name
@@ -31,7 +31,7 @@ module AppropriateBodies::Importers
       where e.heading = 'placeholder'
       and e.event_type = 'induction_period_closed'
       and e.teacher_id = t.id
-      and e.appropriate_body_period_id = ab.id;
+      and e.appropriate_body_period_id = ab.id
     RELEASED
       update events e
       set heading = t.trs_first_name || ' ' || t.trs_last_name || ' passed induction'
@@ -39,7 +39,7 @@ module AppropriateBodies::Importers
       where e.heading = 'placeholder'
       and e.event_type = 'teacher_passes_induction'
       and e.teacher_id = t.id
-      and e.appropriate_body_period_id = ab.id;
+      and e.appropriate_body_period_id = ab.id
     PASSED
       update events e
       set heading = t.trs_first_name || ' ' || t.trs_last_name || ' failed induction'
@@ -47,17 +47,21 @@ module AppropriateBodies::Importers
       where e.heading = 'placeholder'
       and e.event_type = 'teacher_fails_induction'
       and e.teacher_id = t.id
-      and e.appropriate_body_period_id = ab.id;
+      and e.appropriate_body_period_id = ab.id
     FAILED
 
     # @return [Hash{String => Array<Struct>}] All inductions including previously imported
     attr_reader :teachers_with_inductions
     # @return [TeacherParser]
     attr_reader :teachers
+    # @return [Array<String>]
+    attr_reader :existing_trns
     # @return [Logger]
     attr_reader :logger
 
     def initialize(teachers_csv:, induction_period_csv:, logger: nil)
+      @existing_trns = Teacher.pluck(:trn)
+
       @teachers_with_inductions =
         InductionPeriodParser.new(data_csv: induction_period_csv).periods_by_trn
 
@@ -124,42 +128,51 @@ module AppropriateBodies::Importers
         finalised_rows.each_slice(BATCH_SIZE).each do |batch|
           induction_period_data = batch.map(&:to_record)
           induction_period_result = InductionPeriod.insert_all!(induction_period_data, returning: [:id])
-
           logger.info("Induction periods inserted: #{induction_period_result.count}")
 
-          event_data = batch
-                        .each_with_index { |row, i| row.id = induction_period_result[i]["id"] }
-                        .flat_map(&:events).flatten
-
-          event_result = Event.insert_all!(event_data)
-
-          logger.info("Events inserted: #{event_result.count}")
+          batch.each_with_index { |row, i| row.id = induction_period_result[i]["id"] }
+          event_data = batch.flat_map(&:events)
+          event_data.each_slice(BATCH_SIZE) do |event_batch|
+            event_result = Event.insert_all!(event_batch)
+            logger.info("Events inserted: #{event_result.count}")
+          end
         end
       end
     end
 
     def import_induction_extensions
-      data = teachers.rows.select { |tir| tir.extension_terms.present? }.map do |row|
-        {
-          teacher_id: teacher_trn_to_id.fetch(row.trn),
-          number_of_terms: row.extension_terms
-        }
-      end
+      ActiveRecord::Base.transaction do
+        teachers.rows.select { |tir| tir.extension_terms.present? }.each_slice(BATCH_SIZE).each do |batch|
+          data = batch.map do |row|
+            {
+              teacher_id: teacher_trn_to_id.fetch(row.trn),
+              number_of_terms: row.extension_terms
+            }
+          end
 
-      extension_result = InductionExtension.insert_all!(data)
-      logger.info("Induction extensions inserted: #{extension_result.count}")
+          extension_result = InductionExtension.insert_all!(data)
+
+          logger.info("Induction extensions inserted: #{extension_result.count}")
+        end
+      end
     end
 
     def update_event_titles
-      ActiveRecord::Base.connection.execute(STATEMENTS.join(";"))
-      logger.info "Event heading placeholders replaced"
+      ActiveRecord::Base.transaction do
+        STATEMENTS.each do |statement|
+          ActiveRecord::Base.connection.execute(statement)
+        end
+
+        logger.info "Event heading placeholders replaced"
+      end
     end
 
     # @return [Array<AppropriateBodies::Importers::InductionPeriodParser::Row>]
     def finalised_rows
       induction_period_rows = []
+      target_trns = teachers.trns - existing_trns
 
-      teachers_with_inductions.slice(*teachers.trns).each do |trn, induction_periods|
+      teachers_with_inductions.slice(*target_trns).each do |trn, induction_periods|
         induction_periods.each do |ip|
           ip.teacher_id = teacher_trn_to_id.fetch(trn)
           ip.appropriate_body_period_id = ab_legacy_uuid_to_id.fetch(ip.legacy_appropriate_body_id)

--- a/lib/appropriate_bodies/importers/teacher_induction_importer.rb
+++ b/lib/appropriate_bodies/importers/teacher_induction_importer.rb
@@ -54,13 +54,18 @@ module AppropriateBodies::Importers
     attr_reader :teachers_with_inductions
     # @return [TeacherParser]
     attr_reader :teachers
-    # @return [Array<String>]
+    # @return [Set<String>]
     attr_reader :existing_trns
+    # @return [Set<String>]
+    attr_reader :existing_trns_without_inductions
+    # @return [Set<String>]
+    attr_reader :importing_trns_with_inductions
     # @return [Logger]
     attr_reader :logger
 
     def initialize(teachers_csv:, induction_period_csv:, logger: nil)
-      @existing_trns = Teacher.pluck(:trn)
+      @existing_trns = Teacher.pluck(:trn).to_set
+      @existing_trns_without_inductions = Teacher.left_joins(:induction_periods).where(induction_periods: { id: nil }).pluck(:trn).to_set
 
       @teachers_with_inductions =
         InductionPeriodParser.new(data_csv: induction_period_csv).periods_by_trn
@@ -70,6 +75,8 @@ module AppropriateBodies::Importers
           data_csv: teachers_csv,
           trns_with_induction_periods: @teachers_with_inductions.keys
         )
+
+      @importing_trns_with_inductions = @teachers.trns.to_set
 
       File.open(IMPORT_INFO_LOG, "w") { |f| f.truncate(0) }
       @logger = logger || Logger.new(IMPORT_INFO_LOG, File::CREAT)
@@ -170,7 +177,8 @@ module AppropriateBodies::Importers
     # @return [Array<AppropriateBodies::Importers::InductionPeriodParser::Row>]
     def finalised_rows
       induction_period_rows = []
-      target_trns = teachers.trns - existing_trns
+
+      target_trns = ((importing_trns_with_inductions - existing_trns) + existing_trns_without_inductions).to_a
 
       teachers_with_inductions.slice(*target_trns).each do |trn, induction_periods|
         induction_periods.each do |ip|

--- a/spec/lib/appropriate_bodies/importers/induction_period_parser_spec.rb
+++ b/spec/lib/appropriate_bodies/importers/induction_period_parser_spec.rb
@@ -17,14 +17,14 @@ RSpec.describe AppropriateBodies::Importers::InductionPeriodParser do
   let!(:ab_1) { FactoryBot.create(:appropriate_body_period, :local_authority) }
   let!(:ab_2) { FactoryBot.create(:appropriate_body_period, :local_authority) }
   let!(:ab_3) { FactoryBot.create(:appropriate_body_period, :local_authority) }
-  let!(:ab_4) { FactoryBot.create(:appropriate_body_period, :local_authority) }
-  let!(:ab_5) { FactoryBot.create(:appropriate_body_period, :local_authority) }
+  let!(:ab_4) { FactoryBot.create(:appropriate_body_period, :teaching_school_hub, dqt_id: Faker::Internet.uuid) }
+  let!(:ab_5) { FactoryBot.create(:appropriate_body_period, :istip, dqt_id: Faker::Internet.uuid) }
 
   let!(:ect_1) { FactoryBot.create(:teacher, :induction_passed) }
   let!(:ect_2) { FactoryBot.create(:teacher, :induction_failed_in_wales) }
   let!(:ect_3) { FactoryBot.create(:teacher, trs_induction_status: "None") }
-  let!(:ect_4) { FactoryBot.create(:teacher, id: described_class::UNWANTED_TEACHER_IDS[0]) }
-  let!(:ect_5) { FactoryBot.create(:teacher, id: described_class::UNWANTED_TEACHER_IDS[1]) }
+  let!(:ect_4) { FactoryBot.create(:teacher) }
+  let!(:ect_5) { FactoryBot.create(:teacher) }
 
   let(:sample_csv_data) do
     <<~CSV
@@ -143,14 +143,6 @@ RSpec.describe AppropriateBodies::Importers::InductionPeriodParser do
       end
     end
 
-    # it "orders inductions by start date" do
-    #   # TODO: - add more dates
-    # end
-
-    # it "applies the ECT's induction status to their final period" do
-    #   # TODO
-    # end
-
     context "when started_on is nil" do
       let(:sample_csv_data) do
         <<~CSV
@@ -211,21 +203,6 @@ RSpec.describe AppropriateBodies::Importers::InductionPeriodParser do
       end
     end
 
-    context "when teacher_id is excluded" do
-      let(:sample_csv_data) do
-        <<~CSV
-          appropriate_body_id,started_on,finished_on,induction_programme_choice,number_of_terms,trn
-          #{ab_1.dqt_id},01/01/2012 00:00:00,01/02/2012 00:00:00,,1,#{ect_4.trn}
-        CSV
-      end
-
-      it "is rejected because teacher exists with data" do
-        expect(parsed).to be_empty
-        expect(fake_logger).to have_received(:error).once.with(/teacher already exists with inductions/)
-        expect(fake_logger).to have_received(:error).once.with(/trn: .* dqt_id:/)
-      end
-    end
-
     context "when started_on is invalid" do
       let(:sample_csv_data) do
         <<~CSV
@@ -252,6 +229,21 @@ RSpec.describe AppropriateBodies::Importers::InductionPeriodParser do
       it "does not import the row" do
         expect(parsed).to be_empty
         expect(fake_logger).to have_received(:error).once.with(/started_on is greater than finished_on/)
+        expect(fake_logger).to have_received(:error).once.with(/trn: .* dqt_id:/)
+      end
+    end
+
+    context "when the induction period is 1 day or shorter" do
+      let(:sample_csv_data) do
+        <<~CSV
+          appropriate_body_id,started_on,finished_on,induction_programme_choice,number_of_terms,trn
+          #{ab_1.dqt_id},01/01/2023 00:00:00,01/01/2023 00:00:00,Core Induction Programme,3,#{ect_1.trn}
+        CSV
+      end
+
+      it "rejects the row and logs an error" do
+        expect(parsed).to be_empty
+        expect(fake_logger).to have_received(:error).once.with(/1 day or shorter/)
         expect(fake_logger).to have_received(:error).once.with(/trn: .* dqt_id:/)
       end
     end
@@ -330,15 +322,16 @@ RSpec.describe AppropriateBodies::Importers::InductionPeriodParser do
         end
       end
 
-      context "when the finish date is later than the import cutoff date" do
+      context "when an LA AB period non-LA AB period span 2024-08-31" do
         let(:sample_csv_data) do
           <<~CSV
             appropriate_body_id,started_on,finished_on,induction_programme_choice,number_of_terms,trn
             #{ab_1.dqt_id},01/01/2019 00:00:00,10/31/2024 00:00:00,Core Induction Programme,3,#{ect_1.trn}
+            #{ab_4.dqt_id},01/01/2019 00:00:00,10/31/2024 00:00:00,Core Induction Programme,3,#{ect_2.trn}
           CSV
         end
 
-        it "trims the end date to 2024-08-31" do
+        it "trims the LA end date leaving the non-LA end date unchanged" do
           expect(parsed_to_record).to eql(
             {
               ect_1.trn => [
@@ -351,9 +344,49 @@ RSpec.describe AppropriateBodies::Importers::InductionPeriodParser do
                   induction_programme: "pre_september_2021",
                   number_of_terms: 3.0,
                 }
+              ],
+              ect_2.trn => [
+                {
+                  teacher_id: nil,
+                  appropriate_body_period_id: nil,
+                  outcome: :fail,
+                  started_on: Date.new(2019, 1, 1),
+                  finished_on: Date.new(2024, 10, 31),
+                  induction_programme: "pre_september_2021",
+                  number_of_terms: 3.0,
+                }
               ]
             }
           )
+        end
+      end
+
+      context "when merging periods results in a 1-day or shorter period" do
+        let(:sample_csv_data) do
+          <<~CSV
+            appropriate_body_id,started_on,finished_on,induction_programme_choice,number_of_terms,trn
+            #{ab_1.dqt_id},01/01/2022 00:00:00,01/01/2022 00:00:00,Full Induction Programme,1,#{ect_1.trn}
+            #{ab_1.dqt_id},01/01/2022 00:00:00,01/01/2022 00:00:00,Full Induction Programme,2,#{ect_1.trn}
+          CSV
+        end
+
+        it "rejects the merged period because it is too short" do
+          expect(parsed).to be_empty
+          expect(fake_logger).to have_received(:error).with(/1 day or shorter/).at_least(:once)
+        end
+      end
+
+      context "when the LA period starts on or after the cutoff date" do
+        let(:sample_csv_data) do
+          <<~CSV
+            appropriate_body_id,started_on,finished_on,induction_programme_choice,number_of_terms,trn
+            #{ab_1.dqt_id},08/31/2024 00:00:00,10/31/2024 00:00:00,Core Induction Programme,3,#{ect_1.trn}
+          CSV
+        end
+
+        it "produces a one-day period that is then rejected" do
+          expect(parsed).to be_empty
+          expect(fake_logger).to have_received(:error).with(/1 day or shorter/)
         end
       end
 
@@ -922,6 +955,37 @@ RSpec.describe AppropriateBodies::Importers::InductionPeriodParser do
           end
         end
       end
+    end
+  end
+
+  describe "rejected CSV output" do
+    let(:sample_csv_data) do
+      <<~CSV
+        appropriate_body_id,started_on,finished_on,induction_programme_choice,number_of_terms,trn
+        #{ab_1.dqt_id},01/01/2023 00:00:00,01/01/2023 00:00:00,Core Induction Programme,3,#{ect_1.trn}
+        #{ab_1.dqt_id},02/02/2023 00:00:00,01/01/2023 00:00:00,Core Induction Programme,3,#{ect_2.trn}
+      CSV
+    end
+
+    before do
+      FileUtils.rm_f(described_class::PARSER_ERROR_CSV)
+      parsed
+    end
+
+    it "writes a header row" do
+      lines = File.readlines(described_class::PARSER_ERROR_CSV)
+      expect(lines.first.chomp).to eq("reason,trn,dqt_id,started_on,finished_on")
+    end
+
+    it "writes one row per rejected record" do
+      lines = File.readlines(described_class::PARSER_ERROR_CSV)
+      expect(lines.count).to be >= 3 # header + at least 2 rejections
+    end
+
+    it "includes the rejection reason" do
+      contents = File.read(described_class::PARSER_ERROR_CSV)
+      expect(contents).to include("1 day or shorter")
+      expect(contents).to include("started_on is greater than finished_on")
     end
   end
 end

--- a/spec/lib/appropriate_bodies/importers/induction_period_parser_spec.rb
+++ b/spec/lib/appropriate_bodies/importers/induction_period_parser_spec.rb
@@ -966,6 +966,7 @@ RSpec.describe AppropriateBodies::Importers::InductionPeriodParser do
         #{ab_1.dqt_id},02/02/2023 00:00:00,01/01/2023 00:00:00,Core Induction Programme,3,#{ect_2.trn}
       CSV
     end
+    let(:output) { File.readlines(described_class::PARSER_ERROR_CSV) }
 
     before do
       FileUtils.rm_f(described_class::PARSER_ERROR_CSV)
@@ -973,19 +974,15 @@ RSpec.describe AppropriateBodies::Importers::InductionPeriodParser do
     end
 
     it "writes a header row" do
-      lines = File.readlines(described_class::PARSER_ERROR_CSV)
-      expect(lines.first.chomp).to eq("reason,trn,dqt_id,started_on,finished_on")
+      expect(output.first.chomp).to eq("reason,trn,dqt_id,dqt_id_other,started_on,started_on_other,finished_on,finished_on_other")
     end
 
     it "writes one row per rejected record" do
-      lines = File.readlines(described_class::PARSER_ERROR_CSV)
-      expect(lines.count).to be >= 3 # header + at least 2 rejections
+      expect(output.count).to eq(3)
     end
 
     it "includes the rejection reason" do
-      contents = File.read(described_class::PARSER_ERROR_CSV)
-      expect(contents).to include("1 day or shorter")
-      expect(contents).to include("started_on is greater than finished_on")
+      expect(output.join).to include("1 day or shorter").and(include("started_on is greater than finished_on"))
     end
   end
 end

--- a/spec/lib/appropriate_bodies/importers/teacher_induction_importer_spec.rb
+++ b/spec/lib/appropriate_bodies/importers/teacher_induction_importer_spec.rb
@@ -55,6 +55,24 @@ RSpec.describe AppropriateBodies::Importers::TeacherInductionImporter do
       FactoryBot.create(:teacher, trn: "2345678", trs_first_name: "Lisa", trs_induction_status: "Failed")
     end
 
+    context "when a teacher is already persisted" do
+      let(:persisted_trn) { "2345678" }
+
+      let(:induction_period_csv) do
+        <<~CSV
+          appropriate_body_id,started_on,finished_on,induction_programme_choice,number_of_terms,trn
+          #{ab_1.dqt_id},01/01/2012 00:00:00,10/31/2012 00:00:00,Core Induction Programme,,#{persisted_trn}
+        CSV
+      end
+
+      it "does not import any induction periods for that teacher" do
+        expect { induction_importer.import! }.not_to raise_error
+
+        persisted_teacher = Teacher.find_by(trn: persisted_trn)
+        expect(persisted_teacher.induction_periods).to be_empty
+      end
+    end
+
     it "imports expected data", :aggregate_failures do
       expect(AppropriateBodyPeriod.count).to eq(2)
 
@@ -105,18 +123,18 @@ RSpec.describe AppropriateBodies::Importers::TeacherInductionImporter do
 
       expect { induction_importer.import! }.not_to raise_error
 
-      expect(Teacher.count).to eq(589_839) # On prod where some already exist we will see 588_533 imported (1_306 delta)
+      expect(Teacher.count).to eq(589_988) # On prod where some already exist we will see 588_533 imported (1_306 delta)
       expect(Teacher.induction_status_in_progress.count).to be_zero
       expect(Teacher.induction_status_required_to_complete.count).to be_zero
       expect(Teacher.induction_status_failed.count).to eq(308)
       expect(Teacher.induction_status_failed_in_wales.count).to eq(2)
-      expect(Teacher.induction_status_passed.count).to eq(589_222)
+      expect(Teacher.induction_status_passed.count).to eq(589_371)
       expect(Teacher.induction_status_exempt.count).to eq(302)
 
       expect(InductionPeriod.unfinished.count).to be_zero
-      expect(InductionPeriod.count).to eq(634_213)
+      expect(InductionPeriod.count).to eq(635_002)
       expect(InductionPeriod.finished.count).to eq(InductionPeriod.count)
-      expect(InductionPeriod.released.count).to eq(44_681)
+      expect(InductionPeriod.released.count).to eq(45_321)
 
       expect(InductionPeriod.failed.count).to eq(Teacher.induction_status_failed.count + Teacher.induction_status_failed_in_wales.count)
       expect(InductionPeriod.passed.count).to eq(Teacher.induction_status_passed.count)
@@ -138,26 +156,26 @@ RSpec.describe AppropriateBodies::Importers::TeacherInductionImporter do
       expect(teacher_induction_period_frequency.values.sum).to eq(Teacher.count)
 
       expect(teacher_induction_period_frequency).to eq({
-        1 => 548_978,
-        2 => 37_581,
-        3 => 3_070,
-        4 => 193,
-        5 => 13,
+        1 => 548_690,
+        2 => 37_839,
+        3 => 3_227,
+        4 => 213,
+        5 => 15,
         6 => 2,
         7 => 2
       })
 
       expect(InductionExtension.count).to eq(3_472)
 
-      expect(Event.count).to eq(1_275_068)
-      expect(Event.where(body: "Imported from DQT").count).to eq(1_268_119)
+      expect(Event.count).to eq(1_274_530)
+      expect(Event.where(body: "Imported from DQT").count).to eq(1_269_697)
       expect(Event.where(body: "Imported from DQT").count).to eq(
         Event.with_event_type(:induction_period_opened).count +
         Event.with_event_type(:teacher_fails_induction).count +
         Event.with_event_type(:teacher_passes_induction).count +
         Event.with_event_type(:induction_period_closed).count
       )
-      expect(Event.with_event_type(:import_from_dqt).count).to eq(6_949)
+      expect(Event.with_event_type(:import_from_dqt).count).to eq(4_833)
       expect(Event.with_event_type(:induction_period_opened).count).to eq(InductionPeriod.count)
       expect(Event.with_event_type(:teacher_fails_induction).count).to eq(InductionPeriod.failed.count)
       expect(Event.with_event_type(:teacher_passes_induction).count).to eq(InductionPeriod.passed.count)

--- a/spec/lib/appropriate_bodies/importers/teacher_induction_importer_spec.rb
+++ b/spec/lib/appropriate_bodies/importers/teacher_induction_importer_spec.rb
@@ -56,25 +56,38 @@ RSpec.describe AppropriateBodies::Importers::TeacherInductionImporter do
     end
 
     context "when a teacher is already persisted" do
-      let(:persisted_trn) { "2345678" }
+      let(:teacher) { lisa }
 
       let(:induction_period_csv) do
         <<~CSV
           appropriate_body_id,started_on,finished_on,induction_programme_choice,number_of_terms,trn
-          #{ab_1.dqt_id},01/01/2012 00:00:00,10/31/2012 00:00:00,Core Induction Programme,,#{persisted_trn}
+          #{ab_1.dqt_id},01/01/2012 00:00:00,10/31/2012 00:00:00,Core Induction Programme,,#{teacher.trn}
         CSV
       end
 
-      it "does not import any induction periods for that teacher" do
-        expect { induction_importer.import! }.not_to raise_error
+      context "without induction data" do
+        it "imports data" do
+          expect(teacher.induction_periods.count).to eq(0)
+          expect { induction_importer.import! }.not_to raise_error
+          expect(teacher.reload.induction_periods.count).to eq(1)
+        end
+      end
 
-        persisted_teacher = Teacher.find_by(trn: persisted_trn)
-        expect(persisted_teacher.induction_periods).to be_empty
+      context "with induction data" do
+        before { FactoryBot.create(:induction_period, teacher:) }
+
+        it "skips import" do
+          expect(teacher.induction_periods.count).to eq(1)
+          expect { induction_importer.import! }.not_to raise_error
+          expect(teacher.induction_periods.count).to eq(1)
+        end
       end
     end
 
     it "imports expected data", :aggregate_failures do
       expect(AppropriateBodyPeriod.count).to eq(2)
+
+      FactoryBot.create(:induction_period, :fail, teacher: lisa)
 
       expect { induction_importer.import! }.not_to raise_error
 
@@ -83,11 +96,11 @@ RSpec.describe AppropriateBodies::Importers::TeacherInductionImporter do
       expect(Teacher.induction_status_passed.count).to eq(1)
       expect(Teacher.induction_status_failed.count).to eq(2) # 1 already + 1 imported
       expect(Teacher.induction_status_failed_in_wales.count).to eq(1)
-      expect(InductionPeriod.count).to eq(4)
+      expect(InductionPeriod.count).to eq(6)
 
       # Lisa was InProgress and imported in the first round but has since failed
-      # therefore her IPs should not be imported
-      expect(lisa.induction_periods).to be_empty
+      # therefore her IPs should not be imported again and duplicated
+      expect(lisa.induction_periods.count).to be(1)
 
       # Tina has Passed after two inductions
       # therefore her timeline should reflect this


### PR DESCRIPTION
### Context

Planned bulk import of data that predates the service's launch. This PR is in response to analysis of the data after having been applied in a production-like environment. 

### Changes proposed in this pull request

Refine the importer scripts:

- only curtail **_LA_** AB periods if the period extends past `2024-08-31`
- reduce induction period manipulation events by 1k as a result
- add CSV generation to capture skipped inductions for analysis
- improve resource management with more batching
- exclude all existing teachers with induction period data
- log every rejection with triage info
- script validation check

### Guidance to review

Work is now being done on the CSV files and we plan to iterate and rerun on migration until we are happy.

https://www.register-early-career-teachers.education.gov.uk/admin/blazer/queries/476-dqt-import-induction-period-changes
