### PR TITLE
[4017] Merge deletes predecessor school

### DIFF
--- a/app/services/gias/reconciliation/eligibility.rb
+++ b/app/services/gias/reconciliation/eligibility.rb
@@ -49,10 +49,6 @@ module GIAS::Reconciliation
       closed_on <= Date.current
     end
 
-    def school_merged_event_recorded?
-      Event.where(school:, event_type: :school_merged).exists?
-    end
-
     def school_closed_event_recorded?
       Event.where(school:, event_type: :school_closed).exists?
     end

--- a/app/services/gias/reconciliation/eligibility.rb
+++ b/app/services/gias/reconciliation/eligibility.rb
@@ -36,8 +36,7 @@ module GIAS::Reconciliation
         closed_on_or_before_today? &&
         school.present? &&
         school_being_merged_or_amalgamated? &&
-        has_one_open_successor? &&
-        successor.school.present?
+        has_one_open_successor?
     end
 
   private

--- a/app/services/gias/reconciliation/eligibility.rb
+++ b/app/services/gias/reconciliation/eligibility.rb
@@ -36,8 +36,8 @@ module GIAS::Reconciliation
         closed_on_or_before_today? &&
         school.present? &&
         school_being_merged_or_amalgamated? &&
-        !school_merged_event_recorded? &&
-        has_one_open_successor?
+        has_one_open_successor? &&
+        successor.school.present?
     end
 
   private

--- a/app/services/gias/reconciliation/merge.rb
+++ b/app/services/gias/reconciliation/merge.rb
@@ -85,7 +85,7 @@ module GIAS::Reconciliation
     def successor_school = @successor_school ||= successor.school
 
     delegate :school, :closed_on, :successor, to: :gias_school
-    delegate :mentor_teachers, :ect_teachers, to: :school, prefix: false
+    delegate :mentor_teachers, to: :school, prefix: false
 
     def author = Events::SystemAuthor.new
   end

--- a/app/services/gias/reconciliation/merge.rb
+++ b/app/services/gias/reconciliation/merge.rb
@@ -1,48 +1,57 @@
 module GIAS::Reconciliation
   class Merge
-    def self.merge!(gias_school) = new(gias_school).merge!
+    def self.merge!(gias_school, refresh_metadata: true) = new(gias_school, refresh_metadata:).merge!
 
-    def initialize(gias_school)
+    def initialize(gias_school, refresh_metadata: true)
       @gias_school = gias_school
+      @refresh_metadata = refresh_metadata
     end
 
     def merge!
       return false unless eligibility.can_be_merged?
 
-      ActiveRecord::Base.transaction do
-        ensure_successor_school_exists!
+      teachers_to_refresh = affected_teachers
 
-        mentor_teachers.each do |teacher|
-          overlapping_mentor_at_school_periods(teacher).each do |periods|
-            MentorAtSchoolPeriods::Merge.call(periods:, predecessor_school:, successor_school:)
+      DeclarativeUpdates.skip(:metadata) do
+        ActiveRecord::Base.transaction do
+          ensure_successor_school_exists!
+
+          mentor_teachers.each do |teacher|
+            overlapping_mentor_at_school_periods(teacher).each do |periods|
+              MentorAtSchoolPeriods::Merge.call(periods:, predecessor_school:, successor_school:)
+            end
           end
+
+          remaining_mentor_periods = predecessor_school.mentor_at_school_periods.reload
+
+          remaining_mentor_periods.each do |mentor_at_school_period|
+            MentorAtSchoolPeriods::Transfer.call(mentor_at_school_period:, predecessor_school:, successor_school:)
+          end
+
+          remaining_ect_periods = predecessor_school.ect_at_school_periods.reload
+
+          remaining_ect_periods.each do |ect_at_school_period|
+            ECTAtSchoolPeriods::Transfer.call(ect_at_school_period:, predecessor_school:, successor_school:)
+          end
+
+          destroy_predecessor_school_events!
+          destroy_predecessor_school_partnerships!
+          destroy_predecessor_school_metadata!
+          destroy_predecessor_school!
+
+          record_school_merged_event!
         end
-
-        remaining_mentor_periods = predecessor_school.mentor_at_school_periods.reload
-
-        remaining_mentor_periods.each do |mentor_at_school_period|
-          MentorAtSchoolPeriods::Transfer.call(mentor_at_school_period:, predecessor_school:, successor_school:)
-        end
-
-        remaining_ect_periods = predecessor_school.ect_at_school_periods.reload
-
-        remaining_ect_periods.each do |ect_at_school_period|
-          ECTAtSchoolPeriods::Transfer.call(ect_at_school_period:, predecessor_school:, successor_school:)
-        end
-
-        destroy_events!
-        destroy_school_partnerships!
-        destroy_predecessor_school!
-
-        record_school_merged_event!
       end
+
+      refresh_school_metadata!
+      refresh_teacher_metadata!(teachers_to_refresh)
 
       true
     end
 
   private
 
-    attr_reader :gias_school
+    attr_reader :gias_school, :refresh_metadata
 
     def eligibility
       @eligibility ||= GIAS::Reconciliation::Eligibility.new(gias_school)
@@ -62,11 +71,16 @@ module GIAS::Reconciliation
       )
     end
 
-    def destroy_school_partnerships!
+    def destroy_predecessor_school_partnerships!
       predecessor_school.school_partnerships.destroy_all
     end
 
