### PR TITLE
[4198] Add trs_response status and trs_redirected_to on teachers table and remove flags

### DIFF
--- a/app/jobs/teachers/schedule_trs_sync_job.rb
+++ b/app/jobs/teachers/schedule_trs_sync_job.rb
@@ -8,8 +8,7 @@ module Teachers
       teachers =
         Teacher
           .with_trn
-          .found_in_trs
-          .active_in_trs
+          .syncable_with_trs
           .ordered_by_trs_data_last_refreshed_at_nulls_first
           .limit(BATCH_SIZE)
 

--- a/app/jobs/teachers/sync_teacher_with_trs_job.rb
+++ b/app/jobs/teachers/sync_teacher_with_trs_job.rb
@@ -6,7 +6,7 @@ module Teachers
 
     # @param teacher [Teacher]
     def perform(teacher:)
-      return if teacher.trnless? || teacher.trs_deactivated? || teacher.trs_not_found?
+      return if teacher.trnless? || !teacher.syncable_with_trs?
 
       Teachers::RefreshTRSAttributes.new(teacher, api_client:).refresh!
     end

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -9,6 +9,8 @@ class Teacher < ApplicationRecord
 
   TRN_FORMAT = %r{\A\d{7}\z}
 
+  TRS_RESPONSES = %i[ok not_found gone permanent_redirect].index_with(&:to_s).freeze
+
   self.ignored_columns = %i[search]
 
   # Enums
@@ -22,6 +24,7 @@ class Teacher < ApplicationRecord
     registered_in_error: "registered_in_error",
     teacher_record_merged: "teacher_record_merged",
   }
+  enum :trs_response, TRS_RESPONSES, prefix: true
 
   # Associations
   has_many :ect_at_school_periods, inverse_of: :teacher

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -11,7 +11,7 @@ class Teacher < ApplicationRecord
 
   TRS_RESPONSES = %i[ok not_found gone permanent_redirect].index_with(&:to_s).freeze
 
-  self.ignored_columns = %i[search]
+  self.ignored_columns = %i[search trs_deactivated trs_not_found]
 
   # Enums
   enum :migration_mode, MIGRATION_MODES, validate: { message: "Must be latest_induction_records, all_induction_records or not_migrated" }, suffix: true
@@ -132,10 +132,7 @@ class Teacher < ApplicationRecord
 
   scope :with_trn, -> { where.not(trn: nil) }
   scope :without_trn, -> { where(trnless: true) }
-  scope :deactivated_in_trs, -> { where(trs_deactivated: true) }
-  scope :active_in_trs, -> { where(trs_deactivated: false) }
-  scope :not_found_in_trs, -> { where(trs_not_found: true) } # TRS returned either 404 or 308
-  scope :found_in_trs, -> { where(trs_not_found: false) }
+  scope :syncable_with_trs, -> { where(trs_response: [nil, :ok]) }
   scope :without_qts_award, -> { where(trs_qts_awarded_on: nil) }
   scope :induction_status_missing, -> { where(trs_induction_status: nil) }
   scope :induction_status_passed, -> { where(trs_induction_status: "Passed") }
@@ -163,5 +160,9 @@ class Teacher < ApplicationRecord
   # Methods
   def eligible_for_funding?
     Teachers::MentorFundingEligibility.new(trn:).eligible?
+  end
+
+  def syncable_with_trs?
+    trs_response.nil? || trs_response_ok?
   end
 end

--- a/app/services/concerns/teachers/manageable.rb
+++ b/app/services/concerns/teachers/manageable.rb
@@ -58,8 +58,9 @@ module Teachers
     end
 
     # @return [Boolean]
-    def mark_teacher_as_merged!(event_body:)
+    def mark_teacher_as_merged!(redirected_to:, event_body:)
       manage_teacher.mark_teacher_as_merged!(
+        redirected_to:,
         event_body:,
         trs_data_last_refreshed_at: Time.zone.now
       )

--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -283,7 +283,7 @@ module Events
       event_type = :teacher_trs_merged
       teacher_name = Teachers::Name.new(teacher).full_name
       heading = "#{teacher_name} was merged into another TRS record"
-      body = "TRS API returned 308 so the record was marked as not found. #{body}"
+      body = "TRS API returned 308 so the record was marked as merged. #{body}"
 
       new(event_type:, author:, teacher:, heading:, body:, happened_at:).record_event!
     end

--- a/app/services/teachers/manage.rb
+++ b/app/services/teachers/manage.rb
@@ -3,8 +3,7 @@
 # 1. teacher name changes
 # 2. induction status and date changes
 # 3. QTS and ITT changes
