### PR TITLE
2895 - Stop creation of Managed Redis

### DIFF
--- a/config/terraform/application/config/review.tfvars.json
+++ b/config/terraform/application/config/review.tfvars.json
@@ -7,5 +7,5 @@
     "gcp_table_deletion_protection": false,
     "create_bigquery_dataset": false,
     "worker_memory_max": "2Gi",
-    "redis_mode": "managed"
+    "redis_mode": "legacy"
 }

--- a/config/terraform/application/database.tf
+++ b/config/terraform/application/database.tf
@@ -55,18 +55,18 @@ module "redis-cache" {
   server_version            = "6"
 }
 
-module "redis-managed-cache" {
-  source = "./vendor/modules/aks//aks/redis_managed"
+# module "redis-managed-cache" {
+#   source = "./vendor/modules/aks//aks/redis_managed"
 
-  name                      = "cache"
-  namespace                 = var.namespace
-  environment               = var.environment
-  azure_resource_prefix     = var.azure_resource_prefix
-  service_name              = var.service_name
-  service_short             = var.service_short
-  config_short              = var.config_short
-  cluster_configuration_map = module.cluster_data.configuration_map
-  use_azure                 = var.deploy_azure_backing_services
-  azure_enable_monitoring   = var.enable_monitoring
-  azure_managed_redis_sku   = var.redis_managed_cache_sku_name
-}
+#   name                      = "cache"
+#   namespace                 = var.namespace
+#   environment               = var.environment
+#   azure_resource_prefix     = var.azure_resource_prefix
+#   service_name              = var.service_name
+#   service_short             = var.service_short
+#   config_short              = var.config_short
+#   cluster_configuration_map = module.cluster_data.configuration_map
+#   use_azure                 = var.deploy_azure_backing_services
+#   azure_enable_monitoring   = var.enable_monitoring
+#   azure_managed_redis_sku   = var.redis_managed_cache_sku_name
+# }

--- a/config/terraform/application/variables.tf
+++ b/config/terraform/application/variables.tf
@@ -151,9 +151,9 @@ locals {
     legacy = {
       cache_url = module.redis-cache.url
     }
-    managed = {
-      cache_url = module.redis-managed-cache.url
-    }
+    # managed = {
+    #   cache_url = module.redis-managed-cache.url
+    # }
   }
   selected_redis = local.redis[var.redis_mode]
 }


### PR DESCRIPTION
### Context

Microsoft has announced the retirement of Azure Cache for Redis and we therefore need to migrate from Azure Cache for Redis to Azure Managed Redis.
[Redis Migration](https://github.com/DFE-Digital/teacher-services-cloud/blob/main/documentation/redis-migration.md)
[Procedure](https://github.com/DFE-Digital/teacher-services-cloud/blob/main/documentation/redis-migration-deployment-steps.md) 

There is currently insufficient capacity in UK South to create these resources. It was originally envisaged that we would create the managed Redis instances by default ready for switching but the insufficient capacity cause builds of main to break.

### Changes proposed in this pull request

- Comment out the Azure Managed Redis block and linked variable to stop Managed Redis instances being created by default.

### Guidance to review

- Run `make staging terraform-plan` where you should see resources for Kubernetes only

### Link to Trello card

https://trello.com/c/qiWpQm07/2895-service-rect-migrate-redis

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally