### PR TITLE
Product team users can preview data fixes

### DIFF
--- a/app/controllers/admin/data_fixes_controller.rb
+++ b/app/controllers/admin/data_fixes_controller.rb
@@ -14,6 +14,10 @@ module Admin
                   unless: -> { wizard_class.step?(@previous_step) },
                   only: :new
 
+    around_action :wrap_in_transaction,
+                  if: -> { @current_step == :preview },
+                  only: :create
+
     def new
       render @current_step
     end
@@ -49,5 +53,13 @@ module Admin
     end
 
     def wizard_class = DataFixesWizard::Wizard
+
+    def wrap_in_transaction
+      ActiveRecord::Base.transaction do
+        yield
+      ensure
+        raise ActiveRecord::Rollback
+      end
+    end
   end
 end

--- a/app/views/admin/data_fixes/preview.html.erb
+++ b/app/views/admin/data_fixes/preview.html.erb
@@ -2,3 +2,13 @@
     title: "Preview the proposed data fix",
     backlink_href: @wizard.previous_step_path
 ) %>
+
+<%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |form| %>
+  <%= content_for(:error_summary) do %>
+    <%= form.govuk_error_summary(presenter: @wizard.current_step.error_presenter) %>
+  <% end %>
+
+  <%= govuk_list(@wizard.current_step.parsed_rows, type: :bullet) %>
+
+  <%= form.govuk_submit "Preview" %>
+<% end %>

--- a/app/views/admin/data_fixes/verify.html.erb
+++ b/app/views/admin/data_fixes/verify.html.erb
@@ -1,0 +1,6 @@
+<% page_data(
+    title: "Verify the proposed data fix",
+    backlink_href: @wizard.previous_step_path
+) %>
+
+<%= govuk_list(@wizard.current_step.processed_changes, type: :bullet) %>

--- a/app/wizards/admin/data_fixes_wizard/csv_step.rb
+++ b/app/wizards/admin/data_fixes_wizard/csv_step.rb
@@ -19,5 +19,18 @@ module Admin::DataFixesWizard
     def inline_csv
       @inline_csv ||= Admin::DataFixes::InlineCSV.new(csv_string:)
     end
+
+    def pre_populate_attributes
+      self.csv_string = generate_csv_from(store.parsed_rows) if store.parsed_rows
+    end
+
+    def generate_csv_from(parsed_rows)
+      CSV.generate do |csv|
+        csv << parsed_rows.first.keys
+        parsed_rows.each do |row|
+          csv << row.values
+        end
+      end
+    end
   end
 end

--- a/app/wizards/admin/data_fixes_wizard/preview_step.rb
+++ b/app/wizards/admin/data_fixes_wizard/preview_step.rb
@@ -1,6 +1,33 @@
 module Admin::DataFixesWizard
   class PreviewStep < Step
     def previous_step = :csv
-    def next_step = nil
+    def next_step = :verify
+
+    def save!
+      processed_changes = changes.process
+      store.processed_changes = processed_changes if processed_changes
+    end
+
+    delegate :errors, to: :changes
+    delegate :parsed_rows, to: :store
+    def error_presenter = ErrorSummaryPresenter
+
+  private
+
+    def changes
+      @changes ||= Admin::DataFixes::Changes.new(parsed_rows: store.parsed_rows)
+    end
+
+    class ErrorSummaryPresenter
+      def initialize(error_messages)
+        @error_messages = error_messages
+      end
+
+      def formatted_error_messages
+        @error_messages.flat_map do |attribute, messages|
+          messages.map { |message| [attribute, message] }
+        end
+      end
+    end
   end
 end

--- a/app/wizards/admin/data_fixes_wizard/verify_step.rb
+++ b/app/wizards/admin/data_fixes_wizard/verify_step.rb
@@ -1,0 +1,10 @@
+module Admin::DataFixesWizard
+  class VerifyStep < Step
+    def previous_step = :preview
+    def next_step = nil
+
+    def save! = nil
+
+    delegate :processed_changes, to: :store
+  end
+end

