### PR TITLE
Send user identifier to DfE Analytics

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -13,7 +13,7 @@ private
 
   # `current_user` needed for DfE::Analytics
   def current_user
-    current_lead_provider
+    API::AnalyticsUser.new(current_lead_provider)
   end
 
   def append_info_to_payload(payload)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,7 +24,7 @@ class ApplicationController < ActionController::Base
     Sentry.set_user(
       email: current_user&.email,
       id: current_user.try(:id),
-      dfe_sign_in_user_fingerprint: current_user_dfe_sign_in_user_fingerprint
+      dfe_sign_in_user_fingerprint: current_user&.fingerprint
     )
   end
 
@@ -41,11 +41,6 @@ private
     super
     payload[:current_user_class] = current_user&.class&.name
     payload[:current_user_id] = current_user.try(:id)
-    payload[:current_user_dfe_sign_in_user_fingerprint] =
-      current_user_dfe_sign_in_user_fingerprint
-  end
-
-  def current_user_dfe_sign_in_user_fingerprint
-    current_user&.fingerprint
+    payload[:current_user_dfe_sign_in_user_fingerprint] = current_user&.fingerprint
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -46,14 +46,6 @@ private
   end
 
   def current_user_dfe_sign_in_user_fingerprint
-    dfe_sign_in_user_id = current_user.try(:dfe_sign_in_user_id)
-
-    return if dfe_sign_in_user_id.blank?
-
-    OpenSSL::HMAC.hexdigest(
-      "SHA256",
-      Rails.application.secret_key_base,
-      dfe_sign_in_user_id
-    )
+    current_user&.fingerprint
   end
 end

--- a/app/services/api/analytics_user.rb
+++ b/app/services/api/analytics_user.rb
@@ -1,0 +1,14 @@
+module API
+  class AnalyticsUser
+    attr_reader :lead_provider
+
+    def initialize(lead_provider)
+      @lead_provider = lead_provider
+    end
+
+    delegate :name, to: :lead_provider
+
+    # NOTE: would short_name make more sense here?
+    def fingerprint = lead_provider.id
+  end
+end

--- a/app/services/api/request.rb
+++ b/app/services/api/request.rb
@@ -8,8 +8,8 @@ module API
         response_data = response_data.with_indifferent_access
         request_headers = request_data.fetch(:headers, {})
 
-        lead_provider = fetch_lead_provider(request_headers.delete("HTTP_AUTHORIZATION"))
-        return unless lead_provider
+        analytics_user = fetch_lead_provider_analytics_user(request_headers.delete("HTTP_AUTHORIZATION"))
+        return unless analytics_user
 
         response_headers = response_data[:headers]
         response_body = response_data[:body]
@@ -22,8 +22,8 @@ module API
           response_headers:,
           response_body: response_hash(response_body, status_code),
           status_code:,
-          user_description: user_description(lead_provider),
-          lead_provider:,
+          user_description: user_description(analytics_user),
+          lead_provider: analytics_user.lead_provider,
           created_at:,
         }
 
@@ -32,7 +32,7 @@ module API
           .with_request_uuid(uuid)
           .with_entity_table_name(:api_requests)
           .with_data(data:)
-          .with_user(lead_provider)
+          .with_user(analytics_user)
 
         DfE::Analytics::SendEvents.do(Array.wrap(event.as_json))
       end
@@ -46,7 +46,7 @@ module API
         response = ActionDispatch::Response.new(429)
 
         user = fetch_user(request.session)
-        user ||= fetch_lead_provider(request.authorization)
+        user ||= fetch_lead_provider_analytics_user(request.authorization)
 
         rate_limit_event = DfE::Analytics::Event.new
           .with_type(:web_request)
@@ -89,11 +89,14 @@ module API
         Sessions::User.from_session(session["user_session"])
       end
 
-      def fetch_lead_provider(http_authorization)
+      def fetch_lead_provider_analytics_user(http_authorization)
         token = http_authorization.to_s.split("Bearer ").last
         return if token.blank?
 
