### PR TITLE
[4144] Add Reconciliation to daily GIAS job

### DIFF
--- a/app/jobs/gias_import_job.rb
+++ b/app/jobs/gias_import_job.rb
@@ -1,8 +1,8 @@
 class GIASImportJob < ApplicationJob
   queue_as :default
 
-  # TODO: Enable automatic reconciliation
   def perform
-    GIAS::Importer.new.fetch
+    urns = GIAS::Importer.new.fetch
+    GIAS::Reconcile.new(urns).call
   end
 end

--- a/spec/jobs/gias_import_job_spec.rb
+++ b/spec/jobs/gias_import_job_spec.rb
@@ -1,15 +1,22 @@
 RSpec.describe GIASImportJob, type: :job do
+  let(:importer) { instance_spy(GIAS::Importer) }
+  let(:reconciler) { instance_spy(GIAS::Reconcile) }
+
+  before do
+    allow(GIAS::Importer).to receive(:new).and_return(importer)
+    allow(importer).to receive(:fetch).and_return(%w[urn1 urn2])
+    allow(GIAS::Reconcile).to receive(:new).and_return(reconciler)
+    allow(reconciler).to receive(:call)
+  end
+
   describe "#perform" do
-    it "runs the importer" do
-      importer = instance_spy(GIAS::Importer)
-
-      allow(GIAS::Importer).to receive(:new).and_return(importer)
-      allow(importer).to receive(:fetch)
-
+    it "runs the importer and reconciler" do
       described_class.new.perform
 
       expect(GIAS::Importer).to have_received(:new)
       expect(importer).to have_received(:fetch)
+      expect(GIAS::Reconcile).to have_received(:new).with(%w[urn1 urn2])
+      expect(reconciler).to have_received(:call)
     end
   end
 end


### PR DESCRIPTION
### Context
Now we have tested the Reconciler on migration we're happy to start running it daily after the importer.

### Changes proposed in this pull request
Pass the urns that require reconciliation direct to the `Reconcile` service once the import has completed.

### Guidance to review
