### PR TITLE
Product team users can input a data fixes CSV

### DIFF
--- a/app/controllers/admin/data_fixes_controller.rb
+++ b/app/controllers/admin/data_fixes_controller.rb
@@ -1,0 +1,53 @@
+module Admin
+  class DataFixesController < AdminController
+    include WizardStoreRescuable
+
+    before_action :set_steps,
+                  :set_store,
+                  :set_wizard
+
+    before_action -> { redirect_to "/404", as: :not_found },
+                  unless: -> { wizard_class.step?(@current_step) }
+
+    before_action -> { @wizard.reset },
+                  if: -> { @current_step == :csv },
+                  unless: -> { wizard_class.step?(@previous_step) },
+                  only: :new
+
+    def new
+      render @current_step
+    end
+
+    def create
+      if @wizard.save!
+        redirect_to @wizard.next_step_path
+      else
+        render @current_step, status: :unprocessable_content
+      end
+    end
+
+  private
+
+    def authorised? = current_user&.dfe_user? && current_user.product_team?
+
+    def set_steps
+      @current_step = request.path.split("/").last.underscore.to_sym
+      @previous_step = request.referer&.split("/")&.last&.underscore&.to_sym
+    end
+
+    def set_store
+      @store = SessionRepository.new(session:, form_key: :admin_data_fixes_wizard)
+    end
+
+    def set_wizard
+      @wizard = wizard_class.new(
+        current_step: @current_step,
+        author: current_user,
+        step_params: params,
+        store: @store
+      )
+    end
+
+    def wizard_class = DataFixesWizard::Wizard
+  end
+end

--- a/app/services/admin/data_fixes/inline_csv.rb
+++ b/app/services/admin/data_fixes/inline_csv.rb
@@ -1,25 +1,22 @@
 module Admin::DataFixes
   class InlineCSV
-    class InvalidHeaderError < ArgumentError; end
-
     include ActiveModel::Model
     include ActiveModel::Attributes
     include ActiveModel::Validations
 
     HEADER_ROW = %w[object_type object_id action attributes].freeze
-    Row = Data.define(*HEADER_ROW)
 
     attribute :csv_string, :string
 
-    validates :csv_string, presence: true
+    validates :csv_string, presence: { message: "CSV can’t be blank" }
     validate :expected_headers
 
     def parse
       return false unless valid?
 
-      parsed_csv.map { Row.new(**it) }
+      parsed_csv.map(&:to_hash)
     rescue CSV::MalformedCSVError => _e
-      errors.add(:csv_string, "is malformed")
+      errors.add(:csv_string, "CSV is malformed")
       false
     end
 
@@ -29,7 +26,7 @@ module Admin::DataFixes
 
     def expected_headers
       if parsed_csv.headers != HEADER_ROW
-        errors.add(:csv_string, "has invalid headers")
+        errors.add(:csv_string, "CSV has invalid headers")
       end
     end
   end

--- a/app/views/admin/data_fixes/csv.html.erb
+++ b/app/views/admin/data_fixes/csv.html.erb
@@ -1,0 +1,19 @@
+<% page_data(
+    title: "Enter data fixes in CSV format",
+    header: false,
+    error: @wizard.current_step.errors.present?,
+    backlink_href: admin_path,
+) %>
+
+<%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |form| %>
+  <%= content_for(:error_summary) { form.govuk_error_summary } %>
+
+  <%= form.govuk_text_area(
+        :csv_string,
+        label: { text: "Enter data fixes in CSV format", tag: "h1", size: "l" },
+        hint: { text: "Include a header row: #{Admin::DataFixes::InlineCSV::HEADER_ROW.join(',')}" },
+        rows: 10
+      ) %>
+
+  <%= form.govuk_submit "Continue" %>
+<% end %>

--- a/app/views/admin/data_fixes/preview.html.erb
+++ b/app/views/admin/data_fixes/preview.html.erb
@@ -1,0 +1,4 @@
+<% page_data(
+    title: "Preview the proposed data fix",
+    backlink_href: @wizard.previous_step_path
+) %>

--- a/app/wizards/admin/data_fixes_wizard/csv_step.rb
+++ b/app/wizards/admin/data_fixes_wizard/csv_step.rb
@@ -1,0 +1,23 @@
+module Admin::DataFixesWizard
+  class CSVStep < Step
+    def self.permitted_params = %i[csv_string]
+
+    attribute :csv_string, :string
+
+    def previous_step = nil
+    def next_step = :preview
+
+    def save!
+      parsed_rows = inline_csv.parse
+      store.parsed_rows = parsed_rows if parsed_rows
+    end
+
+    delegate :errors, to: :inline_csv
+
+  private
+
+    def inline_csv
+      @inline_csv ||= Admin::DataFixes::InlineCSV.new(csv_string:)
+    end
+  end
+end

