### PR TITLE
[4304] Allow adding contracts until period is frozen

### DIFF
--- a/app/controllers/admin/finance/active_lead_providers/contracts_controller.rb
+++ b/app/controllers/admin/finance/active_lead_providers/contracts_controller.rb
@@ -4,8 +4,7 @@ module Admin::Finance::ActiveLeadProviders
 
     before_action :set_active_lead_provider
     before_action :set_contract, only: %i[show edit update delete destroy]
-    before_action :redirect_unless_editable, only: %i[edit update]
-    before_action :redirect_if_finished, only: %i[new create delete destroy]
+    before_action :redirect_unless_editable, only: %i[new create delete destroy edit update]
 
     def index
       @breadcrumbs = {
@@ -96,15 +95,8 @@ module Admin::Finance::ActiveLeadProviders
     def redirect_unless_editable
       unless @active_lead_provider.editable?
         redirect_to contracts_path,
-                    flash: { error: "Contracts cannot be changed once the contract period has started" }
+                    flash: { error: "Contracts cannot be changed once payments have been frozen for the contract period" }
       end
-    end
-
-    def redirect_if_finished
-      return unless @active_lead_provider.finished_on_before_today?
-
-      redirect_to contracts_path,
-                  flash: { error: "Contracts cannot be changed once the contract period has finished" }
     end
 
     def contract_params

--- a/spec/requests/admin/finance/active_lead_providers/contracts_spec.rb
+++ b/spec/requests/admin/finance/active_lead_providers/contracts_spec.rb
@@ -239,6 +239,52 @@ RSpec.describe "Admin finance active lead provider contracts", type: :request do
         end
       end
     end
+
+    context "when editing the current contract period" do
+      include_context "sign in as finance DfE user"
+
+      around do |example|
+        travel_to(1.day.after(contract_period.started_on)) { example.run }
+      end
+
+      it "renders the edit page" do
+        get edit_path
+
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context "when editing a past contract period" do
+      include_context "sign in as finance DfE user"
+
+      let(:contract_period) { FactoryBot.create(:contract_period, :previous) }
+
+      around do |example|
+        travel_to(1.day.after(contract_period.finished_on)) { example.run }
+      end
+
+      it "renders the edit page" do
+        get edit_path
+
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context "when editing a frozen contract period" do
+      include_context "sign in as finance DfE user"
+
+      let(:contract_period) { FactoryBot.create(:contract_period, :previous, payments_frozen_at: 1.week.ago) }
+
+      around do |example|
+        travel_to(1.day.after(contract_period.payments_frozen_at)) { example.run }
+      end
+
+      it "blocks editing a contract" do
+        get edit_path
+        expect(response).to redirect_to(contracts_path)
+        expect(flash[:error]).to eq("Contracts cannot be changed once payments have been frozen for the contract period")
+      end
+    end
   end
 
   describe "PATCH .../contracts/:id" do
@@ -290,12 +336,48 @@ RSpec.describe "Admin finance active lead provider contracts", type: :request do
     context "when signed in as a finance DfE user" do
       include_context "sign in as finance DfE user"
 
-      it "updates the contract and its band terms" do
-        patch contract_path, params: update_params
+      context "when editing the current contract period" do
+        around do |example|
+          travel_to(1.day.after(contract_period.started_on)) { example.run }
+        end
 
-        expect(response).to redirect_to(contract_path)
-        expect(contract.reload.vat_rate).to eq(0.1)
-        expect(band_term.reload.fee_per_declaration).to eq(999)
+        it "updates the contract and its band terms" do
+          patch contract_path, params: update_params
+
+          expect(response).to redirect_to(contract_path)
+          expect(contract.reload.vat_rate).to eq(0.1)
+          expect(band_term.reload.fee_per_declaration).to eq(999)
+        end
+      end
+
+      context "when editing a past contract period" do
+        let(:contract_period) { FactoryBot.create(:contract_period, :previous) }
+
+        around do |example|
+          travel_to(1.day.after(contract_period.finished_on)) { example.run }
+        end
+
+        it "updates the contract and its band terms" do
+          patch contract_path, params: update_params
+
+          expect(response).to redirect_to(contract_path)
+          expect(contract.reload.vat_rate).to eq(0.1)
+          expect(band_term.reload.fee_per_declaration).to eq(999)
+        end
+      end
+
+      context "when editing a frozen contract period" do
+        let(:contract_period) { FactoryBot.create(:contract_period, :previous, payments_frozen_at: 1.week.ago) }
+
+        around do |example|
+          travel_to(1.day.after(contract_period.payments_frozen_at)) { example.run }
+        end
+
+        it "blocks editing a contract" do
+          patch contract_path, params: update_params
+          expect(response).to redirect_to(contracts_path)
+          expect(flash[:error]).to eq("Contracts cannot be changed once payments have been frozen for the contract period")
+        end
       end
     end
   end
@@ -336,14 +418,44 @@ RSpec.describe "Admin finance active lead provider contracts", type: :request do
       end
 
       context "when the contract has no statements" do
-        around do |example|
-          travel_to(1.day.after(contract_period.started_on)) { example.run }
+        context "when deleting in the current contract period" do
+          around do |example|
+            travel_to(1.day.after(contract_period.started_on)) { example.run }
+          end
+
+          it "allows deleting a contract" do
+            expect { delete contract_path }.to change(Contract, :count).by(-1)
+            expect(response).to redirect_to(contracts_path)
+            expect(flash[:notice]).to eq("Contract deleted")
+          end
         end
 
-        it "allows deleting a contract" do
-          expect { delete contract_path }.to change(Contract, :count).by(-1)
-          expect(response).to redirect_to(contracts_path)
-          expect(flash[:notice]).to eq("Contract deleted")
+        context "when deleting in a past contract period" do
+          let(:contract_period) { FactoryBot.create(:contract_period, :previous) }
+
+          around do |example|
+            travel_to(1.day.after(contract_period.finished_on)) { example.run }
+          end
+
+          it "allows deleting a contract" do
+            expect { delete contract_path }.to change(Contract, :count).by(-1)
+            expect(response).to redirect_to(contracts_path)
+            expect(flash[:notice]).to eq("Contract deleted")
+          end
+        end
+
+        context "when deleting from a frozen contract period" do
+          let(:contract_period) { FactoryBot.create(:contract_period, :previous, payments_frozen_at: 1.week.ago) }
+
+          around do |example|
+            travel_to(1.day.after(contract_period.payments_frozen_at)) { example.run }
+          end
+
+          it "redirects back with an error and does not delete the contract" do
+            expect { delete contract_path }.not_to change(Contract, :count)
+            expect(response).to redirect_to(contracts_path)
+            expect(flash[:error]).to eq("Contracts cannot be changed once payments have been frozen for the contract period")
+          end
         end
       end
     end

--- a/spec/requests/admin/finance/active_lead_providers/contracts_spec.rb
+++ b/spec/requests/admin/finance/active_lead_providers/contracts_spec.rb
@@ -179,10 +179,25 @@ RSpec.describe "Admin finance active lead provider contracts", type: :request do
           travel_to(1.day.after(contract_period.finished_on)) { example.run }
         end
 
+        it "allows creating a new contract" do
+          expect { post contracts_path, params: contract_params }.to change(Contract, :count).by(1)
+
+          created_contract = Contract.last
+          expect(response).to redirect_to(admin_contract_period_active_lead_provider_contract_path(contract_period, active_lead_provider, created_contract))
+        end
+      end
+
+      context "when editing a frozen contract period" do
+        let(:contract_period) { FactoryBot.create(:contract_period, :previous, payments_frozen_at: 1.week.ago) }
+
+        around do |example|
+          travel_to(1.day.after(contract_period.payments_frozen_at)) { example.run }
+        end
+
         it "blocks creating a new contract" do
           expect { post contracts_path, params: contract_params }.not_to change(Contract, :count)
           expect(response).to redirect_to(contracts_path)
-          expect(flash[:error]).to eq("Contracts cannot be changed once the contract period has finished")
+          expect(flash[:error]).to eq("Contracts cannot be changed once payments have been frozen for the contract period")
         end
       end
     end


### PR DESCRIPTION
### Context

Finance users should be able to add contract versions until the contract period is frozen. Currently they could only be added until the `finished_on` date of the `ContractPeriod`

### Changes proposed in this pull request

Change the behaviour of contract creation/deletion to match that of editing which is to use `active_lead_provider.editable?` which in turn checks the value of the `ContractPeriod.payments_frozen_at` against `Time.zone.now`.

### Guidance to review

Signed in as a finance user, you should be able to add a new `Contract` to a lead provider for any `ContractPeriod` that is not frozen and be prevented from doing so for a frozen `ContractPeriod`.