### PR TITLE
[3544] Fix heading semantics across the app

### DIFF
--- a/app/components/admin/add_lead_providers_form_component.html.erb
+++ b/app/components/admin/add_lead_providers_form_component.html.erb
@@ -5,7 +5,7 @@
 
   <% if current_partnerships.any? %>
     <div class="govuk-inset-text">
-      <h3 class="govuk-heading-s">Currently working with:</h3>
+      <p class="govuk-body govuk-!-font-weight-bold">Currently working with:</p>
       <%= govuk_list(current_partnership_names, type: :bullet) %>
     </div>
   <% end %>

--- a/app/components/admin/schools/partnerships_summary_component.html.erb
+++ b/app/components/admin/schools/partnerships_summary_component.html.erb
@@ -3,7 +3,7 @@
     <h3 class="govuk-heading-m"><%= "#{year} partnerships" %></h3>
 
     <% school_partnerships_by_year[year].each do |school_partnership| %>
-      <%= govuk_summary_card(title: school_partnership_title(school_partnership)) do |card| %>
+      <%= govuk_summary_card(title: school_partnership_title(school_partnership), heading_level: 4) do |card| %>
         <%= card.with_summary_list(actions: false) do |list| %>
           <% list.with_row do |row| %>
             <% row.with_key(text: "Lead provider") %>

--- a/app/components/admin/teachers/school_summary_component.rb
+++ b/app/components/admin/teachers/school_summary_component.rb
@@ -12,7 +12,7 @@ module Admin
       end
 
       def call
-        govuk_summary_card(title: card_title) do |card|
+        govuk_summary_card(title: card_title, heading_level: 4) do |card|
           card.with_summary_list(actions: false) do |list|
             rows.each do |row|
               list.with_row do |r|

--- a/app/components/admin/teachers/training_summary_component.rb
+++ b/app/components/admin/teachers/training_summary_component.rb
@@ -12,7 +12,7 @@ module Admin
       def call
         summary_rows = rows
 
-        govuk_summary_card(title: card_title) do |card|
+        govuk_summary_card(title: card_title, heading_level: 4) do |card|
           if show_move_partnership_link?
             card.with_action { helpers.govuk_link_to("Move to a different partnership", move_partnership_path) }
           end

--- a/app/components/schools/ects/listing_card_component.html.erb
+++ b/app/components/schools/ects/listing_card_component.html.erb
@@ -1,8 +1,8 @@
 <div class="govuk-summary-card">
   <div class="govuk-summary-card__title-wrapper">
-    <h3 class="govuk-summary-card__title govuk-!-font-size-24">
+    <h2 class="govuk-summary-card__title govuk-!-font-size-24">
       <strong><%= link_to_ect(ect_at_school_period) %></strong>
-    </h3>
+    </h2>
   </div>
   <div class="govuk-summary-card__content">
     <% if withdrawn? %>

--- a/app/components/schools/mentors/summary_component.html.erb
+++ b/app/components/schools/mentors/summary_component.html.erb
@@ -1,8 +1,8 @@
 <div class="govuk-summary-card">
   <div class="govuk-summary-card__title-wrapper">
-    <h3 class="govuk-summary-card__title govuk-!-font-size-24">
+    <h2 class="govuk-summary-card__title govuk-!-font-size-24">
       <strong><%= link_to_mentor %></strong>
-    </h3>
+    </h2>
   </div>
   <div class="govuk-summary-card__content">
     <div class="govuk-grid-row">

--- a/app/components/test_guidance/trs_example_teacher_details.html.erb
+++ b/app/components/test_guidance/trs_example_teacher_details.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h3 class="govuk-heading-m">Information to review this journey</h3>
+    <h2 class="govuk-heading-m">Information to review this journey</h2>
 
     <p class="govuk-body">To successfully locate an ECT from the TRS API, use credentials from the table below:</p>
 

--- a/app/components/test_guidance/trs_fake_api_instructions.html.erb
+++ b/app/components/test_guidance/trs_fake_api_instructions.html.erb
@@ -1,4 +1,4 @@
-<h3 class="govuk-heading-m">Information to review this journey</h3>
+<h2 class="govuk-heading-m">Information to review this journey</h2>
 
 <p class="govuk-body">Enter any TRN with the date of birth 03-02-1977 to register a random ECT.</p>
 <p class="govuk-body">The following TRNs are special and will result in an early exit.</p>

