### PR TITLE
Fix failing `CascadeDelete` spec

### DIFF
--- a/spec/services/active_lead_providers/cascade_delete_spec.rb
+++ b/spec/services/active_lead_providers/cascade_delete_spec.rb
@@ -1,7 +1,8 @@
 describe ActiveLeadProviders::CascadeDelete do
   subject(:service) { described_class.new(active_lead_provider:, author:) }
 
-  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
+  let(:contract_period) { FactoryBot.create(:contract_period, :next) }
+  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, contract_period:) }
   let!(:contract) do
     FactoryBot.create(:contract, :for_ittecf_ectp, :with_bands_and_band_terms,
                       active_lead_provider:)
@@ -72,6 +73,13 @@ describe ActiveLeadProviders::CascadeDelete do
       FactoryBot.create(:training_period, :with_only_expression_of_interest, expression_of_interest: active_lead_provider)
 
       expect { service.call }.to raise_error(described_class::CascadeDeleteError, "Expressions of interest are present")
+      expect(ActiveLeadProvider).to exist(active_lead_provider.id)
+    end
+
+    it "raises when the contract period has started, destroying nothing" do
+      contract_period.update!(started_on: 1.day.ago)
+
+      expect { service.call }.to raise_error(ActiveRecord::RecordNotDestroyed)
       expect(ActiveLeadProvider).to exist(active_lead_provider.id)
     end
   end


### PR DESCRIPTION
We are seeing a failure on `main` due to the `CascadeDelete` spec attempting to destroy a `Band` that belongs to a `ContractPeriod` that has already started; we have validation in place in the model to prevent this.

I can't see why this has only just started failing, but to unblock the pipeline we can make sure the spec operates over a contract period that has not yet started.

We should look into consolidating our validation approach at some point; we have validation split between the `Band` model and `CascadeDelete` service just now.