### PR TITLE
[4277] Blazer query for schools with post-closure successor links

### DIFF
--- a/db/seeds/blazer_queries.rb
+++ b/db/seeds/blazer_queries.rb
@@ -84,3 +84,6 @@ end
 
 require Rails.root.join("db/seeds/blazer_queries/school_comms")
 BlazerQueries::SchoolComms.sync!
+
+require Rails.root.join("db/seeds/blazer_queries/post_closure_school_links")
+BlazerQueries::PostClosureSchoolLinks.sync!

--- a/db/seeds/blazer_queries/post_closure_school_links.rb
+++ b/db/seeds/blazer_queries/post_closure_school_links.rb
@@ -1,0 +1,284 @@
+module BlazerQueries
+  # Only GIAS::Reconciliation::Close records a school_closed event, and it refuses
+  # to run while the school has any successor link. Therefore, any successor link on
+  # a school with that event arrived after we had already finished or deleted its
+  # teachers' periods.
+  class PostClosureSchoolLinks
+    SCHOOLS_QUERY_NAME = "GIAS: Schools closed without a link that gained one later"
+    TEACHERS_QUERY_NAME = "GIAS: Teachers affected by a school link added after closure"
+
+    class << self
+      def sync!
+        definitions.map do |definition|
+          query = Blazer::Query.find_or_initialize_by(name: definition[:name])
+          query.update!(
+            description: definition[:description],
+            statement: definition[:statement],
+            data_source: :main,
+            status: "active"
+          )
+          query
+        end
+      end
+
+      def definitions
+        [affected_schools, affected_teachers]
+      end
+
+    private
+
+      delegate :quote, to: "ActiveRecord::Base.connection", private: true
+
+      def affected_schools
+        {
+          name: SCHOOLS_QUERY_NAME,
+          description: "Schools that RECT closed because GIAS gave us no successor " \
+                       "link, where GIAS has since given a successor link to, and that " \
+                       "had ECTs or mentors registered when they closed. Those " \
+                       "teachers had their periods finished or deleted instead of " \
+                       "being moved to the linked school. Row per closed school & link.",
+          statement: <<~SQL.strip
+            #{common_ctes}
+            SELECT
+              l.urn AS closed_school_urn,
+              l.school_name AS closed_school_name,
+              l.closed_on,
+              l.closure_processed_at,
+              l.link_type,
+              l.link_urn,
+              l.link_school_name,
+              l.link_school_status,
+              l.link_school_registered_in_rect,
+              l.link_date AS link_established_on_in_gias,
+              l.link_first_imported_at,
+              l.link_last_changed_at,
+              l.days_between_closure_and_link,
+              counts.teachers_affected,
+              counts.ect_periods_affected,
+              counts.mentor_periods_affected,
+              counts.teachers_registered_elsewhere_since,
+              counts.teachers_registered_at_linked_school_since
+            FROM late_links l
+            INNER JOIN LATERAL (
+              SELECT
+                COUNT(DISTINCT a.teacher_id) AS teachers_affected,
+                COUNT(*) FILTER (WHERE a.role = 'ECT') AS ect_periods_affected,
+                COUNT(*) FILTER (WHERE a.role = 'Mentor') AS mentor_periods_affected,
+                COUNT(DISTINCT a.teacher_id) FILTER (
+                  WHERE #{registered_elsewhere_since_sql}
+                ) AS teachers_registered_elsewhere_since,
+                COUNT(DISTINCT a.teacher_id) FILTER (
+                  WHERE #{registered_at_linked_school_since_sql}
+                ) AS teachers_registered_at_linked_school_since
+              FROM affected a
+              WHERE a.closure_event_id = l.closure_event_id
+            ) counts ON counts.teachers_affected > 0
+            ORDER BY l.link_first_imported_at DESC, l.urn;
+          SQL
+        }
+      end
+
+      def affected_teachers
+        {
+          name: TEACHERS_QUERY_NAME,
+          description: "The teachers behind '#{SCHOOLS_QUERY_NAME}'. One row per " \
+                       "ECT or mentor period that RECT finished or deleted when we " \
+                       "closed a school GIAS has since linked to a successor. " \
+                       "'registered_elsewhere_since' and " \
+                       "'registered_at_linked_school_since' flag teachers who have " \
+                       "already been registered again (at any other school / at the " \
+                       "linked school) on or after the closure date, so they " \
+                       "probably need no further action.",
+          statement: <<~SQL.strip
+            #{common_ctes}
+            SELECT
+              l.urn AS closed_school_urn,
+              l.school_name AS closed_school_name,
+              l.closed_on,
+              l.link_type,
+              l.link_urn,
+              l.link_school_name,
+              l.link_school_status,
+              l.link_school_registered_in_rect,
+              l.days_between_closure_and_link,
+              a.role,
+              a.teacher_id,
+              t.trn,
+              #{teacher_name_sql} AS teacher_name,
+              a.what_happened,
+              a.started_on AS period_started_on,
+              a.finished_on AS period_finished_on,
+              #{registered_elsewhere_since_sql} AS registered_elsewhere_since,
+              #{registered_at_linked_school_since_sql} AS registered_at_linked_school_since
+            FROM late_links l
+            INNER JOIN affected a ON a.closure_event_id = l.closure_event_id
+            INNER JOIN teachers t ON t.id = a.teacher_id
+            ORDER BY l.link_first_imported_at DESC, l.urn, a.role, a.teacher_id;
+          SQL
+        }
+      end
+
+      def common_ctes
+        <<~SQL.strip
+          WITH #{closures_cte},
+          #{late_links_cte},
+          #{affected_cte}
+        SQL
+      end
+
+      def closures_cte
+        <<~SQL.strip
+          closures AS (
+            SELECT
+              e.id AS closure_event_id,
+              e.school_id,
+              (e.metadata ->> 'gias_school_urn')::integer AS urn,
+              e.metadata ->> 'gias_school_name' AS school_name,
+              e.created_at AS closure_processed_at
+            FROM events e
+            WHERE e.event_type = 'school_closed'
+          )
+        SQL
+      end
+
+      def late_links_cte
+        <<~SQL.strip
+          late_links AS (
+            SELECT
+              c.closure_event_id,
+              c.school_id,
+              c.urn,
+              c.school_name,
+              c.closure_processed_at,
+              gs.closed_on,
+              ls.link_type,
+              ls.link_urn,
+              ls.link_date,
+              ls.created_at AS link_first_imported_at,
+              ls.updated_at AS link_last_changed_at,
+              #{london_date_sql('ls.created_at')} - gs.closed_on AS days_between_closure_and_link,
+              lgs.name AS link_school_name,
+              lgs.status::text AS link_school_status,
+              (lrs.id IS NOT NULL) AS link_school_registered_in_rect
+            FROM closures c
+            INNER JOIN gias_schools gs ON gs.urn = c.urn
+            INNER JOIN gias_school_links ls
+              ON ls.urn = c.urn
+             AND ls.link_type IN (#{successor_link_types_sql})
+            LEFT JOIN gias_schools lgs ON lgs.urn = ls.link_urn
+            LEFT JOIN schools lrs ON lrs.urn = ls.link_urn
+          )
+        SQL
+      end
+
+      # Close finishes ongoing periods on the closure date and destroys unstarted
+      # ones, which leaves nothing behind but the deletion event.
+      def affected_cte
+        <<~SQL.strip
+          affected AS (
+            #{finished_periods_sql('ECT', 'ect_at_school_periods')}
+            UNION ALL
+            #{finished_periods_sql('Mentor', 'mentor_at_school_periods')}
+            UNION ALL
+            #{deleted_periods_sql('ECT', 'teacher_ect_at_school_period_deleted')}
+            UNION ALL
+            #{deleted_periods_sql('Mentor', 'teacher_mentor_at_school_period_deleted')}
+          )
+        SQL
+      end
+
+      def finished_periods_sql(role, table)
+        <<~SQL.strip
+          SELECT
+              c.closure_event_id,
+              c.school_id,
+              gs.closed_on,
+              #{quote(role)} AS role,
+              p.teacher_id,
+              p.started_on,
+              p.finished_on,
+              'period finished on the closure date' AS what_happened
+            FROM closures c
+            INNER JOIN gias_schools gs ON gs.urn = c.urn
+            INNER JOIN #{table} p
+              ON p.school_id = c.school_id
+             AND p.finished_on = gs.closed_on
+        SQL
+      end
+
+      def deleted_periods_sql(role, event_type)
+        <<~SQL.strip
+          SELECT
+              c.closure_event_id,
+              c.school_id,
+              gs.closed_on,
+              #{quote(role)} AS role,
+              e.teacher_id,
+              NULL::date AS started_on,
+              NULL::date AS finished_on,
+              'period deleted before it started' AS what_happened
+            FROM closures c
+            INNER JOIN gias_schools gs ON gs.urn = c.urn
+            INNER JOIN events e
+              ON e.school_id = c.school_id
+             AND e.event_type = #{quote(event_type)}
+             AND e.author_type = 'system'
+             AND e.teacher_id IS NOT NULL
+             AND #{london_date_sql('e.happened_at')} = gs.closed_on
+        SQL
+      end
+
+      def registered_elsewhere_since_sql
+        <<~SQL.strip
+          EXISTS (
+                SELECT 1 FROM ect_at_school_periods x
+                WHERE x.teacher_id = a.teacher_id
+                  AND x.school_id <> a.school_id
+                  AND x.started_on >= a.closed_on
+                UNION ALL
+                SELECT 1 FROM mentor_at_school_periods x
+                WHERE x.teacher_id = a.teacher_id
+                  AND x.school_id <> a.school_id
+                  AND x.started_on >= a.closed_on
+              )
+        SQL
+      end
+
+      def registered_at_linked_school_since_sql
+        <<~SQL.strip
+          EXISTS (
+                SELECT 1 FROM ect_at_school_periods x
+                INNER JOIN schools xs ON xs.id = x.school_id
+                WHERE x.teacher_id = a.teacher_id
+                  AND xs.urn = l.link_urn
+                  AND x.started_on >= a.closed_on
+                UNION ALL
+                SELECT 1 FROM mentor_at_school_periods x
+                INNER JOIN schools xs ON xs.id = x.school_id
+                WHERE x.teacher_id = a.teacher_id
+                  AND xs.urn = l.link_urn
+                  AND x.started_on >= a.closed_on
+              )
+        SQL
+      end
+
+      # mirrors Teachers::Name#full_name
+      def teacher_name_sql
+        "COALESCE(NULLIF(t.corrected_name, ''), " \
+          "NULLIF(TRIM(CONCAT_WS(' ', NULLIF(t.trs_first_name, '.'), NULLIF(t.trs_last_name, '.'))), ''), " \
+          "'Unknown')"
+      end
+
+      # mirrors the successors check in GIAS::Reconciliation::Eligibility#can_be_closed?
+      def successor_link_types_sql
+        GIAS::SchoolLink::SUCCESSOR_LINK_TYPES.map { quote it }.join(", ")
+      end
+
+      # Timestamps are stored naively in UTC, so a bare cast to date lands a day
+      # early on anything written during BST.
+      def london_date_sql(column)
+        "((#{column} AT TIME ZONE 'UTC') AT TIME ZONE 'Europe/London')::date"
+      end
+    end
+  end
+end

--- a/db/seeds/blazer_queries/post_closure_school_links.rb
+++ b/db/seeds/blazer_queries/post_closure_school_links.rb
@@ -36,7 +36,11 @@ module BlazerQueries
                        "link, where GIAS has since given a successor link to, and that " \
                        "had ECTs or mentors registered when they closed. Those " \
                        "teachers had their periods finished or deleted instead of " \
-                       "being moved to the linked school. Row per closed school & link.",
+                       "being moved to the linked school. Row per closed school & link. " \
+                       "Assumes GIAS does not revise a closure date after the school " \
+                       "has closed: if it did, the periods would keep the date we " \
+                       "acted on, match nothing, and the school would drop out of " \
+                       "this report rather than appear with a wrong date.",
           statement: <<~SQL.strip
             #{common_ctes}
             SELECT
@@ -56,8 +60,8 @@ module BlazerQueries
               counts.teachers_affected,
               counts.ect_periods_affected,
               counts.mentor_periods_affected,
-              counts.teachers_registered_elsewhere_since,
-              counts.teachers_registered_at_linked_school_since
+              counts.teachers_at_another_school_after_closure,
+              counts.teachers_at_linked_school_after_closure
             FROM late_links l
             INNER JOIN LATERAL (
               SELECT
@@ -65,11 +69,11 @@ module BlazerQueries
                 COUNT(*) FILTER (WHERE a.role = 'ECT') AS ect_periods_affected,
                 COUNT(*) FILTER (WHERE a.role = 'Mentor') AS mentor_periods_affected,
                 COUNT(DISTINCT a.teacher_id) FILTER (
-                  WHERE #{registered_elsewhere_since_sql}
-                ) AS teachers_registered_elsewhere_since,
+                  WHERE #{at_another_school_after_closure_sql}
+                ) AS teachers_at_another_school_after_closure,
                 COUNT(DISTINCT a.teacher_id) FILTER (
-                  WHERE #{registered_at_linked_school_since_sql}
-                ) AS teachers_registered_at_linked_school_since
+                  WHERE #{at_linked_school_after_closure_sql}
+                ) AS teachers_at_linked_school_after_closure
               FROM affected a
               WHERE a.closure_event_id = l.closure_event_id
             ) counts ON counts.teachers_affected > 0