-        ::API::TokenManager.find_lead_provider_api_token(token:)&.lead_provider
+        lead_provider = ::API::TokenManager.find_lead_provider_api_token(token:)&.lead_provider
+        return if lead_provider.blank?
+
+        ::API::AnalyticsUser.new(lead_provider)
       end
 
       def user_description(lead_provider)

--- a/app/services/sessions/user.rb
+++ b/app/services/sessions/user.rb
@@ -32,6 +32,7 @@ module Sessions
     end
 
     def dfe_analytics_user_id = nil
+    def fingerprint = nil
 
     # User?
     def dfe_sign_in_authorisable? = false

--- a/app/services/sessions/user.rb
+++ b/app/services/sessions/user.rb
@@ -31,6 +31,8 @@ module Sessions
       @last_active_at = last_active_at.is_a?(String) ? Time.zone.parse(last_active_at) : last_active_at
     end
 
+    def dfe_analytics_user_id = nil
+
     # User?
     def dfe_sign_in_authorisable? = false
     def appropriate_body_user? = false

--- a/app/services/sessions/users/appropriate_body_user.rb
+++ b/app/services/sessions/users/appropriate_body_user.rb
@@ -1,6 +1,8 @@
 module Sessions
   module Users
     class AppropriateBodyUser < User
+      include Fingerprint
+
       class UnknownOrganisationId < Sessions::User::InvalidSession; end
 
       USER_TYPE = :appropriate_body_user

--- a/app/services/sessions/users/appropriate_body_user.rb
+++ b/app/services/sessions/users/appropriate_body_user.rb
@@ -73,6 +73,9 @@ module Sessions
       # @return [Array<String>]
       alias_method :roles, :dfe_sign_in_roles
 
+      # @return [String]
+      alias_method :dfe_analytics_user_id, :dfe_sign_in_user_id
+
     private
 
       def appropriate_body_period_from(dfe_sign_in_organisation_id)

--- a/app/services/sessions/users/dfe_persona.rb
+++ b/app/services/sessions/users/dfe_persona.rb
@@ -11,6 +11,8 @@ module Sessions
 
       attr_reader :id, :name, :user
 
+      alias_method :dfe_analytics_user_id, :id
+
       def initialize(email:, **)
         fail DfEPersonaDisabledError unless Rails.application.config.enable_personas
 

--- a/app/services/sessions/users/dfe_persona.rb
+++ b/app/services/sessions/users/dfe_persona.rb
@@ -4,6 +4,7 @@ module Sessions
       class DfEPersonaDisabledError < Sessions::User::InvalidSession; end
       class UnknownUserEmail < Sessions::User::InvalidSession; end
 
+      include Fingerprint
       include Sessions::ImpersonateSchoolUser
 
       USER_TYPE = :dfe_staff_user

--- a/app/services/sessions/users/dfe_user.rb
+++ b/app/services/sessions/users/dfe_user.rb
@@ -3,6 +3,7 @@ module Sessions
     class DfEUser < User
       class UnknownUserEmail < Sessions::User::InvalidSession; end
 
+      include Fingerprint
       include Sessions::ImpersonateSchoolUser
 
       USER_TYPE = :dfe_staff_user

--- a/app/services/sessions/users/dfe_user.rb
+++ b/app/services/sessions/users/dfe_user.rb
@@ -10,6 +10,8 @@ module Sessions
 
       attr_reader :id, :name, :user
 
+      alias_method :dfe_analytics_user_id, :id
+
       def initialize(email:, **)
         @user = user_from(email)
         @id = user.id

--- a/app/services/sessions/users/dfe_user_impersonating_school_user.rb
+++ b/app/services/sessions/users/dfe_user_impersonating_school_user.rb
@@ -3,6 +3,8 @@ module Sessions
     class DfEUserImpersonatingSchoolUser < DfEUser
       class UnknownOrganisationURN < Sessions::User::InvalidSession; end
 
+      include Fingerprint
+
       attr_reader :original_type, :school
 
       USER_TYPE = :dfe_user_impersonating_school_user

--- a/app/services/sessions/users/dfe_user_impersonating_school_user.rb
+++ b/app/services/sessions/users/dfe_user_impersonating_school_user.rb
@@ -7,6 +7,8 @@ module Sessions
 
       USER_TYPE = :dfe_user_impersonating_school_user
 