-    def destroy_events!
+    def destroy_predecessor_school_metadata!
+      Metadata::SchoolContractPeriod.where(school_id: predecessor_school.id).delete_all
+      Metadata::SchoolLeadProviderContractPeriod.where(school_id: predecessor_school.id).delete_all
+    end
+
+    def destroy_predecessor_school_events!
       predecessor_school.events.destroy_all
     end
 
@@ -93,11 +107,31 @@ module GIAS::Reconciliation
       )
     end
 
+    def affected_teachers
+      return unless refresh_metadata
+
+      @affected_teachers ||= (mentor_teachers + ect_teachers).uniq
+    end
+
+    def refresh_school_metadata!
+      return unless refresh_metadata
+
+      Metadata::Handlers::School.new(successor_school).refresh_metadata!
+    end
+
+    def refresh_teacher_metadata!(teachers)
+      return unless refresh_metadata
+
+      teachers.each do |teacher|
+        Metadata::Handlers::Teacher.new(teacher).refresh_metadata!
+      end
+    end
+
     def predecessor_school = school
     def successor_school = @successor_school ||= successor.school
 
     delegate :school, :closed_on, :successor, to: :gias_school
-    delegate :mentor_teachers, to: :school, prefix: false
+    delegate :mentor_teachers, :ect_teachers, to: :school, prefix: false
 
     def author = Events::SystemAuthor.new
   end

--- a/app/services/gias/reconciliation/merge.rb
+++ b/app/services/gias/reconciliation/merge.rb
@@ -1,10 +1,9 @@
 module GIAS::Reconciliation
   class Merge
-    def self.merge!(gias_school, refresh_metadata: true) = new(gias_school, refresh_metadata:).merge!
+    def self.merge!(gias_school) = new(gias_school).merge!
 
-    def initialize(gias_school, refresh_metadata: true)
+    def initialize(gias_school)
       @gias_school = gias_school
-      @refresh_metadata = refresh_metadata
     end
 
     def merge!
@@ -34,6 +33,8 @@ module GIAS::Reconciliation
         predecessor_school.events.each(&:destroy!)
         predecessor_school.school_partnerships.each(&:destroy!)
         predecessor_school.destroy!
+
+        record_school_merged_event!
       end
 
       true
@@ -41,7 +42,7 @@ module GIAS::Reconciliation
 
   private
 
-    attr_reader :gias_school, :refresh_metadata
+    attr_reader :gias_school
 
     def eligibility
       @eligibility ||= GIAS::Reconciliation::Eligibility.new(gias_school)
@@ -61,11 +62,6 @@ module GIAS::Reconciliation
       )
     end
 
-    def destroy_predecessor_school_metadata!
-      Metadata::SchoolContractPeriod.where(school_id: predecessor_school.id).delete_all
-      Metadata::SchoolLeadProviderContractPeriod.where(school_id: predecessor_school.id).delete_all
-    end
-
     def record_school_merged_event!
       Events::Record.record_school_merged_event!(
         school: successor_school,
@@ -83,26 +79,6 @@ module GIAS::Reconciliation
         happened_at: closed_on,
         author:
       )
-    end
-
-    def affected_teachers
-      return unless refresh_metadata
-
-      @affected_teachers ||= (mentor_teachers + ect_teachers).uniq
-    end
-
-    def refresh_school_metadata!
-      return unless refresh_metadata
-
-      Metadata::Handlers::School.new(successor_school).refresh_metadata!
-    end
-
-    def refresh_teacher_metadata!(teachers)
-      return unless refresh_metadata
-
-      teachers.each do |teacher|
-        Metadata::Handlers::Teacher.new(teacher).refresh_metadata!
-      end
     end
 
     def predecessor_school = school

--- a/app/services/gias/reconciliation/merge.rb
+++ b/app/services/gias/reconciliation/merge.rb
@@ -10,41 +10,31 @@ module GIAS::Reconciliation
     def merge!
       return false unless eligibility.can_be_merged?
 
-      teachers_to_refresh = affected_teachers
+      ActiveRecord::Base.transaction do
+        ensure_successor_school_exists!
 
-      DeclarativeUpdates.skip(:metadata) do
-        ActiveRecord::Base.transaction do
-          ensure_successor_school_exists!
-
-          mentor_teachers.each do |teacher|
-            overlapping_mentor_at_school_periods(teacher).each do |periods|
-              MentorAtSchoolPeriods::Merge.call(periods:, predecessor_school:, successor_school:)
-            end
+        mentor_teachers.each do |teacher|
+          overlapping_mentor_at_school_periods(teacher).each do |periods|
+            MentorAtSchoolPeriods::Merge.call(periods:, predecessor_school:, successor_school:)
           end
-
-          remaining_mentor_periods = predecessor_school.mentor_at_school_periods.reload
-
-          remaining_mentor_periods.each do |mentor_at_school_period|
-            MentorAtSchoolPeriods::Transfer.call(mentor_at_school_period:, predecessor_school:, successor_school:)
-          end
-
-          remaining_ect_periods = predecessor_school.ect_at_school_periods.reload
-
-          remaining_ect_periods.each do |ect_at_school_period|
-            ECTAtSchoolPeriods::Transfer.call(ect_at_school_period:, predecessor_school:, successor_school:)
-          end
-
-          destroy_predecessor_school_metadata!
-          predecessor_school.events.each(&:destroy!)
-          predecessor_school.school_partnerships.each(&:destroy!)
-          predecessor_school.destroy!
-
-          record_school_merged_event!
         end
-      end
 
