### PR TITLE
Fix flaky teacher_spec.rb

### DIFF
--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -189,8 +189,8 @@ describe Teacher do
       end
 
       context "when there are multiple ECT at school periods" do
-        let!(:latest_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, started_on: 1.year.ago, teacher:) }
-        let!(:earliest_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, started_on: 2.years.ago, teacher:) }
+        let!(:earliest_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, started_on: 2.years.ago, finished_on: 1.year.ago, teacher:) }
+        let!(:latest_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, started_on: earliest_ect_at_school_period.finished_on.next_day, teacher:) }
 
         it { is_expected.to eq(earliest_ect_at_school_period) }
       end


### PR DESCRIPTION
Fixes flakey spec observed in https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/32366733352/job/96417748291

When `end_date` is towards the maximum of the factory's random range and finished_on reaches `1.year.ago`, it collides with the first period and trips `overlap_validation` in `ECTAtSchoolPeriod`.

Fixed by creating the earliest first and fixing both dates.