-# 4. teacher deactivated in TRS
-# 5. teacher not found in TRS
+# 4. the response TRS last gave for the teacher's TRN: deactivated, not found or merged
 #
 # @see Teachers::Manageable
 class Teachers::Manage

--- a/app/services/teachers/manage.rb
+++ b/app/services/teachers/manage.rb
@@ -84,35 +84,35 @@ class Teachers::Manage
 
       record_teacher_trs_attribute_update(modifications: teacher.changes)
 
-      teacher.trs_data_last_refreshed_at = trs_data_last_refreshed_at
+      teacher.assign_attributes(trs_response: :ok, trs_redirected_to: nil, trs_data_last_refreshed_at:)
       teacher.save!
     end
   end
 
   def mark_teacher_as_deactivated!(trs_data_last_refreshed_at:)
-    fail(AlreadyFlagged) if teacher.trs_deactivated?
+    fail(AlreadyFlagged) if teacher.trs_response_gone?
 
     Teacher.transaction do
-      teacher.update!(trs_deactivated: true, trs_data_last_refreshed_at:)
+      teacher.update!(trs_response: :gone, trs_data_last_refreshed_at:)
       record_teacher_deactivated_event
     end
   end
 
   def mark_teacher_as_not_found!(trs_data_last_refreshed_at:)
-    fail(AlreadyFlagged) if teacher.trs_not_found?
+    fail(AlreadyFlagged) if teacher.trs_response_not_found?
 
     Teacher.transaction do
-      teacher.update!(trs_not_found: true, trs_data_last_refreshed_at:)
+      teacher.update!(trs_response: :not_found, trs_data_last_refreshed_at:)
       record_teacher_not_found_event
       update_induction_status_indicator
     end
   end
 
   def mark_teacher_as_merged!(trs_data_last_refreshed_at:, redirected_to:, event_body:)
-    fail(AlreadyFlagged) if teacher.trs_not_found?
+    fail(AlreadyFlagged) if teacher.trs_response_permanent_redirect?
 
     Teacher.transaction do
-      teacher.update!(trs_not_found: true, trs_response: :permanent_redirect, trs_redirected_to: redirected_to, trs_data_last_refreshed_at:)
+      teacher.update!(trs_response: :permanent_redirect, trs_redirected_to: redirected_to, trs_data_last_refreshed_at:)
       record_teacher_merged_event(event_body)
       update_induction_status_indicator
     end

--- a/app/services/teachers/manage.rb
+++ b/app/services/teachers/manage.rb
@@ -108,11 +108,11 @@ class Teachers::Manage
     end
   end
 
-  def mark_teacher_as_merged!(trs_data_last_refreshed_at:, event_body:)
+  def mark_teacher_as_merged!(trs_data_last_refreshed_at:, redirected_to:, event_body:)
     fail(AlreadyFlagged) if teacher.trs_not_found?
 
     Teacher.transaction do
-      teacher.update!(trs_not_found: true, trs_data_last_refreshed_at:)
+      teacher.update!(trs_not_found: true, trs_response: :permanent_redirect, trs_redirected_to: redirected_to, trs_data_last_refreshed_at:)
       record_teacher_merged_event(event_body)
       update_induction_status_indicator
     end

--- a/app/services/teachers/refresh_trs_attributes.rb
+++ b/app/services/teachers/refresh_trs_attributes.rb
@@ -25,7 +25,7 @@ module Teachers
     rescue TRS::Errors::TeacherNotFound
       update_not_found!
     rescue TRS::Errors::TeacherMerged => e
-      update_merged!(e.message)
+      update_merged!(e)
     rescue TRS::Errors::TeacherDeactivated
       deactivate!
     end
@@ -74,11 +74,11 @@ module Teachers
       end
     end
 
-    # @param error_message [String] API redirect
+    # @param error [TRS::Errors::TeacherMerged]
     # @return [Symbol]
-    def update_merged!(error_message)
+    def update_merged!(error)
       Teacher.transaction do
-        mark_teacher_as_merged!(event_body: error_message)
+        mark_teacher_as_merged!(redirected_to: error.redirected_to, event_body: error.message)
 
         :teacher_merged
       end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -38,8 +38,6 @@ shared:
     - trs_initial_teacher_training_provider_name
     - trs_initial_teacher_training_end_date
     - trs_data_last_refreshed_at
-    - trs_deactivated
-    - trs_not_found
     - trs_response
     - trs_redirected_to
     - trs_induction_start_date

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -40,6 +40,8 @@ shared:
     - trs_data_last_refreshed_at
     - trs_deactivated
     - trs_not_found
