### PR TITLE
[4298] add training period FK constraint to declarations

### DIFF
--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -5,6 +5,7 @@ class Declaration < ApplicationRecord
   VOIDABLE_PAYMENT_STATUSES = %w[no_payment eligible payable].freeze
   BILLABLE_PAYMENT_STATUSES = %w[eligible payable paid].freeze
   REFUNDABLE_CLAWBACK_STATUSES = %w[awaiting_clawback clawed_back].freeze
+  DESTROYABLE_PAYMENT_STATUSES = %w[no_payment voided].freeze
 
   # Associations
   belongs_to :training_period
@@ -97,6 +98,7 @@ class Declaration < ApplicationRecord
   # Declaration can be both billable and refundable, paid in one month and clawed_back in another
   scope :billable, -> { where(payment_status: BILLABLE_PAYMENT_STATUSES) }
   scope :refundable, -> { where(clawback_status: REFUNDABLE_CLAWBACK_STATUSES) }
+  scope :destroyable, -> { where(payment_status: DESTROYABLE_PAYMENT_STATUSES) }
 
   touch -> { self },
         timestamp_attribute: :api_updated_at,

--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -98,7 +98,7 @@ class TrainingPeriod < ApplicationRecord
   end
 
   # Callbacks
-  before_destroy :abort_destruction_when_billable_declarations_exist
+  before_destroy :destroy_destroyable_declarations
 
   # Scopes
   scope :for_ect, ->(ect_at_school_period_id) { where(ect_at_school_period_id:) }
@@ -199,11 +199,14 @@ class TrainingPeriod < ApplicationRecord
 
 private
 
-  def abort_destruction_when_billable_declarations_exist
-    return unless declarations.billable.exists?
+  def destroy_destroyable_declarations
+    if declarations.billable.exists?
+      errors.add(:base, "Cannot delete a training period with billable declarations")
+      throw(:abort)
+    end
 
-    errors.add(:base, "Cannot delete a training period with billable declarations")
-    throw(:abort)
+    declarations.destroyable.find_each(&:destroy!)
+    true
   end
 
   def only_one_at_school_period_present

--- a/db/migrate/20260814092340_add_training_period_fk_to_declarations.rb
+++ b/db/migrate/20260814092340_add_training_period_fk_to_declarations.rb
@@ -1,0 +1,12 @@
+class AddTrainingPeriodFkToDeclarations < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    add_foreign_key :declarations, :training_periods, on_delete: :restrict, validate: false
+    validate_foreign_key :declarations, :training_periods
+  end
+
+  def down
+    remove_foreign_key :declarations, :training_periods
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_13_103015) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_14_092340) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -969,6 +969,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_13_103015) do
   add_foreign_key "declarations", "delivery_partners", column: "delivery_partner_when_created_id"
   add_foreign_key "declarations", "statements", column: "clawback_statement_id"
   add_foreign_key "declarations", "statements", column: "payment_statement_id"
+  add_foreign_key "declarations", "training_periods", on_delete: :restrict
   add_foreign_key "declarations", "users", column: "voided_by_user_id"
   add_foreign_key "ect_at_school_periods", "appropriate_body_periods", column: "school_reported_appropriate_body_id"
   add_foreign_key "ect_at_school_periods", "schools"

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -2,6 +2,7 @@ describe Declaration do
   describe "declarative updates" do
     def will_change_attribute(attribute_to_change:, new_value:)
       FactoryBot.create(:statement, id: new_value) if attribute_to_change.in?(%i[payment_statement_id clawback_statement_id])
+      FactoryBot.create(:training_period, id: new_value) if attribute_to_change == :training_period_id
     end
 
     describe "declarative touch target self" do
@@ -94,6 +95,28 @@ describe Declaration do
         let(:declaration_type) { :completed }
 
         it { is_expected.to have_error(:base, "Uplifts are only applicable to started declarations in an uplift enabled contract period") }
+      end
+    end
+
+    describe "training_period_id foreign key constraint" do
+      it "prevents creating a declaration that references a missing training period" do
+        declaration = FactoryBot.build(:declaration, training_period_id: TrainingPeriod.maximum(:id).to_i.next)
+
+        expect { declaration.save(validate: false) }.to raise_error(ActiveRecord::InvalidForeignKey)
+      end
+
+      it "prevents deleting a training period that has declarations" do
+        declaration = FactoryBot.create(:declaration)
+        training_period = declaration.training_period
+
+        expect { training_period.delete }.to raise_error(ActiveRecord::InvalidForeignKey)
+      end
+
+      it "allows destroying a training period that has declarations via callback" do
+        declaration = FactoryBot.create(:declaration)
+        training_period = declaration.training_period
+
+        expect { training_period.destroy! }.not_to raise_error
       end
     end
 
@@ -407,11 +430,14 @@ describe Declaration do
       end
 
       describe ".refundable" do
-        let(:declarations) { described_class.clawback_statuses.keys.map { |status| FactoryBot.create(:declaration, :"#{status}") } }
-        let(:refundable_declarations) { declarations.select { |d| described_class::REFUNDABLE_CLAWBACK_STATUSES.include?(d.clawback_status) } }
-
         it "returns declarations with refundable statuses" do
           expect(described_class.refundable.pluck(:clawback_status)).to all(be_in(described_class::REFUNDABLE_CLAWBACK_STATUSES))
+        end
+      end
+
+      describe ".destroyable" do
+        it "returns declarations with destroyable statuses" do
+          expect(described_class.destroyable.pluck(:payment_status)).to all(be_in(described_class::DESTROYABLE_PAYMENT_STATUSES))
         end
       end
     end

--- a/spec/models/training_period_spec.rb
+++ b/spec/models/training_period_spec.rb
@@ -932,6 +932,38 @@ describe TrainingPeriod do
         }
       end
     end