--- a/app/wizards/admin/data_fixes_wizard/preview_step.rb
+++ b/app/wizards/admin/data_fixes_wizard/preview_step.rb
@@ -1,0 +1,6 @@
+module Admin::DataFixesWizard
+  class PreviewStep < Step
+    def previous_step = :csv
+    def next_step = nil
+  end
+end

--- a/app/wizards/admin/data_fixes_wizard/step.rb
+++ b/app/wizards/admin/data_fixes_wizard/step.rb
@@ -1,0 +1,9 @@
+module Admin::DataFixesWizard
+  class Step < ApplicationWizardStep
+    def self.permitted_params = []
+
+  private
+
+    def pre_populate_attributes = nil
+  end
+end

--- a/app/wizards/admin/data_fixes_wizard/wizard.rb
+++ b/app/wizards/admin/data_fixes_wizard/wizard.rb
@@ -1,0 +1,32 @@
+module Admin
+  module DataFixesWizard
+    class Wizard < ApplicationWizard
+      steps do
+        [
+          {
+            csv: CSVStep,
+            preview: PreviewStep,
+            # confirmation: ConfirmationStep
+          }
+        ]
+      end
+
+      def self.step?(step_name) = Array(steps).first[step_name].present?
+
+      attr_accessor :store, :author
+
+      delegate :save!, to: :current_step
+      delegate :reset, to: :store
+
+      def current_step_path = step_path(current_step_name)
+      def next_step_path = step_path(current_step.next_step)
+      def previous_step_path = step_path(current_step.previous_step)
+
+    private
+
+      def step_path(step_name)
+        url_helpers.public_send("admin_data_fixes_#{step_name}_path")
+      end
+    end
+  end
+end

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -17,6 +17,12 @@ namespace :admin do
   end
   resources :batches, only: %i[index], path: "bulk" # all activity
 
+  constraints -> { Rails.application.config.enable_admin_data_fixes } do
+    namespace :data_fixes do
+      concerns :wizardable, wizard: Admin::DataFixesWizard
+    end
+  end
+
   resources :organisations, only: %i[index] do
     collection do
       resources :appropriate_bodies, only: %i[index show], path: "appropriate-bodies" do

--- a/spec/features/admin/data_fixes/paste_inline_csv_spec.rb
+++ b/spec/features/admin/data_fixes/paste_inline_csv_spec.rb
@@ -1,0 +1,92 @@
+RSpec.describe "Product team users can paste inline CSV to fix data" do
+  before { enable_admin_data_fixes_feature_flag }
+
+  it "validates CSV and redirects to preview step" do
+    given_i_am_signed_in_as_a_product_team_user
+    when_i_visit_the_admin_data_fixes_csv_page
+    then_i_see_the_csv_form
+
+    and_i_continue
+    then_i_see_an_error("CSV can’t be blank")
+
+    given_i_input_an_invalid_csv_string
+    and_i_continue
+    then_i_see_an_error("CSV is malformed")
+
+    given_i_input_a_valid_csv_string_with_invalid_headers
+    and_i_continue
+    then_i_see_an_error("CSV has invalid headers")
+
+    given_i_input_a_valid_csv_string_with_correct_headers
+    and_i_continue
+    then_i_am_taken_to_the_preview_page
+    and_the_preview_is_displayed
+  end
+
+private
+
+  def enable_admin_data_fixes_feature_flag
+    allow(Rails.application.config).to receive(:enable_admin_data_fixes).and_return(true)
+  end
+
+  def given_i_am_signed_in_as_a_product_team_user
+    sign_in_as_dfe_user(role: :product_team)
+  end
+
+  def when_i_visit_the_admin_data_fixes_csv_page
+    page.goto("/admin/data_fixes/csv")
+  end
+
+  def then_i_see_the_csv_form
+    heading = page.get_by_role("heading", name: "Enter data fixes in CSV format")
+    expect(heading).to be_visible
+  end
+
+  def given_i_input_an_invalid_csv_string
+    invalid_csv_rows = <<~ROWS
+      object_type,object_id,action,attributes
+      something,1,create,"unterminated,string
+    ROWS
+    input_csv_string(invalid_csv_rows)
+  end
+
+  def input_csv_string(rows)
+    page.get_by_label("Enter data fixes in CSV format").fill(rows)
+  end
+
+  def and_i_continue
+    page.get_by_role("button", name: "Continue", exact: true).click
+  end
+
+  def then_i_see_an_error(error_message)
+    error_summary = page.locator(".govuk-error-summary")
+    expect(error_summary).to have_text(error_message)
+  end
+
+  def given_i_input_a_valid_csv_string_with_invalid_headers
+    invalid_headers_rows = <<~ROWS
+      object_type,object_id,action,wrong_header
+      something,1,create,"attribute1,value1,attribute2,value2"
+      anotherthing,2,destroy,""
+    ROWS
+    input_csv_string(invalid_headers_rows)
+  end
+
+  def given_i_input_a_valid_csv_string_with_correct_headers
+    valid_rows = <<~ROWS
+      object_type,object_id,action,attributes
+      something,1,create,"attribute1,value1,attribute2,value2"
+      another_thing,2,destroy,""
+    ROWS
+    input_csv_string(valid_rows)
+  end
+
+  def then_i_am_taken_to_the_preview_page
+    expect(page).to have_path("/admin/data_fixes/preview")
+  end
+
+  def and_the_preview_is_displayed
+    heading = page.get_by_role("heading", name: "Preview the proposed data fix")
+    expect(heading).to be_visible
+  end
+end