--- a/app/wizards/admin/data_fixes_wizard/wizard.rb
+++ b/app/wizards/admin/data_fixes_wizard/wizard.rb
@@ -6,7 +6,7 @@ module Admin
           {
             csv: CSVStep,
             preview: PreviewStep,
-            # confirmation: ConfirmationStep
+            verify: VerifyStep
           }
         ]
       end

--- a/spec/features/admin/data_fixes/paste_inline_csv_spec.rb
+++ b/spec/features/admin/data_fixes/paste_inline_csv_spec.rb
@@ -1,5 +1,9 @@
 RSpec.describe "Product team users can paste inline CSV to fix data" do
-  before { enable_admin_data_fixes_feature_flag }
+  before do
+    freeze_time
+    enable_admin_data_fixes_feature_flag
+    setup_data_to_fix
+  end
 
   it "validates CSV and redirects to preview step" do
     given_i_am_signed_in_as_a_product_team_user
@@ -9,24 +13,45 @@ RSpec.describe "Product team users can paste inline CSV to fix data" do
     and_i_continue
     then_i_see_an_error("CSV can’t be blank")
 
-    given_i_input_an_invalid_csv_string
+    given_i_input_a_csv_string_with(invalid_csv_rows)
     and_i_continue
     then_i_see_an_error("CSV is malformed")
 
-    given_i_input_a_valid_csv_string_with_invalid_headers
+    given_i_input_a_csv_string_with(invalid_headers_rows)
     and_i_continue
     then_i_see_an_error("CSV has invalid headers")
 
-    given_i_input_a_valid_csv_string_with_correct_headers
+    given_i_input_a_csv_string_with(valid_rows)
     and_i_continue
-    then_i_am_taken_to_the_preview_page
-    and_the_preview_is_displayed
+    then_i_am_taken_to_the_preview_step
+    and_parsed_valid_rows_are_displayed
+
+    given_i_preview_the_changes
+    then_i_see_an_error_for_each_invalid_row
+
+    given_i_go_back
+    then_i_am_taken_to_the_csv_step
+    and_the_csv_string_is_displayed_for(valid_rows)
+
+    given_i_input_a_csv_string_with(processable_rows)
+    and_i_continue
+    then_i_am_taken_to_the_preview_step
+    and_parsed_processable_rows_are_displayed
+
+    given_i_preview_the_changes
+    then_i_am_taken_to_the_verify_step
+    then_the_proposed_processed_changes_are_displayed
   end
 
 private
 
   def enable_admin_data_fixes_feature_flag
     allow(Rails.application.config).to receive(:enable_admin_data_fixes).and_return(true)
+  end
+
+  def setup_data_to_fix
+    @ect_at_school_period = FactoryBot.create(:ect_at_school_period)
+    @teacher = @ect_at_school_period.teacher
   end
 
   def given_i_am_signed_in_as_a_product_team_user
@@ -42,18 +67,6 @@ private
     expect(heading).to be_visible
   end
 
-  def given_i_input_an_invalid_csv_string
-    invalid_csv_rows = <<~ROWS
-      object_type,object_id,action,attributes
-      something,1,create,"unterminated,string
-    ROWS
-    input_csv_string(invalid_csv_rows)
-  end
-
-  def input_csv_string(rows)
-    page.get_by_label("Enter data fixes in CSV format").fill(rows)
-  end
-
   def and_i_continue
     page.get_by_role("button", name: "Continue", exact: true).click
   end
@@ -63,30 +76,114 @@ private
     expect(error_summary).to have_text(error_message)
   end
 
-  def given_i_input_a_valid_csv_string_with_invalid_headers
-    invalid_headers_rows = <<~ROWS
-      object_type,object_id,action,wrong_header
-      something,1,create,"attribute1,value1,attribute2,value2"
-      anotherthing,2,destroy,""
-    ROWS
-    input_csv_string(invalid_headers_rows)
-  end
-
-  def given_i_input_a_valid_csv_string_with_correct_headers
-    valid_rows = <<~ROWS
-      object_type,object_id,action,attributes
-      something,1,create,"attribute1,value1,attribute2,value2"
-      another_thing,2,destroy,""
-    ROWS
-    input_csv_string(valid_rows)
-  end
-
-  def then_i_am_taken_to_the_preview_page
+  def then_i_am_taken_to_the_preview_step
     expect(page).to have_path("/admin/data_fixes/preview")
   end
 