-      refresh_school_metadata!
-      refresh_teacher_metadata!(teachers_to_refresh)
+        remaining_mentor_periods = predecessor_school.mentor_at_school_periods.reload
+
+        remaining_mentor_periods.each do |mentor_at_school_period|
+          MentorAtSchoolPeriods::Transfer.call(mentor_at_school_period:, predecessor_school:, successor_school:)
+        end
+
+        remaining_ect_periods = predecessor_school.ect_at_school_periods.reload
+
+        remaining_ect_periods.each do |ect_at_school_period|
+          ECTAtSchoolPeriods::Transfer.call(ect_at_school_period:, predecessor_school:, successor_school:)
+        end
+
+        predecessor_school.events.each(&:destroy!)
+        predecessor_school.school_partnerships.each(&:destroy!)
+        predecessor_school.destroy!
+      end
 
       true
     end

--- a/app/services/gias/reconciliation/merge.rb
+++ b/app/services/gias/reconciliation/merge.rb
@@ -34,10 +34,10 @@ module GIAS::Reconciliation
             ECTAtSchoolPeriods::Transfer.call(ect_at_school_period:, predecessor_school:, successor_school:)
           end
 
-          destroy_predecessor_school_events!
-          destroy_predecessor_school_partnerships!
           destroy_predecessor_school_metadata!
-          destroy_predecessor_school!
+          predecessor_school.events.each(&:destroy!)
+          predecessor_school.school_partnerships.each(&:destroy!)
+          predecessor_school.destroy!
 
           record_school_merged_event!
         end
@@ -71,21 +71,9 @@ module GIAS::Reconciliation
       )
     end
 
-    def destroy_predecessor_school_partnerships!
-      predecessor_school.school_partnerships.destroy_all
-    end
-
     def destroy_predecessor_school_metadata!
       Metadata::SchoolContractPeriod.where(school_id: predecessor_school.id).delete_all
       Metadata::SchoolLeadProviderContractPeriod.where(school_id: predecessor_school.id).delete_all
-    end
-
-    def destroy_predecessor_school_events!
-      predecessor_school.events.destroy_all
-    end
-
-    def destroy_predecessor_school!
-      predecessor_school.destroy!
     end
 
     def record_school_merged_event!

--- a/app/services/gias/reconciliation/merge.rb
+++ b/app/services/gias/reconciliation/merge.rb
@@ -30,6 +30,10 @@ module GIAS::Reconciliation
           ECTAtSchoolPeriods::Transfer.call(ect_at_school_period:, predecessor_school:, successor_school:)
         end
 
+        destroy_events!
+        destroy_school_partnerships!
+        destroy_predecessor_school!
+
         record_school_merged_event!
       end
 
@@ -58,9 +62,21 @@ module GIAS::Reconciliation
       )
     end
 
+    def destroy_school_partnerships!
+      predecessor_school.school_partnerships.destroy_all
+    end
+
+    def destroy_events!
+      predecessor_school.events.destroy_all
+    end
+
+    def destroy_predecessor_school!
+      predecessor_school.destroy!
+    end
+
     def record_school_merged_event!
       Events::Record.record_school_merged_event!(
-        school: predecessor_school,
+        school: successor_school,
         successor_gias_school: successor,
         predecessor_gias_school: gias_school,
         happened_at: closed_on,

--- a/spec/services/gias/reconciliation/eligibility_spec.rb
+++ b/spec/services/gias/reconciliation/eligibility_spec.rb
@@ -267,14 +267,6 @@ RSpec.describe GIAS::Reconciliation::Eligibility do
         it { is_expected.to be false }
       end
 
-      context "when a merged event has already been recorded" do
-        before do
-          FactoryBot.create(:event, event_type: :school_merged, school: gias_school.school)
-        end
-
-        it { is_expected.to be false }
-      end
-
       context "when the link represents an amalgamation" do
         let(:link_type) { :successor_amalgamated }
 

--- a/spec/services/gias/reconciliation/merge_spec.rb
+++ b/spec/services/gias/reconciliation/merge_spec.rb
@@ -3,6 +3,9 @@ RSpec.describe GIAS::Reconciliation::Merge do
 
   let(:gias_school) { FactoryBot.create(:gias_school, :with_school, :closed) }
   let(:successor_gias_school) { FactoryBot.create(:gias_school, :with_school, :open) }
+  let(:predecessor_school) { gias_school.school }
+  let(:successor_school) { successor_gias_school.school }
+
   let!(:school_link) do
     FactoryBot.create(
       :gias_school_link,
@@ -11,13 +14,36 @@ RSpec.describe GIAS::Reconciliation::Merge do
       to_gias_school: successor_gias_school
     )
   end
+
+  let(:mentor_at_two_schools_teacher) { FactoryBot.create(:teacher) }
+  let!(:overlapping_mentor_at_school_period_1) do
+    FactoryBot.create(
+      :mentor_at_school_period,
+      teacher: mentor_at_two_schools_teacher,
+      school: predecessor_school,
+      started_on: 1.year.ago
+    )
+  end
+  let!(:overlapping_mentor_at_school_period_2) do
+    FactoryBot.create(
+      :mentor_at_school_period,
+      teacher: mentor_at_two_schools_teacher,
+      school: successor_school,
+      started_on: 6.months.ago
+    )
+  end
+  let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, school: predecessor_school) }
+  let!(:ect_at_school_period) do
+    FactoryBot.create(
+      :ect_at_school_period,
+      school: predecessor_school
+    )
+  end
+
   let(:eligibility) { instance_double(GIAS::Reconciliation::Eligibility) }
 
   describe "#merge!" do
     subject(:merge!) { service.merge! }