--- a/spec/requests/admin/data_fixes_spec.rb
+++ b/spec/requests/admin/data_fixes_spec.rb
@@ -1,0 +1,158 @@
+RSpec.describe "Admin::DataFixesController" do
+  describe "GET #new" do
+    subject do
+      get path_for_step("csv")
+      response
+    end
+
+    before do
+      allow(Rails.application.config)
+        .to receive(:enable_admin_data_fixes)
+        .and_return(enable_admin_data_fixes)
+    end
+
+    context "when `enable_admin_data_fixes` is true" do
+      let(:enable_admin_data_fixes) { true }
+
+      context "when not signed in" do
+        it { is_expected.to redirect_to(sign_in_path) }
+      end
+
+      context "when signed in as a non-DfE user" do
+        include_context "sign in as non-DfE user"
+
+        it { is_expected.to have_http_status(:unauthorized) }
+      end
+
+      context "when signed in as a non-product DfE user" do
+        include_context "sign in as DfE user"
+
+        it { is_expected.to have_http_status(:unauthorized) }
+      end
+
+      context "when signed in as a product team user" do
+        include_context "sign in as product_team DfE user"
+
+        it { is_expected.to have_http_status(:ok) }
+      end
+    end
+
+    context "when `enable_admin_data_fixes` is false" do
+      let(:enable_admin_data_fixes) { false }
+
+      context "when not signed in" do
+        it { is_expected.to have_http_status(:not_found) }
+      end
+
+      context "when signed in as a non-DfE user" do
+        include_context "sign in as non-DfE user"
+
+        it { is_expected.to have_http_status(:not_found) }
+      end
+
+      context "when signed in as a non-product DfE user" do
+        include_context "sign in as DfE user"
+
+        it { is_expected.to have_http_status(:not_found) }
+      end
+
+      context "when signed in as a product team user" do
+        include_context "sign in as product_team DfE user"
+
+        it { is_expected.to have_http_status(:not_found) }
+      end
+    end
+  end
+
+  describe "POST #create" do
+    subject do
+      post(path_for_step("csv"), params:)
+      response
+    end
+
+    let(:params) { { csv: { csv_string: } } }
+    let(:csv_string) do
+      <<~ROWS
+        object_type,object_id,action,attributes
+        something,1,create,"attribute1,value1,attribute2,value2"
+        another_thing,2,destroy,""
+      ROWS
+    end
+
+    before do
+      allow(Rails.application.config)
+        .to receive(:enable_admin_data_fixes)
+        .and_return(enable_admin_data_fixes)
+    end
+
+    context "when `enable_admin_data_fixes` is true" do
+      let(:enable_admin_data_fixes) { true }
+
+      context "when not signed in" do
+        it { is_expected.to redirect_to(sign_in_path) }
+      end
+
+      context "when signed in as a non-DfE user" do
+        include_context "sign in as non-DfE user"
+
+        it { is_expected.to have_http_status(:unauthorized) }
+      end
+
+      context "when signed in as a non-product DfE user" do
+        include_context "sign in as DfE user"
+
+        it { is_expected.to have_http_status(:unauthorized) }
+      end
+
+      context "when signed in as a product team user" do
+        include_context "sign in as product_team DfE user"
+
+        context "when the CSV is valid" do
+          it { is_expected.to redirect_to(path_for_step("preview")) }
+        end
+
+        context "when the CSV is invalid" do
+          let(:csv_string) do
+            <<~ROWS
+              object_type,object_id,attributes
+              something,1,create,"attribute1,value1,attribute2,value2"
+              another_thing,2,destroy,""
+            ROWS
+          end
+
+          it { is_expected.to have_http_status(:unprocessable_content) }
+        end
+      end
+    end
+
+    context "when `enable_admin_data_fixes` is false" do
+      let(:enable_admin_data_fixes) { false }
+
+      context "when not signed in" do
+        it { is_expected.to have_http_status(:not_found) }
+      end
+
+      context "when signed in as a non-DfE user" do
+        include_context "sign in as non-DfE user"
+
+        it { is_expected.to have_http_status(:not_found) }
+      end
+
+      context "when signed in as a non-product DfE user" do
+        include_context "sign in as DfE user"
+
+        it { is_expected.to have_http_status(:not_found) }
+      end
+
+      context "when signed in as a product team user" do
+        include_context "sign in as product_team DfE user"
+
+        it { is_expected.to have_http_status(:not_found) }
+      end
+    end
+  end
+
+private
+
+  def path_for_step(step) = "/admin/data_fixes/#{step}"
+end