@@ -84,11 +88,13 @@ module BlazerQueries
           description: "The teachers behind '#{SCHOOLS_QUERY_NAME}'. One row per " \
                        "ECT or mentor period that RECT finished or deleted when we " \
                        "closed a school GIAS has since linked to a successor. " \
-                       "'registered_elsewhere_since' and " \
-                       "'registered_at_linked_school_since' flag teachers who have " \
-                       "already been registered again (at any other school / at the " \
-                       "linked school) on or after the closure date, so they " \
-                       "probably need no further action.",
+                       "'at_another_school_after_closure' and " \
+                       "'at_linked_school_after_closure' flag teachers holding a " \
+                       "period at another school (or at the linked school) that had " \
+                       "not already ended before the closure, so they are probably " \
+                       "placed already and need no further action. These are period " \
+                       "dates, not registration dates: a school can backdate or " \
+                       "future-date a start date.",
           statement: <<~SQL.strip
             #{common_ctes}
             SELECT
@@ -108,8 +114,8 @@ module BlazerQueries
               a.what_happened,
               a.started_on AS period_started_on,
               a.finished_on AS period_finished_on,
-              #{registered_elsewhere_since_sql} AS registered_elsewhere_since,
-              #{registered_at_linked_school_since_sql} AS registered_at_linked_school_since
+              #{at_another_school_after_closure_sql} AS at_another_school_after_closure,
+              #{at_linked_school_after_closure_sql} AS at_linked_school_after_closure
             FROM late_links l
             INNER JOIN affected a ON a.closure_event_id = l.closure_event_id
             INNER JOIN teachers t ON t.id = a.teacher_id
