### PR TITLE
Silence the semantic logger while seeding

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -23,12 +23,17 @@ seed_files = Dir["db/seeds/*.rb"].sort_by do |path|
   priority_seeds.index(filename.chomp(".rb")) || Float::INFINITY
 end
 
-DeclarativeUpdates.skip(:metadata) do
-  seed_files.each do |seed_file|
-    puts "\r\n🪴 planting #{seed_file}"
+SemanticLogger.silence(:warn) do
+  DeclarativeUpdates.skip(:metadata) do
+    seed_files.each do |seed_file|
+      puts "\r\n🪴 planting #{seed_file}"
 
-    ApplicationRecord.transaction { load(seed_file) }
+      ApplicationRecord.transaction { load(seed_file) }
+    end
   end
+  puts "\n🚜 seeding complete"
+  puts "🌱🌱🌱🌱🌱🌱🌱🌱🌱"
+  puts "\n" * 5
 end
 
 # Refresh all metadata


### PR DESCRIPTION
The seeds output is interrupted by the semantic logger's io appender logging event creation $stdout.

Silencing it while seeding seems sensible, it's easy enough to disable while debugging.

Also, there's now a little notification when seeding is complete so it can be differentiated from the following job/event logs.

<img width="805" height="224" alt="image" src="https://github.com/user-attachments/assets/f266fbec-fd97-411a-8790-910d36d2b0a2" />

It's easier to review with whitespace disabled.