--- a/spec/services/admin/data_fixes/inline_csv_spec.rb
+++ b/spec/services/admin/data_fixes/inline_csv_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Admin::DataFixes::InlineCSV do
 
       it "validates the CSV is present" do
         parse
-        expect(inline_csv.errors).to be_added(:csv_string, "can't be blank")
+        expect(inline_csv.errors).to be_added(:csv_string, "CSV can’t be blank")
       end
     end
 
@@ -27,7 +27,7 @@ RSpec.describe Admin::DataFixes::InlineCSV do
 
       it "validates the CSV is formatted correctly" do
         parse
-        expect(inline_csv.errors).to be_added(:csv_string, "is malformed")
+        expect(inline_csv.errors).to be_added(:csv_string, "CSV is malformed")
       end
     end
 
@@ -43,7 +43,7 @@ RSpec.describe Admin::DataFixes::InlineCSV do
 
       it "validates the CSV has the correct headers" do
         parse
-        expect(inline_csv.errors).to be_added(:csv_string, "has invalid headers")
+        expect(inline_csv.errors).to be_added(:csv_string, "CSV has invalid headers")
       end
     end
 
@@ -60,7 +60,7 @@ RSpec.describe Admin::DataFixes::InlineCSV do
 
       it "validates the CSV has the correct headers" do
         parse
-        expect(inline_csv.errors).to be_added(:csv_string, "has invalid headers")
+        expect(inline_csv.errors).to be_added(:csv_string, "CSV has invalid headers")
       end
     end
 
@@ -77,7 +77,7 @@ RSpec.describe Admin::DataFixes::InlineCSV do
 
       it "validates the CSV has the correct headers" do
         parse
-        expect(inline_csv.errors).to be_added(:csv_string, "has invalid headers")
+        expect(inline_csv.errors).to be_added(:csv_string, "CSV has invalid headers")
       end
     end
 
@@ -92,19 +92,22 @@ RSpec.describe Admin::DataFixes::InlineCSV do
 
       it { is_expected.to be_truthy }
 