-
-    let(:predecessor_school) { gias_school.school }
-    let(:successor_school) { successor_gias_school.school }
 
     before do
       allow(GIAS::Reconciliation::Eligibility).to receive(:new).with(gias_school).and_return(eligibility)
@@ -58,55 +84,51 @@ RSpec.describe GIAS::Reconciliation::Merge do
 
         merge!
       end
+
+      it "does not destroy any events associated with the predecessor school" do
+        FactoryBot.create(:event, school: predecessor_school)
+
+        expect { merge! }.not_to(change { predecessor_school.events.count })
+      end
+
+      it "does not destroy any school_partnerships associated with the predecessor school" do
+        FactoryBot.create(:school_partnership, school: predecessor_school)
+
+        expect { merge! }.not_to(change { predecessor_school.school_partnerships.count })
+      end
+
+      it "does not destroy the predecessor school" do
+        expect { merge! }.not_to change { School.exists?(predecessor_school.id) }.from(true)
+      end
     end
 
     context "when the GIAS school can be merged" do
       let(:gias_school_can_be_merged?) { true }
 
-      let(:predecessor_school) { FactoryBot.create(:school) }
-      let(:gias_school) do
-        FactoryBot.create(
-          :gias_school,
-          :with_school,
-          :closed,
-          school: predecessor_school
-        )
-      end
-
-      let(:mentor_teacher) { FactoryBot.create(:teacher) }
-      let!(:mentor_at_school_period) do
-        FactoryBot.create(
-          :mentor_at_school_period,
-          teacher: mentor_teacher,
-          school: predecessor_school
-        )
-      end
-      let!(:ect_at_school_period) do
-        FactoryBot.create(
-          :ect_at_school_period,
-          school: predecessor_school
-        )
-      end
-
       before do
-        allow(GIAS::Reconciliation::MentorAtSchoolPeriods::Overlapping)
-          .to receive(:find)
-          .and_return([[mentor_at_school_period]])
-        allow(GIAS::Reconciliation::MentorAtSchoolPeriods::Merge).to receive(:call)
-        allow(GIAS::Reconciliation::MentorAtSchoolPeriods::Transfer).to receive(:call)
-        allow(GIAS::Reconciliation::ECTAtSchoolPeriods::Transfer).to receive(:call)
+        allow(GIAS::Reconciliation::MentorAtSchoolPeriods::Overlapping).to receive(:find).and_call_original
+        allow(GIAS::Reconciliation::MentorAtSchoolPeriods::Merge).to receive(:call).and_call_original
+        allow(GIAS::Reconciliation::MentorAtSchoolPeriods::Transfer).to receive(:call).and_call_original
+        allow(GIAS::Reconciliation::ECTAtSchoolPeriods::Transfer).to receive(:call).and_call_original
         allow(Events::Record).to receive(:record_school_merged_event!)
       end
 
       it { expect(merge!).to be_truthy }
 
-      it "finds overlapping `MentorAtSchoolPeriod` records for each mentor teacher" do
+      it "finds overlapping `MentorAtSchoolPeriod` records for each teacher mentoring at the school" do
         merge!
 
         expect(GIAS::Reconciliation::MentorAtSchoolPeriods::Overlapping)
           .to have_received(:find)
           .with(
-            teacher: mentor_teacher,
+            teacher: mentor_at_two_schools_teacher,
+            schools: [predecessor_school, successor_school]
+          )
+
+        expect(GIAS::Reconciliation::MentorAtSchoolPeriods::Overlapping)
+          .to have_received(:find)
+          .with(
+            teacher: mentor_at_school_period.teacher,
             schools: [predecessor_school, successor_school]
           )
       end
@@ -117,7 +139,7 @@ RSpec.describe GIAS::Reconciliation::Merge do
         expect(GIAS::Reconciliation::MentorAtSchoolPeriods::Merge)
           .to have_received(:call)
           .with(
-            periods: [mentor_at_school_period],
+            periods: [overlapping_mentor_at_school_period_1, overlapping_mentor_at_school_period_2],
             predecessor_school:,
             successor_school:
           )
@@ -147,13 +169,29 @@ RSpec.describe GIAS::Reconciliation::Merge do
           )
       end
 
+      it "deletes any events associated with the predecessor school" do
+        event = FactoryBot.create(:event, school: predecessor_school)
+
+        expect { merge! }.to change { Event.exists?(event.id) }.from(true).to(false)
+      end
+
+      it "destroys any school_partnerships associated with the predecessor school" do
+        school_partnership = FactoryBot.create(:school_partnership, school: predecessor_school)
+
+        expect { merge! }.to change { SchoolPartnership.exists?(school_partnership.id) }.from(true).to(false)
+      end
+
+      it "destroys the school" do
+        expect { merge! }.to change { School.exists?(predecessor_school.id) }.from(true).to(false)
+      end
+
       it "records a school merged event" do
         merge!
 
         expect(Events::Record)
           .to have_received(:record_school_merged_event!)
           .with(
-            school: predecessor_school,
+            school: successor_school,
             successor_gias_school:,
             predecessor_gias_school: gias_school,
             happened_at: gias_school.closed_on,

--- a/spec/services/gias/reconciliation/merge_spec.rb
+++ b/spec/services/gias/reconciliation/merge_spec.rb
@@ -17,23 +17,6 @@ RSpec.describe GIAS::Reconciliation::Merge do
     )
   end
 
