### PR TITLE
Announce band service fee changes to screen readers

### DIFF
--- a/app/controllers/admin/finance/active_lead_providers/contracts_controller.rb
+++ b/app/controllers/admin/finance/active_lead_providers/contracts_controller.rb
@@ -118,7 +118,6 @@ module Admin::Finance::ActiveLeadProviders
                     band_id
                     fee_per_declaration
                     output_fee_percentage
-                    service_fee_percentage
                     _destroy
                   ]
                 ]

--- a/app/javascript/controllers/band_controller.js
+++ b/app/javascript/controllers/band_controller.js
@@ -1,20 +1,60 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class BandController extends Controller {
-  static targets = ["outputPercentage", "servicePercentage"]
+  static targets = ["outputPercentage", "servicePercentage", "serviceFeeStatus"]
+  static values = { announceDelay: { type: Number, default: 750 } }
 
-  // Ensure output_fee_percentage is 0..100
-  // Update service_fee_percentage with delta
+  connect() {
+    this.servicePercentageTarget.value = this.#serviceFeePercentage()
+  }
+
+  disconnect() {
+    clearTimeout(this.announceTimeout)
+  }
+
   updateServiceFee() {
-    let output = Number.parseFloat(this.outputPercentageTarget.value)
+    const serviceFee = this.#serviceFeePercentage()
 
-    if (Number.isNaN(output)) {
-      this.servicePercentageTarget.value = ""
-      return
-    }
+    this.servicePercentageTarget.value = serviceFee
+    this.#announce(serviceFee)
+  }
 
-    output = Math.max(0, Math.min(100, Math.round(output)))
-    this.outputPercentageTarget.value = output
-    this.servicePercentageTarget.value = (100 - output)
+  roundAndCapOutputFee() {
+    const outputFee = this.#roundedAndCappedOutputFee()
+
+    if (outputFee === null) return
+
+    this.outputPercentageTarget.value = outputFee
+    this.updateServiceFee()
+  }
+
+  #announce(serviceFee) {
+    clearTimeout(this.announceTimeout)
+
+    this.announceTimeout = setTimeout(() => {
+      this.serviceFeeStatusTarget.textContent = serviceFee === "" ? "" : `Service fee ${serviceFee}%`
+    }, this.announceDelayValue)
+  }
+
+  #serviceFeePercentage() {
+    const outputFee = this.#outputFee()
+
+    if (outputFee === null || outputFee < 0 || outputFee > 100) return ""
+
+    return String(100 - Math.round(outputFee))
+  }
+
+  #roundedAndCappedOutputFee() {
+    const outputFee = this.#outputFee()
+
+    if (outputFee === null) return null
+
+    return Math.max(0, Math.min(100, Math.round(outputFee)))
+  }
+
+  #outputFee() {
+    const outputFee = Number.parseFloat(this.outputPercentageTarget.value)
+
+    return Number.isNaN(outputFee) ? null : outputFee
   }
 }

--- a/app/models/contract/banded_fee_structure/band_term.rb
+++ b/app/models/contract/banded_fee_structure/band_term.rb
@@ -15,18 +15,16 @@ class Contract::BandedFeeStructure::BandTerm < ApplicationRecord
               greater_than: 0,
               message: "Fee per declaration must be a number greater than zero"
             }
-  validates :output_fee_ratio,
-            presence: { message: "Output fee ratio is required" },
+  validates :output_fee_percentage,
+            presence: { message: "Output fee percentage is required" },
             numericality: {
-              in: 0..1,
-              message: "Output fee ratio must be between 0 and 1"
+              in: 0..100,
+              allow_nil: true,
+              message: "Output fee percentage must be between 0 and 100"
             }
   validates :service_fee_ratio,
             presence: { message: "Service fee ratio is required" },
-            numericality: {
-              in: 0..1,
-              message: "Service fee ratio must be between 0 and 1"
-            }
+            if: -> { output_fee_ratio.present? }
 
   validate :sum_of_ratios_equals_one,
            if: -> { output_fee_ratio? && service_fee_ratio? }
@@ -41,14 +39,11 @@ class Contract::BandedFeeStructure::BandTerm < ApplicationRecord
 
   def output_fee_percentage=(val)
     self.output_fee_ratio = val.present? ? val.to_d / 100 : nil
