### PR TITLE
Introduce `Admin::DataFixes::Changes` class

### DIFF
--- a/app/services/admin/data_fixes/changes.rb
+++ b/app/services/admin/data_fixes/changes.rb
@@ -1,0 +1,31 @@
+module Admin::DataFixes
+  class Changes
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+    include ActiveModel::Validations
+
+    attribute :parsed_rows
+
+    validate :all_results_successful
+
+    def process
+      return false unless valid?
+
+      results.map(&:saved_change)
+    end
+
+  private
+
+    def results = @results ||= parsed_rows.map { process_row(it) }
+
+    def process_row(row)
+      Processor.new.process!(data_change: row.with_indifferent_access)
+    end
+
+    def all_results_successful
+      results.each.with_index do |result, index|
+        errors.add(:base, "Row #{index + 1}: #{result.error}") unless result.success?
+      end
+    end
+  end
+end

--- a/app/services/admin/data_fixes/processor.rb
+++ b/app/services/admin/data_fixes/processor.rb
@@ -1,6 +1,16 @@
 class Admin::DataFixes::Processor
   Result = Data.define(:data_change, :target_object, :error) do
     def success? = error.nil?
+
+    def saved_change
+      return if error.present?
+
+      {
+        record_identifier: "#{target_object.model_name}(##{target_object.id})",
+        action: data_change[:action],
+        changes: target_object.saved_changes
+      }
+    end
   end
 
   attr_reader :batch_refs, :update_readonly_attrs

--- a/spec/services/admin/data_fixes/changes_spec.rb
+++ b/spec/services/admin/data_fixes/changes_spec.rb
@@ -1,0 +1,119 @@
+RSpec.describe Admin::DataFixes::Changes do
+  subject(:changes) { described_class.new(parsed_rows:) }
+
+  describe "#process" do
+    subject(:process) { changes.process }
+
+    context "when none of the changes are valid" do
+      let!(:teacher) { FactoryBot.create(:teacher) }
+
+      let(:parsed_rows) do
+        [
+          {
+            "object_type" => "Teacher",
+            "object_id" => teacher.id.to_s,
+            "action" => "update",
+            "attributes" => "trn,,trs_first_name,New Name"
+          },
+          {
+            "object_type" => "ECTAtSchoolPeriod",
+            "object_id" => "99",
+            "action" => "delete",
+            "attributes" => ""
+          }
+        ]
+      end
+
+      it { is_expected.to be_falsey }
+
+      it "validates the data changes are successful" do
+        process
+        expect(changes.errors.count).to eq(2)
+        expect(changes.errors[:base].first)
+          .to match(/Row 1: Validation failed: TRN/)
+        expect(changes.errors[:base].second)
+          .to match(/Row 2: Couldn't find ECTAtSchoolPeriod/)
+      end
+    end
+
+    context "when only some of the changes are valid" do
+      let!(:teacher) { FactoryBot.create(:teacher) }
+      let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period) }
+
+      let(:parsed_rows) do
+        [
+          {
+            "object_type" => "Teacher",
+            "object_id" => teacher.id.to_s,
+            "action" => "update",
+            "attributes" => "trn,123456,trs_first_name,New Name"
+          },
+          {
+            "object_type" => "ECTAtSchoolPeriod",
+            "object_id" => ect_at_school_period.id.to_s,
+            "action" => "destroy",
+            "attributes" => ""
+          }
+        ]
+      end
+
+      it { is_expected.to be_falsey }
+
+      it "validates the data changes are successful" do
+        process
+        expect(changes.errors.count).to eq(1)
+        expect(changes.errors[:base].first)
+          .to match(/Row 2: Unknown action 'destroy'/)
+      end
+    end
+
+    context "when all the changes are valid" do
+      let!(:teacher) { FactoryBot.create(:teacher) }
+      let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period) }
+
+      let(:parsed_rows) do
+        [
+          {
+            "object_type" => "Teacher",
+            "object_id" => teacher.id.to_s,
+            "action" => "update",
+            "attributes" => "trn,123456,trs_first_name,New Name"
+          },
+          {
+            "object_type" => "ECTAtSchoolPeriod",
+            "object_id" => ect_at_school_period.id.to_s,
+            "action" => "delete",
+            "attributes" => ""
+          }
+        ]
+      end
+
+      it { is_expected.to be_truthy }
+
+      it "has no errors" do
+        process
+        expect(changes.errors).to be_empty
+      end
+
+      it "returns the results" do
+        expect(process).to match(
+          [
+            {
+              record_identifier: "Teacher(##{teacher.id})",
+              action: "update",
+              changes: hash_including(
+                "trn" => [teacher.trn.to_s, "123456"],
+                "trs_first_name" => [teacher.trs_first_name, "New Name"]
+              )
+            },
+            {
+              record_identifier: "ECTAtSchoolPeriod(##{ect_at_school_period.id})",
+              action: "delete",
+              changes: {}
+            }
+          ]
+        )
+      end
+    end
+  end
+end

--- a/spec/services/admin/data_fixes/processor/result_spec.rb
+++ b/spec/services/admin/data_fixes/processor/result_spec.rb
@@ -1,35 +1,43 @@
 describe Admin::DataFixes::Processor::Result do
+  subject(:result) { described_class.new(data_change:, target_object:, error:) }
+
   let(:data_change) { { action: "update" } }
+  let(:target_object) do
+    instance_double(
+      TrainingPeriod,
+      id: 1,
+      model_name: "TrainingPeriod",
+      saved_changes: "something"
+    )
+  end
 
   describe "#success?" do
-    it "returns true when there is no error" do
-      target_object = instance_double(TrainingPeriod)
+    context "when there is no error" do
+      let(:error) { nil }
 
-      result = described_class.new(
-        data_change:,
-        target_object:,
-        error: nil
-      )
-
-      expect(result).to be_success
-      expect(result.data_change).to eq(data_change)
-      expect(result.target_object).to eq(target_object)
-      expect(result.error).to be_nil
+      it { is_expected.to be_success }
     end
 
-    it "returns false when there is an error" do
-      error = ArgumentError.new("Invalid change")
+    context "when there is an error" do
+      let(:error) { ArgumentError.new("Invalid change") }
 
-      result = described_class.new(
-        data_change:,
-        target_object: nil,
-        error:
-      )
+      it { is_expected.not_to be_success }
+    end
+  end
 
-      expect(result).not_to be_success
-      expect(result.data_change).to eq(data_change)
-      expect(result.target_object).to be_nil
-      expect(result.error).to equal(error)
+  describe "#saved_change" do
+    subject(:saved_change) { result.saved_change }
+
+    context "when there is no error" do
+      let(:error) { nil }
+
+      it { is_expected.to eq({ record_identifier: "TrainingPeriod(#1)", action: "update", changes: "something" }) }
+    end
+
+    context "when there is an error" do
+      let(:error) { ArgumentError.new("Invalid change") }
+
+      it { is_expected.to be_nil }
     end
   end
 end


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/4272

### Changes proposed in this pull request

This PORO is intended to act as some more of the plumbing between a user submitting a form with some CSV as text, and eventually driving some data fix changes.

It takes the parsed rows from an `InlineCSV` and passes them to the `Processor` for processing. Errors are accumulated over each row. If all rows are processed successfully, then users will proceed to the next step of the wizard (where changes will be committed).

The class isn't used anywhere yet, but will be used in the `Admin::DataFixesWizard`.

### Guidance to review