+      alias_method :dfe_analytics_user_id, :id
+
       def initialize(email:, school_urn:, original_type:, **)
         @user = user_from(email)
         @id = user.id

--- a/app/services/sessions/users/fingerprint.rb
+++ b/app/services/sessions/users/fingerprint.rb
@@ -1,0 +1,9 @@
+module Sessions
+  module Users
+    module Fingerprint
+      def fingerprint(key = Rails.application.secret_key_base)
+        OpenSSL::HMAC.hexdigest("SHA256", key, dfe_analytics_user_id.to_s)
+      end
+    end
+  end
+end

--- a/app/services/sessions/users/school_user.rb
+++ b/app/services/sessions/users/school_user.rb
@@ -76,6 +76,9 @@ module Sessions
       # @return [Array<String>]
       alias_method :roles, :dfe_sign_in_roles
 
+      # @return [String]
+      alias_method :dfe_analytics_user_id, :dfe_sign_in_user_id
+
     private
 
       def school_from(urn)

--- a/app/services/sessions/users/school_user.rb
+++ b/app/services/sessions/users/school_user.rb
@@ -3,6 +3,8 @@ module Sessions
     class SchoolUser < User
       class UnknownOrganisationURN < Sessions::User::InvalidSession; end
 
+      include Fingerprint
+
       USER_TYPE = :school_user
       PROVIDER = :dfe_sign_in
 

--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -51,7 +51,7 @@ DfE::Analytics.configure do |config|
   # return the identifier for the user. This is useful for systems with
   # users that don't use the id field.
   #
-  config.user_identifier = proc { |user| user&.id if user.respond_to?(:id) }
+  config.user_identifier = proc { |user| user&.fingerprint }
 
   # Whether to run entity table checksum job.
   #

--- a/spec/services/api/analytics_user_spec.rb
+++ b/spec/services/api/analytics_user_spec.rb
@@ -1,0 +1,23 @@
+describe API::AnalyticsUser do
+  subject { API::AnalyticsUser.new(lead_provider) }
+
+  let(:lead_provider) { FactoryBot.build(:lead_provider, id: 123) }
+
+  describe "#lead_provider" do
+    it "returns the provided lead_provider" do
+      expect(subject.lead_provider).to eql(lead_provider)
+    end
+  end
+
+  describe "#name" do
+    it "returns the lead provider's name" do
+      expect(subject.name).to be(lead_provider.name)
+    end
+  end
+
+  describe "#fingerprint" do
+    it "returns lead_provider's fingerprint" do
+      expect(subject.fingerprint).to be(123)
+    end
+  end
+end

--- a/spec/services/sessions/users/appropriate_body_persona_spec.rb
+++ b/spec/services/sessions/users/appropriate_body_persona_spec.rb
@@ -29,6 +29,10 @@ RSpec.describe Sessions::Users::AppropriateBodyPersona do
     end
   end
 
+  describe "#dfe_analytics_user_id" do
+    it { expect(appropriate_body_persona.dfe_analytics_user_id).to be_nil }
+  end
+
   describe "#provider" do
     it { expect(appropriate_body_persona.provider).to be(:persona) }
   end

--- a/spec/services/sessions/users/appropriate_body_persona_spec.rb
+++ b/spec/services/sessions/users/appropriate_body_persona_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe Sessions::Users::AppropriateBodyPersona do
     let(:user_props) { { email:, name:, appropriate_body_period_id: } }
   end
 
+  it_behaves_like "an unfingerprintable user" do
+    let(:user_props) { { email:, name:, appropriate_body_period_id: } }
+  end
+
   context "when personas are disabled" do
     before { allow(Rails.application.config).to receive(:enable_personas).and_return(false) }
 

--- a/spec/services/sessions/users/appropriate_body_persona_spec.rb
+++ b/spec/services/sessions/users/appropriate_body_persona_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Sessions::Users::AppropriateBodyPersona do
     let(:user_props) { { email:, name:, appropriate_body_period_id: } }
   end
 
-  it_behaves_like "an unfingerprintable user" do
+  it_behaves_like "an unidentifiable user" do
     let(:user_props) { { email:, name:, appropriate_body_period_id: } }
   end
 