+    self.service_fee_ratio = output_fee_ratio.present? ? 1 - output_fee_ratio : nil
   end
 
   def service_fee_percentage
     (service_fee_ratio * 100).to_i if service_fee_ratio
-  end
-
-  def service_fee_percentage=(val)
-    self.service_fee_ratio = val.present? ? val.to_d / 100 : nil
   end
 
 private

--- a/app/views/admin/finance/active_lead_providers/contracts/_fields.html.erb
+++ b/app/views/admin/finance/active_lead_providers/contracts/_fields.html.erb
@@ -56,6 +56,8 @@
 
   <h3 class="govuk-heading-s">Bands</h3>
 
+  <p class="govuk-hint" id="bands-service-fee-hint">Service fee is 100% minus the output fee.</p>
+
   <%= govuk_table do |table| %>
     <% table.with_head do |head| %>
       <% head.with_row do |row| %>
@@ -80,20 +82,28 @@
             <% row.with_cell(text: band_term.min_declarations.to_s) %>
             <% row.with_cell(text: band_term.max_declarations.to_s) %>
             <% row.with_cell do %>
-              <%= bt.text_field :service_fee_percentage,
+              <%= tag.input type: "text",
                     class: "govuk-input govuk-input--width-5 app-input-read-only",
                     inputmode: "numeric",
                     readonly: true,
                     tabindex: -1,
                     aria: { label: "Band #{("A".ord + index).chr} service fee percentage" },
                     data: { band_target: "servicePercentage" } %>
+              <span id="band-<%= ("a".ord + index).chr %>-service-fee-status"
+                    class="govuk-visually-hidden"
+                    aria-live="polite"
+                    aria-atomic="true"
+                    data-band-target="serviceFeeStatus"></span>
             <% end %>
             <% row.with_cell do %>
               <%= bt.text_field :output_fee_percentage,
-                    class: "govuk-input govuk-input--width-5 #{" govuk-input--error" if bt.object.errors[:output_fee_ratio].any?}",
-                    aria: { label: "Band #{("A".ord + index).chr} output fee percentage" },
+                    class: "govuk-input govuk-input--width-5 #{" govuk-input--error" if bt.object.errors[:output_fee_percentage].any?}",
+                    aria: {
+                      label: "Band #{("A".ord + index).chr} output fee percentage",
+                      describedby: "bands-service-fee-hint band-#{("a".ord + index).chr}-service-fee-status"
+                    },
                     inputmode: "numeric",
-                    data: { band_target: "outputPercentage", action: "input->band#updateServiceFee" } %>
+                    data: { band_target: "outputPercentage", action: "input->band#updateServiceFee change->band#roundAndCapOutputFee" } %>
             <% end %>
             <% row.with_cell do %>
               <%= bt.text_field :fee_per_declaration,

--- a/spec/features/admin/finance/active_lead_providers/contracts/update_contract_band_percentages_spec.rb
+++ b/spec/features/admin/finance/active_lead_providers/contracts/update_contract_band_percentages_spec.rb
@@ -8,33 +8,45 @@ RSpec.describe "Update contract band percentages", :js do
 
     when_i_change_the_output_fee_percentage_to("30")
     then_the_service_fee_percentage_is("70")
+    and_the_service_fee_is_announced_as("Service fee 70%")
 
     when_i_change_the_output_fee_percentage_to("60")
     then_the_service_fee_percentage_is("40")
+    and_the_service_fee_is_announced_as("Service fee 40%")
   end
 
-  scenario "Output fee percentage is clamped to 0..100" do
+  scenario "Output fee percentage is capped to 0..100 when the field is left" do
     given_an_editable_contract_with_bands_exists
     when_i_visit_the_contract_edit_page
 
     when_i_change_the_output_fee_percentage_to("150")
+    then_the_service_fee_percentage_is("")
+
+    and_i_move_away_from_the_output_fee_field
     then_the_output_fee_percentage_is("100")
     and_the_service_fee_percentage_is("0")
 
     when_i_change_the_output_fee_percentage_to("-20")