-      it "returns an array of structured row data" do
-        parsed_data = parse
-        expect(parsed_data.first).to have_attributes(
-          object_type: "something",
-          object_id: "1",
-          action: "create",
-          attributes: "attribute1,value1,attribute2,value2"
-        )
-        expect(parsed_data.second).to have_attributes(
-          object_type: "another_thing",
-          object_id: "2",
-          action: "destroy",
-          attributes: ""
+      it "returns an array of hashes containing data changes" do
+        expect(parse).to eq(
+          [
+            {
+              "object_type" => "something",
+              "object_id" => "1",
+              "action" => "create",
+              "attributes" => "attribute1,value1,attribute2,value2"
+            },
+            {
+              "object_type" => "another_thing",
+              "object_id" => "2",
+              "action" => "destroy",
+              "attributes" => ""
+            }
+          ]
         )
       end
     end

--- a/spec/support/shared_contexts/requests/sign_in.rb
+++ b/spec/support/shared_contexts/requests/sign_in.rb
@@ -19,3 +19,11 @@ RSpec.shared_context "sign in as finance DfE user" do
     sign_in_as(:dfe_user, user:)
   end
 end
+
+RSpec.shared_context "sign in as product_team DfE user" do
+  let(:user) { FactoryBot.create(:user, :product_team) }
+
+  before do
+    sign_in_as(:dfe_user, user:)
+  end
+end

--- a/spec/wizards/admin/data_fixes_wizard/csv_step_spec.rb
+++ b/spec/wizards/admin/data_fixes_wizard/csv_step_spec.rb
@@ -1,0 +1,101 @@
+RSpec.describe Admin::DataFixesWizard::CSVStep do
+  subject(:current_step) { wizard.current_step }
+
+  let(:wizard) do
+    Admin::DataFixesWizard::Wizard.new(
+      current_step: :csv,
+      step_params: ActionController::Parameters.new(csv: params),
+      author:,
+      store:
+    )
+  end
+  let(:store) { FactoryBot.build(:session_repository) }
+  let(:author) { FactoryBot.build(:dfe_user, role: :product_team) }
+  let(:params) { { csv_string: } }
+  let(:csv_string) { "" }
+
+  describe ".permitted_params" do
+    subject(:permitted_params) { described_class.permitted_params }
+
+    it { is_expected.to contain_exactly(:csv_string) }
+  end
+
+  describe "#previous_step" do
+    subject(:previous_step) { current_step.previous_step }
+
+    it { is_expected.to be_nil }
+  end
+
+  describe "#next_step" do
+    subject(:next_step) { current_step.next_step }
+
+    it { is_expected.to eq(:preview) }
+  end
+
+  describe "#save!" do
+    subject(:save!) { current_step.save! }
+
+    context "when the CSV is valid" do
+      let(:csv_string) do
+        <<~ROWS
+          object_type,object_id,action,attributes
+          something,1,create,"attribute1,value1,attribute2,value2"
+          another_thing,2,destroy,""
+        ROWS
+      end
+
+      it { is_expected.to be_truthy }
+
+      it "persists rows in the store" do
+        expect { save! }
+          .to change { current_step.store.parsed_rows }
+          .from(nil)
+          .to(
+            [
+              {
+                "object_type" => "something",
+                "object_id" => "1",
+                "action" => "create",
+                "attributes" => "attribute1,value1,attribute2,value2"
+              },
+              {
+                "object_type" => "another_thing",
+                "object_id" => "2",
+                "action" => "destroy",
+                "attributes" => ""
+              }
+            ]
+          )
+      end
+
+      it "has no errors" do
+        save!
+
+        expect(current_step.errors).to be_empty
+      end
+    end
+
+    context "when the CSV is invalid" do
+      let(:csv_string) do
+        <<~ROWS
+          object_type,object_id,attributes
+          something,1,create,"attribute1,value1,attribute2,value2"
+          another_thing,2,destroy,""
+        ROWS
+      end
+
+      it { is_expected.to be_falsey }
+
+      it "does not persist any rows in the store" do
+        expect { save! }.not_to(change { current_step.store.parsed_rows })
+      end
+
+      it "propagates errors from `InlineCSV` parsing" do
+        save!
+
+        expect(current_step.errors)
+          .to be_added(:csv_string, "CSV has invalid headers")
+      end
+    end
+  end
+end

--- a/spec/wizards/admin/data_fixes_wizard/preview_step_spec.rb
+++ b/spec/wizards/admin/data_fixes_wizard/preview_step_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe Admin::DataFixesWizard::PreviewStep do
+  subject(:current_step) { wizard.current_step }
+
+  let(:wizard) do
+    Admin::DataFixesWizard::Wizard.new(
+      current_step: :preview,
+      step_params: ActionController::Parameters.new(preview: params),
+      author:,
+      store:
+    )
+  end
+  let(:store) { FactoryBot.build(:session_repository) }
+  let(:author) { FactoryBot.build(:dfe_user, role: :product_team) }
+  let(:params) { {} }
+
+  describe ".permitted_params" do
+    subject(:permitted_params) { described_class.permitted_params }
+
+    it { is_expected.to be_empty }
+  end
+
+  describe "#previous_step" do
+    subject(:previous_step) { current_step.previous_step }
+
+    it { is_expected.to eq(:csv) }
+  end
+
+  describe "#next_step" do
+    subject(:next_step) { current_step.next_step }
+
+    it { is_expected.to be_nil }
+  end
+end


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/4251

### Changes proposed in this pull request

This build out the first step of the `Admin::DataFixes` user journey.

Product team users can input rows of data fixes in CSV format via the UI.

The CSV is validated and parsed, and the proposed changes are stored in the
session.

A wizard approach has been taken, since this felt like a straightforward, but
multi-step, journey —and this is a pattern we use across the application.

This journey is currently restricted to review apps only, since it requires
`ENABLE_ADMIN_DATA_FIXES` to be enabled.

There is also no way to navigate to this page directly yet. Discussions are
ongoing to decide how we want users to access the journey.

We expect to iterate on the design and content as we build this journey out.

### Guidance to review
