### PR TITLE
[4198] Drop the trs_deactivated and trs_not_found columns

### DIFF
--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -11,7 +11,7 @@ class Teacher < ApplicationRecord
 
   TRS_RESPONSES = %i[ok not_found gone permanent_redirect].index_with(&:to_s).freeze
 
-  self.ignored_columns = %i[search trs_deactivated trs_not_found]
+  self.ignored_columns = %i[search]
 
   # Enums
   enum :migration_mode, MIGRATION_MODES, validate: { message: "Must be latest_induction_records, all_induction_records or not_migrated" }, suffix: true

--- a/db/migrate/20260813112837_remove_trs_flags_from_teachers.rb
+++ b/db/migrate/20260813112837_remove_trs_flags_from_teachers.rb
@@ -1,0 +1,8 @@
+class RemoveTRSFlagsFromTeachers < ActiveRecord::Migration[8.1]
+  def change
+    change_table :teachers, bulk: true do |t|
+      t.remove :trs_deactivated, type: :boolean, default: false
+      t.remove :trs_not_found, type: :boolean, default: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_13_103015) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_13_112837) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -879,7 +879,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_13_103015) do
     t.string "trn"
     t.boolean "trnless", default: false, null: false
     t.datetime "trs_data_last_refreshed_at", precision: nil
-    t.boolean "trs_deactivated", default: false
     t.string "trs_first_name"
     t.date "trs_induction_completed_date"
     t.date "trs_induction_start_date"
@@ -887,7 +886,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_13_103015) do
     t.date "trs_initial_teacher_training_end_date"
     t.string "trs_initial_teacher_training_provider_name"
     t.string "trs_last_name"
-    t.boolean "trs_not_found", default: false
     t.date "trs_qts_awarded_on"
     t.string "trs_qts_status_description"
     t.string "trs_redirected_to"

--- a/documentation/domain-model.md
+++ b/documentation/domain-model.md
@@ -206,7 +206,6 @@ erDiagram
     string trn
     boolean trnless
     datetime trs_data_last_refreshed_at
-    boolean trs_deactivated
     string trs_first_name
     date trs_induction_completed_date
     date trs_induction_start_date
@@ -214,12 +213,11 @@ erDiagram
     date trs_initial_teacher_training_end_date
     string trs_initial_teacher_training_provider_name
     string trs_last_name
-    boolean trs_not_found
     date trs_qts_awarded_on
     string trs_qts_status_description
-    datetime updated_at
-    enum trs_response
     string trs_redirected_to
+    enum trs_response
+    datetime updated_at
   }
   PendingInductionSubmission {
     integer id


### PR DESCRIPTION
> [!IMPORTANT]
> The base for this PR is the #3378 so that the diff shows the actual changes in this PR instead of both.
> Once that PR is merged, the base for this PR will revert to `main`.
> Do not merge this PR before #3378 is fully merged and deployed! 

### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/4198
Part 1 PR: https://github.com/DFE-Digital/register-early-career-teachers-public/pull/3378

### Changes proposed in this pull request

Drop the columns that #3378 makes redundant after that one's been fully migrated and deployed in production.