### PR TITLE
[4292] Fix metadata refresh bug

### DIFF
--- a/app/models/concerns/at_school_period.rb
+++ b/app/models/concerns/at_school_period.rb
@@ -16,6 +16,8 @@ module AtSchoolPeriod
     touch -> { teacher }, on_event: %i[create destroy update], when_changing: %i[email], timestamp_attribute: :api_updated_at
     refresh_metadata -> { school }, on_event: %i[create destroy update]
     refresh_metadata -> { teacher }, on_event: %i[create destroy update]
+    # if the school_id changes, refresh the metadata for the previous school
+    refresh_metadata -> { School.find_by(id: school_id_was) }, on_event: %i[update], when_changing: %i[school_id]
 
     # Validations
     validates :email,

--- a/app/models/concerns/at_school_period.rb
+++ b/app/models/concerns/at_school_period.rb
@@ -17,7 +17,7 @@ module AtSchoolPeriod
     refresh_metadata -> { school }, on_event: %i[create destroy update]
     refresh_metadata -> { teacher }, on_event: %i[create destroy update]
     # if the school_id changes, refresh the metadata for the previous school
-    refresh_metadata -> { School.find_by(id: school_id_was) }, on_event: %i[update], when_changing: %i[school_id]
+    refresh_metadata -> { School.find_by(id: school_id_before_last_save) }, on_event: %i[update], when_changing: %i[school_id]
 
     # Validations
     validates :email,

--- a/app/models/concerns/declarative_updates.rb
+++ b/app/models/concerns/declarative_updates.rb
@@ -15,9 +15,10 @@ module DeclarativeUpdates
         next unless evaluated_target
         next unless evaluated_target.class.exists?(evaluated_target.id)
 
-        should_touch = destroyed? || when_changing.blank? || when_changing.any? do |attr|
+        relevant_attribute_changed = (when_changing.blank? && saved_changes.any?) || when_changing.any? do |attr|
           saved_change_to_attribute?(attr)
         end
+        should_touch = destroyed? || relevant_attribute_changed
 
         next unless should_touch
 

--- a/app/models/school_partnership.rb
+++ b/app/models/school_partnership.rb
@@ -18,7 +18,7 @@ class SchoolPartnership < ApplicationRecord
   touch -> { teachers }, when_changing: %i[lead_provider_delivery_partnership_id], timestamp_attribute: :api_updated_at
   refresh_metadata -> { school }, on_event: %i[create destroy update]
   # if the school_id changes, refresh the metadata for the previous school
-  refresh_metadata -> { School.find_by(id: school_id_was) }, on_event: %i[update], when_changing: %i[school_id]
+  refresh_metadata -> { School.find_by(id: school_id_before_last_save) }, on_event: %i[update], when_changing: %i[school_id]
 
   # Validations
   validates :lead_provider_delivery_partnership_id, presence: true

--- a/app/models/school_partnership.rb
+++ b/app/models/school_partnership.rb
@@ -17,6 +17,8 @@ class SchoolPartnership < ApplicationRecord
   touch -> { declarations }, when_changing: %i[lead_provider_delivery_partnership_id], timestamp_attribute: :api_updated_at
   touch -> { teachers }, when_changing: %i[lead_provider_delivery_partnership_id], timestamp_attribute: :api_updated_at
   refresh_metadata -> { school }, on_event: %i[create destroy update]
+  # if the school_id changes, refresh the metadata for the previous school
+  refresh_metadata -> { School.find_by(id: school_id_was) }, on_event: %i[update], when_changing: %i[school_id]
 
   # Validations
   validates :lead_provider_delivery_partnership_id, presence: true

--- a/spec/models/ect_at_school_period_spec.rb
+++ b/spec/models/ect_at_school_period_spec.rb
@@ -5,6 +5,20 @@ describe ECTAtSchoolPeriod do
       let!(:target) { FactoryBot.create(:school) }
 
       it_behaves_like "a declarative metadata model", on_event: %i[create destroy update]
+
+      context "when changing :school_id", :with_metadata do
+        let!(:manager) { instance_double(Metadata::Manager, refresh_metadata!: nil) }
+        let!(:new_school) { FactoryBot.create(:school) }
+
+        before do
+          allow(Metadata::Manager).to receive(:new).and_return(manager)
+        end
+
+        it "refreshes the metadata of the previous school" do
+          instance.update!(school: new_school)
+          expect(manager).to have_received(:refresh_metadata!).with(target)
+        end
+      end
     end
 
     describe "teacher target" do

--- a/spec/models/ect_at_school_period_spec.rb
+++ b/spec/models/ect_at_school_period_spec.rb
@@ -6,18 +6,12 @@ describe ECTAtSchoolPeriod do
 
       it_behaves_like "a declarative metadata model", on_event: %i[create destroy update]
 
