### PR TITLE
[4299] Prevent deleting TrainingPeriod with billable declarations

### DIFF
--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -97,6 +97,9 @@ class TrainingPeriod < ApplicationRecord
     validates :deferral_reason, absence: true
   end
 
+  # Callbacks
+  before_destroy :abort_destruction_when_billable_declarations_exist
+
   # Scopes
   scope :for_ect, ->(ect_at_school_period_id) { where(ect_at_school_period_id:) }
   scope :for_mentor, ->(mentor_at_school_period_id) { where(mentor_at_school_period_id:) }
@@ -195,6 +198,13 @@ class TrainingPeriod < ApplicationRecord
   end
 
 private
+
+  def abort_destruction_when_billable_declarations_exist
+    return unless declarations.billable.exists?
+
+    errors.add(:base, "Cannot delete a training period with billable declarations")
+    throw(:abort)
+  end
 
   def only_one_at_school_period_present
     ids = [ect_at_school_period_id, mentor_at_school_period_id]

--- a/spec/models/training_period_spec.rb
+++ b/spec/models/training_period_spec.rb
@@ -881,6 +881,59 @@ describe TrainingPeriod do
     end
   end
 
+  describe "destroying" do
+    subject(:training_period) { declaration.training_period }
+
+    Declaration::BILLABLE_PAYMENT_STATUSES.each do |payment_status|
+      context "when there is a #{payment_status} declaration" do
+        let(:declaration) { FactoryBot.create(:declaration, payment_status.to_sym) }
+
+        it "refuses to destroy the training period" do
+          expect { training_period.destroy! }.to raise_error(ActiveRecord::RecordNotDestroyed)
+          expect(training_period.errors[:base]).to include("Cannot delete a training period with billable declarations")
+        end
+      end
+    end
+
+    context "when there is a clawed back declaration" do
+      let(:declaration) { FactoryBot.create(:declaration, :clawed_back) }
+
+      it "refuses to destroy the training period" do
+        expect { training_period.destroy! }.to raise_error(ActiveRecord::RecordNotDestroyed)
+        expect(training_period.errors[:base]).to include("Cannot delete a training period with billable declarations")
+      end
+    end
+
+    %i[no_payment voided].each do |payment_status|
+      context "when there is only a #{payment_status} declaration" do
+        let!(:declaration) { FactoryBot.create(:declaration, payment_status) }
+
+        it "destroys the training period" do
+          expect { training_period.destroy! }.to change(described_class, :count).by(-1)
+        end
+      end
+    end
+
+    context "when there are no declarations" do
+      subject!(:training_period) { FactoryBot.create(:training_period) }
+
+      it "destroys the training period" do
+        expect { training_period.destroy! }.to change(described_class, :count).by(-1)
+      end
+    end
+
+    context "when the trainee's at school period is destroyed" do
+      let(:declaration) { FactoryBot.create(:declaration, :paid) }
+
+      it "refuses to destroy the at school period" do
+        expect { training_period.ect_at_school_period.destroy! }.to raise_error(ActiveRecord::RecordNotDestroyed) { |error|
+          expect(error.record).to be_a(described_class)
+          expect(error.record.errors[:base]).to include("Cannot delete a training period with billable declarations")
+        }
+      end
+    end
+  end
+
   describe "check constraints" do
     subject { FactoryBot.build(:training_period, ect_at_school_period:, started_on: Date.current, finished_on: Date.yesterday) }
 


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/4299

### Changes proposed in this pull request

As mentioned in the ticket, a foreign key constraint enforces this at the database layer, and the change here is to catch that in the application layer with a model error.

Simple `dependent: :restrict_with_error` doesn't fit here because we only care about _billable_ declarations, so I've used a destroy callback instead.