### PR TITLE
Remove `role="main"` from `<main>` element

### DIFF
--- a/app/views/layouts/api_docs.html.erb
+++ b/app/views/layouts/api_docs.html.erb
@@ -13,7 +13,7 @@
     <div class="govuk-width-container">
       <%= yield(:backlink_or_breadcrumb) %>
 
-      <main class="govuk-main-wrapper" id="main-content" role="main">
+      <main class="govuk-main-wrapper" id="main-content">
         <%= render partial: "layouts/shared/main_preamble" %>
 
         <div class="govuk-grid-row">

--- a/app/views/layouts/api_guidance.html.erb
+++ b/app/views/layouts/api_guidance.html.erb
@@ -9,7 +9,7 @@
     <div class="govuk-width-container">
       <%= yield(:backlink_or_breadcrumb) %>
 
-      <main class="govuk-main-wrapper" id="main-content" role="main">
+      <main class="govuk-main-wrapper" id="main-content">
         <%= render partial: "layouts/shared/main_preamble" %>
 
         <div class="govuk-grid-row govuk-!-padding-top-7">

--- a/app/views/layouts/api_home.html.erb
+++ b/app/views/layouts/api_home.html.erb
@@ -7,7 +7,7 @@
       <%= render partial: "layouts/shared/header", locals: { inverse: true } %>
     </div>
 
-    <main class="govuk-main-wrapper" id="main-content" role="main">
+    <main class="govuk-main-wrapper" id="main-content">
       <div class="x-govuk-masthead">
         <div class="govuk-width-container">
           <div class="govuk-grid-row">

--- a/app/views/layouts/shared/_page.html.erb
+++ b/app/views/layouts/shared/_page.html.erb
@@ -15,7 +15,7 @@
         <%= yield(:backlink_or_breadcrumb) %>
       </div>
 
-      <main class="govuk-main-wrapper" id="main-content" role="main">
+      <main class="govuk-main-wrapper" id="main-content">
         <%= render partial: "layouts/shared/main_preamble" %>
 
         <%= yield(:content) %>

--- a/maintenance_page/html/index.html
+++ b/maintenance_page/html/index.html
@@ -46,7 +46,7 @@
       </div>
     </header>
     <div class="govuk-width-container">
-      <main class="govuk-main-wrapper" id="main-content" role="main">
+      <main class="govuk-main-wrapper" id="main-content">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">
             <h1 class="govuk-heading-l">Sorry, the service is unavailable</h1>


### PR DESCRIPTION
This is no longer needed as <main>'s default role is "main".

It used to be done on GOV.UK services to provide some backwards compatibility with legacy screen readers, but now GOV.UK doesn't do it and it's been removed from the Design System documentation.
