### PR TITLE
Rename MigrationFixes::Processor to Admin::DataFixes::Processor

### DIFF
--- a/app/services/admin/data_fixes/processor.rb
+++ b/app/services/admin/data_fixes/processor.rb
@@ -1,4 +1,4 @@
-class MigrationFixes::Processor
+class Admin::DataFixes::Processor
   Result = Data.define(:data_change, :target_object, :error) do
     def success? = error.nil?
   end

--- a/app/services/migration_fixes/spec_generator.rb
+++ b/app/services/migration_fixes/spec_generator.rb
@@ -38,7 +38,7 @@ class MigrationFixes::SpecGenerator
         end
 
         before do
-          result = MigrationFixes::Processor.new.process!(data_change: migration_fix)
+          result = Admin::DataFixes::Processor.new.process!(data_change: migration_fix)
           raise result.error unless result.success?
         end
 

--- a/db/scripts/migration_data_fixes.rb
+++ b/db/scripts/migration_data_fixes.rb
@@ -17,7 +17,7 @@ begin
   csv_file = Rails.root.join("db/scripts/migration_data_fixes.csv")
   csv_log = CSV.open(Rails.root.join("tmp/migration_data_fixes_log-#{Time.zone.now.to_fs(:iso8601)}.csv"), "w")
   csv_log << %w[object_type object_id action attributes errors]
-  processor = MigrationFixes::Processor.new(update_readonly_attrs:)
+  processor = Admin::DataFixes::Processor.new(update_readonly_attrs:)
 
   CSV.foreach(csv_file, headers: true, header_converters: :symbol) do |row|
     result = processor.process!(data_change: row.to_h)

--- a/knapsack_rspec_report.json
+++ b/knapsack_rspec_report.json
@@ -697,7 +697,7 @@
   "spec/services/api/release_note_spec.rb": 0.008862914000019373,
   "spec/views/admin/finance/active_lead_providers/lead_provider_delivery_partnerships/delete.html.erb_spec.rb": 0.05538250400013567,
   "spec/services/schools/access_blocker_spec.rb": 0.1945621630000005,
-  "spec/services/admin/data_fixes/processor_spec.rb": 0.533833980999816,
+  "spec/services/migration_fixes/processor_spec.rb": 0.533833980999816,
   "spec/features/schools/ects/register/edge_cases/appropriate_body_selection/independent_school_selects_istip_spec.rb": 1.191689737999923,
   "spec/views/errors/internal_server_error.html.erb_spec.rb": 0.007447897000020021,
   "spec/requests/api/v3/unfunded_mentors_spec.rb": 12.42776434300004,

--- a/knapsack_rspec_report.json
+++ b/knapsack_rspec_report.json
@@ -697,7 +697,7 @@
   "spec/services/api/release_note_spec.rb": 0.008862914000019373,
   "spec/views/admin/finance/active_lead_providers/lead_provider_delivery_partnerships/delete.html.erb_spec.rb": 0.05538250400013567,
   "spec/services/schools/access_blocker_spec.rb": 0.1945621630000005,
-  "spec/services/migration_fixes/processor_spec.rb": 0.533833980999816,
+  "spec/services/admin/data_fixes/processor_spec.rb": 0.533833980999816,
   "spec/features/schools/ects/register/edge_cases/appropriate_body_selection/independent_school_selects_istip_spec.rb": 1.191689737999923,
   "spec/views/errors/internal_server_error.html.erb_spec.rb": 0.007447897000020021,
   "spec/requests/api/v3/unfunded_mentors_spec.rb": 12.42776434300004,

--- a/spec/migration_fixes/real_examples/teacher_117308_spec.rb
+++ b/spec/migration_fixes/real_examples/teacher_117308_spec.rb
@@ -27,7 +27,7 @@ describe "Real data check for teacher 117308" do
     ]
   end
 
-  let(:processor) { MigrationFixes::Processor.new }
+  let(:processor) { Admin::DataFixes::Processor.new }
 
   before do
     migration_fixes.each do |data_change|

--- a/spec/migration_fixes/real_examples/teacher_210915_spec.rb
+++ b/spec/migration_fixes/real_examples/teacher_210915_spec.rb
@@ -141,7 +141,7 @@ describe "Real data check for teacher 210915 (missing training period and declar
     ]
   end
 
-  let(:processor) { MigrationFixes::Processor.new }
+  let(:processor) { Admin::DataFixes::Processor.new }
 
   before do
     migration_fixes.each do |data_change|

--- a/spec/migration_fixes/real_examples/teacher_34082_spec.rb
+++ b/spec/migration_fixes/real_examples/teacher_34082_spec.rb
@@ -70,7 +70,7 @@ describe "Real data check for teacher 34082" do
   end
 
   before do
-    processor = MigrationFixes::Processor.new
+    processor = Admin::DataFixes::Processor.new
 
     migration_fixes.each do |data_change|
       # convert from easy to read hash to string version as per CSV

--- a/spec/services/admin/data_fixes/processor/result_spec.rb
+++ b/spec/services/admin/data_fixes/processor/result_spec.rb
@@ -1,4 +1,4 @@
-describe MigrationFixes::Processor::Result do
+describe Admin::DataFixes::Processor::Result do
   let(:data_change) { { action: "update" } }
 
   describe "#success?" do

--- a/spec/services/admin/data_fixes/processor_spec.rb
+++ b/spec/services/admin/data_fixes/processor_spec.rb
@@ -1,4 +1,4 @@
-describe MigrationFixes::Processor do
+describe Admin::DataFixes::Processor do
   subject(:processor) { described_class.new }
 
   let!(:target_object) { FactoryBot.create(:training_period) }
@@ -112,7 +112,7 @@ describe MigrationFixes::Processor do
       it "returns a successful no-op result" do
         result = processor.process!(data_change: {})
 
-        expect(result).to be_a(MigrationFixes::Processor::Result)
+        expect(result).to be_a(Admin::DataFixes::Processor::Result)
         expect(result).to be_success
         expect(result.data_change).to eq({})
         expect(result.target_object).to be_nil


### PR DESCRIPTION
### Context
This PR renames and moves `MigrationFixes::Processor` to `Admin::DataFixes::Processor`

### Changes proposed in this pull request
- Rename MigrationFixes::Processor to Admin::DataFixes::Processor
- Move the processor and specs to the new namespace
- Update all callers and data example specs
- Update the processor spec path in the Knapsack report

### Guidance to review
- Confirm all processor references use `Admin::DataFixes::Processor`
- Other classes and files under MigrationFixes are intentionally unchanged
