### PR TITLE
[3260] DQT analysis

### DIFF
--- a/.github/workflows/check-validity.yml
+++ b/.github/workflows/check-validity.yml
@@ -1,0 +1,44 @@
+name: Check data validity
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+
+jobs:
+  check-validity:
+    name: Analyse invalid records on migration
+    runs-on: ubuntu-latest
+    environment: migration
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - uses: Azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+
+      - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
+        with:
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+
+      - uses: DFE-Digital/github-actions/set-kubectl@master
+
+      - name: Set AKS credentials
+        shell: bash
+        run: make ci migration get-cluster-credentials
+
+      - name: Truncate and re-run invalidity scan
+        shell: bash
+        run: |
+          kubectl -n cpd-production exec deployment/cpd-ec2-migration-web -- /bin/sh -c '
+            cd /app &&
+            DISABLE_DATABASE_ENVIRONMENT_CHECK=1 \
+            RAILS_ENV=migration \
+            /usr/local/bin/bundle exec rails runner "InvalidRecord.delete_all; CheckValidity.new.call"
+          '

--- a/app/models/invalid_record.rb
+++ b/app/models/invalid_record.rb
@@ -1,0 +1,11 @@
+# A data source for identifying invalid records captured for analyst triage.
+# No foreign keys are needed on this table: `table_name` + `record_id` are
+# sufficient for Blazer to surface any entity using smart columns and linked columns.
+#
+# Queries can alias using AS:
+#
+# ```sql
+#   SELECT record_id AS teacher_id FROM invalid_records WHERE table_name = 'teachers'
+# ```
+class InvalidRecord < ApplicationRecord
+end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -1,5 +1,12 @@
 ---
 :shared:
+  :invalid_records:
+    - id
+    - table_name
+    - record_id
+    - error_messages
+    - created_at
+    - updated_at
   :dfe_sign_in_organisations:
     - id
     - name

--- a/db/migrate/20260813120000_create_invalid_records.rb
+++ b/db/migrate/20260813120000_create_invalid_records.rb
@@ -1,0 +1,12 @@
+class CreateInvalidRecords < ActiveRecord::Migration[8.1]
+  def change
+    create_table :invalid_records do |t|
+      t.string  :table_name, null: false
+      t.bigint  :record_id, null: false
+      t.text    :error_messages, null: false
+      t.timestamps
+    end
+
+    add_index :invalid_records, %i[table_name record_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_13_103015) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_13_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -425,6 +425,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_13_103015) do
     t.check_constraint "finished_on >= started_on", name: "finished_on_not_before_started_on"
   end
 
+  create_table "invalid_records", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.text "error_messages", null: false
+    t.bigint "record_id", null: false
+    t.string "table_name", null: false
+    t.datetime "updated_at", null: false
+    t.index ["table_name", "record_id"], name: "index_invalid_records_on_table_name_and_record_id", unique: true
+  end
+
   create_table "lead_provider_delivery_partnerships", force: :cascade do |t|
     t.bigint "active_lead_provider_id", null: false
     t.datetime "created_at", null: false

--- a/db/seeds/blazer_queries.rb
+++ b/db/seeds/blazer_queries.rb
@@ -82,6 +82,33 @@ end
     name: "Active lead provider bands",
     statement: "SELECT * FROM active_lead_provider_bands ORDER BY active_lead_provider_id, allocation_order",
     description: "new data model"
+  },
+  {
+    name: "Invalid teachers",
+    description: "Fails model validations",
+    statement: <<~SQL.strip
+      SELECT record_id AS teacher_id,
+             error_messages,
+             created_at
+      FROM invalid_records
+      WHERE table_name = 'teachers'
+      ORDER BY teacher_id
+    SQL
+  },
+  {
+    name: "Invalid induction periods",
+    description: "Fails model validations",
+    statement: <<~SQL.strip
+      SELECT t.id AS teacher_id,
+            record_id AS induction_period_id,
+            error_messages,
+            ir.created_at
+      FROM invalid_records ir
+      JOIN induction_periods ip ON ip.id = ir.record_id
+      JOIN teachers t ON t.id = ip.teacher_id
+      WHERE table_name = 'induction_periods'
+      ORDER BY teacher_id
+    SQL
   }
 ].each do |query|
   create_query(creator: user_manager, **query)

