### PR TITLE
[3150] Remove redundant induction timeline link

### DIFF
--- a/app/views/admin/teachers/inductions/show.html.erb
+++ b/app/views/admin/teachers/inductions/show.html.erb
@@ -10,9 +10,10 @@
 
 <%= render 'admin/teachers/navigation', navigation_items: @navigation_items %>
 
-<% if admin_latest_induction_complete_with_outcome?(@teacher) %>
-  <%= govuk_button_link_to "Reopen induction", confirm_admin_teacher_reopen_induction_path(@teacher), warning: true %>
-<% end %>
+<% if @teacher.induction_periods.any? %>
+  <% if admin_latest_induction_complete_with_outcome?(@teacher) %>
+    <%= govuk_button_link_to "Reopen induction", confirm_admin_teacher_reopen_induction_path(@teacher), warning: true %>
+  <% end %>
 
 <%= render Teachers::DetailsComponent.new(mode: :admin, teacher: @teacher) do |component|
   component.with_induction_outcome_actions
@@ -20,12 +21,9 @@
   component.with_current_induction_period(enable_edit: true, enable_delete: true)
   component.with_past_induction_periods(enable_edit: true)
 end %>
+<% else %>
+  <p class="govuk-body">There is no induction history recorded for this teacher.</p>
 
-<p class="govuk-body">
-  <%= govuk_link_to('View change history', admin_teacher_timeline_path(@teacher)) %>
-</p>
-
-<% if @teacher.induction_periods.none? %>
   <p class="govuk-body">
     <%= govuk_link_to("Add an induction period", new_admin_teacher_induction_period_path(@teacher)) %>
   </p>

--- a/spec/views/admin/teachers/inductions/show.html.erb_spec.rb
+++ b/spec/views/admin/teachers/inductions/show.html.erb_spec.rb
@@ -32,10 +32,6 @@ RSpec.describe "admin/teachers/inductions/show.html.erb" do
     expect(view.content_for(:page_caption)).to have_text("TRN: 1234567")
   end
 
-  it "links to teacher timeline" do
-    expect(rendered).to have_link("View change history", href: admin_teacher_timeline_path(teacher))
-  end
-
   it "displays current induction period" do
     expect(rendered).to have_text("Current induction period")
   end
@@ -45,7 +41,11 @@ RSpec.describe "admin/teachers/inductions/show.html.erb" do
   end
 
   context "when there are no induction periods" do
-    before { teacher.induction_periods.destroy_all }
+    let!(:induction_period) { nil }
+
+    it "displays a message explaining there is no induction history" do
+      expect(rendered).to have_text("There is no induction history recorded for this teacher.")
+    end
 
     it "displays a link to add an induction period" do
       expect(rendered).to have_link("Add an induction period")


### PR DESCRIPTION
### Summary

- Remove the now redundant change history link from the induction tab
- Add an empty state when a teacher has no induction history