@@ -228,36 +234,36 @@ module BlazerQueries
         SQL
       end
 
-      def registered_elsewhere_since_sql
+      def at_another_school_after_closure_sql
         <<~SQL.strip
           EXISTS (
                 SELECT 1 FROM ect_at_school_periods x
                 WHERE x.teacher_id = a.teacher_id
                   AND x.school_id <> a.school_id
-                  AND x.started_on >= a.closed_on
+                  AND (x.started_on >= a.closed_on OR x.finished_on IS NULL OR x.finished_on > a.closed_on)
                 UNION ALL
                 SELECT 1 FROM mentor_at_school_periods x
                 WHERE x.teacher_id = a.teacher_id
                   AND x.school_id <> a.school_id
-                  AND x.started_on >= a.closed_on
+                  AND (x.started_on >= a.closed_on OR x.finished_on IS NULL OR x.finished_on > a.closed_on)
               )
         SQL
       end
 
-      def registered_at_linked_school_since_sql
+      def at_linked_school_after_closure_sql
         <<~SQL.strip
           EXISTS (
                 SELECT 1 FROM ect_at_school_periods x
                 INNER JOIN schools xs ON xs.id = x.school_id
                 WHERE x.teacher_id = a.teacher_id
                   AND xs.urn = l.link_urn
-                  AND x.started_on >= a.closed_on
+                  AND (x.started_on >= a.closed_on OR x.finished_on IS NULL OR x.finished_on > a.closed_on)
                 UNION ALL
                 SELECT 1 FROM mentor_at_school_periods x
                 INNER JOIN schools xs ON xs.id = x.school_id
                 WHERE x.teacher_id = a.teacher_id
                   AND xs.urn = l.link_urn
-                  AND x.started_on >= a.closed_on
+                  AND (x.started_on >= a.closed_on OR x.finished_on IS NULL OR x.finished_on > a.closed_on)
               )
         SQL
       end

--- a/lib/tasks/blazer.rake
+++ b/lib/tasks/blazer.rake
@@ -8,4 +8,14 @@ namespace :blazer do
     queries = BlazerQueries::SchoolComms.sync!
     logger.info("Synced #{queries.size} school comms Blazer queries: #{queries.map(&:name).join(', ')}")
   end
+
+  desc "Create or update the Blazer SQL queries for schools linked to a successor after we closed them (idempotent)"
+  task sync_post_closure_school_link_queries: :environment do
+    require Rails.root.join("db/seeds/blazer_queries/post_closure_school_links")
+
+    logger = Logger.new($stdout)
+    logger.info("Syncing post closure school link Blazer queries...")
+    queries = BlazerQueries::PostClosureSchoolLinks.sync!
+    logger.info("Synced #{queries.size} post closure school link Blazer queries: #{queries.map(&:name).join(', ')}")
+  end
 end