--- a/app/components/timeline_component.rb
+++ b/app/components/timeline_component.rb
@@ -3,8 +3,8 @@ class TimelineComponent < ApplicationComponent
 
   attr_reader :events
 
-  def initialize(events)
-    events.each { |event| with_item(event) }
+  def initialize(events, heading_level: 2)
+    events.each { |event| with_item(event, heading_level:) }
   end
 
   def call
@@ -14,10 +14,11 @@ class TimelineComponent < ApplicationComponent
   end
 
   class ItemComponent < ApplicationComponent
-    attr_reader :event
+    attr_reader :event, :heading_level
 
-    def initialize(event)
+    def initialize(event, heading_level:)
       @event = event
+      @heading_level = heading_level
     end
 
     def call
@@ -35,7 +36,7 @@ class TimelineComponent < ApplicationComponent
     end
 
     def title
-      tag.h2(event.heading, class: "app-timeline__title")
+      content_tag(heading_tag, event.heading, class: "app-timeline__title")
     end
 
     def timestamp
@@ -77,7 +78,7 @@ class TimelineComponent < ApplicationComponent
 
       safe_join(
         [
-          tag.h3("Changes", class: "govuk-heading-s"),
+          content_tag(subheading_tag, "Changes", class: "govuk-heading-s"),
           govuk_list(event.modifications)
         ]
       )
@@ -87,6 +88,14 @@ class TimelineComponent < ApplicationComponent
       attribution = event.author_name || event.author&.name || event.author_type
 
       tag.p("by #{attribution}", class: "app-timeline__byline")
+    end
+
+    def heading_tag
+      "h#{heading_level}"
+    end
+
+    def subheading_tag
+      "h#{heading_level + 1}"
     end
   end
 end

--- a/app/views/admin/teachers/record_failed_induction/show.html.erb
+++ b/app/views/admin/teachers/record_failed_induction/show.html.erb
@@ -1,5 +1,6 @@
 <% page_data(
   title: "Outcome recorded",
+  header: false,
   backlink_href: admin_teacher_induction_path(@teacher)
 ) %>
 

--- a/app/views/admin/teachers/record_passed_induction/show.html.erb
+++ b/app/views/admin/teachers/record_passed_induction/show.html.erb
@@ -1,5 +1,6 @@
 <% page_data(
   title: "Outcome recorded",
+  header: false,
   backlink_href: admin_teacher_induction_path(@teacher)
 ) %>
 

--- a/app/views/admin/teachers/timeline/show.html.erb
+++ b/app/views/admin/teachers/timeline/show.html.erb
@@ -13,7 +13,7 @@
 <h2 class="govuk-heading-m">Timeline</h2>
 
 <% if @events.any? %>
-  <%= render(TimelineComponent.new(@events)) %>
+  <%= render(TimelineComponent.new(@events, heading_level: 3)) %>
 <% else %>
   <p class='govuk-body'>No timeline of events for this teacher.</p>
 <% end %>

--- a/app/views/schools/induction_tutor/show.html.erb
+++ b/app/views/schools/induction_tutor/show.html.erb
@@ -9,7 +9,7 @@
 
 <p class="govuk-body">This person is your school’s main point of contact for early career training and induction. We share these details with your appropriate body and lead providers (if your school uses provider-led training programmes).</p>
 
-<h1 class="govuk-heading-m">Induction tutor details</h1>
+<h2 class="govuk-heading-m">Induction tutor details</h2>
 
 <%= govuk_summary_list do |sl|
   sl.with_row do |row|

--- a/app/views/schools/register_ect_wizard/_start_date.html.erb
+++ b/app/views/schools/register_ect_wizard/_start_date.html.erb
@@ -9,7 +9,7 @@
 
   <%= f.govuk_date_field :start_date,
                          width: "two-thirds",
-                         legend: { text: 'Start date', size: "m", tag: "h3", hidden: true },
+                         legend: { text: 'Start date', size: "m", hidden: true },
                          hint: { text: "For example, 17 9 #{Date.current.year}" }
   %>
 