+    - trs_response
+    - trs_redirected_to
     - trs_induction_start_date
     - trs_induction_completed_date
     - trs_first_name

--- a/db/migrate/20260812163524_add_trs_response_to_teachers.rb
+++ b/db/migrate/20260812163524_add_trs_response_to_teachers.rb
@@ -1,0 +1,10 @@
+class AddTRSResponseToTeachers < ActiveRecord::Migration[8.1]
+  def change
+    create_enum :trs_responses, %w[ok not_found gone permanent_redirect]
+
+    change_table :teachers, bulk: true do |t|
+      t.enum :trs_response, enum_type: :trs_responses
+      t.string :trs_redirected_to
+    end
+  end
+end

--- a/db/migrate/20260813103015_backfill_trs_response_on_teachers.rb
+++ b/db/migrate/20260813103015_backfill_trs_response_on_teachers.rb
@@ -33,9 +33,11 @@ class BackfillTRSResponseOnTeachers < ActiveRecord::Migration[8.1]
                  substring(body from 'redirects to TRN (\\d+)') AS redirected_to
           FROM events
           WHERE event_type = 'teacher_trs_merged'
+            AND teacher_id BETWEEN #{first} AND #{last}
           ORDER BY teacher_id, created_at DESC
         ) AS merged
         WHERE merged.teacher_id = teachers.id
+          AND teachers.trs_response = 'permanent_redirect'
           AND merged.redirected_to IS NOT NULL
           AND teachers.trs_redirected_to IS NULL
           AND teachers.id BETWEEN #{first} AND #{last}

--- a/db/migrate/20260813103015_backfill_trs_response_on_teachers.rb
+++ b/db/migrate/20260813103015_backfill_trs_response_on_teachers.rb
@@ -1,0 +1,58 @@
+class BackfillTRSResponseOnTeachers < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  BATCH_SIZE = 5_000
+
+  def up
+    each_batch do |first, last|
+      execute(<<~SQL)
+        UPDATE teachers SET trs_response = (
+          CASE
+            WHEN trs_deactivated THEN 'gone'
+            WHEN trs_not_found AND EXISTS (
+              SELECT 1 FROM events
+              WHERE events.teacher_id = teachers.id
+                AND events.event_type = 'teacher_trs_merged'
+            ) THEN 'permanent_redirect'
+            WHEN trs_not_found THEN 'not_found'
+            ELSE 'ok'
+          END
+        )::trs_responses
+        WHERE teachers.id BETWEEN #{first} AND #{last}
+          AND teachers.trs_response IS NULL
+          AND (teachers.trs_deactivated
+               OR teachers.trs_not_found
+               OR teachers.trs_data_last_refreshed_at IS NOT NULL)
+      SQL
+
+      execute(<<~SQL)
+        UPDATE teachers SET trs_redirected_to = merged.redirected_to
+        FROM (
+          SELECT DISTINCT ON (teacher_id)
+                 teacher_id,
+                 substring(body from 'redirects to TRN (\\d+)') AS redirected_to
+          FROM events
+          WHERE event_type = 'teacher_trs_merged'
+          ORDER BY teacher_id, created_at DESC
+        ) AS merged
+        WHERE merged.teacher_id = teachers.id
+          AND merged.redirected_to IS NOT NULL
+          AND teachers.trs_redirected_to IS NULL
+          AND teachers.id BETWEEN #{first} AND #{last}
+      SQL
+    end
+  end
+
+  def down
+    execute("UPDATE teachers SET trs_response = NULL, trs_redirected_to = NULL")
+  end
+
+private
+
+  def each_batch
+    first, last = select_rows("SELECT MIN(id), MAX(id) FROM teachers").first
+    return if first.nil?
+
+    (first..last).step(BATCH_SIZE) { |batch_start| yield(batch_start, batch_start + BATCH_SIZE - 1) }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_06_113458) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_12_163524) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -46,6 +46,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_06_113458) do
   create_enum "schedule_identifiers", ["ecf-extended-april", "ecf-extended-january", "ecf-extended-september", "ecf-reduced-april", "ecf-reduced-january", "ecf-reduced-september", "ecf-replacement-april", "ecf-replacement-january", "ecf-replacement-september", "ecf-standard-april", "ecf-standard-january", "ecf-standard-september"]
   create_enum "statement_statuses", ["open", "payable", "paid"]
   create_enum "training_programme", ["provider_led", "school_led"]
+  create_enum "trs_responses", ["ok", "not_found", "gone", "permanent_redirect"]
   create_enum "withdrawal_reasons", ["left_teaching_profession", "moved_school", "mentor_no_longer_being_mentor", "switched_to_school_led", "other", "changed_lead_provider"]
   create_enum "working_pattern", ["part_time", "full_time"]
 