-  def and_the_preview_is_displayed
-    heading = page.get_by_role("heading", name: "Preview the proposed data fix")
-    expect(heading).to be_visible
+  def given_i_preview_the_changes
+    page.get_by_role("button", name: "Preview", exact: true).click
+  end
+
+  def then_i_see_an_error_for_each_invalid_row
+    row1_error_message = <<~TXT.squish
+      Row 1: Validation failed: TRN Teacher reference number must include at
+      least 5 digits
+    TXT
+    row2_error_message = "Row 2: Unknown action 'destroy'"
+    then_i_see_an_error(row1_error_message)
+    then_i_see_an_error(row2_error_message)
+  end
+
+  def given_i_go_back
+    page.get_by_role("link", name: "Back", exact: true).click
+  end
+
+  def then_i_am_taken_to_the_csv_step
+    expect(page).to have_path("/admin/data_fixes/csv")
+  end
+
+  def csv_input = page.get_by_label("Enter data fixes in CSV format")
+  def given_i_input_a_csv_string_with(rows) = csv_input.fill(rows)
+  def invalid_csv_rows = <<~ROWS
+    object_type,object_id,action,attributes
+    something,1,create,"unterminated,string
+  ROWS
+  def invalid_headers_rows = <<~ROWS
+    object_type,object_id,action,wrong_header
+    teacher,#{@teacher.id},update,"trn,1"
+    ect_at_school_period,#{@ect_at_school_period.id},destroy,""
+  ROWS
+  def valid_rows = <<~ROWS
+    object_type,object_id,action,attributes
+    teacher,#{@teacher.id},update,"trn,1"
+    ect_at_school_period,#{@ect_at_school_period.id},destroy,""
+  ROWS
+  def processable_rows = <<~ROWS
+    object_type,object_id,action,attributes
+    teacher,#{@teacher.id},update,"trn,1234567"
+    ect_at_school_period,#{@ect_at_school_period.id},delete,""
+  ROWS
+
+  def and_the_csv_string_is_displayed_for(rows)
+    expect(csv_input.input_value).to eq(rows)
+  end
+
+  def and_parsed_valid_rows_are_displayed
+    parsed_row1 = <<~TXT.squish
+      {"object_type" => "teacher",
+      "object_id" => "#{@teacher.id}",
+      "action" => "update",
+      "attributes" => "trn,1"}
+    TXT
+    row1 = page.locator("li", hasText: parsed_row1)
+    expect(row1).to be_visible
+    parsed_row2 = <<~TXT.squish
+      {"object_type" => "ect_at_school_period",
+      "object_id" => "#{@ect_at_school_period.id}",
+      "action" => "destroy",
+      "attributes" => ""}
+    TXT
+    row2 = page.locator("li", hasText: parsed_row2)
+    expect(row2).to be_visible
+  end
+
+  def and_parsed_processable_rows_are_displayed
+    parsed_row1 = <<~TXT.squish
+      {"object_type" => "teacher",
+      "object_id" => "#{@teacher.id}",
+      "action" => "update",
+      "attributes" => "trn,1234567"}
+    TXT
+    row1 = page.locator("li", hasText: parsed_row1)
+    expect(row1).to be_visible
+    parsed_row2 = <<~TXT.squish
+      {"object_type" => "ect_at_school_period",
+      "object_id" => "#{@ect_at_school_period.id}",
+      "action" => "delete",
+      "attributes" => ""}
+    TXT
+    row2 = page.locator("li", hasText: parsed_row2)
+    expect(row2).to be_visible
+  end
+
+  def then_i_am_taken_to_the_verify_step
+    expect(page).to have_path("/admin/data_fixes/verify")
+  end
+
+  def then_the_proposed_processed_changes_are_displayed
+    proposed_row1 = <<~TXT.squish
+      {"record_identifier" => "Teacher(##{@teacher.id})",
+      "action" => "update",
+      "changes" => {"trn" => ["#{@teacher.trn}", "1234567"]}
+    TXT
+    row1 = page.locator("li", hasText: proposed_row1)
+    expect(row1).to be_visible
+    proposed_row2 = <<~TXT.squish
+      {"record_identifier" => "ECTAtSchoolPeriod(##{@ect_at_school_period.id})",
+      "action" => "delete",
+      "changes" => {}}
+    TXT
+    row2 = page.locator("li", hasText: proposed_row2)
+    expect(row2).to be_visible
   end
 end

--- a/spec/requests/admin/data_fixes_spec.rb
+++ b/spec/requests/admin/data_fixes_spec.rb
@@ -1,14 +1,14 @@
 RSpec.describe "Admin::DataFixesController" do
+  before do
+    allow(Rails.application.config)
+      .to receive(:enable_admin_data_fixes)
+      .and_return(enable_admin_data_fixes)
+  end
+
   describe "GET #new" do
     subject do
       get path_for_step("csv")
       response
-    end
-
-    before do
-      allow(Rails.application.config)
-        .to receive(:enable_admin_data_fixes)
-        .and_return(enable_admin_data_fixes)
     end
 
     context "when `enable_admin_data_fixes` is true" do
@@ -66,23 +66,17 @@ RSpec.describe "Admin::DataFixesController" do
 
   describe "POST #create" do
     subject do
-      post(path_for_step("csv"), params:)
+      post(path_for_step("csv"), params: csv_params)
       response
     end
 
-    let(:params) { { csv: { csv_string: } } }
+    let(:csv_params) { { csv: { csv_string: } } }
     let(:csv_string) do
       <<~ROWS
         object_type,object_id,action,attributes
         something,1,create,"attribute1,value1,attribute2,value2"
         another_thing,2,destroy,""
       ROWS
-    end
-
-    before do
-      allow(Rails.application.config)
-        .to receive(:enable_admin_data_fixes)
-        .and_return(enable_admin_data_fixes)
     end
 
     context "when `enable_admin_data_fixes` is true" do
@@ -107,8 +101,47 @@ RSpec.describe "Admin::DataFixesController" do
       context "when signed in as a product team user" do
         include_context "sign in as product_team DfE user"
 
-        context "when the CSV is valid" do
-          it { is_expected.to redirect_to(path_for_step("preview")) }
+        let(:teacher) { FactoryBot.create(:teacher, trn: "123456") }
+
+        context "when the CSV is valid and changes can be processed" do
+          let(:csv_string) do
+            <<~ROWS
+              object_type,object_id,action,attributes
+              Teacher,#{teacher.id},update,"trn,345678"
+            ROWS
+          end
+
+          it "redirects to preview step, then redirects to verify step " \
+             "without persisting any changes" do
+            expect(subject).to redirect_to(path_for_step("preview"))
+
+            follow_redirect!
+
+            expect { post path_for_step("preview") }
+              .not_to(change { teacher.reload.trn })
+
+            expect(response).to redirect_to(path_for_step("verify"))
+          end
+        end
+
+        context "when the CSV is valid but the changes cannot be processed" do
+          let(:csv_string) do
+            <<~ROWS
+              object_type,object_id,action,attributes
+              Teacher,#{teacher.id},update,"trn,123"
+            ROWS
+          end
+
+          it "redirects to preview step, then returns unprocessable_content" do
+            expect(subject).to redirect_to(path_for_step("preview"))
+
+            follow_redirect!
+
+            expect { post path_for_step("preview") }
+              .not_to(change { teacher.reload.trn })
+
+            expect(response).to have_http_status(:unprocessable_content)
+          end
         end
 
         context "when the CSV is invalid" do

--- a/spec/wizards/admin/data_fixes_wizard/csv_step_spec.rb
+++ b/spec/wizards/admin/data_fixes_wizard/csv_step_spec.rb
@@ -9,10 +9,13 @@ RSpec.describe Admin::DataFixesWizard::CSVStep do
       store:
     )
   end