--- a/lib/tasks/product_review/4277.rake
+++ b/lib/tasks/product_review/4277.rake
@@ -1,0 +1,118 @@
+namespace :product_review do
+  desc "Close schools that GIAS later gives a successor link to, for the post-closure link queries (#4277)"
+  task "4277" => :environment do
+    if Teacher.exists?(trn: "0000070")
+      puts "Scenario already set up — Randall Boggs (TRN 0000070) exists. Aborting."
+      next
+    end
+
+    # Close records its events through ActiveJob and the Blazer queries read
+    # those events, so they have to be written before the task returns.
+    ActiveJob::Base.queue_adapter = :inline
+
+    frank_mccay = GIAS::School.find_by!(urn: 9_123_505)
+    monsters_junior = GIAS::School.find_by!(urn: 9_123_506)
+
+    ApplicationRecord.transaction do
+      Scenario4277.close_school!(frank_mccay)
+      Scenario4277.link_to_successor!(frank_mccay, monsters_junior, GIAS::SchoolLink::SUCCESSOR)
+
+      waternoose = Scenario4277.create_gias_school!(
+        urn: 9_123_510,
+        name: "Henry J. Waternoose Preparatory School",
+        status: :closed,
+        closed_on: Date.new(2026, 5, 31)
+      )
+      celia_mae = Scenario4277.create_gias_school!(urn: 9_123_511, name: "Celia Mae Academy", status: :open)
+
+      randall = Scenario4277.create_teacher!("0000070", "Randall", "Boggs")
+      fungus = Scenario4277.create_teacher!("0000071", "Fungus", "Bile")
+      needleman = Scenario4277.create_teacher!("0000072", "Needleman", "Smitty")
+
+      ECTAtSchoolPeriod.create!(teacher: randall, school: waternoose.school, started_on: Date.new(2025, 9, 1), finished_on: nil)
+      MentorAtSchoolPeriod.create!(teacher: fungus, school: waternoose.school, started_on: Date.new(2025, 9, 1), finished_on: nil)
+      ECTAtSchoolPeriod.create!(teacher: needleman, school: waternoose.school, started_on: Date.new(2026, 9, 1), finished_on: nil)
+
+      Scenario4277.close_school!(waternoose)
+      Scenario4277.link_to_successor!(waternoose, celia_mae, GIAS::SchoolLink::SUCCESSOR_SPLIT)
+
+      ECTAtSchoolPeriod.create!(teacher: randall, school: celia_mae.school, started_on: Date.new(2026, 9, 1), finished_on: nil)
+    end
+
+    require Rails.root.join("db/seeds/blazer_queries/post_closure_school_links")
+    queries = BlazerQueries::PostClosureSchoolLinks.sync!
+
+    puts
+    puts "=" * 78
+    puts "  Schools linked to a successor after we closed them (#4277)"
+    puts "=" * 78
+    puts
+    puts "  State seeded by this task:"
+    puts "    - Frank McCay Technical College (9123505), closed 30 April 2026 with 3 ECTs"
+    puts "      and 3 mentors, since linked to Monsters Junior School (9123506) as its"
+    puts "      Successor. Monsters Junior is not registered in RECT."
+    puts "    - Henry J. Waternoose Preparatory School (9123510), closed 31 May 2026,"
+    puts "      since linked to Celia Mae Academy (9123511) as a split school:"
+    puts "        - Randall Boggs (ECT) had his period finished at the closure, and has"
+    puts "          since been re-registered at Celia Mae Academy"
+    puts "        - Fungus Bile (mentor) had his period finished at the closure"
+    puts "        - Needleman Smitty (ECT) was due to start in September and had his"
+    puts "          registration deleted by the closure"
+    puts
+    puts "  To verify:"
+    puts "    1. Sign in as Daphne Blake (DfE staff) and go to /admin/blazer"
+    puts "    2. Run '#{queries.first.name}'"
+    puts "       Expect both schools, with 6 and 3 teachers affected respectively, and"
+    puts "       1 teacher already registered at the linked school for Waternoose"
+    puts "    3. Run '#{queries.last.name}'"
+    puts "       Expect a row per teacher, Needleman Smitty showing 'period deleted"
+    puts "       before it started', and Randall Boggs flagged as registered at the"
+    puts "       linked school since"
+    puts
+  end
+end
+
+# Rake loads every task file into one namespace, and a bare `def` here would
+# define these on Object for the whole process.
+module Scenario4277
+module_function
+
+  def close_school!(gias_school)
+    return if GIAS::Reconciliation::Close.close!(gias_school)
+
+    raise "#{gias_school.name} (#{gias_school.urn}) cannot be closed — has it already been processed?"
+  end
+
+  def link_to_successor!(gias_school, successor, link_type)
+    GIAS::SchoolLink.create!(
+      urn: gias_school.urn,
+      link_urn: successor.urn,
+      link_type:,
+      link_date: gias_school.closed_on
+    )
+  end
+
+  def create_gias_school!(urn:, name:, status:, closed_on: nil)
+    GIAS::School.create!(
+      urn:,
+      name:,
+      status:,
+      closed_on:,
+      type_name: "Community school",
+      local_authority_code: 201,
+      in_england: true,
+      section_41_approved: false,
+      eligible: true
+    ).tap { School.create!(urn:) }
+  end
+
+  def create_teacher!(trn, first_name, last_name)
+    Teacher.create!(
+      trn:,
+      trs_first_name: first_name,
+      trs_last_name: last_name,
+      trs_qts_awarded_on: Date.new(2022, 1, 1),
+      trs_induction_status: "InProgress"
+    )
+  end
+end

--- a/spec/lib/tasks/blazer_spec.rb
+++ b/spec/lib/tasks/blazer_spec.rb
@@ -1,19 +1,30 @@
 require Rails.root.join("db/seeds/blazer_queries/school_comms")