--- a/app/views/schools/register_mentor_wizard/confirmation.md.erb
+++ b/app/views/schools/register_mentor_wizard/confirmation.md.erb
@@ -15,7 +15,7 @@ This completes <%= @ect_name %>’s registration for ECT training at your school
 You do not need to give us any more information.
 
 <% unless @mentor.already_active_at_school %>
-### What happens next
+## What happens next
 
 We’ll email <%= @mentor.full_name %> to confirm that you’ve registered them as a mentor.
 

--- a/app/views/time_travellers/new.html.erb
+++ b/app/views/time_travellers/new.html.erb
@@ -12,7 +12,7 @@
     <%= form.govuk_date_field(
           :travel_to,
           width: "two-thirds",
-          legend: { text: "Travel to date", size: "m", tag: "h3", hidden: true },
+          legend: { text: "Travel to date", hidden: true },
           hint: { text: "For example, 17 9 #{Date.current.year.next}" }
         ) %>
 

--- a/spec/components/admin/schools/partnerships_summary_component_spec.rb
+++ b/spec/components/admin/schools/partnerships_summary_component_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe Admin::Schools::PartnershipsSummaryComponent, type: :component do
 
     describe "card titles" do
       it "renders the lead provider and delivery partner names" do
-        expect(rendered).to have_css(".govuk-summary-card__title", text: "Alpha Provider and Delta Partner")
-        expect(rendered).to have_css(".govuk-summary-card__title", text: "Beta Provider and Gamma Partner")
+        expect(rendered).to have_css("h4.govuk-summary-card__title", text: "Alpha Provider and Delta Partner")
+        expect(rendered).to have_css("h4.govuk-summary-card__title", text: "Beta Provider and Gamma Partner")
       end
     end
 

--- a/spec/components/admin/teachers/school_summary_component_spec.rb
+++ b/spec/components/admin/teachers/school_summary_component_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe Admin::Teachers::SchoolSummaryComponent, type: :component do
     let(:school_period) { FactoryBot.create(:ect_at_school_period, **school_period_attributes) }
 
     context "card title" do
-      it "links to the admin school overview" do
+      it "renders the school link as a h4" do
+        expect(rendered).to have_css("h4.govuk-summary-card__title", text: school.name)
         expect(rendered).to have_link(school.name, href: admin_school_overview_path(school.urn))
       end
     end

--- a/spec/components/admin/teachers/training_summary_component_spec.rb
+++ b/spec/components/admin/teachers/training_summary_component_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Admin::Teachers::TrainingSummaryComponent, type: :component do
 
       context "when the partnership is confirmed" do
         it "shows the combined card title" do
-          expect(rendered_content).to have_css(".govuk-summary-card__title", text: "#{training_period.lead_provider_name} & #{training_period.delivery_partner_name}")
+          expect(rendered_content).to have_css("h4.govuk-summary-card__title", text: "#{training_period.lead_provider_name} & #{training_period.delivery_partner_name}")
         end
 
         it "shows the lead provider row" do

--- a/spec/components/schools/ects/listing_card_component_spec.rb
+++ b/spec/components/schools/ects/listing_card_component_spec.rb
@@ -11,6 +11,12 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
   let(:valid_withdrawal_reason) { TrainingPeriod.withdrawal_reasons.keys.first }
   let(:valid_deferral_reason) { TrainingPeriod.deferral_reasons.keys.first }
 
+  it "renders the ECT name as a h2" do
+    render_inline(described_class.new(teacher:, ect_at_school_period:, training_period:))
+
+    expect(rendered_content).to have_css("h2.govuk-summary-card__title", text: "Naruto Uzumaki")
+  end
+
   context "when the ECT has a mentor assigned" do
     before do
       FactoryBot.create(:mentorship_period, :unfinished, started_on: ect_at_school_period.started_on, mentee: ect_at_school_period, mentor:)

--- a/spec/components/schools/mentors/summary_component_spec.rb
+++ b/spec/components/schools/mentors/summary_component_spec.rb
@@ -23,6 +23,10 @@ RSpec.describe Schools::Mentors::SummaryComponent, type: :component do
   let(:ect3_teacher) { FactoryBot.create(:teacher, trs_first_name: "Kakashi", trs_last_name: "Hatake") }
   let(:ect4_teacher) { FactoryBot.create(:teacher, :induction_completed, trs_first_name: "Jiraiya", trs_last_name: "Sannin") }
 