+    then_the_service_fee_percentage_is("")
+
+    and_i_move_away_from_the_output_fee_field
     then_the_output_fee_percentage_is("0")
     and_the_service_fee_percentage_is("100")
   end
 
-  scenario "Output fee percentage is rounded to whole numbers" do
+  scenario "Output fee percentage is rounded to whole numbers when the field is left" do
     given_an_editable_contract_with_bands_exists
     when_i_visit_the_contract_edit_page
 
     when_i_change_the_output_fee_percentage_to("33.7")
+    then_the_output_fee_percentage_is("33.7")
+
+    and_i_move_away_from_the_output_fee_field
     then_the_output_fee_percentage_is("34")
     and_the_service_fee_percentage_is("66")
 
     when_i_change_the_output_fee_percentage_to("49.4")
+    and_i_move_away_from_the_output_fee_field
     then_the_output_fee_percentage_is("49")
     and_the_service_fee_percentage_is("51")
   end
@@ -45,6 +57,39 @@ RSpec.describe "Update contract band percentages", :js do
 
     then_the_service_fee_input_is_read_only
     and_the_service_fee_input_is_not_tabable
+    and_the_service_fee_input_is_not_submitted
+  end
+
+  scenario "Service fee percentage changes are announced to screen readers" do
+    given_an_editable_contract_with_bands_exists
+    when_i_visit_the_contract_edit_page
+
+    then_the_service_fee_status_is_a_polite_live_region
+    and_it_is_silent_until_something_changes
+    and_the_output_fee_input_is_described_by_the_hint_and_the_status
+  end
+
+  scenario "Only the final service fee percentage is announced while typing" do
+    given_an_editable_contract_with_bands_exists
+    when_i_visit_the_contract_edit_page
+
+    when_i_type_the_output_fee_percentage("60")
+    then_nothing_is_announced_yet
+    and_the_service_fee_is_announced_as("Service fee 40%")
+  end
+
+  context "without JavaScript", js: false do
+    scenario "Service fee percentage is worked out by the server" do
+      given_an_editable_contract_with_bands_exists
+      when_i_visit_the_contract_edit_page
+      then_the_service_fee_percentage_is("")
+
+      when_i_change_the_output_fee_percentage_to("30")
+      and_the_service_fee_percentage_is("")
+
+      when_i_save_the_contract
+      then_the_band_term_percentages_are(output: 0.3, service: 0.7)
+    end
   end
 
   def given_an_editable_contract_with_bands_exists
@@ -70,6 +115,10 @@ RSpec.describe "Update contract band percentages", :js do
     output_input.fill(value.to_s)
   end
 
+  def and_i_move_away_from_the_output_fee_field
+    output_input.blur
+  end
+
   def then_the_output_fee_percentage_is(value)
     expect(output_input.input_value).to eq(value.to_s)
   end
@@ -87,12 +136,58 @@ RSpec.describe "Update contract band percentages", :js do
     expect(service_input).to have_attribute("tabindex", "-1")
   end
 
+  def and_the_service_fee_input_is_not_submitted
+    expect(service_input.get_attribute("name")).to be_nil
+  end
+
+  def and_the_service_fee_is_announced_as(announcement)
+    expect(service_fee_status).to have_text(announcement)
+  end
+
+  def when_i_type_the_output_fee_percentage(value)
+    output_input.fill("")
+    output_input.press_sequentially(value.to_s)
+  end
+
+  def then_nothing_is_announced_yet
+    expect(service_fee_status.text_content).to eq("")
+  end
+
+  def then_the_service_fee_status_is_a_polite_live_region
+    expect(service_fee_status).to have_attribute("aria-live", "polite")
+    expect(service_fee_status).to have_attribute("aria-atomic", "true")
+  end
+
+  def and_it_is_silent_until_something_changes
+    expect(service_fee_status.text_content).to eq("")
+  end
+
+  def and_the_output_fee_input_is_described_by_the_hint_and_the_status
+    expect(output_input).to have_attribute("aria-describedby", "bands-service-fee-hint band-a-service-fee-status")
+    expect(page.locator("#bands-service-fee-hint").text_content).to eq("Service fee is 100% minus the output fee.")
+  end
+
+  def when_i_save_the_contract
+    page.get_by_role("button", name: "Save contract").click
+  end
+
+  def then_the_band_term_percentages_are(output:, service:)
+    band_term = @contract.banded_fee_structure.band_terms.first
+
+    expect(band_term.reload.output_fee_ratio).to eq(output)
+    expect(band_term.service_fee_ratio).to eq(service)
+  end
+
   def output_input
     page.get_by_label("Band A output fee percentage", exact: true)
   end
 
   def service_input
     page.get_by_label("Band A service fee percentage", exact: true)
