### PR TITLE
Make the induction tutor details list wider

### DIFF
--- a/app/views/schools/induction_tutor/show.html.erb
+++ b/app/views/schools/induction_tutor/show.html.erb
@@ -1,10 +1,10 @@
-<% 
+<%
   page_data(
-    title: "Induction tutor", 
-    error: false, 
-    caption: @school.name, 
+    title: "Induction tutor",
+    error: false,
+    caption: @school.name,
     caption_size: 'l'
-  ) 
+  )
 %>
 
 <p class="govuk-body">This person is your school’s main point of contact for early career training and induction. We share these details with your appropriate body and lead providers (if your school uses provider-led training programmes).</p>
@@ -24,5 +24,3 @@
 end %>
 
 <%= govuk_link_to "Change induction tutor details", schools_induction_tutor_update_induction_tutor_wizard_edit_path, class: "govuk-button" %>
-
-

--- a/app/views/schools/induction_tutor/show.html.erb
+++ b/app/views/schools/induction_tutor/show.html.erb
@@ -11,7 +11,7 @@
 
 <h2 class="govuk-heading-m">Induction tutor details</h2>
 
-<%= govuk_summary_list do |sl|
+<%= govuk_summary_list(actions: false) do |sl|
   sl.with_row do |row|
     row.with_key(text: "Name")
     row.with_value(text: @school.induction_tutor_name)


### PR DESCRIPTION
### Context

Email addresses were wrapping unnecessarily, making them harder to read.

First commit makes the change, second is just whitespace trimming :scissors: 

### Changes proposed in this pull request

- **Make the induction tutor summary list wider**
- **Remove trailing whitespace from template**

### Preview

| Before | After |
| ----- | ------ |
|<img width="979" height="667" alt="Screenshot From 2026-08-19 14-58-02" src="https://github.com/user-attachments/assets/816beeb3-f8a3-4433-aaca-6da4969c12c1" /> | <img width="979" height="667" alt="Screenshot From 2026-08-19 14-58-16" src="https://github.com/user-attachments/assets/79c2b917-2f5f-440e-842a-ab09b614a994" /> |
