### PR TITLE
Alias `dfe_sign_in_user_id` to `id` so it's picked up by dfe-analytics

### DIFF
--- a/app/services/sessions/users/appropriate_body_user.rb
+++ b/app/services/sessions/users/appropriate_body_user.rb
@@ -73,6 +73,12 @@ module Sessions
       # @return [Array<String>]
       alias_method :roles, :dfe_sign_in_roles
 
+      # dfe-analytics is configured to add the current_user#id to the web
+      # request log, so alias it here
+      #
+      # @return [String] the UUID returned by DfE Sign-in
+      alias_method :id, :dfe_sign_in_user_id
+
     private
 
       def appropriate_body_period_from(dfe_sign_in_organisation_id)

--- a/app/services/sessions/users/school_user.rb
+++ b/app/services/sessions/users/school_user.rb
@@ -76,6 +76,12 @@ module Sessions
       # @return [Array<String>]
       alias_method :roles, :dfe_sign_in_roles
 
+      # dfe-analytics is configured to add the current_user#id to the web
+      # request log, so alias it here
+      #
+      # @return [String] the UUID returned by DfE Sign-in
+      alias_method :id, :dfe_sign_in_user_id
+
     private
 
       def school_from(urn)

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ApplicationController, type: :controller do
 
     expect(Sentry).to have_received(:set_user).with(
       email:,
-      id: nil,
+      id: dfe_sign_in_user_id,
       dfe_sign_in_user_fingerprint:
     )
   end
@@ -47,7 +47,7 @@ RSpec.describe ApplicationController, type: :controller do
 
     expect(payload).to include(
       current_user_class: "Sessions::Users::SchoolUser",
-      current_user_id: nil,
+      current_user_id: dfe_sign_in_user_id,
       current_user_dfe_sign_in_user_fingerprint: dfe_sign_in_user_fingerprint
     )
     expect(payload).not_to have_key(:current_user_dfe_sign_in_user_id)

--- a/spec/services/sessions/users/appropriate_body_user_spec.rb
+++ b/spec/services/sessions/users/appropriate_body_user_spec.rb
@@ -72,6 +72,12 @@ RSpec.describe Sessions::Users::AppropriateBodyUser do
     end
   end
 
+  describe "#id" do
+    it "returns the id of the user in DfE SignIn" do
+      expect(appropriate_body_user.id).to eql(dfe_sign_in_user_id)
+    end
+  end
+
   describe "#has_authorised_role?" do
     it { expect(appropriate_body_user).to have_authorised_role }
   end

--- a/spec/services/sessions/users/school_user_spec.rb
+++ b/spec/services/sessions/users/school_user_spec.rb
@@ -73,6 +73,12 @@ RSpec.describe Sessions::Users::SchoolUser do
     end
   end
 
+  describe "#id" do
+    it "returns the id of the user in DfE SignIn" do
+      expect(school_user.id).to eql(dfe_sign_in_user_id)
+    end
+  end
+
   describe "user type methods" do
     it { expect(school_user).to be_school_user }
     it { expect(school_user).to be_dfe_sign_in_authorisable }


### PR DESCRIPTION
We are currently missing user identifiers for non-DfE staff in our analytics.

Our DfE Analytics setup has called `#id` on the `current_user` object since it was introduced.

This change adds an `id`->`dfe_sign_in_user_id` alias to:

* `Sessions::Users::SchoolUser`
* `Sessions::Users::AppropriateBodyUser`

Those classes represent users who sign in via DfE Sign-in, they don't have `#id` and instead use `#dfe_sign_in_user_id`.

Aliasing to `#id` provides a quick way to test this mapping to ensure dataflows through correctly.

## Next steps

If all is successful it will probably make things more robust if we replace the alias with `#dfe_analytics_user_id` so it's clearer (without needing comments) why we're doing it.