-  let(:mentor_at_two_schools_teacher) { FactoryBot.create(:teacher) }
-  let!(:overlapping_mentor_at_school_period_1) do
-    FactoryBot.create(
-      :mentor_at_school_period,
-      teacher: mentor_at_two_schools_teacher,
-      school: predecessor_school,
-      started_on: 1.year.ago
-    )
-  end
-  let!(:overlapping_mentor_at_school_period_2) do
-    FactoryBot.create(
-      :mentor_at_school_period,
-      teacher: mentor_at_two_schools_teacher,
-      school: successor_school,
-      started_on: 6.months.ago
-    )
-  end
   let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, school: predecessor_school) }
   let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, school: predecessor_school) }
 
@@ -41,7 +24,6 @@ RSpec.describe GIAS::Reconciliation::Merge do
 
   let(:school_metadata_handler) { instance_spy(Metadata::Handlers::School) }
   let(:teacher_metadata_handler) { instance_spy(Metadata::Handlers::Teacher) }
-  let(:teachers) { [mentor_at_two_schools_teacher, mentor_at_school_period.teacher, ect_at_school_period.teacher] }
 
   describe "#merge!" do
     subject(:merge!) { service.merge! }
@@ -162,46 +144,109 @@ RSpec.describe GIAS::Reconciliation::Merge do
 
       it { expect(merge!).to be_truthy }
 
-      it "finds overlapping `MentorAtSchoolPeriod` records for each teacher mentoring at the school" do
-        merge!
+      context "when the successor school does not have a school record" do
+        let(:successor_gias_school) { FactoryBot.create(:gias_school, :open) }
 
-        expect(GIAS::Reconciliation::MentorAtSchoolPeriods::Overlapping)
-          .to have_received(:find)
-          .with(
+        it "creates a school record for the successor GIAS school" do
+          merge!
+
+          expect(successor_gias_school.reload.school).to be_present
+        end
+
+        it "records a school opened event for the successor GIAS school" do
+          allow(Events::Record).to receive(:record_school_opened_event!)
+
+          merge!
+
+          expect(Events::Record)
+            .to have_received(:record_school_opened_event!)
+            .with(
+              school: successor_gias_school.reload.school,
+              gias_school: successor_gias_school,
+              happened_at: gias_school.closed_on,
+              author: an_instance_of(Events::SystemAuthor)
+            )
+        end
+
+        it "does not merge any records because there are none at the successor school" do
+          expect(GIAS::Reconciliation::MentorAtSchoolPeriods::Merge).not_to receive(:call)
+
+          merge!
+        end
+
+        it "transfers all `MentorAtSchoolPeriod` records" do
+          merge!
+
+          expect(GIAS::Reconciliation::MentorAtSchoolPeriods::Transfer)
+            .to have_received(:call)
+            .with(
+              mentor_at_school_period:,
+              predecessor_school:,
+              successor_school:
+            )
+        end
+      end
+
+      context "when the successor school already has a school record" do
+        let(:mentor_at_two_schools_teacher) { FactoryBot.create(:teacher) }
+        let!(:overlapping_mentor_at_school_period_1) do
+          FactoryBot.create(
+            :mentor_at_school_period,
             teacher: mentor_at_two_schools_teacher,
-            schools: [predecessor_school, successor_school]
+            school: predecessor_school,
+            started_on: 1.year.ago
           )
-
-        expect(GIAS::Reconciliation::MentorAtSchoolPeriods::Overlapping)
-          .to have_received(:find)
-          .with(
-            teacher: mentor_at_school_period.teacher,
-            schools: [predecessor_school, successor_school]
+        end
+        let!(:overlapping_mentor_at_school_period_2) do
+          FactoryBot.create(
+            :mentor_at_school_period,
+            teacher: mentor_at_two_schools_teacher,
+            school: successor_school,
+            started_on: 6.months.ago
           )
-      end
+        end
 
-      it "merges overlapping `MentorAtSchoolPeriod` records" do
-        merge!
+        it "finds overlapping `MentorAtSchoolPeriod` records for each teacher mentoring at the school" do
+          merge!
 
-        expect(GIAS::Reconciliation::MentorAtSchoolPeriods::Merge)
-          .to have_received(:call)
-          .with(
-            periods: [overlapping_mentor_at_school_period_1, overlapping_mentor_at_school_period_2],
-            predecessor_school:,
-            successor_school:
-          )
-      end
+          expect(GIAS::Reconciliation::MentorAtSchoolPeriods::Overlapping)
+            .to have_received(:find)
+            .with(
+              teacher: mentor_at_two_schools_teacher,
+              schools: [predecessor_school, successor_school]
+            )
 
-      it "transfers remaining `MentorAtSchoolPeriod` records" do
-        merge!
+          expect(GIAS::Reconciliation::MentorAtSchoolPeriods::Overlapping)
+            .to have_received(:find)
+            .with(
+              teacher: mentor_at_school_period.teacher,
+              schools: [predecessor_school, successor_school]
+            )
+        end
 
-        expect(GIAS::Reconciliation::MentorAtSchoolPeriods::Transfer)
-          .to have_received(:call)
-          .with(
-            mentor_at_school_period:,
-            predecessor_school:,
-            successor_school:
-          )
+        it "merges overlapping `MentorAtSchoolPeriod` records" do
+          merge!
+
+          expect(GIAS::Reconciliation::MentorAtSchoolPeriods::Merge)
+            .to have_received(:call)
+            .with(
+              periods: [overlapping_mentor_at_school_period_1, overlapping_mentor_at_school_period_2],
+              predecessor_school:,
+              successor_school:
+            )
+        end
+
+        it "transfers remaining `MentorAtSchoolPeriod` records" do
+          merge!
+
+          expect(GIAS::Reconciliation::MentorAtSchoolPeriods::Transfer)
+            .to have_received(:call)
+            .with(
+              mentor_at_school_period:,
+              predecessor_school:,
+              successor_school:
+            )
+        end
       end
 
       it "transfers remaining `ECTAtSchoolPeriod` records" do
@@ -242,16 +287,19 @@ RSpec.describe GIAS::Reconciliation::Merge do
 
         merge!
 
-        teachers.each do |teacher|
-          expect(Metadata::Handlers::Teacher)
-            .to have_received(:new)
-            .with(teacher)
-            .once
-        end
+        expect(Metadata::Handlers::Teacher)
+          .to have_received(:new)
+          .with(mentor_at_school_period.teacher)
+          .once
+
+        expect(Metadata::Handlers::Teacher)
+          .to have_received(:new)
+          .with(ect_at_school_period.teacher)
+          .once
 
         expect(teacher_metadata_handler)
           .to have_received(:refresh_metadata!)
-          .exactly(teachers.count).times
+          .twice
       end
 
       context "when called with `refresh_metadata: false`" do
@@ -314,31 +362,6 @@ RSpec.describe GIAS::Reconciliation::Merge do
             happened_at: gias_school.closed_on,
             author: an_instance_of(Events::SystemAuthor)
           )
-      end
-
-      context "when the successor school does not have a school record" do
-        let(:successor_gias_school) { FactoryBot.create(:gias_school, :open) }
-
-        it "creates a school record for the successor GIAS school" do
-          expect { merge! }.to change(School, :count).by(1)
-
-          expect(successor_gias_school.reload.school).to be_present
-        end
-
-        it "records a school opened event for the successor GIAS school" do
-          allow(Events::Record).to receive(:record_school_opened_event!)
-
-          merge!
-
-          expect(Events::Record)
-            .to have_received(:record_school_opened_event!)
-            .with(
-              school: successor_gias_school.reload.school,
-              gias_school: successor_gias_school,
-              happened_at: gias_school.closed_on,
-              author: an_instance_of(Events::SystemAuthor)
-            )
-        end
       end
     end
   end

--- a/spec/services/gias/reconciliation/merge_spec.rb
+++ b/spec/services/gias/reconciliation/merge_spec.rb
@@ -1,7 +1,5 @@
 RSpec.describe GIAS::Reconciliation::Merge do
-  subject(:service) { described_class.new(gias_school, refresh_metadata:) }
-
-  let(:refresh_metadata) { true }
+  subject(:service) { described_class.new(gias_school) }
 
   let(:gias_school) { FactoryBot.create(:gias_school, :with_school, :closed) }
   let(:successor_gias_school) { FactoryBot.create(:gias_school, :with_school, :open) }
@@ -21,9 +19,6 @@ RSpec.describe GIAS::Reconciliation::Merge do
   let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, school: predecessor_school) }
 
   let(:eligibility) { instance_double(GIAS::Reconciliation::Eligibility) }
-
-  let(:school_metadata_handler) { instance_spy(Metadata::Handlers::School) }
-  let(:teacher_metadata_handler) { instance_spy(Metadata::Handlers::Teacher) }
 
   describe "#merge!" do
     subject(:merge!) { service.merge! }
@@ -68,18 +63,6 @@ RSpec.describe GIAS::Reconciliation::Merge do
         merge!
       end
 
-      it "does not refresh the school metadata" do
-        expect(Metadata::Handlers::School).not_to receive(:new)
-
-        merge!
-      end
-
-      it "does not refresh the metadata for any teachers mentoring at the school" do
-        expect(Metadata::Handlers::Teacher).not_to receive(:new)
-
-        merge!
-      end
-
       it "does not destroy the predecessor school" do
         merge!
 
@@ -103,30 +86,6 @@ RSpec.describe GIAS::Reconciliation::Merge do
           merge!
 
           expect(SchoolPartnership).to exist(school_partnership.id)
-        end
-      end
-
-      context "when there is school_contract_period metadata associated with the predecessor school" do
-        let!(:school_contract_period) do
-          FactoryBot.create(:school_contract_period_metadata, school: predecessor_school)
-        end
-
-        it "does not destroy any school_contract_period metadata associated with the predecessor school" do
-          merge!
-
-          expect(Metadata::SchoolContractPeriod).to exist(school_contract_period.id)
-        end
-      end
-
-      context "when there is school_lead_provider_contract_period metadata associated with the predecessor school" do
-        let!(:school_lead_provider_contract_period) do
-          FactoryBot.create(:school_lead_provider_contract_period_metadata, school: predecessor_school)
-        end
-
-        it "does not destroy any school_lead_provider_contract_period metadata associated with the predecessor school" do
-          merge!
-
-          expect(Metadata::SchoolLeadProviderContractPeriod).to exist(school_lead_provider_contract_period.id)
         end
       end
     end
@@ -267,52 +226,6 @@ RSpec.describe GIAS::Reconciliation::Merge do
         expect(School).not_to exist(predecessor_school.id)
       end
 