--- a/db/seeds/invalid_records.rb
+++ b/db/seeds/invalid_records.rb
@@ -1,0 +1,41 @@
+# Generate date that is invalid bypassing validations in order to test data triage
+appropriate_body_period = AppropriateBodyPeriod.first
+
+teacher = Teacher.new(
+  trn: "9999999",
+  trs_first_name: "Demo",
+  trs_last_name: "Invalid",
+  trs_qts_awarded_on: Date.new(2025, 1, 1),
+  mentor_became_ineligible_for_funding_on: Date.current - 30,
+  mentor_became_ineligible_for_funding_reason: nil,
+  trs_induction_status: "Invalid",                      # unrecognised status
+  trs_induction_start_date: nil,                        # missing
+  trs_induction_completed_date: Date.new(1999, 1, 1)    # differs from induction data predates QTS
+)
+teacher.save!(validate: false)
+
+teacher.reload
+
+ranges = [
+  [Date.new(2023, 9, 1), Date.new(2024, 8, 31)],  # predates QTS overlaps next
+  [Date.new(2024, 1, 1), Date.new(2024, 12, 31)], # overlaps next
+  [Date.new(2024, 6, 1), Date.new(2099, 5, 31)]   # future date
+]
+
+periods = ranges.map do |started_on, finished_on|
+  InductionPeriod.new(
+    teacher:,
+    appropriate_body_period:,
+    induction_programme: "fip",
+    started_on:,
+    finished_on:
+  ).tap do |ip|
+    ip.save!(validate: false)
+    ip.reload
+  end
+end
+
+print_seed_info(
+  "Seeded invalid teacher TRN #{teacher.trn} + #{periods.size} invalid inductions",
+  indent: 2
+)

--- a/lib/check_validity.rb
+++ b/lib/check_validity.rb
@@ -1,0 +1,35 @@
+class CheckValidity
+  TABLES = %w[
+    teachers
+    appropriate_body_periods
+    induction_periods
+    induction_extensions
+    training_periods
+    declarations
+  ].freeze
+
+  BATCH_SIZE = 1_000
+
+  def call(tables: TABLES)
+    raise StandardError, "Do not query live production data" if Rails.env.production?
+    raise ArgumentError, "No tables specified" if tables.blank?
+
+    tables.each do |table_name|
+      model = table_name.singularize.camelize.constantize
+
+      model.find_in_batches(batch_size: BATCH_SIZE) do |batch|
+        rows = batch.reject(&:valid?).map do |record|
+          {
+            table_name:,
+            record_id: record.id,
+            error_messages: record.errors.full_messages.join("; "),
+          }
+        end
+
+        next if rows.empty?
+
+        InvalidRecord.upsert_all(rows, unique_by: %i[table_name record_id])
+      end
+    end
+  end
+end

--- a/lib/tasks/check_validity.rake
+++ b/lib/tasks/check_validity.rake
@@ -1,0 +1,7 @@
+namespace :data do
+  desc "Scan configured tables and record invalid records into invalid_records"
+  task check_validity: :environment do
+    totals = CheckValidity.new.call
+    $stdout.puts "Total invalid records: #{totals.values.sum}" if totals.any?
+  end
+end


### PR DESCRIPTION
### Context

- The justified use of mechanisms that bypass validation runs the risk of importing invalid data 
- Oversites in the schema can lead to orphaned records
- Legacy data imports have and will be shoehorned in to ECF2's new structure and need finessing afterwards
- Gaps and manipulations that naturally occur over the life of the service

### Changes proposed in this pull request

A way to process and navigate invalid records within the service to aid in the triage of wonky data.

An iteration on the existing script runner that exports to CSV. 

### Guidance to review
