### PR TITLE
Introduce `Admin::DataFixes::InlineCSV` class

### DIFF
--- a/app/services/admin/data_fixes/inline_csv.rb
+++ b/app/services/admin/data_fixes/inline_csv.rb
@@ -1,0 +1,36 @@
+module Admin::DataFixes
+  class InlineCSV
+    class InvalidHeaderError < ArgumentError; end
+
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+    include ActiveModel::Validations
+
+    HEADER_ROW = %w[object_type object_id action attributes].freeze
+    Row = Data.define(*HEADER_ROW)
+
+    attribute :csv_string, :string
+
+    validates :csv_string, presence: true
+    validate :expected_headers
+
+    def parse
+      return false unless valid?
+
+      parsed_csv.map { Row.new(**it) }
+    rescue CSV::MalformedCSVError => _e
+      errors.add(:csv_string, "is malformed")
+      false
+    end
+
+  private
+
+    def parsed_csv = @parsed_csv ||= CSV.parse(csv_string, headers: true)
+
+    def expected_headers
+      if parsed_csv.headers != HEADER_ROW
+        errors.add(:csv_string, "has invalid headers")
+      end
+    end
+  end
+end

--- a/spec/services/admin/data_fixes/inline_csv_spec.rb
+++ b/spec/services/admin/data_fixes/inline_csv_spec.rb
@@ -1,0 +1,112 @@
+RSpec.describe Admin::DataFixes::InlineCSV do
+  subject(:inline_csv) { described_class.new(csv_string:) }
+
+  describe "#parse" do
+    subject(:parse) { inline_csv.parse }
+
+    context "when the CSV is missing" do
+      let(:csv_string) { "" }
+
+      it { is_expected.to be_falsey }
+
+      it "validates the CSV is present" do
+        parse
+        expect(inline_csv.errors).to be_added(:csv_string, "can't be blank")
+      end
+    end
+
+    context "when the CSV is malformed" do
+      let(:csv_string) do
+        <<~ROWS
+          object_type,object_id,action,attributes
+          something,1,create,"unterminated,string
+        ROWS
+      end
+
+      it { is_expected.to be_falsey }
+
+      it "validates the CSV is formatted correctly" do
+        parse
+        expect(inline_csv.errors).to be_added(:csv_string, "is malformed")
+      end
+    end
+
+    context "when the CSV has no headers" do
+      let(:csv_string) do
+        <<~ROWS
+          something,1,create,"attribute1,value1,attribute2,value2"
+          anotherthing,2,destroy,""
+        ROWS
+      end
+
+      it { is_expected.to be_falsey }
+
+      it "validates the CSV has the correct headers" do
+        parse
+        expect(inline_csv.errors).to be_added(:csv_string, "has invalid headers")
+      end
+    end
+
+    context "when the CSV has missing headers" do
+      let(:csv_string) do
+        <<~ROWS
+          object_type,object_id,attributes
+          something,1,create,"attribute1,value1,attribute2,value2"
+          anotherthing,2,destroy,""
+        ROWS
+      end
+
+      it { is_expected.to be_falsey }
+
+      it "validates the CSV has the correct headers" do
+        parse
+        expect(inline_csv.errors).to be_added(:csv_string, "has invalid headers")
+      end
+    end
+
+    context "when the CSV has the wrong headers" do
+      let(:csv_string) do
+        <<~ROWS
+          object_type,object_id,action,wrong_header
+          something,1,create,"attribute1,value1,attribute2,value2"
+          anotherthing,2,destroy,""
+        ROWS
+      end
+
+      it { is_expected.to be_falsey }
+
+      it "validates the CSV has the correct headers" do
+        parse
+        expect(inline_csv.errors).to be_added(:csv_string, "has invalid headers")
+      end
+    end
+
+    context "when the CSV is formatted correctly with the expected headers" do
+      let(:csv_string) do
+        <<~ROWS
+          object_type,object_id,action,attributes
+          something,1,create,"attribute1,value1,attribute2,value2"
+          another_thing,2,destroy,""
+        ROWS
+      end
+
+      it { is_expected.to be_truthy }
+
+      it "returns an array of structured row data" do
+        parsed_data = parse
+        expect(parsed_data.first).to have_attributes(
+          object_type: "something",
+          object_id: "1",
+          action: "create",
+          attributes: "attribute1,value1,attribute2,value2"
+        )
+        expect(parsed_data.second).to have_attributes(
+          object_type: "another_thing",
+          object_id: "2",
+          action: "destroy",
+          attributes: ""
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/4252

### Changes proposed in this pull request

This PORO is intended to act as some of the plumbing between a user submitting a form with some CSV as text, and eventually driving some data fix changes.

It does some basic validation and explicitly expects the correct headers to be used.

The `#parse` method intentionally returns something "truthy" when valid and "falsey" when invalid, so it can be used in controllers like this:

```ruby
if @inline_csv.parse
  # do something
else
  render :new, status: :unprocessable_content
end
```

The class isn't used anywhere yet, but will be once we start building out some user-facing slices of the admin data fixes journey.

### Guidance to review
