### PR TITLE
[4017] Do not update metadata on destroyed objects

### DIFF
--- a/app/models/concerns/declarative_updates.rb
+++ b/app/models/concerns/declarative_updates.rb
@@ -11,11 +11,17 @@ module DeclarativeUpdates
       after_commit(on: on_event) do
         next if DeclarativeUpdates.skip?(:metadata)
 
+        evaluated_target = instance_exec(&target)
+        next unless evaluated_target
+        next unless evaluated_target.class.exists?(evaluated_target.id)
+
         should_touch = destroyed? || when_changing.blank? || when_changing.any? do |attr|
           saved_change_to_attribute?(attr)
         end
 
-        Metadata::Manager.new.refresh_metadata!(instance_exec(&target)) if should_touch
+        next unless should_touch
+
+        Metadata::Manager.new.refresh_metadata!(evaluated_target)
       end
     end
 

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -23,8 +23,8 @@ class School < ApplicationRecord
   has_many :mentor_at_school_periods, inverse_of: :school
   has_many :mentor_teachers, -> { distinct }, through: :mentor_at_school_periods, source: :teacher
   has_many :school_partnerships
-  has_many :lead_provider_contract_period_metadata, class_name: "Metadata::SchoolLeadProviderContractPeriod"
-  has_many :contract_period_metadata, class_name: "Metadata::SchoolContractPeriod"
+  has_many :lead_provider_contract_period_metadata, class_name: "Metadata::SchoolLeadProviderContractPeriod", dependent: :delete_all
+  has_many :contract_period_metadata, class_name: "Metadata::SchoolContractPeriod", dependent: :delete_all
   has_many :training_periods, through: :school_partnerships
   has_many :school_funding_eligibilities, through: :gias_school
 

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -81,8 +81,8 @@ RSpec.describe School do
     it { is_expected.to have_many(:mentor_at_school_periods).inverse_of(:school) }
     it { is_expected.to have_many(:mentor_teachers).through(:mentor_at_school_periods).source(:teacher) }
     it { is_expected.to have_many(:school_partnerships) }
-    it { is_expected.to have_many(:contract_period_metadata).class_name("Metadata::SchoolContractPeriod") }
-    it { is_expected.to have_many(:lead_provider_contract_period_metadata).class_name("Metadata::SchoolLeadProviderContractPeriod") }
+    it { is_expected.to have_many(:contract_period_metadata).class_name("Metadata::SchoolContractPeriod").dependent(:delete_all) }
+    it { is_expected.to have_many(:lead_provider_contract_period_metadata).class_name("Metadata::SchoolLeadProviderContractPeriod").dependent(:delete_all) }
     it { is_expected.to have_many(:training_periods).through(:school_partnerships) }
     it { is_expected.to have_many(:school_funding_eligibilities).through(:gias_school) }
   end

--- a/spec/support/shared_examples/declarative_updates.rb
+++ b/spec/support/shared_examples/declarative_updates.rb
@@ -348,6 +348,24 @@ RSpec.shared_examples "a declarative metadata model", :with_metadata do |when_ch
 
           expect(manager).to have_received(:refresh_metadata!).with(target)
         end
+
+        context "when the target is also destroyed in the same transaction" do
+          it "does not refresh the metadata" do
+            # In order for the target to be destroyed in the same transaction,
+            # we need to ensure that anything associated with the target that would prevent its destruction is also destroyed.
+            dependent_associations = %i[ect_at_school_periods mentor_at_school_periods school_partnerships]
+
+            ActiveRecord::Base.transaction do
+              instance.destroy!
+              dependent_associations.each do |association|
+                target.send(association).destroy_all if target.respond_to?(association)
+              end
+              target.destroy!
+            end
+
+            expect(manager).not_to have_received(:refresh_metadata!).with(target)
+          end
+        end
       end
 
       context "when wrapped in a skip(:metadata) block" do

--- a/spec/support/shared_examples/declarative_updates.rb
+++ b/spec/support/shared_examples/declarative_updates.rb
@@ -350,17 +350,20 @@ RSpec.shared_examples "a declarative metadata model", :with_metadata do |when_ch
         end
 
         context "when the target is also destroyed in the same transaction" do
+          # If the target has multiple in-memory references during a transaction, one
+          # reference can delete the database row while another still appears persisted.
+          # Use a separate reference here to reproduce that state.
+          # Additionally, referential integrity is disabled because some metadata
+          # targets have dependent records that intentionally prevent deletion.
+
           it "does not refresh the metadata" do
-            # In order for the target to be destroyed in the same transaction,
-            # we need to ensure that anything associated with the target that would prevent its destruction is also destroyed.
-            dependent_associations = %i[ect_at_school_periods mentor_at_school_periods school_partnerships]
+            separate_target_reference = target.class.where(id: target.id)
 
             ActiveRecord::Base.transaction do
               instance.destroy!
-              dependent_associations.each do |association|
-                target.send(association).destroy_all if target.respond_to?(association)
+              ActiveRecord::Base.connection.disable_referential_integrity do
+                separate_target_reference.delete_all
               end
-              target.destroy!
             end
 
             expect(manager).not_to have_received(:refresh_metadata!).with(target)


### PR DESCRIPTION
### Context

When trying to update the `GIAS::Reconciliation::Merge` service so that it removed the old schools, I hit an issue with `DeclarativeUpdates`.  This PR resolves that issue by ensuring we check whether the object referenced by the metadata exists, before updating its metadata.



### Changes proposed in this pull request
Check the target of the metadata refresh exists before updating its metadata.

We also ensure that when a school is destroyed, its metadata is cleaned up to.

We test the situation where the object and the target of the metadata update have been destroyed in the same transaction. For instance if a `SchoolPartnership` and a `School` were destroyed in the same transaction, the destruction of the `SchoolPartnership` would have previously caused a metadata update on the school.  If the `School` was also destroyed this would raise an error.

### Guidance to review
