### PR TITLE
Add timezones to recurring jobs

### DIFF
--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -26,12 +26,12 @@ production:
   touch_school_partnership_for_participants_currently_training_job:
     class: TouchSchoolPartnershipForParticipantsCurrentlyTrainingJob
     queue: default
-    schedule: every day at 00:01
+    schedule: every day at 00:01 UTC
 
   mark_statements_as_payable:
     class: Statements::MarkAsPayableJob
     queue: default
-    schedule: every day at 12am
+    schedule: every day at 12am UTC
 
   gias_import:
     class: GIASImportJob
@@ -59,7 +59,7 @@ sandbox:
   touch_school_partnership_for_participants_currently_training_job:
     class: TouchSchoolPartnershipForParticipantsCurrentlyTrainingJob
     queue: default
-    schedule: every day at 00:01
+    schedule: every day at 00:01 UTC
 
 staging:
   purge_pending_induction_submissions:
@@ -79,7 +79,7 @@ staging:
   touch_school_partnership_for_participants_currently_training_job:
     class: TouchSchoolPartnershipForParticipantsCurrentlyTrainingJob
     queue: default
-    schedule: every day at 00:01
+    schedule: every day at 00:01 UTC
 
 review:
   purge_pending_induction_submissions:
@@ -95,4 +95,4 @@ review:
   touch_school_partnership_for_participants_currently_training_job:
     class: TouchSchoolPartnershipForParticipantsCurrentlyTrainingJob
     queue: default
-    schedule: every day at 00:01
+    schedule: every day at 00:01 UTC


### PR DESCRIPTION
It turns out by default SolidQueue uses the Rails `config.timezone`, which we have set to `London`.

For most recurring jobs this doesn't really matter, but we have a couple of jobs that need to be ran at 12am each day and are actually running at 11pm the previous day due to BST:

- `TouchSchoolPartnershipForParticipantsCurrentlyTrainingJob` is working a day behind because of this (as it finds training periods that start today/finish yesterday in order to touch the partnership `api_updated_at`).
- `Statements::MarkAsPayable` will mark statements as payable two days after theiir `deadline_date` instead of the day after.

As SolidQueue uses `fugit` we can pass in the timezone for these jobs.