-  let(:store) { FactoryBot.build(:session_repository) }
+  let(:store) { FactoryBot.build(:session_repository, parsed_rows:) }
   let(:author) { FactoryBot.build(:dfe_user, role: :product_team) }
   let(:params) { { csv_string: } }
   let(:csv_string) { "" }
+  let(:parsed_rows) { nil }
+
+  it { is_expected.to delegate_method(:errors).to(:inline_csv) }
 
   describe ".permitted_params" do
     subject(:permitted_params) { described_class.permitted_params }
@@ -35,66 +38,68 @@ RSpec.describe Admin::DataFixesWizard::CSVStep do
   describe "#save!" do
     subject(:save!) { current_step.save! }
 
+    before do
+      allow(Admin::DataFixes::InlineCSV)
+        .to receive(:new)
+        .and_return(fake_inline_csv)
+    end
+
     context "when the CSV is valid" do
-      let(:csv_string) do
-        <<~ROWS
-          object_type,object_id,action,attributes
-          something,1,create,"attribute1,value1,attribute2,value2"
-          another_thing,2,destroy,""
-        ROWS
+      let(:fake_inline_csv) do
+        instance_double(
+          Admin::DataFixes::InlineCSV,
+          parse: [{ test: "something" }, { test: "another_thing" }]
+        )
       end
 
       it { is_expected.to be_truthy }
 
