### PR TITLE
Move the registration window banner above content

### DIFF
--- a/app/views/layouts/shared/_page.html.erb
+++ b/app/views/layouts/shared/_page.html.erb
@@ -9,7 +9,6 @@
 
     <div class="govuk-width-container">
       <div class="govuk-!-display-none-print">
-        <%= render partial: "layouts/shared/schools_registration_window_banner" %>
         <%= render TimeTravellerComponent.new %>
         <%= render Admin::ImpersonationBannerComponent.new(user: current_user, school: @school) %>
         <%= yield(:backlink_or_breadcrumb) %>
@@ -17,7 +16,7 @@
 
       <main class="govuk-main-wrapper" id="main-content">
         <%= render partial: "layouts/shared/main_preamble" %>
-
+        <%= render partial: "layouts/shared/schools_registration_window_banner" %>
         <%= yield(:content) %>
         <%= yield(:test_guidance) %>
       </main>


### PR DESCRIPTION
The Design System documentation says:

> Position a notification banner immediately before the page `<h1>`

We don't have any guarantee where the `<h1>` will be but in the vast majority of cases (when it's set using `page_data`) it'll be right at the top of `:content`.

This shouldn't look any different.