+  it "renders the mentor name as a h2" do
+    expect(subject).to have_css("h2.govuk-summary-card__title", text: "Naruto Uzumaki")
+  end
+
   describe "assigned ECTs" do
     context "with no ECTs" do
       it { is_expected.to have_summary_list_row("Assigned ECTs", value: "No ECTs assigned") }

--- a/spec/components/test_guidance_component_spec.rb
+++ b/spec/components/test_guidance_component_spec.rb
@@ -37,6 +37,10 @@ describe TestGuidanceComponent, type: :component do
         end
       end
 
+      it "renders the guidance title as a h2" do
+        expect(rendered_content).to have_css("h2", text: "Information to review this journey")
+      end
+
       context "with an Appropriate body persona" do
         let(:current_user) { double(appropriate_body_user?: true, school_user?: false) }
 
@@ -65,6 +69,10 @@ describe TestGuidanceComponent, type: :component do
 
       it "contains a list of fake TRNs" do
         expect(rendered_content).to have_text("Enter any TRN with the date of birth 03-02-1977 to register a random ECT.")
+      end
+
+      it "renders the guidance title as a h2" do
+        expect(rendered_content).to have_css("h2", text: "Information to review this journey")
       end
     end
   end

--- a/spec/components/timeline_component_spec.rb
+++ b/spec/components/timeline_component_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe TimelineComponent, type: :component do
 
   it "shows the title and byline in the header" do
     events.each do |event|
-      expect(rendered_content).to have_css(".app-timeline__header > .app-timeline__title", text: event.heading)
+      expect(rendered_content).to have_css(".app-timeline__header > h2.app-timeline__title", text: event.heading)
       expect(rendered_content).to have_css(".app-timeline__header > .app-timeline__byline", text: event.author_name)
     end
   end
@@ -66,6 +66,19 @@ RSpec.describe TimelineComponent, type: :component do
       it "renders no list" do
         expect(rendered_content).not_to have_css(".govuk-list")
       end
+    end
+  end
+
+  context "with a custom heading level" do
+    let(:component) { TimelineComponent.new(events, heading_level: 3) }
+    let(:one_day_ago) { FactoryBot.build(:event, :with_modifications, created_at: 1.day.ago) }
+
+    it "uses the specified level for event headings" do
+      expect(rendered_content).to have_css("h3.app-timeline__title", text: one_day_ago.heading)
+    end
+
+    it "uses the next level for changes headings" do
+      expect(rendered_content).to have_css("h4", text: "Changes")
     end
   end
 end

--- a/spec/views/admin/delivery_partners/delivery_partnerships/new.html.erb_spec.rb
+++ b/spec/views/admin/delivery_partners/delivery_partnerships/new.html.erb_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "admin/delivery_partners/delivery_partnerships/new.html.erb" do
       render
 
       expect(rendered).to have_css(".govuk-inset-text")
-      expect(rendered).to have_css("h3", text: "Currently working with:")
+      expect(rendered).to have_css("p", text: "Currently working with:")
       expect(rendered).to have_css("li", text: "Lead Provider 1")
     end
 

--- a/spec/views/admin/delivery_partners/edit.html.erb_spec.rb
+++ b/spec/views/admin/delivery_partners/edit.html.erb_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "admin/delivery_partners/delivery_partnerships/new.html.erb" do
       render
 
       expect(rendered).to have_css(".govuk-inset-text")
-      expect(rendered).to have_css("h3", text: "Currently working with:")
+      expect(rendered).to have_css("p", text: "Currently working with:")
       expect(rendered).to have_css("li", text: "Lead Provider 1")
     end
 

--- a/spec/views/admin/teachers/timeline/show.html.erb_spec.rb
+++ b/spec/views/admin/teachers/timeline/show.html.erb_spec.rb
@@ -1,9 +1,10 @@
 RSpec.describe "admin/teachers/timeline/show.html.erb" do
   let(:teacher) { FactoryBot.create(:teacher) }