-      it "persists rows in the store" do
+      it "persists parsed rows in the store" do
         expect { save! }
           .to change { current_step.store.parsed_rows }
           .from(nil)
-          .to(
-            [
-              {
-                "object_type" => "something",
-                "object_id" => "1",
-                "action" => "create",
-                "attributes" => "attribute1,value1,attribute2,value2"
-              },
-              {
-                "object_type" => "another_thing",
-                "object_id" => "2",
-                "action" => "destroy",
-                "attributes" => ""
-              }
-            ]
-          )
-      end
-
-      it "has no errors" do
-        save!
-
-        expect(current_step.errors).to be_empty
+          .to([{ test: "something" }, { test: "another_thing" }])
       end
     end
 
     context "when the CSV is invalid" do
-      let(:csv_string) do
-        <<~ROWS
-          object_type,object_id,attributes
-          something,1,create,"attribute1,value1,attribute2,value2"
-          another_thing,2,destroy,""
-        ROWS
+      let(:fake_inline_csv) do
+        instance_double(Admin::DataFixes::InlineCSV, parse: false)
       end
 
       it { is_expected.to be_falsey }
 
-      it "does not persist any rows in the store" do
+      it "does not persist parsed rows in the store" do
         expect { save! }.not_to(change { current_step.store.parsed_rows })
       end
+    end
+  end
 
-      it "propagates errors from `InlineCSV` parsing" do
-        save!
+  describe "pre-populating attributes" do
+    context "when there are parsed rows in the store" do
+      let(:params) { {} }
+      let(:parsed_rows) do
+        [
+          { "column1" => "value1", "column2" => "value2" },
+          { "column1" => "value3", "column2" => "value4" },
+        ]
+      end
 
-        expect(current_step.errors)
-          .to be_added(:csv_string, "CSV has invalid headers")
+      it "pre-populates the csv string" do
+        expect(current_step.csv_string).to eq <<~ROWS
+          column1,column2
+          value1,value2
+          value3,value4
+        ROWS
+      end
+    end
+
+    context "when there are not parsed rows in the store" do
+      let(:params) { {} }
+      let(:parsed_rows) { nil }
+
+      it "does not pre-populate the csv string" do
+        expect(current_step.csv_string).to be_nil
       end
     end
   end

--- a/spec/wizards/admin/data_fixes_wizard/preview_step_spec.rb
+++ b/spec/wizards/admin/data_fixes_wizard/preview_step_spec.rb
@@ -9,14 +9,24 @@ RSpec.describe Admin::DataFixesWizard::PreviewStep do
       store:
     )
   end
-  let(:store) { FactoryBot.build(:session_repository) }
+  let(:store) { FactoryBot.build(:session_repository, parsed_rows:) }
   let(:author) { FactoryBot.build(:dfe_user, role: :product_team) }
   let(:params) { {} }
+  let(:parsed_rows) { [{ test: "something" }, { test: "another_thing" }] }
+
+  it { is_expected.to delegate_method(:errors).to(:changes) }
+  it { is_expected.to delegate_method(:parsed_rows).to(:store) }
 
   describe ".permitted_params" do
     subject(:permitted_params) { described_class.permitted_params }
 
     it { is_expected.to be_empty }