@@ -889,6 +890,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_06_113458) do
     t.boolean "trs_not_found", default: false
     t.date "trs_qts_awarded_on"
     t.string "trs_qts_status_description"
+    t.string "trs_redirected_to"
+    t.enum "trs_response", enum_type: "trs_responses"
     t.datetime "updated_at", null: false
     t.index ["api_ect_training_record_id"], name: "index_teachers_on_api_ect_training_record_id", unique: true
     t.index ["api_id"], name: "index_teachers_on_api_id", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_12_163524) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_13_103015) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"

--- a/db/seeds/blazer_queries.rb
+++ b/db/seeds/blazer_queries.rb
@@ -65,13 +65,18 @@ end
   },
   {
     name: "TRS not found",
-    statement: "SELECT id AS teacher_id, trs_not_found FROM teachers WHERE trs_not_found=true",
+    statement: "SELECT id AS teacher_id, trs_data_last_refreshed_at FROM teachers WHERE trs_response='not_found'",
     description: "TRS syncing has flagged missing records"
   },
   {
     name: "TRS deactivated",
-    statement: "SELECT id AS teacher_id, trs_deactivated FROM teachers WHERE trs_deactivated=true",
+    statement: "SELECT id AS teacher_id, trs_data_last_refreshed_at FROM teachers WHERE trs_response='gone'",
     description: "TRS syncing has flagged deactivated records"
+  },
+  {
+    name: "TRS permanent redirects",
+    statement: "SELECT id AS teacher_id, trn, trs_redirected_to, trs_data_last_refreshed_at FROM teachers WHERE trs_response='permanent_redirect'",
+    description: "TRS syncing has flagged records merged into another TRN"
   },
   {
     name: "Active lead provider bands",

--- a/documentation/domain-model.md
+++ b/documentation/domain-model.md
@@ -218,6 +218,8 @@ erDiagram
     date trs_qts_awarded_on
     string trs_qts_status_description
     datetime updated_at
+    enum trs_response
+    string trs_redirected_to
   }
   PendingInductionSubmission {
     integer id

--- a/lib/trs/api_client.rb
+++ b/lib/trs/api_client.rb
@@ -57,7 +57,7 @@ module TRS
       when "Gone"
         raise(TRS::Errors::TeacherDeactivated)
       when "Permanent Redirect"
-        raise(TRS::Errors::TeacherMerged, "TRN #{trn} redirects to TRN #{trs_redirected_trn(response)}")
+        raise(TRS::Errors::TeacherMerged.new(trn:, redirected_to: trs_redirected_trn(response)))
       else
         fail(TRS::Errors::APIRequestError, "#{response.status} #{response.body}")
       end

--- a/lib/trs/errors.rb
+++ b/lib/trs/errors.rb
@@ -6,6 +6,16 @@ module TRS
     class QTSNotAwarded < StandardError; end
     class TeacherDeactivated < StandardError; end
     class TeacherNotFound < StandardError; end
-    class TeacherMerged < StandardError; end
+
+    class TeacherMerged < StandardError
+      attr_reader :trn, :redirected_to
+
+      def initialize(trn:, redirected_to:)
+        @trn = trn
+        @redirected_to = redirected_to
+
+        super("TRN #{trn} redirects to TRN #{redirected_to}")
+      end
+    end
   end
 end

--- a/lib/trs/fake_api_client.rb
+++ b/lib/trs/fake_api_client.rb
@@ -16,6 +16,8 @@ module TRS
   class FakeAPIClient
     class FakeAPIClientUsedInProduction < StandardError; end
 
+    MERGED_TRN_REDIRECTS_TO = "7000012"
+
     def initialize(raise_not_found: false, raise_deactivated: false, raise_merged: false)
       fail(FakeAPIClientUsedInProduction) if Rails.env.production?
 
@@ -27,7 +29,7 @@ module TRS
     def find_teacher(trn:, date_of_birth: "1977-02-03", national_insurance_number: nil)
       raise(TRS::Errors::TeacherNotFound, "Teacher with TRN #{trn} not found") if @raise_not_found
       raise(TRS::Errors::TeacherDeactivated, "Teacher with TRN #{trn} deactivated") if @raise_deactivated
-      raise(TRS::Errors::TeacherMerged, "Teacher with TRN #{trn} merged") if @raise_merged
+      raise(TRS::Errors::TeacherMerged.new(trn:, redirected_to: MERGED_TRN_REDIRECTS_TO)) if @raise_merged
 
       Rails.logger.info("TRSFakeAPIClient pretending to find teacher with TRN=#{trn} and Date of birth=#{date_of_birth} and National Insurance Number=#{national_insurance_number}")
 
@@ -153,7 +155,7 @@ module TRS
       when 7_000_008 then @induction_status = "Failed"
       when 7_000_009 then @induction_status = "Exempt"
       when 7_000_010 then @induction_status = "FailedInWales"
-      when 7_000_011 then raise(TRS::Errors::TeacherMerged)
+      when 7_000_011 then raise(TRS::Errors::TeacherMerged.new(trn:, redirected_to: MERGED_TRN_REDIRECTS_TO))
       else
         @has_itt = true
         @is_prohibited_from_teaching = false

--- a/spec/factories/teacher_factory.rb
+++ b/spec/factories/teacher_factory.rb
@@ -28,16 +28,19 @@ FactoryBot.define do
       corrected_name { [trs_first_name, Faker::Name.middle_name, trs_last_name].join(" ") }
     end
 
+    trait :found_in_trs do
+      trs_response { :ok }
+    end
+
     trait :deactivated_in_trs do
-      trs_deactivated { true }
+      trs_response { :gone }
     end
 
     trait :not_found_in_trs do
-      trs_not_found { true }
+      trs_response { :not_found }
     end
 
     trait :merged_in_trs do
-      trs_not_found { true }
       trs_response { :permanent_redirect }
       trs_redirected_to { APISeedData::Helpers::TRNGenerator.next }
     end

--- a/spec/factories/teacher_factory.rb
+++ b/spec/factories/teacher_factory.rb
@@ -36,6 +36,12 @@ FactoryBot.define do
       trs_not_found { true }
     end
 
+    trait :merged_in_trs do
+      trs_not_found { true }
+      trs_response { :permanent_redirect }
+      trs_redirected_to { APISeedData::Helpers::TRNGenerator.next }
+    end
+
     trait :early_roll_out_mentor do
       mentor_became_ineligible_for_funding_on { Date.new(2021, 4, 19) }
       mentor_became_ineligible_for_funding_reason { "completed_during_early_roll_out" }

--- a/spec/lib/trs/api_client_spec.rb
+++ b/spec/lib/trs/api_client_spec.rb
@@ -108,6 +108,14 @@ RSpec.describe TRS::APIClient do
         it do
           expect { client.find_teacher(trn: merged_trn) }.to raise_error(TRS::Errors::TeacherMerged)
         end
+
+        it "carries the TRN from the location header" do
+          expect { client.find_teacher(trn: merged_trn) }.to raise_error(TRS::Errors::TeacherMerged) { |error|
+            expect(error.trn).to eq(merged_trn)
+            expect(error.redirected_to).to eq("8888888")
+            expect(error.message).to eq("TRN #{merged_trn} redirects to TRN 8888888")
+          }
+        end
       end
     end
   end

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -535,14 +535,6 @@ describe Teacher do
       end
     end
 
-    describe ".deactivated_in_trs" do
-      it "only includes records where trs_deactivated = TRUE" do
-        expected_clause = %("teachers"."trs_deactivated" = TRUE)
-
-        expect(Teacher.deactivated_in_trs.to_sql).to end_with(expected_clause)
-      end
-    end
-
     describe ".without_trn" do
       let(:trnless_teacher) { FactoryBot.create(:teacher, :trnless) }
       let(:teacher) { FactoryBot.create(:teacher) }
@@ -563,27 +555,19 @@ describe Teacher do
       end
     end
 
-    describe ".active_in_trs" do
-      it "only includes records where trs_deactivated = FALSE" do
-        expected_clause = %("teachers"."trs_deactivated" = FALSE)
+    describe ".syncable_with_trs" do
+      let!(:never_synced_teacher) { FactoryBot.create(:teacher) }
+      let!(:found_teacher) { FactoryBot.create(:teacher, :found_in_trs) }
+      let!(:not_found_teacher) { FactoryBot.create(:teacher, :not_found_in_trs) }
+      let!(:deactivated_teacher) { FactoryBot.create(:teacher, :deactivated_in_trs) }
+      let!(:merged_teacher) { FactoryBot.create(:teacher, :merged_in_trs) }
 
-        expect(Teacher.active_in_trs.to_sql).to end_with(expected_clause)
+      it "includes teachers TRS has not answered for, or last answered OK for" do
+        expect(Teacher.syncable_with_trs).to contain_exactly(never_synced_teacher, found_teacher)
       end
-    end
 
-    describe ".not_found_in_trs" do
-      it "only includes records where trs_not_found = TRUE" do
-        expected_clause = %("teachers"."trs_not_found" = TRUE)
-
-        expect(Teacher.not_found_in_trs.to_sql).to end_with(expected_clause)
-      end
-    end
-
-    describe ".found_in_trs" do
-      it "only includes records where trs_not_found = FALSE" do
-        expected_clause = %("teachers"."trs_not_found" = FALSE)
-
-        expect(Teacher.found_in_trs.to_sql).to end_with(expected_clause)
+      it "excludes teachers TRS has stopped serving" do
+        expect(Teacher.syncable_with_trs).not_to include(not_found_teacher, deactivated_teacher, merged_teacher)
       end
     end
 
@@ -670,6 +654,40 @@ describe Teacher do
 
     it "removes leading and trailing spaces from the corrected name" do
       expect(subject.corrected_name).to eql("Tobias Menzies")
+    end
+  end
+
+  describe "#syncable_with_trs?" do
+    subject { FactoryBot.build(:teacher, trs_response:) }
+
+    context "when TRS has not answered for the teacher yet" do
+      let(:trs_response) { nil }
+
+      it { is_expected.to be_syncable_with_trs }
+    end
+
+    context "when TRS last returned the teacher" do
+      let(:trs_response) { :ok }
+
+      it { is_expected.to be_syncable_with_trs }
+    end
+
+    context "when the teacher was not found in TRS" do
+      let(:trs_response) { :not_found }
+
+      it { is_expected.not_to be_syncable_with_trs }
+    end
+
+    context "when the teacher was deactivated in TRS" do
+      let(:trs_response) { :gone }
+
+      it { is_expected.not_to be_syncable_with_trs }
+    end
+
+    context "when the teacher was merged in TRS" do
+      let(:trs_response) { :permanent_redirect }
+
+      it { is_expected.not_to be_syncable_with_trs }
     end
   end
 end

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -622,6 +622,23 @@ RSpec.describe Events::Record do
     end
   end
 
+  describe ".record_teacher_trs_merged_event!" do
+    it "queues a RecordEventJob with the correct values" do
+      freeze_time do
+        Events::Record.record_teacher_trs_merged_event!(author:, teacher:, body: "TRN 1234567 redirects to TRN 7654321")
+
+        expect(RecordEventJob).to have_received(:perform_later).with(
+          teacher:,
+          heading: "Rhys Ifans was merged into another TRS record",
+          event_type: :teacher_trs_merged,
+          happened_at: Time.zone.now,
+          body: "TRS API returned 308 so the record was marked as merged. TRN 1234567 redirects to TRN 7654321",
+          **author_params
+        )
+      end
+    end
+  end
+
   describe "record_teacher_induction_status_reset_event!" do
     let(:event_type) { :teacher_induction_status_reset }
     let(:happened_at) { Time.zone.now }

--- a/spec/services/teachers/manage_spec.rb
+++ b/spec/services/teachers/manage_spec.rb
@@ -391,4 +391,31 @@ RSpec.describe Teachers::Manage do
       end
     end
   end
+
+  describe "#mark_teacher_as_merged!" do
+    subject(:mark_teacher_as_merged) do
+      service.mark_teacher_as_merged!(trs_data_last_refreshed_at:, redirected_to:, event_body: "merged")
+    end
+
+    let(:trs_data_last_refreshed_at) { 2.minutes.ago }
+    let(:redirected_to) { "1234567" }
+
+    context "when the teacher is already flagged" do
+      let(:teacher) { FactoryBot.create(:teacher, :merged_in_trs) }
+
+      it { expect { mark_teacher_as_merged }.to raise_error(Teachers::Manage::AlreadyFlagged) }
+    end
+
+    context "when the teacher is not yet flagged" do
+      before { mark_teacher_as_merged }
+
+      it "records the TRN the teacher was merged into" do
+        teacher.reload
+
+        expect(teacher.trs_redirected_to).to eq(redirected_to)
+        expect(teacher).to be_trs_response_permanent_redirect
+        expect(teacher.trs_data_last_refreshed_at).to be_within(0.001.seconds).of(trs_data_last_refreshed_at)
+      end
+    end
+  end
 end

--- a/spec/services/teachers/manage_spec.rb
+++ b/spec/services/teachers/manage_spec.rb
@@ -314,6 +314,8 @@ RSpec.describe Teachers::Manage do
   end
 
   describe "#mark_teacher_as_deactivated!" do
+    before { freeze_time }
+
     let(:trs_data_last_refreshed_at) { 2.minutes.ago }
 
     context "when the teacher is already flagged" do
@@ -333,13 +335,15 @@ RSpec.describe Teachers::Manage do
         service.mark_teacher_as_deactivated!(trs_data_last_refreshed_at:)
         teacher.reload
 
-        expect(teacher.trs_data_last_refreshed_at).to be_within(0.001.seconds).of(trs_data_last_refreshed_at)
+        expect(teacher.trs_data_last_refreshed_at).to eq(trs_data_last_refreshed_at)
         expect(teacher).to be_trs_response_gone
       end
     end
   end
 
   describe "#mark_teacher_as_not_found!" do
+    before { freeze_time }
+
     let(:trs_data_last_refreshed_at) { 2.minutes.ago }
 
     context "when the teacher is already flagged" do
@@ -359,7 +363,7 @@ RSpec.describe Teachers::Manage do
         service.mark_teacher_as_not_found!(trs_data_last_refreshed_at:)
         teacher.reload
 
-        expect(teacher.trs_data_last_refreshed_at).to be_within(0.001.seconds).of(trs_data_last_refreshed_at)
+        expect(teacher.trs_data_last_refreshed_at).to eq(trs_data_last_refreshed_at)
         expect(teacher).to be_trs_response_not_found
       end
     end
@@ -397,6 +401,8 @@ RSpec.describe Teachers::Manage do
       service.mark_teacher_as_merged!(trs_data_last_refreshed_at:, redirected_to:, event_body: "merged")
     end
 
+    before { freeze_time }
+
     let(:trs_data_last_refreshed_at) { 2.minutes.ago }
     let(:redirected_to) { "1234567" }
 
@@ -414,7 +420,7 @@ RSpec.describe Teachers::Manage do
 
         expect(teacher.trs_redirected_to).to eq(redirected_to)
         expect(teacher).to be_trs_response_permanent_redirect
-        expect(teacher.trs_data_last_refreshed_at).to be_within(0.001.seconds).of(trs_data_last_refreshed_at)
+        expect(teacher.trs_data_last_refreshed_at).to eq(trs_data_last_refreshed_at)
       end
     end
   end

--- a/spec/services/teachers/manage_spec.rb
+++ b/spec/services/teachers/manage_spec.rb
@@ -327,14 +327,14 @@ RSpec.describe Teachers::Manage do
     end
 
     context "when the teacher is not yet flagged" do
-      it "sets the trs_deactivated flag to true" do
-        expect(teacher.trs_deactivated).to be(false)
+      it "records the TRS response as gone" do
+        expect(teacher.trs_response).to be_nil
 
         service.mark_teacher_as_deactivated!(trs_data_last_refreshed_at:)
         teacher.reload
 
         expect(teacher.trs_data_last_refreshed_at).to be_within(0.001.seconds).of(trs_data_last_refreshed_at)
-        expect(teacher.trs_deactivated).to be(true)
+        expect(teacher).to be_trs_response_gone
       end
     end
   end
@@ -353,14 +353,14 @@ RSpec.describe Teachers::Manage do
     end
 
     context "when the teacher is not yet flagged" do
-      it "sets the trs_not_found flag to true" do
-        expect(teacher.trs_not_found).to be(false)
+      it "records the TRS response as not found" do
+        expect(teacher.trs_response).to be_nil
 
         service.mark_teacher_as_not_found!(trs_data_last_refreshed_at:)
         teacher.reload
 
         expect(teacher.trs_data_last_refreshed_at).to be_within(0.001.seconds).of(trs_data_last_refreshed_at)
-        expect(teacher.trs_not_found).to be(true)
+        expect(teacher).to be_trs_response_not_found
       end
     end
 

--- a/spec/services/teachers/refresh_trs_attributes_spec.rb
+++ b/spec/services/teachers/refresh_trs_attributes_spec.rb
@@ -142,6 +142,26 @@ describe Teachers::RefreshTRSAttributes do
           end
         end
       end
+
+      context "when the teacher has been merged in TRS" do
+        include_context "test TRS API returns a merged teacher"
+
+        let(:fake_manage) do
+          double(Teachers::Manage,
+                 mark_teacher_as_merged!: true)
+        end
+
+        it "passes on the destination TRN when TRS reports the teacher as 'Permanent Redirect'" do
+          freeze_time do
+            expect(service.refresh!).to eq(:teacher_merged)
+            expect(fake_manage).to have_received(:mark_teacher_as_merged!).once.with(
+              trs_data_last_refreshed_at: Time.zone.now,
+              redirected_to: TRS::TestAPIClient::MERGED_TRN_REDIRECTS_TO,
+              event_body: "TRN #{teacher.trn} redirects to TRN #{TRS::TestAPIClient::MERGED_TRN_REDIRECTS_TO}"
+            )
+          end
+        end
+      end
     end
 
     context "when the TRN or DoB in TRS have changed" do
@@ -152,6 +172,14 @@ describe Teachers::RefreshTRSAttributes do
         teacher.reload
 
         expect(teacher).to be_trs_not_found
+      end
+
+      it "records the TRN the teacher was merged into" do
+        service.refresh!
+        teacher.reload
+
+        expect(teacher).to be_trs_response_permanent_redirect
+        expect(teacher.trs_redirected_to).to eq(TRS::TestAPIClient::MERGED_TRN_REDIRECTS_TO)
       end
 
       it "adds a teacher_trs_merged event" do

--- a/spec/services/teachers/refresh_trs_attributes_spec.rb
+++ b/spec/services/teachers/refresh_trs_attributes_spec.rb
@@ -171,14 +171,13 @@ describe Teachers::RefreshTRSAttributes do
         expect(service.refresh!).to eq(:teacher_merged)
         teacher.reload
 
-        expect(teacher).to be_trs_not_found
+        expect(teacher).to be_trs_response_permanent_redirect
       end
 
       it "records the TRN the teacher was merged into" do
         service.refresh!
         teacher.reload
 
-        expect(teacher).to be_trs_response_permanent_redirect
         expect(teacher.trs_redirected_to).to eq(TRS::TestAPIClient::MERGED_TRN_REDIRECTS_TO)
       end
 
@@ -201,7 +200,7 @@ describe Teachers::RefreshTRSAttributes do
         service.refresh!
         teacher.reload
 
-        expect(teacher).to be_trs_not_found
+        expect(teacher).to be_trs_response_not_found
       end
 
       it "adds a teacher_trs_not_found event" do
@@ -311,7 +310,7 @@ describe Teachers::RefreshTRSAttributes do
         expect(service.refresh!).to eq(:teacher_deactivated)
         teacher.reload
 
-        expect(teacher).to be_trs_deactivated
+        expect(teacher).to be_trs_response_gone
       end
 
       it "adds a teacher_trs_deactivated event" do

--- a/spec/support/api/trs/test_api_client.rb
+++ b/spec/support/api/trs/test_api_client.rb
@@ -2,6 +2,8 @@ module TRS
   class TestAPIClient
     class TestAPIClientUsedInProduction < StandardError; end
 
+    MERGED_TRN_REDIRECTS_TO = "7000012"
+
     def initialize(
       raise_not_found: false,
       raise_deactivated: false,
@@ -27,7 +29,7 @@ module TRS
     def find_teacher(trn:, date_of_birth: "1977-02-03", national_insurance_number: nil)
       raise(TRS::Errors::TeacherNotFound, "Teacher with TRN #{trn} not found") if @raise_not_found
       raise(TRS::Errors::TeacherDeactivated, "Teacher with TRN #{trn} deactivated") if @raise_deactivated
-      raise(TRS::Errors::TeacherMerged, "Teacher with TRN #{trn} merged") if @raise_merged
+      raise(TRS::Errors::TeacherMerged.new(trn:, redirected_to: MERGED_TRN_REDIRECTS_TO)) if @raise_merged
 
       build_trs_teacher(trn:, date_of_birth:, national_insurance_number:)
     end


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/4198

### Changes proposed in this pull request

Replaces the `trs_not_found` and `trs_deactivated` booleans with a single `trs_response` status plus a `trs_redirected_to` column for the destination TRN on a 308.

Also includes the [backfill assigned to #4152](https://github.com/DFE-Digital/register-ects-project-board/issues/4152), since the old columns can't be dropped until nothing reads them, and nothing can stop reading them while `trs_response` is null everywhere; status is derived from the flags and recovers destination TRNs out of `teacher_trs_merged` events.

Dropping the columns is a [separate PR](https://github.com/DFE-Digital/register-early-career-teachers-public/pull/3379) that can be merged after this one.

### Guidance to review

More moving parts than expected, so I tried to slice this into logical commits that can hopefully be reviewed independently. 

One bit worth noting is `syncable_with_trs?` treating a null `trs_response` as due a sync: the migration job in this PR will finish before the rolling deploy does, so anyone whose status changes in that window is written the old way and won't get backfilled. Leaving them syncable means they self-correct on next sync.

`analytics.yml` changes here rather than alongside the migration that drops the columns because `ignored_columns` takes them out of the model's field list, which `DfE::Analytics` validates.

n.b. [query 396](https://www.register-early-career-teachers.education.gov.uk/admin/blazer/queries/396-teachers-missing-from-trs) selects on `trs_not_found` and will break when the columns go.

Tagging @peteryates here because you had a comment on the backfill ticket!

### TODO before merging

- [ ] Notify data team of column changes