+  let(:events) { [] }
 
   before do
     assign(:teacher, Admin::TeacherPresenter.new(teacher))
-    assign(:events, [])
+    assign(:events, events)
     assign(:breadcrumbs, {
       "Teachers" => admin_teachers_path,
       "Floella Benjamin" => admin_teacher_path(teacher),
@@ -14,5 +15,13 @@ RSpec.describe "admin/teachers/timeline/show.html.erb" do
 
   it "includes a breadcrumb to admin teachers list" do
     expect(view.content_for(:backlink_or_breadcrumb)).to have_link("Teachers", href: admin_teachers_path)
+  end
+
+  context "with timeline events" do
+    let(:events) { [FactoryBot.build(:event, :with_body)] }
+
+    it "renders event titles as level 3 headings" do
+      expect(rendered).to have_css("h3.app-timeline__title", text: events.first.heading)
+    end
   end
 end

--- a/spec/views/schools/induction_tutor/show.html.erb_spec.rb
+++ b/spec/views/schools/induction_tutor/show.html.erb_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe "schools/induction_tutor/show.html.erb" do
+  let(:school) { FactoryBot.create(:school, :with_induction_tutor) }
+
+  before do
+    assign(:school, school)
+    render
+  end
+
+  it "renders the induction tutor details as a h2" do
+    expect(rendered).to have_css("h2", text: "Induction tutor details")
+  end
+end

--- a/spec/views/schools/register_ect_wizard/find_ect.html.erb_spec.rb
+++ b/spec/views/schools/register_ect_wizard/find_ect.html.erb_spec.rb
@@ -39,6 +39,13 @@ RSpec.describe "schools/register_ect_wizard/find_ect.html.erb" do
     expect(rendered).to have_selector("form[action='#{schools_register_ect_wizard_find_ect_path}']")
   end
 
+  it "uses h2's for the teacher reference number and date of birth fields" do
+    render
+
+    expect(rendered).to have_css("h2", text: "Teacher reference number (TRN)")
+    expect(rendered).to have_css("h2", text: "Date of birth")
+  end
+
   describe "test guidance" do
     let(:current_user) { double(appropriate_body_user?: false, school_user?: true) }
 

--- a/spec/views/schools/register_ect_wizard/shared_examples/start_date_view.rb
+++ b/spec/views/schools/register_ect_wizard/shared_examples/start_date_view.rb
@@ -48,4 +48,11 @@ RSpec.shared_examples "a start date view" do |current_step:, back_path:, back_st
 
     expect(rendered).to have_content("For example, 17 9 #{Date.current.year}")
   end
+
+  it "does not render the start date legend as a heading" do
+    render
+
+    expect(rendered).to have_css("legend", text: "Start date")
+    expect(rendered).not_to have_css("legend h1, legend h2, legend h3, legend h4, legend h5, legend h6")
+  end
 end

--- a/spec/views/schools/register_mentor_wizard/confirmation.md.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/confirmation.md.erb_spec.rb
@@ -168,6 +168,10 @@ RSpec.describe "schools/register_mentor_wizard/confirmation.md.erb" do
       expect(rendered).to have_content("We’ll email #{mentor.full_name} to confirm that you’ve registered them as a mentor.")
     end
 
+    it "renders the 'What happens next' subheading as a h2" do
+      expect(rendered).to have_css("h2", text: "What happens next")
+    end
+
     it "mentions passing on details to the lead provider for mentor training" do
       expect(rendered).to have_content("We’ll pass on their details to FraggleRock")
     end


### PR DESCRIPTION
### Context

This PR fixes the heading semantic issues identified in the card, along with similar issues I found while checking the rest of the app. This keeps the heading hierarchy in the right order and makes the pages easier to understand and navigate, especially for screen reader users.

### Pages changed

- ECT and mentor lists
- Find an ECT (coverage)
- ECT Registration -> start date
- Mentor Registration -> confirmation
- Induction tutor details
- School partnerships
- Admin teacher timeline
- Lead provider selection
- Test guidance
- Time travel
- Admin induction outcome pass confirmation
- Admin induction outcome fail confirmation
- Admin teacher training history
- Admin teacher school history

### Guidance to review

Each commit covers a separate page or component, so recommend going commit by commit.