-      context "when changing :school_id", :with_metadata do
-        let!(:manager) { instance_double(Metadata::Manager, refresh_metadata!: nil) }
-        let!(:new_school) { FactoryBot.create(:school) }
-
-        before do
-          allow(Metadata::Manager).to receive(:new).and_return(manager)
+      describe "previous school target" do
+        def will_change_attribute(attribute_to_change:, new_value:)
+          DeclarativeUpdates.skip(:metadata) { FactoryBot.create(:school, id: new_value) } if attribute_to_change == :school_id
         end
 
-        it "refreshes the metadata of the previous school" do
-          instance.update!(school: new_school)
-          expect(manager).to have_received(:refresh_metadata!).with(target)
-        end
+        it_behaves_like "a declarative metadata model", on_event: %i[update], when_changing: %i[school_id], target_optional: false
       end
     end
 

--- a/spec/models/mentor_at_school_period_spec.rb
+++ b/spec/models/mentor_at_school_period_spec.rb
@@ -6,18 +6,12 @@ describe MentorAtSchoolPeriod do
 
       it_behaves_like "a declarative metadata model", on_event: %i[create destroy update]
 
-      context "when changing :school_id", :with_metadata do
-        let!(:manager) { instance_double(Metadata::Manager, refresh_metadata!: nil) }
-        let!(:new_school) { FactoryBot.create(:school) }
-
-        before do
-          allow(Metadata::Manager).to receive(:new).and_return(manager)
+      describe "previous school target" do
+        def will_change_attribute(attribute_to_change:, new_value:)
+          DeclarativeUpdates.skip(:metadata) { FactoryBot.create(:school, id: new_value) } if attribute_to_change == :school_id
         end
 
-        it "refreshes the metadata of the previous school" do
-          instance.update!(school: new_school)
-          expect(manager).to have_received(:refresh_metadata!).with(target)
-        end
+        it_behaves_like "a declarative metadata model", on_event: %i[update], when_changing: %i[school_id], target_optional: false
       end
     end
 

--- a/spec/models/mentor_at_school_period_spec.rb
+++ b/spec/models/mentor_at_school_period_spec.rb
@@ -5,6 +5,20 @@ describe MentorAtSchoolPeriod do
       let!(:target) { FactoryBot.create(:school) }
 
       it_behaves_like "a declarative metadata model", on_event: %i[create destroy update]
+
+      context "when changing :school_id", :with_metadata do
+        let!(:manager) { instance_double(Metadata::Manager, refresh_metadata!: nil) }
+        let!(:new_school) { FactoryBot.create(:school) }
+
+        before do
+          allow(Metadata::Manager).to receive(:new).and_return(manager)
+        end
+
+        it "refreshes the metadata of the previous school" do
+          instance.update!(school: new_school)
+          expect(manager).to have_received(:refresh_metadata!).with(target)
+        end
+      end
     end
 
     describe "teacher target" do

--- a/spec/models/school_partnership_spec.rb
+++ b/spec/models/school_partnership_spec.rb
@@ -34,6 +34,20 @@ describe SchoolPartnership do
       let!(:target) { FactoryBot.create(:school) }
 
       it_behaves_like "a declarative metadata model", on_event: %i[create destroy update]
+
+      context "when changing :school_id", :with_metadata do
+        let!(:manager) { instance_double(Metadata::Manager, refresh_metadata!: nil) }
+        let!(:new_school) { FactoryBot.create(:school) }
+
+        before do
+          allow(Metadata::Manager).to receive(:new).and_return(manager)
+        end
+
+        it "refreshes the metadata of the previous school" do
+          instance.update!(school: new_school)
+          expect(manager).to have_received(:refresh_metadata!).with(target)
+        end
+      end
     end
   end
 

--- a/spec/models/school_partnership_spec.rb
+++ b/spec/models/school_partnership_spec.rb
@@ -35,18 +35,12 @@ describe SchoolPartnership do
 
       it_behaves_like "a declarative metadata model", on_event: %i[create destroy update]
 
-      context "when changing :school_id", :with_metadata do
-        let!(:manager) { instance_double(Metadata::Manager, refresh_metadata!: nil) }
-        let!(:new_school) { FactoryBot.create(:school) }
-
-        before do
-          allow(Metadata::Manager).to receive(:new).and_return(manager)
+      describe "previous school target" do
+        def will_change_attribute(attribute_to_change:, new_value:)
+          DeclarativeUpdates.skip(:metadata) { FactoryBot.create(:school, id: new_value) } if attribute_to_change == :school_id
         end
 
-        it "refreshes the metadata of the previous school" do
-          instance.update!(school: new_school)
-          expect(manager).to have_received(:refresh_metadata!).with(target)
-        end
+        it_behaves_like "a declarative metadata model", on_event: %i[update], when_changing: %i[school_id], target_optional: false
       end
     end
   end


### PR DESCRIPTION
### Context

When the school changes on a `ECTAtSchoolPeriod`, `MentorAtSchoolPeriod` or `SchoolPartnership` the metadata handlers kick in and update the school-related metadata associated with the _new school_ not the original school.  This leads to inconsistent metadata records for the original school, which are picked up and reported in Sentry by an overnight reconciliation job.

### Changes proposed in this pull request

Adds an additional `refresh_metadata` that uses the old `school_id` as the target

### Guidance to review