-      it "does not call any metadata refresh handlers during the process" do
-        expect(Metadata::Resolver).not_to receive(:resolve_handler)
-
-        merge!
-      end
-
-      it "refreshes the school's metadata after the update" do
-        allow(Metadata::Handlers::School).to receive(:new).and_return(school_metadata_handler)
-        expect(school_metadata_handler).to receive(:refresh_metadata!)
-
-        merge!
-      end
-
-      it "refreshes the metadata for each teacher mentoring at the school after the update" do
-        allow(Metadata::Handlers::Teacher)
-          .to receive(:new)
-          .and_return(teacher_metadata_handler)
-
-        merge!
-
-        expect(Metadata::Handlers::Teacher)
-          .to have_received(:new)
-          .with(mentor_at_school_period.teacher)
-          .once
-
-        expect(Metadata::Handlers::Teacher)
-          .to have_received(:new)
-          .with(ect_at_school_period.teacher)
-          .once
-
-        expect(teacher_metadata_handler)
-          .to have_received(:refresh_metadata!)
-          .twice
-      end
-
-      context "when called with `refresh_metadata: false`" do
-        let(:refresh_metadata) { false }
-
-        it "does not refresh any metadata" do
-          expect(Metadata::Handlers::School).not_to receive(:new)
-          expect(Metadata::Handlers::Teacher).not_to receive(:new)
-
-          merge!
-        end
-      end
-
       context "when there are events associated with the predecessor school" do
         let!(:event) { FactoryBot.create(:event, school: predecessor_school) }
 
@@ -330,23 +243,6 @@ RSpec.describe GIAS::Reconciliation::Merge do
           merge!
 
           expect(SchoolPartnership).not_to exist(school_partnership.id)
-        end
-      end
-
-      context "when there is metadata associated with the predecessor school" do
-        let!(:school_contract_period) { FactoryBot.create(:school_contract_period_metadata, school: predecessor_school) }
-        let!(:school_lead_provider_contract_period) { FactoryBot.create(:school_lead_provider_contract_period_metadata, school: predecessor_school) }
-
-        it "destroys any school_contract_period metadata associated with the predecessor school" do
-          merge!
-
-          expect(Metadata::SchoolContractPeriod).not_to exist(school_contract_period.id)
-        end
-
-        it "destroys any school_lead_provider_contract_period metadata associated with the predecessor school" do
-          merge!
-
-          expect(Metadata::SchoolLeadProviderContractPeriod).not_to exist(school_lead_provider_contract_period.id)
         end
       end
 

--- a/spec/services/gias/reconciliation/merge_spec.rb
+++ b/spec/services/gias/reconciliation/merge_spec.rb
@@ -1,5 +1,7 @@
 RSpec.describe GIAS::Reconciliation::Merge do
-  subject(:service) { described_class.new(gias_school) }
+  subject(:service) { described_class.new(gias_school, refresh_metadata:) }
+
+  let(:refresh_metadata) { true }
 
   let(:gias_school) { FactoryBot.create(:gias_school, :with_school, :closed) }
   let(:successor_gias_school) { FactoryBot.create(:gias_school, :with_school, :open) }
@@ -33,14 +35,13 @@ RSpec.describe GIAS::Reconciliation::Merge do
     )
   end
   let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, school: predecessor_school) }
-  let!(:ect_at_school_period) do
-    FactoryBot.create(
-      :ect_at_school_period,
-      school: predecessor_school
-    )
-  end
+  let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, school: predecessor_school) }
 
   let(:eligibility) { instance_double(GIAS::Reconciliation::Eligibility) }
+
+  let(:school_metadata_handler) { instance_spy(Metadata::Handlers::School) }
+  let(:teacher_metadata_handler) { instance_spy(Metadata::Handlers::Teacher) }
+  let(:teachers) { [mentor_at_two_schools_teacher, mentor_at_school_period.teacher, ect_at_school_period.teacher] }
 
   describe "#merge!" do
     subject(:merge!) { service.merge! }
@@ -85,20 +86,66 @@ RSpec.describe GIAS::Reconciliation::Merge do
         merge!
       end
 
-      it "does not destroy any events associated with the predecessor school" do
-        FactoryBot.create(:event, school: predecessor_school)
+      it "does not refresh the school metadata" do
+        expect(Metadata::Handlers::School).not_to receive(:new)
 
-        expect { merge! }.not_to(change { predecessor_school.events.count })
+        merge!
       end
 
-      it "does not destroy any school_partnerships associated with the predecessor school" do
-        FactoryBot.create(:school_partnership, school: predecessor_school)
+      it "does not refresh the metadata for any teachers mentoring at the school" do
+        expect(Metadata::Handlers::Teacher).not_to receive(:new)
 
-        expect { merge! }.not_to(change { predecessor_school.school_partnerships.count })
+        merge!
       end
 
       it "does not destroy the predecessor school" do
-        expect { merge! }.not_to change { School.exists?(predecessor_school.id) }.from(true)
+        merge!
+
+        expect(School).to exist(predecessor_school.id)
+      end
+
+      context "when there are events associated with the predecessor school" do
+        let!(:event) { FactoryBot.create(:event, school: predecessor_school) }
+
+        it "does not destroy any events associated with the predecessor school" do
+          merge!
+
+          expect(Event).to exist(event.id)
+        end
+      end
+
+      context "when there are school_partnerships associated with the predecessor school" do
+        let!(:school_partnership) { FactoryBot.create(:school_partnership, school: predecessor_school) }
+
+        it "does not destroy any school_partnerships associated with the predecessor school" do
+          merge!
+
+          expect(SchoolPartnership).to exist(school_partnership.id)
+        end
+      end
+
+      context "when there is school_contract_period metadata associated with the predecessor school" do
+        let!(:school_contract_period) do
+          FactoryBot.create(:school_contract_period_metadata, school: predecessor_school)
+        end
+
+        it "does not destroy any school_contract_period metadata associated with the predecessor school" do
+          merge!
+
+          expect(Metadata::SchoolContractPeriod).to exist(school_contract_period.id)
+        end
+      end
+
+      context "when there is school_lead_provider_contract_period metadata associated with the predecessor school" do
+        let!(:school_lead_provider_contract_period) do
+          FactoryBot.create(:school_lead_provider_contract_period_metadata, school: predecessor_school)
+        end
+
+        it "does not destroy any school_lead_provider_contract_period metadata associated with the predecessor school" do
+          merge!
+
+          expect(Metadata::SchoolLeadProviderContractPeriod).to exist(school_lead_provider_contract_period.id)
+        end
       end
     end
 