+  end
+
+  describe "#error_presenter" do
+    subject(:error_presenter) { current_step.error_presenter }
+
+    it { is_expected.to eq(Admin::DataFixesWizard::PreviewStep::ErrorSummaryPresenter) }
   end
 
   describe "#previous_step" do
@@ -28,6 +38,44 @@ RSpec.describe Admin::DataFixesWizard::PreviewStep do
   describe "#next_step" do
     subject(:next_step) { current_step.next_step }
 
-    it { is_expected.to be_nil }
+    it { is_expected.to eq(:verify) }
+  end
+
+  describe "#save!" do
+    subject(:save!) { current_step.save! }
+
+    before do
+      allow(Admin::DataFixes::Changes).to receive(:new).and_return(fake_changes)
+    end
+
+    context "when changes are processed successfully" do
+      let(:fake_changes) do
+        instance_double(
+          Admin::DataFixes::Changes,
+          process: [{ record_identifier: "Teacher(#1)", action: "destroy" }]
+        )
+      end
+
+      it { is_expected.to be_truthy }
+
+      it "persists processed changes in the store" do
+        expect { save! }
+          .to change { current_step.store.processed_changes }
+          .from(nil)
+          .to([{ record_identifier: "Teacher(#1)", action: "destroy" }])
+      end
+    end
+
+    context "when changes are not processed successfully" do
+      let(:fake_changes) do
+        instance_double(Admin::DataFixes::Changes, process: false)
+      end
+
+      it { is_expected.to be_falsey }
+
+      it "does not persist processed changes in the store" do
+        expect { save! }.not_to(change { current_step.store.processed_changes })
+      end
+    end
   end
 end

--- a/spec/wizards/admin/data_fixes_wizard/verify_step_spec.rb
+++ b/spec/wizards/admin/data_fixes_wizard/verify_step_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe Admin::DataFixesWizard::VerifyStep do
+  subject(:current_step) { wizard.current_step }
+
+  let(:wizard) do
+    Admin::DataFixesWizard::Wizard.new(
+      current_step: :verify,
+      step_params: ActionController::Parameters.new(verify: params),
+      author:,
+      store:
+    )
+  end
+  let(:store) { FactoryBot.build(:session_repository) }
+  let(:author) { FactoryBot.build(:dfe_user, role: :product_team) }
+  let(:params) { {} }
+
+  it { is_expected.to delegate_method(:processed_changes).to(:store) }
+
+  describe ".permitted_params" do
+    subject(:permitted_params) { described_class.permitted_params }
+
+    it { is_expected.to be_empty }
+  end
+
+  describe "#previous_step" do
+    subject(:previous_step) { current_step.previous_step }
+
+    it { is_expected.to eq(:preview) }
+  end
+
+  describe "#next_step" do
+    subject(:next_step) { current_step.next_step }
+
+    it { is_expected.to be_nil }
+  end
+end


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/4254

### Changes proposed in this pull request

#### Product team users can preview data fixes
Before, in https://github.com/DFE-Digital/register-early-career-teachers-public/pull/3377 users could input a CSV of data fixes which were parsed and
presented to the user.

But we didn't do anything with those changes.

This builds on https://github.com/DFE-Digital/register-early-career-teachers-public/pull/3393 and processes the proposed changes in a preview step. Any
errors are presented to the user. If there are no errors, we display the
"changes".

This is executed in a transaction and rolled back, so no changes are persisted
yet.

Both the parsed rows and the processed changes are displayed to users in the
most rudimentary way possible. We intend to iterate on this soon!

In order to display *all* the errors when processing the CSV, we need to pass a
custom `ErrorPresenter` to the form builder. This ensures each error message is
displayed, rather than only the first.

#### Pre-populate `csv_string` from parsed rows in `CSVStep`
When a user navigates "back" from the `/preview` step to the `/csv` step after
previously entering a CSV, we want to pre-populate the form input with what they
submitted.

This generates a CSV from the parsed rows in the session store if the
`csv_string` is missing.

As part of this change, the step unit tests have been reworked to stub the
behaviour of the `Admin::DataFixes::InlineCSV` class. This is intended to keep
the tests focussed on the behvaiour of the step, rather than the underlying PORO
(which is already extensively tested).

### Guidance to review
