### PR TITLE
[4261] (part 2) Remove `in_partnership` from metadata

### DIFF
--- a/app/models/metadata/school_contract_period.rb
+++ b/app/models/metadata/school_contract_period.rb
@@ -15,10 +15,9 @@ module Metadata
 
     validates :school, presence: true
     validates :contract_period, presence: true
-    validates :in_partnership, inclusion: { in: [true, false] }
     validates :induction_programme_choice, inclusion: { in: induction_programme_choices.keys }
     validates :school_id, uniqueness: { scope: %i[contract_period_year] }
 
-    touch -> { self }, on_event: :update, when_changing: %i[in_partnership induction_programme_choice], timestamp_attribute: :api_updated_at
+    touch -> { self }, on_event: :update, when_changing: %i[induction_programme_choice], timestamp_attribute: :api_updated_at
   end
 end

--- a/app/serializers/api/school_serializer.rb
+++ b/app/serializers/api/school_serializer.rb
@@ -12,7 +12,9 @@ class API::SchoolSerializer < Blueprinter::Base
       options[:contract_period_year].to_s
     end
     field(:in_partnership) do |data, options|
-      contract_period_metadata(school: data[:school], options:).in_partnership
+      data[:school].school_partnerships.any? do |school_partnership|
+        school_partnership.lead_provider_delivery_partnership&.active_lead_provider&.contract_period_year == options[:contract_period_year]
+      end
     end
     field(:induction_programme_choice) do |data, options|
       contract_period_metadata(school: data[:school], options:).induction_programme_choice

--- a/app/services/api/schools/query.rb
+++ b/app/services/api/schools/query.rb
@@ -39,7 +39,7 @@ module API::Schools
     def preload_associations(results)
       preloaded_results = results
         .strict_loading
-        .includes(:gias_school, :contract_period_metadata, :lead_provider_contract_period_metadata)
+        .includes(:gias_school, :contract_period_metadata, :lead_provider_contract_period_metadata, school_partnerships: [lead_provider_delivery_partnership: :active_lead_provider])
 
       unless ignore?(filter: lead_provider_id)
         preloaded_results = preloaded_results
@@ -67,8 +67,9 @@ module API::Schools
     end
 
     def school_ids_with_partnership(contract_period_year)
-      Metadata::SchoolContractPeriod
-        .where(contract_period_year:, in_partnership: true)
+      SchoolPartnership
+        .joins(lead_provider_delivery_partnership: :active_lead_provider)
+        .where(active_lead_provider: { contract_period_year: })
         .select(:school_id)
     end
 

--- a/app/services/api/schools/query.rb
+++ b/app/services/api/schools/query.rb
@@ -39,7 +39,7 @@ module API::Schools
     def preload_associations(results)
       preloaded_results = results
         .strict_loading
-        .includes(:gias_school, :contract_period_metadata, :lead_provider_contract_period_metadata, school_partnerships: [lead_provider_delivery_partnership: :active_lead_provider])
+        .includes(:gias_school, :contract_period_metadata, :lead_provider_contract_period_metadata, school_partnerships: [{ lead_provider_delivery_partnership: :active_lead_provider }])
 
       unless ignore?(filter: lead_provider_id)
         preloaded_results = preloaded_results

--- a/app/services/metadata/handlers/school.rb
+++ b/app/services/metadata/handlers/school.rb
@@ -27,7 +27,6 @@ module Metadata::Handlers
         latest_attributes = {
           school_id: school.id,
           contract_period_year:,
-          in_partnership: contract_period_year.in?(school_partnership_contract_period_years),
           induction_programme_choice: school.training_programme_for(contract_period_year)
         }
 

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -285,7 +285,6 @@
   - id
   - school_id
   - contract_period_year
-  - in_partnership
   - induction_programme_choice
   - created_at
   - updated_at

--- a/db/migrate/20260806160335_remove_in_partnership_from_metadata_school_contract_period.rb
+++ b/db/migrate/20260806160335_remove_in_partnership_from_metadata_school_contract_period.rb
@@ -1,0 +1,5 @@
+class RemoveInPartnershipFromMetadataSchoolContractPeriod < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :metadata_schools_contract_periods, :in_partnership, :boolean, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_23_155410) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_06_160335) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -502,7 +502,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_23_155410) do
     t.datetime "api_updated_at", default: -> { "CURRENT_TIMESTAMP" }
     t.integer "contract_period_year", null: false
     t.datetime "created_at", null: false
-    t.boolean "in_partnership", null: false
     t.enum "induction_programme_choice", null: false, enum_type: "induction_programme_choice"
     t.bigint "school_id", null: false
     t.datetime "updated_at", null: false

--- a/spec/factories/metadata/school_contract_period_factory.rb
+++ b/spec/factories/metadata/school_contract_period_factory.rb
@@ -12,7 +12,6 @@ FactoryBot.define do
     end
 
     updated_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
-    in_partnership { Faker::Boolean.boolean }
     induction_programme_choice { Metadata::SchoolContractPeriod.induction_programme_choices.keys.sample }
   end
 end