+require Rails.root.join("db/seeds/blazer_queries/post_closure_school_links")
 
 describe "blazer tasks" do
+  let(:logger) { instance_double(Logger, info: true) }
+
+  before do
+    allow(Logger).to receive(:new).with($stdout).and_return(logger)
+  end
+
   describe "blazer:sync_school_comms_queries" do
-    let(:logger) { instance_double(Logger, info: true) }
-
-    before do
-      allow(Logger).to receive(:new).with($stdout).and_return(logger)
-    end
-
     it "syncs the school comms queries" do
       allow(BlazerQueries::SchoolComms).to receive(:sync!).and_return([])
 
       Rake::Task["blazer:sync_school_comms_queries"].invoke
 
       expect(BlazerQueries::SchoolComms).to have_received(:sync!)
+    end
+  end
+
+  describe "blazer:sync_post_closure_school_link_queries" do
+    it "syncs the post closure school link queries" do
+      allow(BlazerQueries::PostClosureSchoolLinks).to receive(:sync!).and_return([])
+
+      Rake::Task["blazer:sync_post_closure_school_link_queries"].invoke
+
+      expect(BlazerQueries::PostClosureSchoolLinks).to have_received(:sync!)
     end
   end
 end

--- a/spec/seeds/blazer_queries/post_closure_school_links_spec.rb
+++ b/spec/seeds/blazer_queries/post_closure_school_links_spec.rb
@@ -95,8 +95,8 @@ RSpec.describe BlazerQueries::PostClosureSchoolLinks do
       it "counts them apart from the teachers still needing action" do
         expect(rows.fetch(0)).to include(
           "teachers_affected" => 3,
-          "teachers_registered_elsewhere_since" => 2,
-          "teachers_registered_at_linked_school_since" => 1
+          "teachers_at_another_school_after_closure" => 2,
+          "teachers_at_linked_school_after_closure" => 1
         )
       end
     end
@@ -192,8 +192,8 @@ RSpec.describe BlazerQueries::PostClosureSchoolLinks do
           "what_happened" => "period finished on the closure date",
           "period_started_on" => closed_on - 1.year,
           "period_finished_on" => closed_on,
-          "registered_elsewhere_since" => false,
-          "registered_at_linked_school_since" => false
+          "at_another_school_after_closure" => false,
+          "at_linked_school_after_closure" => false
         )
       end
 
@@ -228,9 +228,49 @@ RSpec.describe BlazerQueries::PostClosureSchoolLinks do
 
       it "flags them as needing no further action" do
         expect(rows.fetch(0)).to include(
-          "registered_elsewhere_since" => true,
-          "registered_at_linked_school_since" => true
+          "at_another_school_after_closure" => true,
+          "at_linked_school_after_closure" => true
         )
+      end
+    end
+
+    # A mentor can hold posts at several schools at once, so one that predates
+    # the closure and outlives it still means somebody has them.
+    context "when the teacher still mentors elsewhere under a period that predates the closure" do
+      before do
+        school = closed_school!(urn: 200_004)
+        link_to_successor!(school)
+        teacher = finish_at_closure!(school, role: :mentor).teacher
+        FactoryBot.create(
+          :mentor_at_school_period,
+          teacher:,
+          school: FactoryBot.create(:school),
+          started_on: closed_on - 1.year,
+          finished_on: nil
+        )
+      end
+
+      it "flags them as already placed" do
+        expect(rows.fetch(0)).to include("at_another_school_after_closure" => true)
+      end
+    end
+
+    context "when the teacher's only other period ended before the closure" do
+      before do
+        school = closed_school!(urn: 200_005)
+        link_to_successor!(school)
+        teacher = finish_at_closure!(school, role: :mentor).teacher
+        FactoryBot.create(
+          :mentor_at_school_period,
+          teacher:,
+          school: FactoryBot.create(:school),
+          started_on: closed_on - 1.year,
+          finished_on: closed_on - 1.month
+        )
+      end
+
+      it "does not flag them" do
+        expect(rows.fetch(0)).to include("at_another_school_after_closure" => false)
       end
     end
   end

