### PR TITLE
[3544] Automate heading hierarchy checks in feature specs

### DIFF
--- a/spec/lib/heading_hierarchy_matcher_spec.rb
+++ b/spec/lib/heading_hierarchy_matcher_spec.rb
@@ -1,0 +1,75 @@
+RSpec.describe "have_valid_heading_hierarchy" do
+  let(:page) { instance_double(Playwright::Page, content: html) }
+
+  context "when heading levels increase one level at a time" do
+    let(:html) do
+      <<~HTML
+        <h1>Page title</h1>
+        <h2>Section</h2>
+        <h3>Subsection</h3>
+        <h2>Another section</h2>
+      HTML
+    end
+
+    it "passes" do
+      expect(page).to have_valid_heading_hierarchy
+    end
+  end
+
+  context "when a level 2 heading appears before the level 1 heading" do
+    let(:html) do
+      <<~HTML
+        <h2>There is a problem</h2>
+        <h1>Page title</h1>
+      HTML
+    end
+
+    it "passes" do
+      expect(page).to have_valid_heading_hierarchy
+    end
+  end
+
+  context "when there is no level 1 heading" do
+    let(:html) do
+      <<~HTML
+        <h3>Subsection</h3>
+      HTML
+    end
+
+    it "fails" do
+      expect { expect(page).to have_valid_heading_hierarchy }
+        .to raise_error(RSpec::Expectations::ExpectationNotMetError, /expected one h1, but found 0/)
+    end
+  end
+
+  context "when there is more than one level 1 heading" do
+    let(:html) do
+      <<~HTML
+        <h1>Page title</h1>
+        <h1>Another page title</h1>
+      HTML
+    end
+
+    it "fails" do
+      expect { expect(page).to have_valid_heading_hierarchy }
+        .to raise_error(RSpec::Expectations::ExpectationNotMetError, /expected one h1, but found 2/)
+    end
+  end
+
+  context "when a heading level is skipped" do
+    let(:html) do
+      <<~HTML
+        <h1>Page title</h1>
+        <h3 class="govuk-visually-hidden">Subsection</h3>
+      HTML
+    end
+
+    it "fails with details of the headings either side of the skipped level" do
+      expect { expect(page).to have_valid_heading_hierarchy }
+        .to raise_error(
+          RSpec::Expectations::ExpectationNotMetError,
+          /h1 "Page title" was followed by h3 "Subsection"/
+        )
+    end
+  end
+end

--- a/spec/support/matchers/have_valid_heading_hierarchy_matcher.rb
+++ b/spec/support/matchers/have_valid_heading_hierarchy_matcher.rb
@@ -1,0 +1,36 @@
+RSpec::Matchers.define :have_valid_heading_hierarchy do
+  match do |page|
+    headings = Capybara.string(page.content)
+      .all("h1, h2, h3, h4, h5, h6", visible: :all)
+
+    @level_one_heading_count = headings.count { |heading| heading_level(heading) == 1 }
+    @skipped_levels = headings.each_cons(2).select do |previous_heading, heading|
+      heading_level(heading) > heading_level(previous_heading) + 1
+    end
+
+    @level_one_heading_count == 1 && @skipped_levels.empty?
+  end
+
+  failure_message do
+    violations = []
+    if @level_one_heading_count != 1
+      violations << "  expected one h1, but found #{@level_one_heading_count}"
+    end
+    violations.concat(@skipped_levels.map do |previous_heading, heading|
+      "  #{describe_heading(previous_heading)} was followed by #{describe_heading(heading)}"
+    end)
+
+    <<~MESSAGE.chomp
+      expected page to have a valid heading hierarchy, but found:
+      #{violations.join("\n")}
+    MESSAGE
+  end
+
+  def heading_level(heading)
+    heading.tag_name.delete_prefix("h").to_i
+  end
+
+  def describe_heading(heading)
+    %(#{heading.tag_name} "#{heading.text(normalize_ws: true)}")
+  end
+end

--- a/spec/support/testing_with_playwright.rb
+++ b/spec/support/testing_with_playwright.rb
@@ -27,8 +27,18 @@ RSpec.configure do |config|
 
   # Close Playwright page after each feature spec
   config.after(type: :feature) do |example|
+    heading_hierarchy_failure = nil
+
+    if example.exception.nil? && !page.closed?
+      begin
+        expect(page).to have_valid_heading_hierarchy
+      rescue RSpec::Expectations::ExpectationNotMetError => e
+        heading_hierarchy_failure = e
+      end
+    end
+
     # Take screenshots on failure for feature tests
-    if example.exception
+    if example.exception || heading_hierarchy_failure
       # Generate a filename based on the test
       filename = "#{example.metadata[:file_path].gsub(/[^0-9A-Za-z]/, '_')}_line#{example.metadata[:line_number]}_#{Time.zone.now.strftime('%Y%m%d%H%M%S')}.png"
       screenshot_path = SCREENSHOT_DIR.join(filename)
@@ -36,7 +46,7 @@ RSpec.configure do |config|
       # Take screenshot if page is available
       if defined?(page) && page.respond_to?(:screenshot)
         begin
-          page.screenshot(path: screenshot_path)
+          page.screenshot(path: screenshot_path.to_s)
           puts "\nScreenshot saved to: #{screenshot_path}"
         rescue StandardError => e
           puts "\nFailed to take screenshot: #{e.message}"
@@ -45,6 +55,8 @@ RSpec.configure do |config|
     end
 
     page.close
+
+    raise heading_hierarchy_failure if heading_hierarchy_failure
   end
 
   # Close Playwright browser after the suite's finished


### PR DESCRIPTION
## Context

Following on from the heading hierarchy clean up in #3364, this adds an automated check to help catch similar issues before they make it to production.

Before the heading fixes, this would have causes 26 feature spec to fail for 4 issues:

- ECT listing cards: 12 failures
- Mentor registration confirmation: 9 failures
- ECT start date: 2 failures
- Mentor listing cards: 3 failures

<details>
<summary>Example failure before the heading fixes</summary>

```text
expected page to have no skipped heading levels, but found:
  h1 "Early career teachers (ECT)" was followed by h3 "Jimmy Searchable"
```

</details>

Those issues are now resolved and the feature specs pass on this stacked branch.

## Approach

Rather than going all out with axe, this takes the simplest approach and checks that the final page contains a `<h1>` and doesn't skip heading levels.

The performance cost is negligible. On my machine, it added 0.84 seconds across 250 feature examples, or around 3.4ms each.

## Limitations

This only checks the page where each feature spec ends, so it won't catch issues on intermediate pages.

If we think it's useful, we could extend it to check intermediate pages too and get much better coverage but this is the first step towards a better future.