+  end
+
+  def service_fee_status
+    page.locator("#band-a-service-fee-status")
   end
 
   def edit_admin_finance_active_lead_provider_contract_path

--- a/spec/models/contract/banded_fee_structure/band_term_spec.rb
+++ b/spec/models/contract/banded_fee_structure/band_term_spec.rb
@@ -8,11 +8,32 @@ RSpec.describe Contract::BandedFeeStructure::BandTerm, type: :model do
     it { is_expected.to validate_presence_of(:fee_per_declaration).with_message("Fee per declaration is required") }
     it { is_expected.to validate_numericality_of(:fee_per_declaration).is_greater_than(0).with_message("Fee per declaration must be a number greater than zero") }
 
-    it { is_expected.to validate_presence_of(:output_fee_ratio).with_message("Output fee ratio is required") }
-    it { is_expected.to validate_numericality_of(:output_fee_ratio).is_in(0..1).with_message("Output fee ratio must be between 0 and 1") }
+    describe "service_fee_ratio" do
+      subject(:band_term) { FactoryBot.build_stubbed(:contract_banded_fee_structure_band_term) }
 
-    it { is_expected.to validate_presence_of(:service_fee_ratio).with_message("Service fee ratio is required") }
-    it { is_expected.to validate_numericality_of(:service_fee_ratio).is_in(0..1).with_message("Service fee ratio must be between 0 and 1") }
+      it "is required once an output fee has been set" do
+        band_term.service_fee_ratio = nil
+        expect(band_term).to be_invalid
+        expect(band_term.errors[:service_fee_ratio]).to eq(["Service fee ratio is required"])
+      end
+    end
+
+    describe "output_fee_percentage" do
+      subject(:band_term) { FactoryBot.build_stubbed(:contract_banded_fee_structure_band_term) }
+
+      it "must be present and between 0 and 100, reporting against the field the user filled in" do
+        band_term.output_fee_percentage = nil
+        expect(band_term).to be_invalid
+        expect(band_term.errors[:output_fee_percentage]).to eq(["Output fee percentage is required"])
+
+        band_term.output_fee_percentage = 150
+        expect(band_term).to be_invalid
+        expect(band_term.errors[:output_fee_percentage]).to eq(["Output fee percentage must be between 0 and 100"])
+
+        band_term.output_fee_percentage = 60
+        expect(band_term).to be_valid
+      end
+    end
 
     describe "output_fee_ratio + service_fee_ratio" do
       subject(:band_term) do
@@ -111,22 +132,20 @@ RSpec.describe Contract::BandedFeeStructure::BandTerm, type: :model do
     end
 
     describe "#output_fee_percentage=" do
-      it "overrides and rounds output_fee_ratio" do
+      it "overrides and rounds output_fee_ratio and derives service_fee_ratio" do
         band_term.output_fee_percentage = 34.56
         expect(band_term.output_fee_ratio.to_f).to eq(0.35)
+        expect(band_term.service_fee_ratio.to_f).to eq(0.65)
+
+        band_term.output_fee_percentage = nil
+        expect(band_term.output_fee_ratio).to be_nil
+        expect(band_term.service_fee_ratio).to be_nil
       end
     end
 
     describe "#service_fee_percentage" do
       it "converts and rounds service_fee_ratio" do
         expect(band_term.service_fee_percentage).to eq(46)
-      end
-    end
-
-    describe "#service_fee_percentage=" do
-      it "overrides and rounds service_fee_ratio" do
-        band_term.service_fee_percentage = 67.89
-        expect(band_term.service_fee_ratio.to_f).to eq(0.68)
       end
     end
   end