--- a/spec/services/sessions/users/appropriate_body_user_spec.rb
+++ b/spec/services/sessions/users/appropriate_body_user_spec.rb
@@ -24,6 +24,12 @@ RSpec.describe Sessions::Users::AppropriateBodyUser do
     end
   end
 
+  it_behaves_like "a fingerprintable user" do
+    let(:user_props) do
+      { email:, name:, dfe_sign_in_organisation_id:, dfe_sign_in_user_id:, dfe_sign_in_roles: }
+    end
+  end
+
   context "when no appropriate body is found" do
     let(:dfe_sign_in_organisation_id) { SecureRandom.uuid }
 

--- a/spec/services/sessions/users/appropriate_body_user_spec.rb
+++ b/spec/services/sessions/users/appropriate_body_user_spec.rb
@@ -66,9 +66,9 @@ RSpec.describe Sessions::Users::AppropriateBodyUser do
     end
   end
 
-  describe "#dfe_sign_in_user_id" do
+  describe "#dfe_analytics_user_id" do
     it "returns the id of the user in DfE SignIn" do
-      expect(appropriate_body_user.dfe_sign_in_user_id).to eql(dfe_sign_in_user_id)
+      expect(appropriate_body_user.dfe_analytics_user_id).to eql(dfe_sign_in_user_id)
     end
   end
 

--- a/spec/services/sessions/users/dfe_persona_spec.rb
+++ b/spec/services/sessions/users/dfe_persona_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe Sessions::Users::DfEPersona do
     let(:user_props) { { email: } }
   end
 
+  it_behaves_like "a fingerprintable user" do
+    let(:user_props) { { email: } }
+  end
+
   context "when personas are disabled" do
     before { allow(Rails.application.config).to receive(:enable_personas).and_return(false) }
 

--- a/spec/services/sessions/users/dfe_persona_spec.rb
+++ b/spec/services/sessions/users/dfe_persona_spec.rb
@@ -44,6 +44,14 @@ RSpec.describe Sessions::Users::DfEPersona do
     it { is_expected.to delegate_method(:can_manage_users?).to(:user) }
   end
 
+  describe "#id" do
+    it { expect(dfe_persona.id).to eql(user.id) }
+  end
+
+  describe "#dfe_analytics_user_id" do
+    it { expect(dfe_persona.dfe_analytics_user_id).to eql(user.id) }
+  end
+
   describe "#provider" do
     it { expect(dfe_persona.provider).to be(:persona) }
   end

--- a/spec/services/sessions/users/dfe_user_impersonating_school_user_spec.rb
+++ b/spec/services/sessions/users/dfe_user_impersonating_school_user_spec.rb
@@ -17,6 +17,14 @@ describe "Sessions::Users::DfEUserImpersonatingSchoolUser" do
     it { expect(dfe_user_impersonating_school_user.original_type).to eql(original_type) }
   end
 