+
+    context "when there are both billable and non-billable declarations" do
+      subject(:training_period) { declaration.training_period }
+
+      let(:declaration) { FactoryBot.create(:declaration, :paid) }
+      let!(:non_billable_declaration) { FactoryBot.create(:declaration, :voided, training_period:) }
+
+      it "refuses to destroy the training period and leaves the non-billable declaration intact" do
+        expect { training_period.destroy! }.to raise_error(ActiveRecord::RecordNotDestroyed)
+
+        expect { training_period.reload }.not_to raise_error
+        expect { non_billable_declaration.reload }.not_to raise_error
+        expect { declaration.reload }.not_to raise_error
+      end
+    end
+
+    context "when a non-billable declaration fails to destroy" do
+      subject(:training_period) { declaration.training_period }
+
+      let(:declaration) { FactoryBot.create(:declaration, :no_payment) }
+
+      before do
+        allow_any_instance_of(Declaration).to receive(:destroy!).and_raise(ActiveRecord::RecordNotDestroyed, "cannot destroy") # rubocop:disable RSpec/AnyInstance
+      end
+
+      it "rolls back and leaves the training period and declaration intact" do
+        expect { training_period.destroy! }.to raise_error(ActiveRecord::RecordNotDestroyed)
+
+        expect { training_period.reload }.not_to raise_error
+        expect { declaration.reload }.not_to raise_error
+      end
+    end
   end
 
   describe "check constraints" do

--- a/spec/services/ect_at_school_periods/finish_spec.rb
+++ b/spec/services/ect_at_school_periods/finish_spec.rb
@@ -211,12 +211,10 @@ describe ECTAtSchoolPeriods::Finish do
       context "when there is a training period that is set to finish before the date the ECT leaves the school" do
         let(:existing_finished_on) { 1.week.ago.to_date }
         let!(:training_period) do
-          FactoryBot.create(
-            :training_period,
-            ect_at_school_period:,
-            started_on:,
-            finished_on: existing_finished_on
-          )
+          FactoryBot.create(:training_period,
+                            ect_at_school_period:,
+                            started_on:,
+                            finished_on: existing_finished_on)
         end
         let(:finished_on) { 1.week.from_now.to_date }
 
@@ -229,12 +227,10 @@ describe ECTAtSchoolPeriods::Finish do
       context "when there is a training period that is set to finish after the date the ECT leaves the school" do
         let(:existing_finished_on) { 1.week.from_now.to_date }
         let!(:training_period) do
-          FactoryBot.create(
-            :training_period,
-            ect_at_school_period:,
-            started_on:,
-            finished_on: existing_finished_on
-          )
+          FactoryBot.create(:training_period,
+                            ect_at_school_period:,
+                            started_on:,
+                            finished_on: existing_finished_on)
         end
         let(:finished_on) { 1.week.ago.to_date }
 
@@ -247,11 +243,9 @@ describe ECTAtSchoolPeriods::Finish do
       context "when the training period has not started yet" do
         let(:training_start_date) { finished_on + 1.week }
         let!(:training_period) do
-          FactoryBot.create(
-            :training_period,
-            ect_at_school_period:,
-            started_on: training_start_date
-          )
+          FactoryBot.create(:training_period,
+                            ect_at_school_period:,
+                            started_on: training_start_date)
         end
 
         it "deletes the training period" do
@@ -266,6 +260,35 @@ describe ECTAtSchoolPeriods::Finish do
           expect(Events::Record).to have_received(:record_teacher_left_school_as_ect!).once.with(
             hash_including(author:, ect_at_school_period:, school:, teacher:, training_period: nil, happened_at: finished_on)
           )
+        end
+      end
+
+      context "when an unstarted training period has declarations" do
+        let!(:training_period) do
+          FactoryBot.create(:training_period,
+                            ect_at_school_period:,
+                            started_on: finished_on.next_day,
+                            finished_on: nil)
+        end
+
+        context "with a non-billable declaration" do
+          let!(:declaration) { FactoryBot.create(:declaration, :no_payment, training_period:) }
+
+          it "destroys the unstarted period and its declaration" do
+            subject.finish!
+
+            expect { training_period.reload }.to raise_error(ActiveRecord::RecordNotFound)
+            expect { declaration.reload }.to raise_error(ActiveRecord::RecordNotFound)
+          end
+        end
+
+        context "with a billable declaration" do
+          let!(:declaration) { FactoryBot.create(:declaration, :paid, training_period:) }
+
+          it "raises and does not destroy the training period" do
+            expect { subject.finish! }.to raise_error(ActiveRecord::RecordNotDestroyed)
+            expect { training_period.reload }.not_to raise_error
+          end
         end
       end
     end

--- a/spec/services/teachers/undo_registration_spec.rb
+++ b/spec/services/teachers/undo_registration_spec.rb
@@ -194,6 +194,7 @@ RSpec.describe Teachers::UndoRegistration do
 
         it "deletes the relevant periods" do
           expect_periods_to_be_deleted(ect_at_school_period:, training_period:, mentorship_period:)
+          expect { declaration.reload }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
 
@@ -202,6 +203,7 @@ RSpec.describe Teachers::UndoRegistration do
 
         it "deletes the relevant periods" do
           expect_periods_to_be_deleted(ect_at_school_period:, training_period:, mentorship_period:)
+          expect { declaration.reload }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
 


### PR DESCRIPTION
### Context

DFE-Digital/register-ects-project-board/issues/4298

> We accidentally deleted a training period that belonged to a declaration.

### Changes proposed in this pull request

Add the foreign key now that all the missing periods have been restored

### Guidance to review

https://www.register-early-career-teachers.education.gov.uk/admin/blazer/queries/478-missing-fk-declarations-training_period_id