--- a/spec/requests/admin/finance/active_lead_providers/contracts_spec.rb
+++ b/spec/requests/admin/finance/active_lead_providers/contracts_spec.rb
@@ -85,19 +85,16 @@ RSpec.describe "Admin finance active lead provider contracts", type: :request do
         band_terms_attributes: {
           "0" => {
             band_id: alp_bands[0].id,
-            service_fee_percentage: "20",
             output_fee_percentage: "80",
             fee_per_declaration: "100"
           },
           "1" => {
             band_id: alp_bands[1].id,
-            service_fee_percentage: "20",
             output_fee_percentage: "80",
             fee_per_declaration: "100"
           },
           "2" => {
             band_id: alp_bands[2].id,
-            service_fee_percentage: "20",
             output_fee_percentage: "80",
             fee_per_declaration: "100"
           },
@@ -138,6 +135,7 @@ RSpec.describe "Admin finance active lead provider contracts", type: :request do
         created_contract = Contract.last
         expect(response).to redirect_to(admin_contract_period_active_lead_provider_contract_path(contract_period, active_lead_provider, created_contract))
         expect(created_contract.banded_fee_structure.band_terms.size).to eq(3)
+        expect(created_contract.banded_fee_structure.band_terms.map(&:service_fee_ratio)).to all(eq(0.2))
         expect(created_contract.flat_rate_fee_structure.fee_per_declaration).to eq(500)
         expect(created_contract.flat_rate_fee_structure.recruitment_target).to eq(100)
       end
@@ -310,7 +308,6 @@ RSpec.describe "Admin finance active lead provider contracts", type: :request do
                 id: band_term.id,
                 band_id: band_term.band_id,
                 fee_per_declaration: "999",
-                service_fee_percentage: "20",
                 output_fee_percentage: "80",
               },
             },
@@ -347,6 +344,8 @@ RSpec.describe "Admin finance active lead provider contracts", type: :request do
           expect(response).to redirect_to(contract_path)
           expect(contract.reload.vat_rate).to eq(0.1)
           expect(band_term.reload.fee_per_declaration).to eq(999)
+          expect(band_term.output_fee_ratio).to eq(0.8)
+          expect(band_term.service_fee_ratio).to eq(0.2)
         end
       end
 

--- a/spec/services/contracts/update_spec.rb
+++ b/spec/services/contracts/update_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe Contracts::Update do
   end
 
   let(:output_fee_percentage) { 80 }
-  let(:service_fee_percentage) { 20 }
 
   let(:params) do
     {
@@ -38,7 +37,6 @@ RSpec.describe Contracts::Update do
             band_id: band_term.band_id,
             fee_per_declaration: 9_999,
             output_fee_percentage:,
-            service_fee_percentage:,
           },
         ],
       },
@@ -91,7 +89,6 @@ RSpec.describe Contracts::Update do
               band_id: band_term.band_id,
               fee_per_declaration: 100,
               output_fee_percentage: 70,
-              service_fee_percentage: 30,
             },
           ],
         },
@@ -126,12 +123,11 @@ RSpec.describe Contracts::Update do
     end
   end
 
-  context "when the fee percentages do not total 100%" do
-    let(:output_fee_percentage) { 99 }
-    let(:service_fee_percentage) { 2 }
+  context "when the output fee percentage is outside 0 to 100" do
+    let(:output_fee_percentage) { 150 }
 
     it "does not update the contract or create an event" do
-      expect { service.call }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Banded fee structure band terms Sum of ratios must equal 1")
+      expect { service.call }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Banded fee structure band terms output fee percentage Output fee percentage must be between 0 and 100")
       expect(Events::Record).not_to have_received(:record_contract_updated_event!)
     end
   end


### PR DESCRIPTION
### Context

Screen readers did not get changes to an input's value, 
so a user got no signal that the page had changed a value in response to their typing. 

### Changes proposed in this pull request

With javascript enabled, the table renders exactly as before, however:
- It always derives service fee from output fee, the javascript is just an affordance.
- The screen reader announces the value onBlur if javascript present
- No Javascript, no service fee, it is left for the user to do the maths. I.e. Setting the output fee to 60%, the service fee isn't shown, but we know it must be 40%.

### Guidance to review