+  describe "#id" do
+    it { expect(dfe_user_impersonating_school_user.id).to eql(user.id) }
+  end
+
+  describe "#dfe_analytics_user_id" do
+    it { expect(dfe_user_impersonating_school_user.dfe_analytics_user_id).to eql(user.id) }
+  end
+
   describe "#to_h" do
     it "returns the session details" do
       expect(dfe_user_impersonating_school_user.to_h.except("last_active_at")).to eq(

--- a/spec/services/sessions/users/dfe_user_impersonating_school_user_spec.rb
+++ b/spec/services/sessions/users/dfe_user_impersonating_school_user_spec.rb
@@ -1,4 +1,4 @@
-describe "Sessions::Users::DfEUserImpersonatingSchoolUser" do
+describe Sessions::Users::DfEUserImpersonatingSchoolUser do # rubocop:disable RSpec/SpecFilePathFormat
   subject(:dfe_user_impersonating_school_user) { Sessions::Users::DfEUserImpersonatingSchoolUser.new(email: user.email, school_urn:, original_type:) }
 
   let(:email) { "timothy.dalton@education.gov.uk" }
@@ -9,6 +9,10 @@ describe "Sessions::Users::DfEUserImpersonatingSchoolUser" do
 
   it "has user type :dfe_user_impersonating_school_user" do
     expect(Sessions::Users::DfEUserImpersonatingSchoolUser::USER_TYPE).to be(:dfe_user_impersonating_school_user)
+  end
+
+  it_behaves_like "a fingerprintable user" do
+    let(:user_props) { { email: user.email, school_urn: school.urn, original_type: } }
   end
 
   describe "initialization" do

--- a/spec/services/sessions/users/dfe_user_spec.rb
+++ b/spec/services/sessions/users/dfe_user_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe Sessions::Users::DfEUser do
     let(:user_props) { { email: } }
   end
 
+  it_behaves_like "a fingerprintable user" do
+    let(:user_props) { { email: } }
+  end
+
   context "when there is no user with the given email" do
     let(:email) { Faker::Internet.email }
 

--- a/spec/services/sessions/users/dfe_user_spec.rb
+++ b/spec/services/sessions/users/dfe_user_spec.rb
@@ -36,6 +36,14 @@ RSpec.describe Sessions::Users::DfEUser do
     it { is_expected.to delegate_method(:can_manage_users?).to(:user) }
   end
 
+  describe "#id" do
+    it { expect(dfe_user.id).to eql(user.id) }
+  end
+
+  describe "#dfe_analytics_user_id" do
+    it { expect(dfe_user.dfe_analytics_user_id).to eql(user.id) }
+  end
+
   describe "#provider" do
     it { expect(dfe_user.provider).to be(:otp) }
   end

--- a/spec/services/sessions/users/fingerprint_spec.rb
+++ b/spec/services/sessions/users/fingerprint_spec.rb
@@ -1,0 +1,47 @@
+class SomeUser
+  include Sessions::Users::Fingerprint
+
+  def dfe_analytics_user_id = "abc123"
+end
+
+describe "Fingerprinting users" do
+  subject { SomeUser.new }
+
+  let(:secret) { "qwerty" }
+
+  describe "#fingerprint" do
+    context "when no key is passed in" do
+      before do
+        allow(OpenSSL::HMAC).to receive(:hexdigest).with("SHA256", secret, "abc123").and_return("SECRET")
+        allow(Rails.application).to receive(:secret_key_base).and_return("qwerty")
+      end
+
+      it "defaults to Rails' secret_key_base" do
+        subject.fingerprint
+        expect(OpenSSL::HMAC).to have_received(:hexdigest).with("SHA256", secret, "abc123")
+      end
+
+      it "returns the result of #hexdigest" do
+        expect(subject.fingerprint).to eql("SECRET")
+      end
+    end
+
+    context "when a key is passed in" do
+      let(:new_secret) { "xyz" }
+
+      before do
+        allow(OpenSSL::HMAC).to receive(:hexdigest).with("SHA256", new_secret, "abc123").and_return("CONFIDENTIAL")
+        allow(Rails.application).to receive(:secret_key_base).and_return("qwerty")
+      end
+
+      it "uses the provided key" do
+        subject.fingerprint(new_secret)
+        expect(OpenSSL::HMAC).to have_received(:hexdigest).with("SHA256", new_secret, "abc123")
+      end
+
+      it "returns the result of #hexdigest" do
+        expect(subject.fingerprint(new_secret)).to eql("CONFIDENTIAL")
+      end
+    end
+  end
+end

--- a/spec/services/sessions/users/school_persona_spec.rb
+++ b/spec/services/sessions/users/school_persona_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Sessions::Users::SchoolPersona do
     let(:user_props) { { email:, name:, school_urn: school.urn } }
   end
 
-  it_behaves_like "an unfingerprintable user" do
+  it_behaves_like "an unidentifiable user" do
     let(:user_props) { { email:, name:, school_urn: school.urn } }
   end
 

--- a/spec/services/sessions/users/school_persona_spec.rb
+++ b/spec/services/sessions/users/school_persona_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe Sessions::Users::SchoolPersona do
     let(:user_props) { { email:, name:, school_urn: school.urn } }
   end
 
+  it_behaves_like "an unfingerprintable user" do
+    let(:user_props) { { email:, name:, school_urn: school.urn } }
+  end
+
   context "when personas are disabled" do
     before { allow(Rails.application.config).to receive(:enable_personas).and_return(false) }
 

--- a/spec/services/sessions/users/school_persona_spec.rb
+++ b/spec/services/sessions/users/school_persona_spec.rb
@@ -29,6 +29,10 @@ RSpec.describe Sessions::Users::SchoolPersona do
     end
   end
 
+  describe "#dfe_analytics_user_id" do
+    it { expect(school_persona.dfe_analytics_user_id).to be_nil }
+  end
+
   describe "#provider" do
     it { expect(school_persona.provider).to be(:persona) }
   end

--- a/spec/services/sessions/users/school_user_spec.rb
+++ b/spec/services/sessions/users/school_user_spec.rb
@@ -73,6 +73,12 @@ RSpec.describe Sessions::Users::SchoolUser do
     end
   end
 
+  describe "#dfe_analytics_user_id" do
+    it "returns the id of the user in DfE SignIn" do
+      expect(school_user.dfe_analytics_user_id).to eql(dfe_sign_in_user_id)
+    end
+  end
+
   describe "user type methods" do
     it { expect(school_user).to be_school_user }
     it { expect(school_user).to be_dfe_sign_in_authorisable }

--- a/spec/services/sessions/users/school_user_spec.rb
+++ b/spec/services/sessions/users/school_user_spec.rb
@@ -26,6 +26,12 @@ RSpec.describe Sessions::Users::SchoolUser do
     end
   end
 
+  it_behaves_like "a fingerprintable user" do
+    let(:user_props) do
+      { email:, name:, school_urn: school.urn, dfe_sign_in_organisation_id:, dfe_sign_in_user_id:, dfe_sign_in_roles: }
+    end
+  end
+
   context "when the gias school exists but no school record has been linked yet" do
     let(:gias_school) { FactoryBot.create(:gias_school, :open, :state_school_type) }
     let(:school_urn) { gias_school.urn }

--- a/spec/support/shared_contexts/fingerprintable_user.rb
+++ b/spec/support/shared_contexts/fingerprintable_user.rb
@@ -14,7 +14,7 @@ shared_examples "a fingerprintable user" do
   end
 end
 
-shared_examples "an unfingerprintable user" do
+shared_examples "an unidentifiable user" do
   subject(:session_user) { described_class.new(email:, **user_props) }
 
   describe "#fingerprint" do

--- a/spec/support/shared_contexts/fingerprintable_user.rb
+++ b/spec/support/shared_contexts/fingerprintable_user.rb
@@ -1,0 +1,23 @@
+shared_examples "a fingerprintable user" do
+  subject(:session_user) { described_class.new(email:, **user_props) }
+
+  describe "#fingerprint" do
+    let(:secret_hash) { "ABC123" }
+
+    before do
+      allow(OpenSSL::HMAC).to receive(:hexdigest).with(any_args).and_return(secret_hash)
+    end
+
+    it "returns a hash" do
+      expect(session_user.fingerprint).to eql(secret_hash)
+    end
+  end
+end
+
+shared_examples "an unfingerprintable user" do
+  subject(:session_user) { described_class.new(email:, **user_props) }
+
+  describe "#fingerprint" do
+    it("returns nil") { expect(session_user.fingerprint).to be_nil }
+  end
+end


### PR DESCRIPTION
### Context

We don't currently send any user identifier to DfE Analytics which makes tracking a single user's journey through the site impossible.

### Changes proposed in this pull request

This PR makes a few changes, it:

1. adds a `#dfe_analytics_user_id` method to all of the `Sessions::User` classes, which refer to either the `user.id` for database-backed users or the `#dfe_sign_in_user_id` for DfE Sign-in users. Users who can't be linked to either (School/AB Persona users) are `nil`
2. moves the existing fingerprint functionality from the `ApplicationController` to `Sesssions::Users::Fingerprint` and adds tests that cover it directly
3. adds a `API::AnalyticsUser` class which bridges the gap between a `LeadProvider` and a `User` by supplementing it with a `#fingerprint` method. This doesn't need to be kept secret so it just uses the `LeadProvider#id` (`#short_name` is a better fit here, see #2837)