--- a/spec/seeds/blazer_queries/post_closure_school_links_spec.rb
+++ b/spec/seeds/blazer_queries/post_closure_school_links_spec.rb
@@ -1,0 +1,315 @@
+require Rails.root.join("db/seeds/blazer_queries/post_closure_school_links")
+
+RSpec.describe BlazerQueries::PostClosureSchoolLinks do
+  let(:closed_on) { Date.new(2026, 6, 30) } # a summer date, so it stores as 23:00 the day before
+
+  describe ".definitions" do
+    subject(:definitions) { described_class.definitions }
+
+    it "defines the school level and teacher level queries" do
+      expect(definitions.pluck(:name)).to contain_exactly(
+        described_class::SCHOOLS_QUERY_NAME,
+        described_class::TEACHERS_QUERY_NAME
+      )
+    end
+
+    it "only counts links that would have stopped us closing the school" do
+      expect(definitions.pluck(:statement)).to all(
+        include("ls.link_type IN ('Successor - amalgamated', 'Successor - merged', 'Successor - Split School', 'Successor')")
+      )
+    end
+
+    it "produces statements that are valid SQL against the schema" do
+      definitions.each do |definition|
+        expect { ActiveRecord::Base.connection.select_all(definition[:statement]) }
+          .not_to raise_error
+      end
+    end
+  end
+
+  describe "the closed schools query" do
+    subject(:rows) { rows_for(described_class::SCHOOLS_QUERY_NAME) }
+
+    context "when a school we closed has since been given a successor link" do
+      let!(:school) { close_school!(urn: 100_001) }
+      let!(:link) { link_to_successor!(school, link_type: GIAS::SchoolLink::SUCCESSOR_MERGED) }
+
+      before { finish_at_closure!(school) }
+
+      it "returns the closed school with the link that arrived too late" do
+        expect(rows.fetch(0)).to include(
+          "closed_school_urn" => 100_001,
+          "closed_school_name" => school.gias_school.name,
+          "closed_on" => closed_on,
+          "link_type" => GIAS::SchoolLink::SUCCESSOR_MERGED,
+          "link_urn" => link.link_urn,
+          "link_school_name" => link.to_gias_school.name,
+          "link_school_status" => "open",
+          "link_school_registered_in_rect" => true,
+          "teachers_affected" => 1
+        )
+      end
+    end
+
+    context "when the closure finished some periods and deleted others" do
+      let!(:school) { close_school!(urn: 100_002) }
+
+      before do
+        link_to_successor!(school)
+        2.times { finish_at_closure!(school, role: :ect) }
+        finish_at_closure!(school, role: :mentor)
+        delete_unstarted_at_closure!(school, role: :ect)
+        delete_unstarted_at_closure!(school, role: :mentor)
+      end
+
+      it "counts the teachers, the ECT periods and the mentor periods" do
+        expect(rows.fetch(0)).to include(
+          "teachers_affected" => 5,
+          "ect_periods_affected" => 3,
+          "mentor_periods_affected" => 2
+        )
+      end
+    end
+
+    context "when the link arrived three weeks after the closure" do
+      let!(:school) { close_school!(urn: 100_003) }
+
+      before do
+        link = link_to_successor!(school)
+        link.update_columns(created_at: closed_on + 21.days, updated_at: closed_on + 21.days)
+        finish_at_closure!(school)
+      end
+
+      it "reports the gap in days" do
+        expect(rows.fetch(0)).to include("days_between_closure_and_link" => 21)
+      end
+    end
+
+    context "when some of the affected teachers have been registered again" do
+      let!(:school) { close_school!(urn: 100_040) }
+
+      before do
+        link = link_to_successor!(school)
+        register_at!(School.find_by(urn: link.link_urn), teacher: finish_at_closure!(school).teacher)
+        register_at!(FactoryBot.create(:school), teacher: finish_at_closure!(school).teacher)
+        finish_at_closure!(school)
+      end
+
+      it "counts them apart from the teachers still needing action" do
+        expect(rows.fetch(0)).to include(
+          "teachers_affected" => 3,
+          "teachers_registered_elsewhere_since" => 2,
+          "teachers_registered_at_linked_school_since" => 1
+        )
+      end
+    end
+
+    context "when the teachers had already left before the school closed" do
+      before do
+        school = close_school!(urn: 100_004)
+        link_to_successor!(school)
+        finish_at_closure!(school, finished_on: closed_on - 1.month)
+      end
+
+      it { is_expected.to be_empty }
+    end
+
+    context "when no link has arrived since the closure" do
+      before do
+        school = close_school!(urn: 100_010)
+        finish_at_closure!(school)
+      end
+
+      it { is_expected.to be_empty }
+    end
+
+    context "when the only link to arrive was a predecessor" do
+      before do
+        school = close_school!(urn: 100_011)
+        link_to_successor!(school, link_type: GIAS::SchoolLink::PREDECESSOR_LINK_TYPES.first)
+        finish_at_closure!(school)
+      end
+
+      it { is_expected.to be_empty }
+    end
+
+    context "when the only link to arrive would not have changed how we closed the school" do
+      before do
+        school = close_school!(urn: 100_012)
+        link_to_successor!(school, link_type: "Sixth Form Centre Link")
+        finish_at_closure!(school)
+      end
+
+      it { is_expected.to be_empty }
+    end
+
+    context "when we did not close the school ourselves" do
+      before do
+        school = close_school!(urn: 100_020, record_closure: false)
+        link_to_successor!(school)
+        finish_at_closure!(school)
+      end
+
+      it { is_expected.to be_empty }
+    end
+
+    context "when nobody was registered at the school when it closed" do
+      before do
+        school = close_school!(urn: 100_030)
+        link_to_successor!(school)
+      end
+
+      it { is_expected.to be_empty }
+    end
+  end
+
+  describe "the affected teachers query" do
+    subject(:rows) { rows_for(described_class::TEACHERS_QUERY_NAME) }
+
+    context "when the closure finished an ECT period and a mentor period" do
+      let!(:school) { close_school!(urn: 200_001) }
+      let!(:link) { link_to_successor!(school) }
+      let!(:ect_period) do
+        finish_at_closure!(school, teacher: FactoryBot.create(:teacher, trn: "1234567", corrected_name: "Alice Adams"))
+      end
+
+      before do
+        finish_at_closure!(
+          school,
+          role: :mentor,
+          teacher: FactoryBot.create(:teacher, trs_first_name: "Bob", trs_last_name: "Best", corrected_name: nil)
+        )
+      end
+
+      it "returns a row for each role" do
+        expect(rows.pluck("role")).to contain_exactly("ECT", "Mentor")
+      end
+
+      it "describes the teacher, their period and the school they should have moved to" do
+        expect(rows.find { it["role"] == "ECT" }).to include(
+          "closed_school_urn" => 200_001,
+          "link_urn" => link.link_urn,
+          "teacher_id" => ect_period.teacher_id,
+          "trn" => "1234567",
+          "teacher_name" => "Alice Adams",
+          "what_happened" => "period finished on the closure date",
+          "period_started_on" => closed_on - 1.year,
+          "period_finished_on" => closed_on,
+          "registered_elsewhere_since" => false,
+          "registered_at_linked_school_since" => false
+        )
+      end
+
+      it "falls back to the TRS name when the teacher has no corrected name" do
+        expect(rows.find { it["role"] == "Mentor" }).to include("teacher_name" => "Bob Best")
+      end
+    end
+
+    context "when the closure deleted a period that had not started" do
+      let!(:school) { close_school!(urn: 200_002) }
+      let!(:teacher) { delete_unstarted_at_closure!(school, role: :mentor) }
+
+      before { link_to_successor!(school) }
+
+      it "returns the teacher with no period dates" do
+        expect(rows.fetch(0)).to include(
+          "teacher_id" => teacher.id,
+          "role" => "Mentor",
+          "what_happened" => "period deleted before it started",
+          "period_started_on" => nil,
+          "period_finished_on" => nil
+        )
+      end
+    end
+
+    context "when the teacher has since been registered at the linked school" do
+      let!(:school) { close_school!(urn: 200_003) }
+
+      before do
+        link = link_to_successor!(school)
+        register_at!(School.find_by(urn: link.link_urn), teacher: finish_at_closure!(school).teacher)
+      end
+
+      it "flags them as needing no further action" do
+        expect(rows.fetch(0)).to include(
+          "registered_elsewhere_since" => true,
+          "registered_at_linked_school_since" => true
+        )
+      end
+    end
+  end
+
+  describe ".sync!" do
+    it "creates each query as an active query against the main data source" do
+      expect { described_class.sync! }.to change(Blazer::Query, :count).by(2)
+
+      query = Blazer::Query.find_by(name: described_class::SCHOOLS_QUERY_NAME)
+      expect(query).to have_attributes(status: "active", data_source: "main")
+      expect(query.statement).to be_present
+    end
+
+    it "is idempotent and refreshes the stored statement on re-run" do
+      described_class.sync!
+      Blazer::Query.find_by(name: described_class::TEACHERS_QUERY_NAME).update!(statement: "SELECT 1;")
+
+      expect { described_class.sync! }.not_to change(Blazer::Query, :count)
+
+      refreshed = Blazer::Query.find_by(name: described_class::TEACHERS_QUERY_NAME)
+      expect(refreshed.statement).to include("FROM late_links l")
+    end
+  end
+
+  def rows_for(name)
+    statement = described_class.definitions.find { |definition| definition[:name] == name }.fetch(:statement)
+    ActiveRecord::Base.connection.select_all(statement).to_a
+  end
+
+  def close_school!(urn:, closed_on: self.closed_on, record_closure: true)
+    gias_school = FactoryBot.create(:gias_school, urn:, status: "closed", closed_on:)
+    school = FactoryBot.create(:school, urn:, gias_school:, create_contract_period: false)
+
+    if record_closure
+      FactoryBot.create(
+        :event,
+        event_type: "school_closed",
+        author_type: "system",
+        school:,
+        happened_at: closed_on,
+        metadata: { gias_school_urn: urn, gias_school_name: gias_school.name }
+      )
+    end
+
+    school
+  end
+
+  def link_to_successor!(school, link_type: GIAS::SchoolLink::SUCCESSOR, successor_urn: nil, status: "open", registered: true)
+    successor_urn ||= school.urn + 1
+    successor_gias_school = FactoryBot.create(:gias_school, urn: successor_urn, status:)
+    FactoryBot.create(:school, urn: successor_urn, gias_school: successor_gias_school, create_contract_period: false) if registered
+
+    FactoryBot.create(
+      :gias_school_link,
+      from_gias_school: school.gias_school,
+      to_gias_school: successor_gias_school,
+      link_type:,
+      link_date: closed_on - 1.week
+    )
+  end
+
+  def finish_at_closure!(school, role: :ect, finished_on: closed_on, **attrs)
+    factory = (role == :ect) ? :ect_at_school_period : :mentor_at_school_period
+
+    FactoryBot.create(factory, school:, started_on: closed_on - 1.year, finished_on:, **attrs)
+  end
+
+  def delete_unstarted_at_closure!(school, role: :ect, teacher: FactoryBot.create(:teacher))
+    event_type = (role == :ect) ? "teacher_ect_at_school_period_deleted" : "teacher_mentor_at_school_period_deleted"
+
+    FactoryBot.create(:event, event_type:, author_type: "system", school:, teacher:, happened_at: closed_on)
+    teacher
+  end
+
+  def register_at!(school, teacher:, started_on: closed_on + 1.day)
+    FactoryBot.create(:ect_at_school_period, teacher:, school:, started_on:, finished_on: nil)
+  end
+end