@@ -169,20 +216,90 @@ RSpec.describe GIAS::Reconciliation::Merge do
           )
       end
 
-      it "deletes any events associated with the predecessor school" do
-        event = FactoryBot.create(:event, school: predecessor_school)
+      it "destroys the predecessor school" do
+        merge!
 
-        expect { merge! }.to change { Event.exists?(event.id) }.from(true).to(false)
+        expect(School).not_to exist(predecessor_school.id)
       end
 
-      it "destroys any school_partnerships associated with the predecessor school" do
-        school_partnership = FactoryBot.create(:school_partnership, school: predecessor_school)
+      it "does not call any metadata refresh handlers during the process" do
+        expect(Metadata::Resolver).not_to receive(:resolve_handler)
 
-        expect { merge! }.to change { SchoolPartnership.exists?(school_partnership.id) }.from(true).to(false)
+        merge!
       end
 
-      it "destroys the school" do
-        expect { merge! }.to change { School.exists?(predecessor_school.id) }.from(true).to(false)
+      it "refreshes the school's metadata after the update" do
+        allow(Metadata::Handlers::School).to receive(:new).and_return(school_metadata_handler)
+        expect(school_metadata_handler).to receive(:refresh_metadata!)
+
+        merge!
+      end
+
+      it "refreshes the metadata for each teacher mentoring at the school after the update" do
+        allow(Metadata::Handlers::Teacher)
+          .to receive(:new)
+          .and_return(teacher_metadata_handler)
+
+        merge!
+
+        teachers.each do |teacher|
+          expect(Metadata::Handlers::Teacher)
+            .to have_received(:new)
+            .with(teacher)
+            .once
+        end
+
+        expect(teacher_metadata_handler)
+          .to have_received(:refresh_metadata!)
+          .exactly(teachers.count).times
+      end
+
+      context "when called with `refresh_metadata: false`" do
+        let(:refresh_metadata) { false }
+
+        it "does not refresh any metadata" do
+          expect(Metadata::Handlers::School).not_to receive(:new)
+          expect(Metadata::Handlers::Teacher).not_to receive(:new)
+
+          merge!
+        end
+      end
+
+      context "when there are events associated with the predecessor school" do
+        let!(:event) { FactoryBot.create(:event, school: predecessor_school) }
+
+        it "deletes any events associated with the predecessor school" do
+          merge!
+
+          expect(Event).not_to exist(school_id: predecessor_school.id)
+        end
+      end
+
+      context "when there are school_partnerships associated with the predecessor school" do
+        let!(:school_partnership) { FactoryBot.create(:school_partnership, school: predecessor_school) }
+
+        it "destroys any school_partnerships associated with the predecessor school" do
+          merge!
+
+          expect(SchoolPartnership).not_to exist(school_partnership.id)
+        end
+      end
+
+      context "when there is metadata associated with the predecessor school" do
+        let!(:school_contract_period) { FactoryBot.create(:school_contract_period_metadata, school: predecessor_school) }
+        let!(:school_lead_provider_contract_period) { FactoryBot.create(:school_lead_provider_contract_period_metadata, school: predecessor_school) }
+
+        it "destroys any school_contract_period metadata associated with the predecessor school" do
+          merge!
+
+          expect(Metadata::SchoolContractPeriod).not_to exist(school_contract_period.id)
+        end
+
+        it "destroys any school_lead_provider_contract_period metadata associated with the predecessor school" do
+          merge!
+
+          expect(Metadata::SchoolLeadProviderContractPeriod).not_to exist(school_lead_provider_contract_period.id)
+        end
       end
 
       it "records a school merged event" do


### PR DESCRIPTION
### Context

In discussion of cleaning up historic data from merged schools it became clear that there was an omission in the `GIAS::Reconciliation::Merge` service.  Once merged, the `school` record of the closed school, along with associated `school_partnerships` and `events` should be removed from the database.

This PR adds this functionality so that as changes occur we clean up the database, and so that it can be used to clean up the data from before the service launched.

### Changes proposed in this pull request

Add methods to `GIAS::Reconciliation::Merge` to destroy all related partnerships and events, as well as the predecessor school itself.

Record the school merged event against the successor school

Correct mocking and test setup:
The tests had been setup so that the service which detects overlapping periods returns one `mentor_at_school_period`.  This is not possible because one period cannot overlap itself.  So the tests are now setup so that there are two overlapping periods. 
Secondly, if overlapping periods are returned, then they would be merged at the successor school.  We then test that any _remaining_ periods (which don't overlap) are then transferred to the successor.  The mocks had set the transfer service and merge service to use the same mentor period.  This is corrected, so we have setup 3 mentor periods.
Thirdly, we need to call the original services in order to allow the service to delete the school.  If there are mentors or ECTs left at the school, we cannot delete it.  Mocking the processes which merge and transfer the periods seems overkill, so making this a straightforward integration test seems to me the best path forward.  
Fourthly, now the mocking has been altered we need to make a couple of adjustments for the scenario where the successor school has to be opened.  In this case there can be no periods at the successor school and so there can be no overlapping mentor periods.

### Guidance to review
Run the merge service from the console on Monster's College and see that it is merged into the School of Excellence and deleted.  