--- a/spec/lib/appropriate_bodies/importers/teacher_induction_importer_spec.rb
+++ b/spec/lib/appropriate_bodies/importers/teacher_induction_importer_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe AppropriateBodies::Importers::TeacherInductionImporter do
+RSpec.xdescribe AppropriateBodies::Importers::TeacherInductionImporter do # problematic
   subject(:induction_importer) do
     described_class.new(
       teachers_csv:,

--- a/spec/lib/appropriate_bodies/importers/teacher_induction_importer_spec.rb
+++ b/spec/lib/appropriate_bodies/importers/teacher_induction_importer_spec.rb
@@ -1,4 +1,4 @@
-RSpec.xdescribe AppropriateBodies::Importers::TeacherInductionImporter do # problematic
+RSpec.describe AppropriateBodies::Importers::TeacherInductionImporter do
   subject(:induction_importer) do
     described_class.new(
       teachers_csv:,

--- a/spec/models/metadata/school_contract_period_spec.rb
+++ b/spec/models/metadata/school_contract_period_spec.rb
@@ -9,7 +9,7 @@ describe Metadata::SchoolContractPeriod do
       Metadata::SchoolContractPeriod.bypass_update_restrictions { example.run }
     end
 
-    it_behaves_like "a declarative touch model", on_event: %i[update], when_changing: %i[in_partnership induction_programme_choice], timestamp_attribute: :api_updated_at
+    it_behaves_like "a declarative touch model", on_event: %i[update], when_changing: %i[induction_programme_choice], timestamp_attribute: :api_updated_at
   end
 
   describe "enums" do
@@ -28,8 +28,6 @@ describe Metadata::SchoolContractPeriod do
 
     it { is_expected.to validate_presence_of(:school) }
     it { is_expected.to validate_presence_of(:contract_period) }
-    it { is_expected.to allow_values(true, false).for(:in_partnership) }
-    it { is_expected.not_to allow_values(nil, "").for(:in_partnership) }
     it { is_expected.to allow_values(*described_class.induction_programme_choices.keys).for(:induction_programme_choice) }
     it { is_expected.to validate_uniqueness_of(:school_id).scoped_to(:contract_period_year) }
   end

--- a/spec/serializers/api/school_serializer_spec.rb
+++ b/spec/serializers/api/school_serializer_spec.rb
@@ -43,7 +43,7 @@ describe API::SchoolSerializer, type: :serializer do
       expect(attributes["name"]).to eq(school.name)
       expect(attributes["urn"]).to eq(school.urn.to_s)
       expect(attributes["cohort"]).to eq(contract_period.year.to_s)
-      expect(attributes["in_partnership"]).to eq(contract_period_metadata.in_partnership)
+      expect(attributes["in_partnership"]).to eq(school.school_partnerships.any? { |sp| sp.lead_provider_delivery_partnership.active_lead_provider.contract_period_year == contract_period.year })
       expect(attributes["induction_programme_choice"]).to eq(contract_period_metadata.induction_programme_choice)
       expect(attributes["expression_of_interest"]).to eq(lead_provider_contract_period_metadata.expression_of_interest_or_school_partnership)
       expect(attributes["induction_tutor_name"]).not_to be_nil

--- a/spec/services/metadata/handlers/school_spec.rb
+++ b/spec/services/metadata/handlers/school_spec.rb
@@ -43,7 +43,6 @@ RSpec.describe Metadata::Handlers::School do
         expect(created_metadata).to have_attributes(
           school:,
           contract_period:,
-          in_partnership: true,
           induction_programme_choice: "not_yet_known"
         )
       end
@@ -55,16 +54,10 @@ RSpec.describe Metadata::Handlers::School do
       end
 
       context "when metadata already exists for a school and contract period" do
-        let!(:metadata) { FactoryBot.create(:school_contract_period_metadata, school:, contract_period:, in_partnership: true, induction_programme_choice: "not_yet_known") }
+        let!(:metadata) { FactoryBot.create(:school_contract_period_metadata, school:, contract_period:, induction_programme_choice: "not_yet_known") }
 
         it "does not create metadata" do
           expect { refresh_metadata }.not_to change(Metadata::SchoolContractPeriod, :count)
-        end
-
-        it "updates the metadata when the partnership changes" do
-          Metadata::SchoolContractPeriod.bypass_update_restrictions { metadata.update!(in_partnership: false) }
-
-          expect { refresh_metadata }.to change { metadata.reload.in_partnership }.from(false).to(true)
         end
 
         it "updates the metadata when the induction programme choice changes" do


### PR DESCRIPTION
### Context

This PR adopts the original approach (reworked a bit) to get the value for `in_partnership` directly in the serializer and not require it to be managed via metadata

### Changes proposed in this pull request

- Add `school_partnership` includes to `API::Schools::Query`
- Check for any school partnerships in place for the given contract period year in the serializer
- Remove in_partnership from metadata models and services

### Guidance to review