--- a/spec/seeds/blazer_queries/post_closure_school_links_spec.rb
+++ b/spec/seeds/blazer_queries/post_closure_school_links_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe BlazerQueries::PostClosureSchoolLinks do
     subject(:rows) { rows_for(described_class::SCHOOLS_QUERY_NAME) }
 
     context "when a school we closed has since been given a successor link" do
-      let!(:school) { close_school!(urn: 100_001) }
+      let!(:school) { closed_school!(urn: 100_001) }
       let!(:link) { link_to_successor!(school, link_type: GIAS::SchoolLink::SUCCESSOR_MERGED) }
 
       before { finish_at_closure!(school) }
@@ -52,9 +52,8 @@ RSpec.describe BlazerQueries::PostClosureSchoolLinks do
     end
 
     context "when the closure finished some periods and deleted others" do
-      let!(:school) { close_school!(urn: 100_002) }
-
       before do
+        school = closed_school!(urn: 100_002)
         link_to_successor!(school)
         2.times { finish_at_closure!(school, role: :ect) }
         finish_at_closure!(school, role: :mentor)
@@ -72,9 +71,8 @@ RSpec.describe BlazerQueries::PostClosureSchoolLinks do
     end
 
     context "when the link arrived three weeks after the closure" do
-      let!(:school) { close_school!(urn: 100_003) }
-
       before do
+        school = closed_school!(urn: 100_003)
         link = link_to_successor!(school)
         link.update_columns(created_at: closed_on + 21.days, updated_at: closed_on + 21.days)
         finish_at_closure!(school)
@@ -86,9 +84,8 @@ RSpec.describe BlazerQueries::PostClosureSchoolLinks do
     end
 
     context "when some of the affected teachers have been registered again" do
-      let!(:school) { close_school!(urn: 100_040) }
-
       before do
+        school = closed_school!(urn: 100_040)
         link = link_to_successor!(school)
         register_at!(School.find_by(urn: link.link_urn), teacher: finish_at_closure!(school).teacher)
         register_at!(FactoryBot.create(:school), teacher: finish_at_closure!(school).teacher)
@@ -106,7 +103,7 @@ RSpec.describe BlazerQueries::PostClosureSchoolLinks do
 
     context "when the teachers had already left before the school closed" do
       before do
-        school = close_school!(urn: 100_004)
+        school = closed_school!(urn: 100_004)
         link_to_successor!(school)
         finish_at_closure!(school, finished_on: closed_on - 1.month)
       end
@@ -116,7 +113,7 @@ RSpec.describe BlazerQueries::PostClosureSchoolLinks do
 
     context "when no link has arrived since the closure" do
       before do
-        school = close_school!(urn: 100_010)
+        school = closed_school!(urn: 100_010)
         finish_at_closure!(school)
       end
 
@@ -125,7 +122,7 @@ RSpec.describe BlazerQueries::PostClosureSchoolLinks do
 
     context "when the only link to arrive was a predecessor" do
       before do
-        school = close_school!(urn: 100_011)
+        school = closed_school!(urn: 100_011)
         link_to_successor!(school, link_type: GIAS::SchoolLink::PREDECESSOR_LINK_TYPES.first)
         finish_at_closure!(school)
       end
@@ -135,7 +132,7 @@ RSpec.describe BlazerQueries::PostClosureSchoolLinks do
 
     context "when the only link to arrive would not have changed how we closed the school" do
       before do
-        school = close_school!(urn: 100_012)
+        school = closed_school!(urn: 100_012)
         link_to_successor!(school, link_type: "Sixth Form Centre Link")
         finish_at_closure!(school)
       end
@@ -143,9 +140,9 @@ RSpec.describe BlazerQueries::PostClosureSchoolLinks do
       it { is_expected.to be_empty }
     end
 
-    context "when we did not close the school ourselves" do
+    context "when there is no closure event recorded" do
       before do
-        school = close_school!(urn: 100_020, record_closure: false)
+        school = closed_school!(urn: 100_020, record_closure: false)
         link_to_successor!(school)
         finish_at_closure!(school)
       end
@@ -155,7 +152,7 @@ RSpec.describe BlazerQueries::PostClosureSchoolLinks do
 
     context "when nobody was registered at the school when it closed" do
       before do
-        school = close_school!(urn: 100_030)
+        school = closed_school!(urn: 100_030)
         link_to_successor!(school)
       end
 
@@ -167,7 +164,7 @@ RSpec.describe BlazerQueries::PostClosureSchoolLinks do
     subject(:rows) { rows_for(described_class::TEACHERS_QUERY_NAME) }
 
     context "when the closure finished an ECT period and a mentor period" do
-      let!(:school) { close_school!(urn: 200_001) }
+      let!(:school) { closed_school!(urn: 200_001) }
       let!(:link) { link_to_successor!(school) }
       let!(:ect_period) do
         finish_at_closure!(school, teacher: FactoryBot.create(:teacher, trn: "1234567", corrected_name: "Alice Adams"))
@@ -206,7 +203,7 @@ RSpec.describe BlazerQueries::PostClosureSchoolLinks do
     end
 
     context "when the closure deleted a period that had not started" do
-      let!(:school) { close_school!(urn: 200_002) }
+      let!(:school) { closed_school!(urn: 200_002) }
       let!(:teacher) { delete_unstarted_at_closure!(school, role: :mentor) }
 
       before { link_to_successor!(school) }
@@ -223,9 +220,8 @@ RSpec.describe BlazerQueries::PostClosureSchoolLinks do
     end
 
     context "when the teacher has since been registered at the linked school" do
-      let!(:school) { close_school!(urn: 200_003) }
-
       before do
+        school = closed_school!(urn: 200_003)
         link = link_to_successor!(school)
         register_at!(School.find_by(urn: link.link_urn), teacher: finish_at_closure!(school).teacher)
       end
@@ -264,7 +260,7 @@ RSpec.describe BlazerQueries::PostClosureSchoolLinks do
     ActiveRecord::Base.connection.select_all(statement).to_a
   end
 
-  def close_school!(urn:, closed_on: self.closed_on, record_closure: true)
+  def closed_school!(urn:, closed_on: self.closed_on, record_closure: true)
     gias_school = FactoryBot.create(:gias_school, urn:, status: "closed", closed_on:)
     school = FactoryBot.create(:school, urn:, gias_school:, create_contract_period: false)
 
@@ -282,15 +278,16 @@ RSpec.describe BlazerQueries::PostClosureSchoolLinks do
     school
   end
 
-  def link_to_successor!(school, link_type: GIAS::SchoolLink::SUCCESSOR, successor_urn: nil, status: "open", registered: true)
-    successor_urn ||= school.urn + 1
-    successor_gias_school = FactoryBot.create(:gias_school, urn: successor_urn, status:)
-    FactoryBot.create(:school, urn: successor_urn, gias_school: successor_gias_school, create_contract_period: false) if registered
+  def link_to_successor!(school, link_type: GIAS::SchoolLink::SUCCESSOR)
+    # The link factory only builds GIAS schools, but link_school_registered_in_rect
+    # reads the schools table, and the default factory status is random.
+    successor = FactoryBot.create(:gias_school, status: "open")
+    FactoryBot.create(:school, urn: successor.urn, gias_school: successor, create_contract_period: false)
 
     FactoryBot.create(
       :gias_school_link,
       from_gias_school: school.gias_school,
-      to_gias_school: successor_gias_school,
+      to_gias_school: successor,
       link_type:,
       link_date: closed_on - 1.week
     )


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/4277

### Changes proposed in this pull request

Adds an idempotent task to create the desired Blazer queries: one at a per-school level, one at a per-teacher level.

This rests entirely on the GIAS integration work that records a `school_closed` event to deterministically detect a school closure with no successor links. With no specific set of columns defined, I've built this with quite a few columns of information, including pre-empting the fact that some teachers may already be registered by the time the results of the queries are observed/actioned. It might be overkill, but I figured better to include the kitchen sink now before an automated process is designed, and trim back later once we know exactly how that process will work.

### Guidance to review

n.b. the Product Review rake task is throwaway, just to make this product-reviewable on a review app.