### PR TITLE
Framework Agreement Table rename

### DIFF
--- a/app/components/admin/select_lead_providers_form_component.rb
+++ b/app/components/admin/select_lead_providers_form_component.rb
@@ -33,7 +33,7 @@ module Admin
     end
 
     def currently_selected_ids
-      @currently_selected_ids ||= current_partnerships.map(&:active_lead_provider_id).map(&:to_s)
+      @currently_selected_ids ||= current_partnerships.map(&:framework_agreement_id).map(&:to_s)
     end
 
     def legend_text

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -1,5 +1,5 @@
 class Contract < ApplicationRecord
-  attr_readonly :active_lead_provider_id
+  attr_readonly :framework_agreement_id
 
   # Enums
   enum :contract_type,
@@ -8,7 +8,7 @@ class Contract < ApplicationRecord
        suffix: true
 
   # Associations
-  belongs_to :framework_agreement, foreign_key: :active_lead_provider_id
+  belongs_to :framework_agreement
   has_one :contract_period, through: :framework_agreement
   has_one :lead_provider, through: :framework_agreement
   has_one :flat_rate_fee_structure, class_name: "Contract::FlatRateFeeStructure", inverse_of: :contract, dependent: :destroy

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -113,7 +113,7 @@ class Event < ApplicationRecord
   belongs_to :appropriate_body_period
 
   # providers
-  belongs_to :framework_agreement, foreign_key: :active_lead_provider_id
+  belongs_to :framework_agreement
   belongs_to :lead_provider
   belongs_to :delivery_partner
   belongs_to :lead_provider_delivery_partnership

--- a/app/models/framework_agreement.rb
+++ b/app/models/framework_agreement.rb
@@ -1,17 +1,15 @@
 class FrameworkAgreement < ApplicationRecord
-  self.table_name = "active_lead_providers"
-
   # Associations
   belongs_to :contract_period, inverse_of: :framework_agreements, foreign_key: :contract_period_year
   belongs_to :lead_provider, inverse_of: :framework_agreements
-  has_many :lead_provider_delivery_partnerships, foreign_key: :active_lead_provider_id
+  has_many :lead_provider_delivery_partnerships
   has_many :school_partnerships, through: :lead_provider_delivery_partnerships
   has_many :delivery_partners, through: :lead_provider_delivery_partnerships
   has_many :expressions_of_interest, class_name: "TrainingPeriod", foreign_key: "expression_of_interest_id", inverse_of: :expression_of_interest
-  has_many :events, foreign_key: :active_lead_provider_id
-  has_many :contracts, foreign_key: :active_lead_provider_id
+  has_many :events
+  has_many :contracts
   has_many :statements, through: :contracts
-  has_many :bands, -> { order(allocation_order: :asc) }, class_name: "FrameworkAgreement::Band", foreign_key: :active_lead_provider_id
+  has_many :bands, -> { order(allocation_order: :asc) }, class_name: "FrameworkAgreement::Band"
 
   # Validations
   validates :contract_period_year,

--- a/app/models/framework_agreement/band.rb
+++ b/app/models/framework_agreement/band.rb
@@ -1,12 +1,10 @@
 class FrameworkAgreement::Band < ApplicationRecord
-  self.table_name = "active_lead_provider_bands"
-
   attr_accessor :allow_creation_when_contracted_or_after_contract_period_start
 
   attr_readonly :allocation_order
 
   # Associations
-  belongs_to :framework_agreement, foreign_key: :active_lead_provider_id
+  belongs_to :framework_agreement
 
   has_many :band_terms,
            class_name: "Contract::BandedFeeStructure::BandTerm",

--- a/app/models/lead_provider_delivery_partnership.rb
+++ b/app/models/lead_provider_delivery_partnership.rb
@@ -1,7 +1,7 @@
 class LeadProviderDeliveryPartnership < ApplicationRecord
   include DeclarativeUpdates
 
-  belongs_to :framework_agreement, foreign_key: :active_lead_provider_id
+  belongs_to :framework_agreement
   belongs_to :delivery_partner
   has_many :school_partnerships
   has_many :events, dependent: :nullify
@@ -12,23 +12,23 @@ class LeadProviderDeliveryPartnership < ApplicationRecord
 
   touch -> { delivery_partner }, on_event: %i[create destroy], timestamp_attribute: :api_updated_at
 
-  validates :active_lead_provider_id, presence: { message: "Select a lead provider framework agreement" }
+  validates :framework_agreement_id, presence: { message: "Select a lead provider framework agreement" }
   validates :delivery_partner_id,
             presence: { message: "Select a delivery partner" },
-            uniqueness: { scope: :active_lead_provider_id, message: "Delivery partner and lead provider framework agreement pairing must be unique" }
+            uniqueness: { scope: :framework_agreement_id, message: "Delivery partner and lead provider framework agreement pairing must be unique" }
   validates :ecf_id, uniqueness: { case_sensitive: false }, allow_nil: true
 
   scope :with_delivery_partner, ->(delivery_partner_id) { where(delivery_partner_id:) }
-  scope :with_framework_agreement, ->(active_lead_provider_id) { where(active_lead_provider_id:) }
+  scope :with_framework_agreement, ->(framework_agreement_id) { where(framework_agreement_id:) }
   scope :for_contract_period, ->(contract_period) {
     joins(:framework_agreement)
-      .where(active_lead_providers: { contract_period_year: contract_period.year })
+      .where(framework_agreements: { contract_period_year: contract_period.year })
       .includes(framework_agreement: :lead_provider)
   }
   scope :framework_agreement_ids_for, ->(delivery_partner, contract_period) {
     where(delivery_partner:)
       .joins(:framework_agreement)
-      .where(active_lead_providers: { contract_period_year: contract_period.year })
-      .select(:active_lead_provider_id)
+      .where(framework_agreements: { contract_period_year: contract_period.year })
+      .select(:framework_agreement_id)
   }
 end

--- a/app/models/school_partnership.rb
+++ b/app/models/school_partnership.rb
@@ -32,15 +32,15 @@ class SchoolPartnership < ApplicationRecord
   scope :for_contract_period, ->(year) { joins(:contract_period).where(contract_periods: { year: }) }
   scope :for_contract_period_year, ->(year) {
     joins(lead_provider_delivery_partnership: :framework_agreement)
-      .where(active_lead_providers: { contract_period_year: year })
+      .where(framework_agreements: { contract_period_year: year })
   }
   scope :excluding_contract_period_year, ->(year) {
     joins(lead_provider_delivery_partnership: :framework_agreement)
-      .where.not(active_lead_providers: { contract_period_year: year })
+      .where.not(framework_agreements: { contract_period_year: year })
   }
   scope :latest_by_contract_year, -> {
     joins(lead_provider_delivery_partnership: :framework_agreement)
-      .order("active_lead_providers.contract_period_year DESC, school_partnerships.created_at DESC")
+      .order("framework_agreements.contract_period_year DESC, school_partnerships.created_at DESC")
   }
 
   def teachers

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -111,7 +111,7 @@ private
     return unless framework_agreement
 
     existing = Statement.joins(:contract)
-                        .where(contracts: { active_lead_provider_id: framework_agreement.id })
+                        .where(contracts: { framework_agreement_id: framework_agreement.id })
                         .where(month:, year:)
                         .where.not(id:)
                         .exists?

--- a/app/services/api/declarations/create.rb
+++ b/app/services/api/declarations/create.rb
@@ -65,7 +65,7 @@ module API::Declarations
 
       @training_period ||= training_periods
                              .includes(:lead_provider)
-                             .where(active_lead_providers: { lead_provider_id: })
+                             .where(framework_agreements: { lead_provider_id: })
                              .latest_first
                              .first
     end
@@ -167,7 +167,7 @@ module API::Declarations
       return false unless teacher
 
       [teacher.ect_training_periods, teacher.mentor_training_periods].any? do |periods|
-        periods.includes(:lead_provider).where(active_lead_providers: { lead_provider_id: }).exists?
+        periods.includes(:lead_provider).where(framework_agreements: { lead_provider_id: }).exists?
       end
     end
 

--- a/app/services/api/declarations/query.rb
+++ b/app/services/api/declarations/query.rb
@@ -108,7 +108,7 @@ module API::Declarations
         #   * Declarations directly associated with the lead provider.
         #   * Billable declarations dated earlier than the latest ECT/mentor training period for the lead provider.
         .where(<<-SQL, payment_statuses: Declaration::BILLABLE_OR_CHANGEABLE_PAYMENT_STATUSES, lead_provider_id:)
-          active_lead_providers.lead_provider_id = :lead_provider_id
+          framework_agreements.lead_provider_id = :lead_provider_id
           OR (
             declarations.payment_status IN (:payment_statuses)
             AND declarations.clawback_status = 'no_clawback'

--- a/app/services/api/delivery_partners/query.rb
+++ b/app/services/api/delivery_partners/query.rb
@@ -42,7 +42,7 @@ module API::DeliveryPartners
 
       delivery_partners_with_lead_provider = DeliveryPartner
         .joins(:framework_agreements)
-        .where(active_lead_providers: { lead_provider_id: })
+        .where(framework_agreements: { lead_provider_id: })
 
       scope.merge!(delivery_partners_with_lead_provider)
     end

--- a/app/services/api/school_partnerships/query.rb
+++ b/app/services/api/school_partnerships/query.rb
@@ -47,7 +47,7 @@ module API::SchoolPartnerships
       @scope = scope
         .joins(:framework_agreement)
         .where(
-          lead_provider_delivery_partnership: { active_lead_providers: { lead_provider_id: } }
+          lead_provider_delivery_partnership: { framework_agreements: { lead_provider_id: } }
         )
     end
 
@@ -57,7 +57,7 @@ module API::SchoolPartnerships
       @scope = scope
         .joins(:framework_agreement)
         .where(
-          lead_provider_delivery_partnership: { active_lead_providers: { contract_period_year: contract_period_years } }
+          lead_provider_delivery_partnership: { framework_agreements: { contract_period_year: contract_period_years } }
         )
     end
 

--- a/app/services/api/teachers/school_transfers/query.rb
+++ b/app/services/api/teachers/school_transfers/query.rb
@@ -104,7 +104,7 @@ module API::Teachers::SchoolTransfers
       @boundary_training_periods_updated_since ||=
         TrainingPeriod
           .joins(school_partnership: { lead_provider_delivery_partnership: :framework_agreement })
-          .where(active_lead_providers: { lead_provider_id: })
+          .where(framework_agreements: { lead_provider_id: })
           .where(api_transfer_updated_at: updated_since..)
           .where(id: boundary_training_period_ids)
     end

--- a/app/services/api_seed_data/ect_become_mentor_scenarios.rb
+++ b/app/services/api_seed_data/ect_become_mentor_scenarios.rb
@@ -131,13 +131,13 @@ module APISeedData
     def teachers_with_ect_and_mentor_training(lead_provider:, ect_year:, mentor_year:)
       teachers_with_ect = Teacher
         .joins(ect_at_school_periods: { training_periods: { school_partnership: { lead_provider_delivery_partnership: :framework_agreement } } })
-        .where(active_lead_providers: { lead_provider_id: lead_provider.id })
+        .where(framework_agreements: { lead_provider_id: lead_provider.id })
         .where(training_periods: { started_on: Date.new(ect_year, 1, 1)..Date.new(ect_year, 12, 31) })
         .select(:id)
 
       Teacher
         .joins(mentor_at_school_periods: { training_periods: { school_partnership: { lead_provider_delivery_partnership: :framework_agreement } } })
-        .where(active_lead_providers: { lead_provider_id: lead_provider.id })
+        .where(framework_agreements: { lead_provider_id: lead_provider.id })
         .where(training_periods: { started_on: Date.new(mentor_year, 1, 1)..Date.new(mentor_year, 12, 31) })
         .where(id: teachers_with_ect)
         .distinct

--- a/app/services/api_seed_data/participant_scenarios.rb
+++ b/app/services/api_seed_data/participant_scenarios.rb
@@ -55,13 +55,13 @@ module APISeedData
           # Count existing participants (ECTs and mentors) in this contract period with this lead provider
           existing_ects = Teacher
             .joins(ect_at_school_periods: { training_periods: :framework_agreement })
-            .where(active_lead_providers: { id: framework_agreement })
+            .where(framework_agreements: { id: framework_agreement })
             .distinct
             .count
 
           existing_mentors = Teacher
             .joins(mentor_at_school_periods: { training_periods: :framework_agreement })
-            .where(active_lead_providers: { id: framework_agreement })
+            .where(framework_agreements: { id: framework_agreement })
             .distinct
             .count
 
@@ -168,7 +168,7 @@ module APISeedData
           existing_count = Teacher
             .joins(:induction_periods, ect_at_school_periods: { training_periods: :framework_agreement })
             .where.not(induction_periods: { started_on: nil })
-            .where(active_lead_providers: { id: framework_agreement })
+            .where(framework_agreements: { id: framework_agreement })
             .distinct
             .count
 
@@ -221,7 +221,7 @@ module APISeedData
           existing_count = Teacher
             .joins(ect_at_school_periods: { training_periods: :framework_agreement })
             .where.missing(:induction_periods)
-            .where(active_lead_providers: { id: framework_agreement })
+            .where(framework_agreements: { id: framework_agreement })
             .distinct
             .count
 
@@ -285,14 +285,14 @@ module APISeedData
           existing_ects = Teacher
             .joins(ect_at_school_periods: { training_periods: %i[declarations framework_agreement] })
             .where(declarations: { payment_status: billable_statuses })
-            .where(active_lead_providers: { id: framework_agreement })
+            .where(framework_agreements: { id: framework_agreement })
             .distinct
             .count
 
           existing_mentors = Teacher
             .joins(mentor_at_school_periods: { training_periods: %i[declarations framework_agreement] })
             .where(declarations: { payment_status: billable_statuses })
-            .where(active_lead_providers: { id: framework_agreement })
+            .where(framework_agreements: { id: framework_agreement })
             .distinct
             .count
 
@@ -369,14 +369,14 @@ module APISeedData
           existing_ects = Teacher
             .joins(ect_at_school_periods: { training_periods: :framework_agreement })
             .where(training_periods: { finished_on: Time.zone.tomorrow.. })
-            .where(active_lead_providers: { id: framework_agreement })
+            .where(framework_agreements: { id: framework_agreement })
             .distinct
             .count
 
           existing_mentors = Teacher
             .joins(mentor_at_school_periods: { training_periods: :framework_agreement })
             .where(training_periods: { finished_on: Time.zone.tomorrow.. })
-            .where(active_lead_providers: { id: framework_agreement })
+            .where(framework_agreements: { id: framework_agreement })
             .distinct
             .count
 
@@ -431,14 +431,14 @@ module APISeedData
           existing_ects = Teacher
             .joins(ect_at_school_periods: { training_periods: :framework_agreement })
             .where(training_periods: { started_on: Time.zone.tomorrow.. })
-            .where(active_lead_providers: { id: framework_agreement })
+            .where(framework_agreements: { id: framework_agreement })
             .distinct
             .count
 
           existing_mentors = Teacher
             .joins(mentor_at_school_periods: { training_periods: :framework_agreement })
             .where(training_periods: { started_on: Time.zone.tomorrow.. })
-            .where(active_lead_providers: { id: framework_agreement })
+            .where(framework_agreements: { id: framework_agreement })
             .distinct
             .count
 
@@ -498,14 +498,14 @@ module APISeedData
           existing_ects = Teacher
             .joins(ect_at_school_periods: { training_periods: :framework_agreement })
             .where(training_periods: { finished_on: 4.months.from_now.. })
-            .where(active_lead_providers: { id: framework_agreement })
+            .where(framework_agreements: { id: framework_agreement })
             .distinct
             .count
 
           existing_mentors = Teacher
             .joins(mentor_at_school_periods: { training_periods: :framework_agreement })
             .where(training_periods: { finished_on: 4.months.from_now.. })
-            .where(active_lead_providers: { id: framework_agreement })
+            .where(framework_agreements: { id: framework_agreement })
             .distinct
             .count
 
@@ -567,7 +567,7 @@ module APISeedData
             .joins(ect_at_school_periods: { training_periods: :framework_agreement })
             .where(training_periods: { started_on: ..Date.current, finished_on: ..Date.current })
             .where.not(training_periods: { withdrawn_at: nil })
-            .where(active_lead_providers: { id: framework_agreement })
+            .where(framework_agreements: { id: framework_agreement })
             .distinct
             .count
 
@@ -575,7 +575,7 @@ module APISeedData
             .joins(mentor_at_school_periods: { training_periods: :framework_agreement })
             .where(training_periods: { started_on: ..Date.current, finished_on: ..Date.current })
             .where.not(training_periods: { withdrawn_at: nil })
-            .where(active_lead_providers: { id: framework_agreement })
+            .where(framework_agreements: { id: framework_agreement })
             .distinct
             .count
 
@@ -637,7 +637,7 @@ module APISeedData
             .joins(ect_at_school_periods: { training_periods: :framework_agreement })
             .where(training_periods: { started_on: ..Date.current, finished_on: ..Date.current })
             .where(training_periods: { withdrawn_at: nil, deferred_at: nil })
-            .where(active_lead_providers: { id: framework_agreement })
+            .where(framework_agreements: { id: framework_agreement })
             .distinct
             .count
 
@@ -645,7 +645,7 @@ module APISeedData
             .joins(mentor_at_school_periods: { training_periods: :framework_agreement })
             .where(training_periods: { started_on: ..Date.current, finished_on: ..Date.current })
             .where(training_periods: { withdrawn_at: nil, deferred_at: nil })
-            .where(active_lead_providers: { id: framework_agreement })
+            .where(framework_agreements: { id: framework_agreement })
             .distinct
             .count
 

--- a/app/services/api_seed_data/school_scenarios.rb
+++ b/app/services/api_seed_data/school_scenarios.rb
@@ -191,12 +191,12 @@ module APISeedData
         # Find ECT periods that have training with this lead provider
         ect_periods_with_lp = ECTAtSchoolPeriod
           .joins(training_periods: { school_partnership: { lead_provider_delivery_partnership: :framework_agreement } })
-          .where(active_lead_providers: { lead_provider_id: lead_provider.id })
+          .where(framework_agreements: { lead_provider_id: lead_provider.id })
 
         # Find ECT periods that also have training with a different lead provider
         ect_periods_transferred = ECTAtSchoolPeriod
           .joins(training_periods: { school_partnership: { lead_provider_delivery_partnership: :framework_agreement } })
-          .where(active_lead_providers: { lead_provider_id: other_lead_provider_ids })
+          .where(framework_agreements: { lead_provider_id: other_lead_provider_ids })
 
         # Schools where the SAME ECT has both
         existing_count = School
@@ -244,7 +244,7 @@ module APISeedData
       framework_agreements.find_each do |framework_agreement|
         existing_count = School
           .joins(school_partnerships: { lead_provider_delivery_partnership: :framework_agreement })
-          .where(active_lead_providers: { id: framework_agreement.id })
+          .where(framework_agreements: { id: framework_agreement.id })
           .left_joins(:ect_at_school_periods, :mentor_at_school_periods)
           .where(ect_at_school_periods: { id: nil }, mentor_at_school_periods: { id: nil })
           .distinct
@@ -282,7 +282,7 @@ module APISeedData
         existing_count = School
           .joins(ect_at_school_periods: { training_periods: [:schedule, { school_partnership: { lead_provider_delivery_partnership: :framework_agreement } }] })
           .where(schedules: { contract_period_year: 2024 })
-          .where(active_lead_providers: { lead_provider_id: lead_provider.id })
+          .where(framework_agreements: { lead_provider_id: lead_provider.id })
           .distinct
           .count
 
@@ -389,14 +389,14 @@ module APISeedData
         ect_periods_with_original_lp = ECTAtSchoolPeriod
           .joins(training_periods: [:schedule, { school_partnership: { lead_provider_delivery_partnership: :framework_agreement } }])
           .where(schedules: { contract_period_year: 2025 })
-          .where(active_lead_providers: { lead_provider_id: lead_provider.id })
+          .where(framework_agreements: { lead_provider_id: lead_provider.id })
           .where.not(training_periods: { expression_of_interest_id: nil })
           .where(training_periods: { finished_on: ...Date.current })
 
         # Find ECT periods that also have training with a different LP
         ect_periods_also_with_other_lp = ECTAtSchoolPeriod
           .joins(training_periods: { school_partnership: { lead_provider_delivery_partnership: :framework_agreement } })
-          .where(active_lead_providers: { lead_provider_id: other_lead_provider_ids })
+          .where(framework_agreements: { lead_provider_id: other_lead_provider_ids })
 
         # Schools where the SAME ECT has both
         existing_count = School
@@ -517,12 +517,12 @@ module APISeedData
         # but no partnerships with any other lead provider
         schools_with_other_lp = School
           .joins(school_partnerships: { lead_provider_delivery_partnership: :framework_agreement })
-          .where.not(active_lead_providers: { lead_provider_id: lead_provider.id })
+          .where.not(framework_agreements: { lead_provider_id: lead_provider.id })
           .select(:id)
 
         existing_count = School
           .joins(school_partnerships: { lead_provider_delivery_partnership: :framework_agreement })
-          .where(active_lead_providers: { lead_provider_id: lead_provider.id })
+          .where(framework_agreements: { lead_provider_id: lead_provider.id })
           .where.not(id: schools_with_other_lp)
           .group(:id)
           .having("COUNT(DISTINCT lead_provider_delivery_partnerships.delivery_partner_id) > 1")
@@ -561,14 +561,14 @@ module APISeedData
         # Count schools that have multiple partnerships with this lead_provider AND at least one with another LP
         schools_with_multiple_partnerships_for_lp = School
           .joins(school_partnerships: { lead_provider_delivery_partnership: :framework_agreement })
-          .where(active_lead_providers: { lead_provider_id: lead_provider.id })
+          .where(framework_agreements: { lead_provider_id: lead_provider.id })
           .group(:id)
           .having("COUNT(DISTINCT lead_provider_delivery_partnerships.delivery_partner_id) > 1")
           .select(:id)
 
         schools_also_with_other_lp = School
           .joins(school_partnerships: { lead_provider_delivery_partnership: :framework_agreement })
-          .where.not(active_lead_providers: { lead_provider_id: lead_provider.id })
+          .where.not(framework_agreements: { lead_provider_id: lead_provider.id })
           .select(:id)
 
         existing_count = School
@@ -661,7 +661,7 @@ module APISeedData
       Teacher
         .joins(ect_at_school_periods: { training_periods: [:schedule, { school_partnership: { lead_provider_delivery_partnership: :framework_agreement } }] })
         .where(schedules: { contract_period_year: year })
-        .where(active_lead_providers: { lead_provider_id: lead_provider.id })
+        .where(framework_agreements: { lead_provider_id: lead_provider.id })
         .select(:id)
     end
 
@@ -679,7 +679,7 @@ module APISeedData
 
       School
         .joins(school_period_join => { training_periods: { school_partnership: { lead_provider_delivery_partnership: :framework_agreement } } })
-        .where(active_lead_providers: { lead_provider_id: lead_provider.id })
+        .where(framework_agreements: { lead_provider_id: lead_provider.id })
         .where(training_periods: { training_programme: "provider_led" })
         .where(training_periods: { started_on: ..Time.zone.now })
         .where(training_periods: { finished_on: [nil, Time.zone.now..] })

--- a/app/services/api_seed_data/sit_become_mentor_scenarios.rb
+++ b/app/services/api_seed_data/sit_become_mentor_scenarios.rb
@@ -33,7 +33,7 @@ module APISeedData
         lead_providers.find_each do |lead_provider|
           school_partnership = SchoolPartnership
             .joins(:school, lead_provider_delivery_partnership: :framework_agreement)
-            .where(active_lead_providers: { lead_provider_id: lead_provider.id, contract_period_year: sit_year })
+            .where(framework_agreements: { lead_provider_id: lead_provider.id, contract_period_year: sit_year })
             .where.not(schools: { induction_tutor_name: nil })
             .order("RANDOM()")
             .first
@@ -49,7 +49,7 @@ module APISeedData
 
           mentor_period = MentorAtSchoolPeriod
             .with_partnerships_for_contract_period(mentor_year)
-            .where(active_lead_providers: { lead_provider_id: lead_provider.id })
+            .where(framework_agreements: { lead_provider_id: lead_provider.id })
             .includes(:teacher, :school)
             .order("RANDOM()")
             .first

--- a/app/services/data_corrections/ect_contract_period_correction.rb
+++ b/app/services/data_corrections/ect_contract_period_correction.rb
@@ -207,7 +207,7 @@ module DataCorrections
             .joins(lead_provider_delivery_partnership: :framework_agreement)
             .where(
               school:,
-              active_lead_providers: {
+              framework_agreements: {
                 id: replacement_framework_agreement.id
               }
             ),

--- a/app/services/delivery_partners/add_lead_provider_pairings.rb
+++ b/app/services/delivery_partners/add_lead_provider_pairings.rb
@@ -29,7 +29,7 @@ module DeliveryPartners
     end
 
     def current_framework_agreement_ids
-      @current_framework_agreement_ids ||= current_partnerships.map(&:active_lead_provider_id)
+      @current_framework_agreement_ids ||= current_partnerships.map(&:framework_agreement_id)
     end
 
     def framework_agreement_ids_to_add
@@ -37,8 +37,8 @@ module DeliveryPartners
     end
 
     def add_partnerships(ids_to_add)
-      ids_to_add.each do |active_lead_provider_id|
-        framework_agreement = FrameworkAgreement.find(active_lead_provider_id)
+      ids_to_add.each do |framework_agreement_id|
+        framework_agreement = FrameworkAgreement.find(framework_agreement_id)
         LeadProviderDeliveryPartnerships::Create.new(
           author:,
           framework_agreement:,

--- a/app/services/delivery_partners/update_lead_provider_pairings.rb
+++ b/app/services/delivery_partners/update_lead_provider_pairings.rb
@@ -32,7 +32,7 @@ module DeliveryPartners
     end
 
     def current_framework_agreement_ids
-      @current_framework_agreement_ids ||= current_partnerships.map(&:active_lead_provider_id)
+      @current_framework_agreement_ids ||= current_partnerships.map(&:framework_agreement_id)
     end
 
     def framework_agreement_ids_to_add
@@ -44,8 +44,8 @@ module DeliveryPartners
     end
 
     def add_partnerships(ids_to_add)
-      ids_to_add.each do |active_lead_provider_id|
-        framework_agreement = FrameworkAgreement.find(active_lead_provider_id)
+      ids_to_add.each do |framework_agreement_id|
+        framework_agreement = FrameworkAgreement.find(framework_agreement_id)
         LeadProviderDeliveryPartnerships::Create.new(
           author:,
           framework_agreement:,
@@ -55,8 +55,8 @@ module DeliveryPartners
     end
 
     def remove_partnerships(ids_to_remove)
-      ids_to_remove.each do |active_lead_provider_id|
-        partnership = current_partnerships.find_by(active_lead_provider_id:)
+      ids_to_remove.each do |framework_agreement_id|
+        partnership = current_partnerships.find_by(framework_agreement_id:)
         next unless partnership
 
         framework_agreement = partnership.framework_agreement

--- a/app/services/lead_providers/active.rb
+++ b/app/services/lead_providers/active.rb
@@ -17,7 +17,7 @@ module LeadProviders
     def self.in_contract_period(contract_period)
       LeadProvider
         .joins(:framework_agreements)
-        .where(active_lead_providers: { contract_period_year: contract_period.id })
+        .where(framework_agreements: { contract_period_year: contract_period.id })
     end
   end
 end

--- a/app/services/migration_fixes/spec_generator.rb
+++ b/app/services/migration_fixes/spec_generator.rb
@@ -136,7 +136,7 @@ class MigrationFixes::SpecGenerator
     dependencies[:lead_provider_delivery_partnerships].map { |_key, value|
       model = value[:data]
       label = value[:label]
-      alp = dependencies[:framework_agreements][model.active_lead_provider_id.to_s][:label]
+      alp = dependencies[:framework_agreements][model.framework_agreement_id.to_s][:label]
       delivery_partner = dependencies[:delivery_partners][model.delivery_partner_id.to_s][:label]
 
       <<~LPDP.chomp

--- a/app/services/payment_calculator/banded.rb
+++ b/app/services/payment_calculator/banded.rb
@@ -103,7 +103,7 @@ module PaymentCalculator
 
     def previous_statements
       Statement.joins(:contract)
-        .where(contracts: { active_lead_provider_id: statement.framework_agreement.id })
+        .where(contracts: { framework_agreement_id: statement.framework_agreement.id })
         .where(payment_date: ...statement.payment_date)
     end
 

--- a/app/services/school_partnerships/create_from_previous.rb
+++ b/app/services/school_partnerships/create_from_previous.rb
@@ -20,14 +20,14 @@ module SchoolPartnerships
       previous_lead_provider_id = previous_framework_agreement.lead_provider_id
       previous_delivery_partner_id = previous_lead_provider_delivery_partnership.delivery_partner_id
 
-      current_active_lead_provider_id = find_current_active_lead_provider_id(
+      current_framework_agreement_id = find_current_framework_agreement_id(
         lead_provider_id: previous_lead_provider_id,
         year: current_year
       )
-      return nil unless current_active_lead_provider_id
+      return nil unless current_framework_agreement_id
 
       current_lead_provider_delivery_partnership = find_current_lead_provider_delivery_partnership(
-        active_lead_provider_id: current_active_lead_provider_id,
+        framework_agreement_id: current_framework_agreement_id,
         delivery_partner_id: previous_delivery_partner_id
       )
       return nil unless current_lead_provider_delivery_partnership
@@ -55,16 +55,16 @@ module SchoolPartnerships
         .find_by(id:)
     end
 
-    def find_current_active_lead_provider_id(lead_provider_id:, year:)
+    def find_current_framework_agreement_id(lead_provider_id:, year:)
       FrameworkAgreement
         .for_lead_provider(lead_provider_id)
         .for_contract_period_year(year)
         .pick(:id)
     end
 
-    def find_current_lead_provider_delivery_partnership(active_lead_provider_id:, delivery_partner_id:)
+    def find_current_lead_provider_delivery_partnership(framework_agreement_id:, delivery_partner_id:)
       LeadProviderDeliveryPartnership.find_by(
-        active_lead_provider_id:,
+        framework_agreement_id:,
         delivery_partner_id:
       )
     end

--- a/app/services/school_partnerships/find_reusable_partnership.rb
+++ b/app/services/school_partnerships/find_reusable_partnership.rb
@@ -54,7 +54,7 @@ module SchoolPartnerships
 
     def current_year_partnership
       base_scope
-        .where(active_lead_providers: { contract_period_year: })
+        .where(framework_agreements: { contract_period_year: })
         .order(created_at: :desc, id: :desc)
         .first
     end
@@ -62,7 +62,7 @@ module SchoolPartnerships
     def most_recent_compatible_partnership
       base_scope
         .reorder(
-          "active_lead_providers.contract_period_year DESC",
+          "framework_agreements.contract_period_year DESC",
           created_at: :desc,
           id: :desc
         )

--- a/app/services/statements/declaration_selection.rb
+++ b/app/services/statements/declaration_selection.rb
@@ -97,7 +97,7 @@ module Statements
 
     def previous_statements
       @previous_statements ||= Statement.joins(:contract)
-        .where(contracts: { active_lead_provider_id: statement.framework_agreement.id })
+        .where(contracts: { framework_agreement_id: statement.framework_agreement.id })
         .where(payment_date: ...statement.payment_date)
     end
 

--- a/app/views/admin/schools/add_partnership_wizard/select_lead_provider.html.erb
+++ b/app/views/admin/schools/add_partnership_wizard/select_lead_provider.html.erb
@@ -15,12 +15,12 @@
       <%= content_for(:error_summary) { f.govuk_error_summary } %>
 
       <%= f.govuk_radio_buttons_fieldset(
-        :active_lead_provider_id,
+        :framework_agreement_id,
         legend: { text: title, size: "l", tag: "h1" }
       ) do %>
         <% @wizard.framework_agreements.each_with_index do |framework_agreement, index| %>
           <%= f.govuk_radio_button(
-            :active_lead_provider_id,
+            :framework_agreement_id,
             framework_agreement.id,
             label: { text: framework_agreement.lead_provider.name },
             link_errors: index.zero?

--- a/app/wizards/admin/schools/add_partnership_wizard/select_contract_period_step.rb
+++ b/app/wizards/admin/schools/add_partnership_wizard/select_contract_period_step.rb
@@ -16,7 +16,7 @@ module Admin
         def persist
           value = step_params["contract_period_year"] || contract_period_year
           store.contract_period_year = value
-          store.active_lead_provider_id = nil
+          store.framework_agreement_id = nil
           store.delivery_partner_id = nil
         end
 

--- a/app/wizards/admin/schools/add_partnership_wizard/select_lead_provider_step.rb
+++ b/app/wizards/admin/schools/add_partnership_wizard/select_lead_provider_step.rb
@@ -2,12 +2,12 @@ module Admin
   module Schools
     module AddPartnershipWizard
       class SelectLeadProviderStep < Step
-        attribute :active_lead_provider_id, :integer
+        attribute :framework_agreement_id, :integer
 
-        validates :active_lead_provider_id, presence: { message: "Select a lead provider" }
+        validates :framework_agreement_id, presence: { message: "Select a lead provider" }
         validate :framework_agreement_available
 
-        def self.permitted_params = %i[active_lead_provider_id]
+        def self.permitted_params = %i[framework_agreement_id]
 
         def previous_step = :select_contract_period
 
@@ -16,16 +16,16 @@ module Admin
       private
 
         def persist
-          value = step_params["active_lead_provider_id"] || active_lead_provider_id
-          store.active_lead_provider_id = value
+          value = step_params["framework_agreement_id"] || framework_agreement_id
+          store.framework_agreement_id = value
           store.delivery_partner_id = nil
         end
 
         def framework_agreement_available
-          return if active_lead_provider_id.blank?
-          return if wizard.framework_agreements.where(id: active_lead_provider_id).exists?
+          return if framework_agreement_id.blank?
+          return if wizard.framework_agreements.where(id: framework_agreement_id).exists?
 
-          errors.add(:active_lead_provider_id, "Select a lead provider")
+          errors.add(:framework_agreement_id, "Select a lead provider")
         end
       end
     end

--- a/app/wizards/admin/schools/add_partnership_wizard/wizard.rb
+++ b/app/wizards/admin/schools/add_partnership_wizard/wizard.rb
@@ -20,7 +20,7 @@ module Admin
           return steps if store.contract_period_year.blank?
 
           steps << :select_lead_provider
-          return steps if store.active_lead_provider_id.blank?
+          return steps if store.framework_agreement_id.blank?
 
           steps << :select_delivery_partner
           return steps if store.delivery_partner_id.blank?
@@ -59,9 +59,9 @@ module Admin
         end
 
         def selected_framework_agreement
-          return if store.active_lead_provider_id.blank?
+          return if store.framework_agreement_id.blank?
 
-          @selected_framework_agreement ||= FrameworkAgreement.includes(:lead_provider).find_by(id: store.active_lead_provider_id)
+          @selected_framework_agreement ||= FrameworkAgreement.includes(:lead_provider).find_by(id: store.framework_agreement_id)
         end
 
         def selected_lead_provider

--- a/app/wizards/schools/register_ect_wizard/use_previous_ect_choices_step.rb
+++ b/app/wizards/schools/register_ect_wizard/use_previous_ect_choices_step.rb
@@ -146,7 +146,7 @@ module Schools
         SchoolPartnership
           .joins(lead_provider_delivery_partnership: :framework_agreement)
           .where(id: reusable_partnership_id)
-          .where(active_lead_providers: { contract_period_year: contract_period.year })
+          .where(framework_agreements: { contract_period_year: contract_period.year })
           .exists?
       end
 
@@ -182,7 +182,7 @@ module Schools
           .at_school(school)
           .where(training_programme: "provider_led")
           .where.not(expression_of_interest_id: nil)
-          .joins("INNER JOIN active_lead_providers ON active_lead_providers.id = training_periods.expression_of_interest_id")
+          .joins("INNER JOIN framework_agreements ON framework_agreements.id = training_periods.expression_of_interest_id")
           .merge(FrameworkAgreement.where(contract_period_year: contract_period.year, lead_provider: school.last_chosen_lead_provider))
           .order(started_on: :desc, id: :desc)
           .first
@@ -194,7 +194,7 @@ module Schools
           .where(training_programme: "provider_led")
           .where.not(expression_of_interest_id: nil)
           .where("training_periods.started_on <= ?", contract_period.finished_on)
-          .joins("INNER JOIN active_lead_providers ON active_lead_providers.id = training_periods.expression_of_interest_id")
+          .joins("INNER JOIN framework_agreements ON framework_agreements.id = training_periods.expression_of_interest_id")
           .merge(FrameworkAgreement.where(lead_provider: school.last_chosen_lead_provider))
           .order(started_on: :desc, id: :desc)
           .first

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -235,7 +235,7 @@ shared:
     - mentor_funding_enabled
     - detailed_evidence_types_enabled
     - uplift_fees_enabled
-  :active_lead_providers:
+  :framework_agreements:
     - id
     - lead_provider_id
     - contract_period_year
@@ -270,7 +270,7 @@ shared:
     - contract_id
   :lead_provider_delivery_partnerships:
     - id
-    - active_lead_provider_id
+    - framework_agreement_id
     - delivery_partner_id
     - created_at
     - updated_at
@@ -291,4 +291,4 @@ shared:
   :contracts:
     - id
     - contract_type
-    - active_lead_provider_id
+    - framework_agreement_id

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -247,7 +247,7 @@
   - school_partnership_id
   - lead_provider_id
   - delivery_partner_id
-  - active_lead_provider_id
+  - framework_agreement_id
   - lead_provider_delivery_partnership_id
   - pending_induction_submission_batch_id
   - schedule_id
@@ -335,9 +335,9 @@
   - service_fee_ratio
   - created_at
   - updated_at
-  :active_lead_provider_bands:
+  :framework_agreement_bands:
   - id
-  - active_lead_provider_id
+  - framework_agreement_id
   - allocation_order
   - capacity
   - created_at

--- a/config/blazer.yml
+++ b/config/blazer.yml
@@ -12,7 +12,7 @@ data_sources:
       batch_status: ['pending', 'processing', 'processed', 'completing', 'completed', 'failed']
       batch_type: ['action', 'claim']
       urn: "SELECT urn, CONCAT(name, ' (', urn, ')') FROM gias_schools ORDER BY name ASC"
-      active_lead_provider_id: "SELECT active_lead_providers.id, lead_providers.name FROM active_lead_providers JOIN lead_providers ON lead_providers.id=active_lead_providers.lead_provider_id ORDER BY lead_providers.name ASC"
+      framework_agreement_id: "SELECT framework_agreements.id, lead_providers.name FROM framework_agreements JOIN lead_providers ON lead_providers.id=framework_agreements.lead_provider_id ORDER BY lead_providers.name ASC"
 
     # https://blazer.dokkuapp.com/queries/2-smart-column
     smart_columns:
@@ -20,7 +20,7 @@ data_sources:
       appropriate_body_period_id: "SELECT id, name FROM appropriate_body_periods WHERE id IN {value}"
       teacher_id: "SELECT id, CONCAT(trs_first_name, ' ', trs_last_name) AS full_name FROM teachers WHERE id IN {value}"
       urn: "SELECT urn, CONCAT(name, ' (', urn, ')') FROM gias_schools WHERE urn IN {value}"
-      active_lead_provider_id: "SELECT active_lead_providers.id, lead_providers.name FROM active_lead_providers JOIN lead_providers ON lead_providers.id=active_lead_providers.lead_provider_id WHERE active_lead_providers.id IN {value}"
+      framework_agreement_id: "SELECT framework_agreements.id, lead_providers.name FROM framework_agreements JOIN lead_providers ON lead_providers.id=framework_agreements.lead_provider_id WHERE framework_agreements.id IN {value}"
 
     # https://blazer.dokkuapp.com/queries/3-linked-column
     linked_columns:
@@ -30,7 +30,7 @@ data_sources:
       induction_period_id: "/admin/teachers/N/induction-periods/{value}/edit"
       zendesk_ticket_id: "https://becomingateacher.zendesk.com/agent/tickets/{value}"
       urn: "/admin/schools/{value}/overview"
-      active_lead_provider_id: "/admin" # TODO: target show page once added
+      framework_agreement_id: "/admin" # TODO: target show page once added
 
 # statement timeout, in seconds
 # none by default

--- a/db/migrate/20260819155844_rename_active_lead_providers_to_framework_agreements.rb
+++ b/db/migrate/20260819155844_rename_active_lead_providers_to_framework_agreements.rb
@@ -1,0 +1,13 @@
+class RenameActiveLeadProvidersToFrameworkAgreements < ActiveRecord::Migration[8.1]
+  def change
+    rename_table :active_lead_providers, :framework_agreements
+    rename_table :active_lead_provider_bands, :framework_agreement_bands
+
+    rename_column :framework_agreement_bands, :active_lead_provider_id, :framework_agreement_id
+    rename_column :contracts, :active_lead_provider_id, :framework_agreement_id
+    rename_column :events, :active_lead_provider_id, :framework_agreement_id
+    rename_column :lead_provider_delivery_partnerships, :active_lead_provider_id, :framework_agreement_id
+
+    rename_index :lead_provider_delivery_partnerships, :idx_lpdps_active_lead_provider, :idx_lpdps_framework_agreement
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_13_103015) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_19_155844) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -49,26 +49,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_13_103015) do
   create_enum "trs_responses", ["ok", "not_found", "gone", "permanent_redirect"]
   create_enum "withdrawal_reasons", ["left_teaching_profession", "moved_school", "mentor_no_longer_being_mentor", "switched_to_school_led", "other", "changed_lead_provider"]
   create_enum "working_pattern", ["part_time", "full_time"]
-
-  create_table "active_lead_provider_bands", force: :cascade do |t|
-    t.bigint "active_lead_provider_id", null: false
-    t.integer "allocation_order", null: false
-    t.integer "capacity", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["active_lead_provider_id", "allocation_order"], name: "idx_on_active_lead_provider_id_allocation_order_3a1b864c94", unique: true
-    t.index ["active_lead_provider_id"], name: "index_active_lead_provider_bands_on_active_lead_provider_id"
-  end
-
-  create_table "active_lead_providers", force: :cascade do |t|
-    t.bigint "contract_period_year", null: false
-    t.datetime "created_at", null: false
-    t.bigint "lead_provider_id", null: false
-    t.datetime "updated_at", null: false
-    t.index ["contract_period_year"], name: "index_active_lead_providers_on_contract_period_year"
-    t.index ["lead_provider_id", "contract_period_year"], name: "idx_on_lead_provider_id_contract_period_year_e442ca2260", unique: true
-    t.index ["lead_provider_id"], name: "index_active_lead_providers_on_lead_provider_id"
-  end
 
   create_table "api_tokens", force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -209,12 +189,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_13_103015) do
   end
 
   create_table "contracts", force: :cascade do |t|
-    t.bigint "active_lead_provider_id", null: false
     t.enum "contract_type", null: false, enum_type: "contract_types"
     t.datetime "created_at", null: false
+    t.bigint "framework_agreement_id", null: false
     t.datetime "updated_at", null: false
     t.decimal "vat_rate", precision: 3, scale: 2, default: "0.2", null: false
-    t.index ["active_lead_provider_id"], name: "index_contracts_on_active_lead_provider_id"
+    t.index ["framework_agreement_id"], name: "index_contracts_on_framework_agreement_id"
   end
 
   create_table "declarations", force: :cascade do |t|
@@ -300,7 +280,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_13_103015) do
   end
 
   create_table "events", force: :cascade do |t|
-    t.bigint "active_lead_provider_id"
     t.integer "appropriate_body_period_id"
     t.citext "author_email"
     t.integer "author_id"
@@ -313,6 +292,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_13_103015) do
     t.integer "delivery_partner_id"
     t.integer "ect_at_school_period_id"
     t.text "event_type"
+    t.bigint "framework_agreement_id"
     t.datetime "happened_at", default: -> { "CURRENT_TIMESTAMP" }
     t.text "heading"
     t.integer "induction_extension_id"
@@ -334,7 +314,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_13_103015) do
     t.datetime "updated_at", null: false
     t.integer "user_id"
     t.integer "zendesk_ticket_id"
-    t.index ["active_lead_provider_id"], name: "index_events_on_active_lead_provider_id"
     t.index ["appropriate_body_period_id"], name: "index_events_on_appropriate_body_period_id"
     t.index ["author_email"], name: "index_events_on_author_email"
     t.index ["author_id"], name: "index_events_on_author_id"
@@ -342,6 +321,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_13_103015) do
     t.index ["declaration_id"], name: "index_events_on_declaration_id"
     t.index ["delivery_partner_id"], name: "index_events_on_delivery_partner_id"
     t.index ["ect_at_school_period_id"], name: "index_events_on_ect_at_school_period_id"
+    t.index ["framework_agreement_id"], name: "index_events_on_framework_agreement_id"
     t.index ["induction_extension_id"], name: "index_events_on_induction_extension_id"
     t.index ["induction_period_id"], name: "index_events_on_induction_period_id"
     t.index ["lead_provider_delivery_partnership_id"], name: "index_events_on_lead_provider_delivery_partnership_id"
@@ -356,6 +336,26 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_13_103015) do
     t.index ["teacher_id"], name: "index_events_on_teacher_id"
     t.index ["training_period_id"], name: "index_events_on_training_period_id"
     t.index ["user_id"], name: "index_events_on_user_id"
+  end
+
+  create_table "framework_agreement_bands", force: :cascade do |t|
+    t.integer "allocation_order", null: false
+    t.integer "capacity", null: false
+    t.datetime "created_at", null: false
+    t.bigint "framework_agreement_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["framework_agreement_id", "allocation_order"], name: "idx_on_framework_agreement_id_allocation_order_2df1ec5b5b", unique: true
+    t.index ["framework_agreement_id"], name: "index_framework_agreement_bands_on_framework_agreement_id"
+  end
+
+  create_table "framework_agreements", force: :cascade do |t|
+    t.bigint "contract_period_year", null: false
+    t.datetime "created_at", null: false
+    t.bigint "lead_provider_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["contract_period_year"], name: "index_framework_agreements_on_contract_period_year"
+    t.index ["lead_provider_id", "contract_period_year"], name: "idx_on_lead_provider_id_contract_period_year_4809d6983e", unique: true
+    t.index ["lead_provider_id"], name: "index_framework_agreements_on_lead_provider_id"
   end
 
   create_table "gias_school_links", force: :cascade do |t|
@@ -426,16 +426,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_13_103015) do
   end
 
   create_table "lead_provider_delivery_partnerships", force: :cascade do |t|
-    t.bigint "active_lead_provider_id", null: false
     t.datetime "created_at", null: false
     t.bigint "delivery_partner_id", null: false
     t.uuid "ecf_id"
+    t.bigint "framework_agreement_id", null: false
     t.datetime "updated_at", null: false
-    t.index ["active_lead_provider_id", "delivery_partner_id"], name: "idx_on_active_lead_provider_id_delivery_partner_id_3c66d9e812", unique: true
-    t.index ["active_lead_provider_id"], name: "idx_lpdps_active_lead_provider"
-    t.index ["active_lead_provider_id"], name: "idx_on_active_lead_provider_id_2f96b67fbb"
     t.index ["delivery_partner_id"], name: "idx_on_delivery_partner_id_fcb95e8215"
     t.index ["ecf_id"], name: "index_lead_provider_delivery_partnerships_on_ecf_id", unique: true
+    t.index ["framework_agreement_id", "delivery_partner_id"], name: "idx_on_framework_agreement_id_delivery_partner_id_9fd91dcb3d", unique: true
+    t.index ["framework_agreement_id"], name: "idx_lpdps_framework_agreement"
+    t.index ["framework_agreement_id"], name: "idx_on_framework_agreement_id_f85a3e1a68"
   end
 
   create_table "lead_providers", force: :cascade do |t|
@@ -956,16 +956,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_13_103015) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
-  add_foreign_key "active_lead_provider_bands", "active_lead_providers"
-  add_foreign_key "active_lead_providers", "contract_periods", column: "contract_period_year", primary_key: "year"
-  add_foreign_key "active_lead_providers", "lead_providers"
   add_foreign_key "appropriate_bodies", "dfe_sign_in_organisations"
   add_foreign_key "appropriate_body_periods", "appropriate_bodies"
-  add_foreign_key "contract_banded_fee_structure_band_terms", "active_lead_provider_bands", column: "band_id"
   add_foreign_key "contract_banded_fee_structure_band_terms", "contract_banded_fee_structures", column: "banded_fee_structure_id", on_delete: :cascade
+  add_foreign_key "contract_banded_fee_structure_band_terms", "framework_agreement_bands", column: "band_id"
   add_foreign_key "contract_banded_fee_structures", "contracts"
   add_foreign_key "contract_flat_rate_fee_structures", "contracts"
-  add_foreign_key "contracts", "active_lead_providers"
+  add_foreign_key "contracts", "framework_agreements"
   add_foreign_key "declarations", "delivery_partners", column: "delivery_partner_when_created_id"
   add_foreign_key "declarations", "statements", column: "clawback_statement_id"
   add_foreign_key "declarations", "statements", column: "payment_statement_id"
@@ -974,12 +971,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_13_103015) do
   add_foreign_key "ect_at_school_periods", "schools"
   add_foreign_key "ect_at_school_periods", "schools", column: "reported_leaving_by_school_id"
   add_foreign_key "ect_at_school_periods", "teachers"
-  add_foreign_key "events", "active_lead_providers", on_delete: :nullify
   add_foreign_key "events", "appropriate_body_periods", on_delete: :nullify
   add_foreign_key "events", "contract_periods", primary_key: "year", on_delete: :nullify
   add_foreign_key "events", "declarations", on_delete: :nullify
   add_foreign_key "events", "delivery_partners", on_delete: :nullify
   add_foreign_key "events", "ect_at_school_periods", on_delete: :nullify
+  add_foreign_key "events", "framework_agreements", on_delete: :nullify
   add_foreign_key "events", "induction_extensions", on_delete: :nullify
   add_foreign_key "events", "induction_periods", on_delete: :nullify
   add_foreign_key "events", "lead_provider_delivery_partnerships", on_delete: :nullify
@@ -995,6 +992,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_13_103015) do
   add_foreign_key "events", "training_periods", on_delete: :nullify
   add_foreign_key "events", "users", column: "author_id", on_delete: :nullify
   add_foreign_key "events", "users", on_delete: :nullify
+  add_foreign_key "framework_agreement_bands", "framework_agreements"
+  add_foreign_key "framework_agreements", "contract_periods", column: "contract_period_year", primary_key: "year"
+  add_foreign_key "framework_agreements", "lead_providers"
   add_foreign_key "gias_school_links", "gias_schools", column: "urn", primary_key: "urn"
   add_foreign_key "induction_extensions", "teachers"
   add_foreign_key "induction_periods", "appropriate_body_periods"
@@ -1043,8 +1043,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_13_103015) do
   add_foreign_key "teacher_id_changes", "teachers", column: "api_to_teacher_id", primary_key: "api_id"
   add_foreign_key "teachers", "contract_periods", column: "ect_payments_frozen_year", primary_key: "year"
   add_foreign_key "teachers", "contract_periods", column: "mentor_payments_frozen_year", primary_key: "year"
-  add_foreign_key "training_periods", "active_lead_providers", column: "expression_of_interest_id"
   add_foreign_key "training_periods", "ect_at_school_periods"
+  add_foreign_key "training_periods", "framework_agreements", column: "expression_of_interest_id"
   add_foreign_key "training_periods", "mentor_at_school_periods"
   add_foreign_key "training_periods", "schedules"
   add_foreign_key "training_periods", "school_partnerships"

--- a/db/seeds/blazer_queries.rb
+++ b/db/seeds/blazer_queries.rb
@@ -80,7 +80,7 @@ end
   },
   {
     name: "Active lead provider bands",
-    statement: "SELECT * FROM active_lead_provider_bands ORDER BY active_lead_provider_id, allocation_order",
+    statement: "SELECT * FROM framework_agreement_bands ORDER BY framework_agreement_id, allocation_order",
     description: "new data model"
   }
 ].each do |query|

--- a/db/seeds/blazer_queries/school_comms.rb
+++ b/db/seeds/blazer_queries/school_comms.rb
@@ -176,8 +176,8 @@ module BlazerQueries
           "SELECT 1 FROM school_partnerships sp " \
           "INNER JOIN lead_provider_delivery_partnerships lpdp " \
           "ON lpdp.id = sp.lead_provider_delivery_partnership_id " \
-          "INNER JOIN active_lead_providers alp " \
-          "ON alp.id = lpdp.active_lead_provider_id " \
+          "INNER JOIN framework_agreements alp " \
+          "ON alp.id = lpdp.framework_agreement_id " \
           "INNER JOIN contract_periods cp ON cp.year = alp.contract_period_year " \
           "WHERE sp.school_id = s.id AND cp.range @> #{current_date_sql})"
       end

--- a/documentation/domain-model.md
+++ b/documentation/domain-model.md
@@ -14,7 +14,7 @@ erDiagram
   Contract_BandedFeeStructure_BandTerm }o--|| FrameworkAgreement_Band : belongs_to
   FrameworkAgreement_Band {
     integer id
-    integer active_lead_provider_id
+    integer framework_agreement_id
     integer allocation_order
     integer capacity
     datetime created_at
@@ -206,7 +206,6 @@ erDiagram
     string trn
     boolean trnless
     datetime trs_data_last_refreshed_at
-    boolean trs_deactivated
     string trs_first_name
     date trs_induction_completed_date
     date trs_induction_start_date
@@ -214,7 +213,6 @@ erDiagram
     date trs_initial_teacher_training_end_date
     string trs_initial_teacher_training_provider_name
     string trs_last_name
-    boolean trs_not_found
     date trs_qts_awarded_on
     string trs_qts_status_description
     datetime updated_at
@@ -308,7 +306,7 @@ erDiagram
   LegacyAppropriateBody }o--|| AppropriateBodyPeriod : belongs_to
   LeadProviderDeliveryPartnership {
     integer id
-    integer active_lead_provider_id
+    integer framework_agreement_id
     datetime created_at
     integer delivery_partner_id
     uuid ecf_id
@@ -443,7 +441,7 @@ erDiagram
   }
   Contract {
     integer id
-    integer active_lead_provider_id
+    integer framework_agreement_id
     enum contract_type
     datetime created_at
     datetime updated_at

--- a/lib/tasks/product_review/3731.rake
+++ b/lib/tasks/product_review/3731.rake
@@ -7,7 +7,7 @@ namespace :product_review do
 
     statement = Statement
       .joins(:contract)
-      .where(contracts: { active_lead_provider_id: framework_agreement.id, contract_type: "ecf" })
+      .where(contracts: { framework_agreement_id: framework_agreement.id, contract_type: "ecf" })
       .find_by!(month: 10, year: 2024, fee_type: "output")
 
     refundable = Declaration

--- a/spec/models/contract_spec.rb
+++ b/spec/models/contract_spec.rb
@@ -82,7 +82,7 @@ describe Contract do
     it { is_expected.to delegate_method(:editable?).to(:framework_agreement) }
   end
 
-  describe "immutable active_lead_provider_id" do
+  describe "immutable framework_agreement_id" do
     let(:framework_agreement) { FactoryBot.create(:framework_agreement) }
 
     context "when creating a new contract" do

--- a/spec/models/lead_provider_delivery_partnership_spec.rb
+++ b/spec/models/lead_provider_delivery_partnership_spec.rb
@@ -11,9 +11,9 @@ describe LeadProviderDeliveryPartnership do
   describe "validation" do
     subject { FactoryBot.create(:lead_provider_delivery_partnership) }
 
-    it { is_expected.to validate_presence_of(:active_lead_provider_id).with_message("Select a lead provider framework agreement") }
+    it { is_expected.to validate_presence_of(:framework_agreement_id).with_message("Select a lead provider framework agreement") }
     it { is_expected.to validate_presence_of(:delivery_partner_id).with_message("Select a delivery partner") }
-    it { is_expected.to validate_uniqueness_of(:delivery_partner_id).scoped_to(:active_lead_provider_id).with_message("Delivery partner and lead provider framework agreement pairing must be unique") }
+    it { is_expected.to validate_uniqueness_of(:delivery_partner_id).scoped_to(:framework_agreement_id).with_message("Delivery partner and lead provider framework agreement pairing must be unique") }
   end
 
   describe "scopes" do
@@ -99,28 +99,28 @@ describe LeadProviderDeliveryPartnership do
 
       it "returns framework agreement IDs for the specified delivery partner and contract period" do
         result = LeadProviderDeliveryPartnership.framework_agreement_ids_for(delivery_partner, contract_period)
-        expect(result.pluck(:active_lead_provider_id)).to contain_exactly(alp_with_partnership.id)
+        expect(result.pluck(:framework_agreement_id)).to contain_exactly(alp_with_partnership.id)
       end
 
       it "excludes partnerships with other delivery partners" do
         result = LeadProviderDeliveryPartnership.framework_agreement_ids_for(delivery_partner, contract_period)
-        expect(result.pluck(:active_lead_provider_id)).not_to include(alp_other_delivery_partner.id)
+        expect(result.pluck(:framework_agreement_id)).not_to include(alp_other_delivery_partner.id)
       end
 
       it "excludes partnerships from other contract periods" do
         result = LeadProviderDeliveryPartnership.framework_agreement_ids_for(delivery_partner, contract_period)
-        expect(result.pluck(:active_lead_provider_id)).not_to include(alp_other_contract_period.id)
+        expect(result.pluck(:framework_agreement_id)).not_to include(alp_other_contract_period.id)
       end
 
       it "excludes framework agreements with no partnerships" do
         result = LeadProviderDeliveryPartnership.framework_agreement_ids_for(delivery_partner, contract_period)
-        expect(result.pluck(:active_lead_provider_id)).not_to include(alp_no_partnership.id)
+        expect(result.pluck(:framework_agreement_id)).not_to include(alp_no_partnership.id)
       end
 
       it "returns a select query that can be used in subqueries" do
         result = LeadProviderDeliveryPartnership.framework_agreement_ids_for(delivery_partner, contract_period)
         expect(result.to_sql).to include("SELECT")
-        expect(result.to_sql).to include("active_lead_provider_id")
+        expect(result.to_sql).to include("framework_agreement_id")
       end
     end
   end

--- a/spec/requests/admin/delivery_partners_spec.rb
+++ b/spec/requests/admin/delivery_partners_spec.rb
@@ -308,7 +308,7 @@ RSpec.describe "Admin delivery partners", type: :request do
             }.to change(LeadProviderDeliveryPartnership, :count).by(-1)
 
             remaining_partnerships = delivery_partner.lead_provider_delivery_partnerships.reload
-            expect(remaining_partnerships.map(&:active_lead_provider_id)).to contain_exactly(framework_agreement_1.id)
+            expect(remaining_partnerships.map(&:framework_agreement_id)).to contain_exactly(framework_agreement_1.id)
           end
 
           it "redirects with success message" do
@@ -330,7 +330,7 @@ RSpec.describe "Admin delivery partners", type: :request do
             }.to change(LeadProviderDeliveryPartnership, :count).by(1)
 
             partnerships = delivery_partner.lead_provider_delivery_partnerships.reload
-            expect(partnerships.map(&:active_lead_provider_id)).to contain_exactly(
+            expect(partnerships.map(&:framework_agreement_id)).to contain_exactly(
               framework_agreement_1.id,
               framework_agreement_2.id,
               framework_agreement_3.id
@@ -360,7 +360,7 @@ RSpec.describe "Admin delivery partners", type: :request do
             # Verify the partnerships were updated correctly
             remaining_partnerships = delivery_partner.lead_provider_delivery_partnerships.for_contract_period(contract_period)
             expect(remaining_partnerships.count).to eq(1)
-            expect(remaining_partnerships.first.active_lead_provider_id).to eq(framework_agreement_1.id)
+            expect(remaining_partnerships.first.framework_agreement_id).to eq(framework_agreement_1.id)
 
             # Reopen form and verify only the selected provider is checked
             get new_path

--- a/spec/requests/admin/schools/add_partnership_wizard_spec.rb
+++ b/spec/requests/admin/schools/add_partnership_wizard_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "Admin::Schools::AddPartnershipWizardController", type: :request 
 
       post(
         path_for_step("select-lead-provider"),
-        params: { select_lead_provider: { active_lead_provider_id: framework_agreement.id } }
+        params: { select_lead_provider: { framework_agreement_id: framework_agreement.id } }
       )
 
       expect(response).to redirect_to(path_for_step("select-delivery-partner"))
@@ -116,7 +116,7 @@ RSpec.describe "Admin::Schools::AddPartnershipWizardController", type: :request 
 
       post(
         path_for_step("select-lead-provider"),
-        params: { select_lead_provider: { active_lead_provider_id: "" } }
+        params: { select_lead_provider: { framework_agreement_id: "" } }
       )
       expect(response.body).to include("Select a lead provider")
     end
@@ -130,7 +130,7 @@ RSpec.describe "Admin::Schools::AddPartnershipWizardController", type: :request 
 
       post(
         path_for_step("select-lead-provider"),
-        params: { select_lead_provider: { active_lead_provider_id: framework_agreement.id } }
+        params: { select_lead_provider: { framework_agreement_id: framework_agreement.id } }
       )
       follow_redirect!
 
@@ -156,7 +156,7 @@ RSpec.describe "Admin::Schools::AddPartnershipWizardController", type: :request 
 
       post(
         path_for_step("select-lead-provider"),
-        params: { select_lead_provider: { active_lead_provider_id: framework_agreement.id } }
+        params: { select_lead_provider: { framework_agreement_id: framework_agreement.id } }
       )
       follow_redirect!
 

--- a/spec/requests/api/v3/declarations_spec.rb
+++ b/spec/requests/api/v3/declarations_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe "Declarations API", :with_metadata, :with_touches, type: :request
 
     FactoryBot.create(:declaration, declaration_trait, training_period:).tap do |declaration|
       # Using update_all bypasses the readonly check on that attribute.
-      active_lead_provider_id = framework_agreement.id
-      Contract.where(id: declaration.payment_statement&.contract).update_all(active_lead_provider_id:)
+      framework_agreement_id = framework_agreement.id
+      Contract.where(id: declaration.payment_statement&.contract).update_all(framework_agreement_id:)
     end
   end
 

--- a/spec/services/api_seed_data/ect_become_mentor_scenarios_spec.rb
+++ b/spec/services/api_seed_data/ect_become_mentor_scenarios_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe APISeedData::ECTBecomeMentorScenarios do
         [2022, 2023].each do |ect_year|
           teachers_for_lp_and_year = new_teachers
             .joins(ect_at_school_periods: { training_periods: { school_partnership: { lead_provider_delivery_partnership: :framework_agreement } } })
-            .where(active_lead_providers: { lead_provider_id: lead_provider.id })
+            .where(framework_agreements: { lead_provider_id: lead_provider.id })
             .where(training_periods: { started_on: Date.new(ect_year, 9, 1) })
             .distinct
 

--- a/spec/services/api_seed_data/ect_scenarios_spec.rb
+++ b/spec/services/api_seed_data/ect_scenarios_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe APISeedData::ECTScenarios do
 
       ects_count = Teacher
         .joins(ect_at_school_periods: { training_periods: :framework_agreement })
-        .where(active_lead_providers: { contract_period_year: contract_period_2025.year })
+        .where(framework_agreements: { contract_period_year: contract_period_2025.year })
         .distinct
         .count
 
@@ -65,7 +65,7 @@ RSpec.describe APISeedData::ECTScenarios do
 
       mentors_count = Teacher
         .joins(mentor_at_school_periods: { training_periods: :framework_agreement })
-        .where(active_lead_providers: { contract_period_year: contract_period_2024.year })
+        .where(framework_agreements: { contract_period_year: contract_period_2024.year })
         .distinct
         .count
 
@@ -77,8 +77,8 @@ RSpec.describe APISeedData::ECTScenarios do
 
       mentorships = MentorshipPeriod
         .joins(:mentor, :mentee)
-        .where(mentee: ECTAtSchoolPeriod.joins(training_periods: :framework_agreement).where(active_lead_providers: { contract_period_year: contract_period_2025.year }))
-        .where(mentor: MentorAtSchoolPeriod.joins(training_periods: :framework_agreement).where(active_lead_providers: { contract_period_year: contract_period_2024.year }))
+        .where(mentee: ECTAtSchoolPeriod.joins(training_periods: :framework_agreement).where(framework_agreements: { contract_period_year: contract_period_2025.year }))
+        .where(mentor: MentorAtSchoolPeriod.joins(training_periods: :framework_agreement).where(framework_agreements: { contract_period_year: contract_period_2024.year }))
 
       expect(mentorships.count).to be >= 1
 
@@ -118,7 +118,7 @@ RSpec.describe APISeedData::ECTScenarios do
 
       ects_count = Teacher
         .joins(ect_at_school_periods: { training_periods: :framework_agreement })
-        .where(active_lead_providers: { contract_period_year: contract_period_2025.year })
+        .where(framework_agreements: { contract_period_year: contract_period_2025.year })
         .distinct
         .count
 
@@ -130,7 +130,7 @@ RSpec.describe APISeedData::ECTScenarios do
 
       mentors_count = Teacher
         .joins(mentor_at_school_periods: { training_periods: :framework_agreement })
-        .where(active_lead_providers: { contract_period_year: contract_period_2023.year })
+        .where(framework_agreements: { contract_period_year: contract_period_2023.year })
         .distinct
         .count
 
@@ -142,8 +142,8 @@ RSpec.describe APISeedData::ECTScenarios do
 
       mentorships = MentorshipPeriod
         .joins(:mentor, :mentee)
-        .where(mentee: ECTAtSchoolPeriod.joins(training_periods: :framework_agreement).where(active_lead_providers: { contract_period_year: contract_period_2025.year }))
-        .where(mentor: MentorAtSchoolPeriod.joins(training_periods: :framework_agreement).where(active_lead_providers: { contract_period_year: contract_period_2023.year }))
+        .where(mentee: ECTAtSchoolPeriod.joins(training_periods: :framework_agreement).where(framework_agreements: { contract_period_year: contract_period_2025.year }))
+        .where(mentor: MentorAtSchoolPeriod.joins(training_periods: :framework_agreement).where(framework_agreements: { contract_period_year: contract_period_2023.year }))
 
       expect(mentorships.count).to be >= 1
 

--- a/spec/services/api_seed_data/mentor_scenarios_spec.rb
+++ b/spec/services/api_seed_data/mentor_scenarios_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe APISeedData::MentorScenarios do
 
       mentors_count = Teacher
         .joins(mentor_at_school_periods: { training_periods: :framework_agreement })
-        .where(active_lead_providers: { contract_period_year: contract_period_2025.year })
+        .where(framework_agreements: { contract_period_year: contract_period_2025.year })
         .distinct
         .count
 
@@ -62,7 +62,7 @@ RSpec.describe APISeedData::MentorScenarios do
 
       ects_count = Teacher
         .joins(ect_at_school_periods: { training_periods: :framework_agreement })
-        .where(active_lead_providers: { contract_period_year: contract_period_2025.year })
+        .where(framework_agreements: { contract_period_year: contract_period_2025.year })
         .distinct
         .count
 
@@ -74,7 +74,7 @@ RSpec.describe APISeedData::MentorScenarios do
 
       schools = Teacher
         .joins(ect_at_school_periods: { training_periods: :framework_agreement })
-        .where(active_lead_providers: { contract_period_year: contract_period_2025.year })
+        .where(framework_agreements: { contract_period_year: contract_period_2025.year })
         .pluck("ect_at_school_periods.school_id").uniq
 
       expect(schools.count).to be >= 2
@@ -110,7 +110,7 @@ RSpec.describe APISeedData::MentorScenarios do
 
       mentors_count = Teacher
         .joins(mentor_at_school_periods: { training_periods: :framework_agreement })
-        .where(active_lead_providers: { contract_period_year: contract_period_2024.year })
+        .where(framework_agreements: { contract_period_year: contract_period_2024.year })
         .distinct
         .count
 
@@ -122,7 +122,7 @@ RSpec.describe APISeedData::MentorScenarios do
 
       ects_count = Teacher
         .joins(ect_at_school_periods: { training_periods: :framework_agreement })
-        .where(active_lead_providers: { contract_period_year: contract_period_2024.year })
+        .where(framework_agreements: { contract_period_year: contract_period_2024.year })
         .distinct
         .count
 
@@ -134,7 +134,7 @@ RSpec.describe APISeedData::MentorScenarios do
 
       schools = Teacher
         .joins(ect_at_school_periods: { training_periods: :framework_agreement })
-        .where(active_lead_providers: { contract_period_year: contract_period_2024.year })
+        .where(framework_agreements: { contract_period_year: contract_period_2024.year })
         .pluck("ect_at_school_periods.school_id").uniq
 
       expect(schools.count).to be >= 2

--- a/spec/services/api_seed_data/participant_scenarios_spec.rb
+++ b/spec/services/api_seed_data/participant_scenarios_spec.rb
@@ -74,14 +74,14 @@ RSpec.describe APISeedData::ParticipantScenarios do
           ects_in_period = Teacher
             .joins(ect_at_school_periods: { training_periods: [:schedule, { school_partnership: { lead_provider_delivery_partnership: :framework_agreement } }] })
             .where(schedules: { contract_period_year: contract_period.year })
-            .where(active_lead_providers: { lead_provider_id: lead_provider.id })
+            .where(framework_agreements: { lead_provider_id: lead_provider.id })
             .distinct
             .count
 
           mentors_in_period = Teacher
             .joins(mentor_at_school_periods: { training_periods: [:schedule, { school_partnership: { lead_provider_delivery_partnership: :framework_agreement } }] })
             .where(schedules: { contract_period_year: contract_period.year })
-            .where(active_lead_providers: { lead_provider_id: lead_provider.id })
+            .where(framework_agreements: { lead_provider_id: lead_provider.id })
             .distinct
             .count
 
@@ -171,7 +171,7 @@ RSpec.describe APISeedData::ParticipantScenarios do
             .joins(ect_at_school_periods: { training_periods: [:declarations, :schedule, { school_partnership: { lead_provider_delivery_partnership: :framework_agreement } }] })
             .where(declarations: { payment_status: billable_statuses })
             .where(schedules: { contract_period_year: year })
-            .where(active_lead_providers: { lead_provider_id: lead_provider.id })
+            .where(framework_agreements: { lead_provider_id: lead_provider.id })
             .distinct
             .count
 
@@ -179,7 +179,7 @@ RSpec.describe APISeedData::ParticipantScenarios do
             .joins(mentor_at_school_periods: { training_periods: [:declarations, :schedule, { school_partnership: { lead_provider_delivery_partnership: :framework_agreement } }] })
             .where(declarations: { payment_status: billable_statuses })
             .where(schedules: { contract_period_year: year })
-            .where(active_lead_providers: { lead_provider_id: lead_provider.id })
+            .where(framework_agreements: { lead_provider_id: lead_provider.id })
             .distinct
             .count
 
@@ -216,14 +216,14 @@ RSpec.describe APISeedData::ParticipantScenarios do
             .joins(ect_at_school_periods: { training_periods: [:schedule, { school_partnership: { lead_provider_delivery_partnership: :framework_agreement } }] })
             .where(training_periods: { finished_on: Time.zone.tomorrow.. })
             .where(schedules: { contract_period_year: year })
-            .where(active_lead_providers: { lead_provider_id: lead_provider.id })
+            .where(framework_agreements: { lead_provider_id: lead_provider.id })
             .distinct
 
           mentors_leaving = Teacher
             .joins(mentor_at_school_periods: { training_periods: [:schedule, { school_partnership: { lead_provider_delivery_partnership: :framework_agreement } }] })
             .where(training_periods: { finished_on: Time.zone.tomorrow.. })
             .where(schedules: { contract_period_year: year })
-            .where(active_lead_providers: { lead_provider_id: lead_provider.id })
+            .where(framework_agreements: { lead_provider_id: lead_provider.id })
             .distinct
 
           # creates 2 participants for each of the 2 contract periods
@@ -253,14 +253,14 @@ RSpec.describe APISeedData::ParticipantScenarios do
             .joins(ect_at_school_periods: { training_periods: [:schedule, { school_partnership: { lead_provider_delivery_partnership: :framework_agreement } }] })
             .where(training_periods: { started_on: Time.zone.tomorrow.. })
             .where(schedules: { contract_period_year: year })
-            .where(active_lead_providers: { lead_provider_id: lead_provider.id })
+            .where(framework_agreements: { lead_provider_id: lead_provider.id })
             .distinct
 
           mentors_joining = Teacher
             .joins(mentor_at_school_periods: { training_periods: [:schedule, { school_partnership: { lead_provider_delivery_partnership: :framework_agreement } }] })
             .where(training_periods: { started_on: Time.zone.tomorrow.. })
             .where(schedules: { contract_period_year: year })
-            .where(active_lead_providers: { lead_provider_id: lead_provider.id })
+            .where(framework_agreements: { lead_provider_id: lead_provider.id })
             .distinct
 
           # creates 2 participants for ECTs and Mentors
@@ -302,14 +302,14 @@ RSpec.describe APISeedData::ParticipantScenarios do
             .joins(ect_at_school_periods: { training_periods: [:schedule, { school_partnership: { lead_provider_delivery_partnership: :framework_agreement } }] })
             .where(training_periods: { finished_on: 4.months.from_now.. })
             .where(schedules: { contract_period_year: year })
-            .where(active_lead_providers: { lead_provider_id: lead_provider.id })
+            .where(framework_agreements: { lead_provider_id: lead_provider.id })
             .distinct
 
           mentors_leaving = Teacher
             .joins(mentor_at_school_periods: { training_periods: [:schedule, { school_partnership: { lead_provider_delivery_partnership: :framework_agreement } }] })
             .where(training_periods: { finished_on: 4.months.from_now.. })
             .where(schedules: { contract_period_year: year })
-            .where(active_lead_providers: { lead_provider_id: lead_provider.id })
+            .where(framework_agreements: { lead_provider_id: lead_provider.id })
             .distinct
 
           # creates 2 participants for ECTs and Mentors
@@ -352,7 +352,7 @@ RSpec.describe APISeedData::ParticipantScenarios do
             .where(training_periods: { started_on: ..Date.current, finished_on: ..Date.current })
             .where.not(training_periods: { withdrawn_at: nil })
             .where(schedules: { contract_period_year: year })
-            .where(active_lead_providers: { lead_provider_id: lead_provider.id })
+            .where(framework_agreements: { lead_provider_id: lead_provider.id })
             .distinct
 
           withdrawn_mentors_left = Teacher
@@ -360,7 +360,7 @@ RSpec.describe APISeedData::ParticipantScenarios do
             .where(training_periods: { started_on: ..Date.current, finished_on: ..Date.current })
             .where.not(training_periods: { withdrawn_at: nil })
             .where(schedules: { contract_period_year: year })
-            .where(active_lead_providers: { lead_provider_id: lead_provider.id })
+            .where(framework_agreements: { lead_provider_id: lead_provider.id })
             .distinct
 
           # creates 2 participants for ECTs and Mentors
@@ -403,7 +403,7 @@ RSpec.describe APISeedData::ParticipantScenarios do
             .where(training_periods: { started_on: ..Date.current, finished_on: ..Date.current })
             .where(training_periods: { withdrawn_at: nil, deferred_at: nil })
             .where(schedules: { contract_period_year: year })
-            .where(active_lead_providers: { lead_provider_id: lead_provider.id })
+            .where(framework_agreements: { lead_provider_id: lead_provider.id })
             .distinct
 
           active_mentors_left = Teacher
@@ -411,7 +411,7 @@ RSpec.describe APISeedData::ParticipantScenarios do
             .where(training_periods: { started_on: ..Date.current, finished_on: ..Date.current })
             .where(training_periods: { withdrawn_at: nil, deferred_at: nil })
             .where(schedules: { contract_period_year: year })
-            .where(active_lead_providers: { lead_provider_id: lead_provider.id })
+            .where(framework_agreements: { lead_provider_id: lead_provider.id })
             .distinct
 
           # creates 2 participants for ECTs and Mentors

--- a/spec/services/api_seed_data/school_scenarios_spec.rb
+++ b/spec/services/api_seed_data/school_scenarios_spec.rb
@@ -94,13 +94,13 @@ RSpec.describe APISeedData::SchoolScenarios do
         teachers_with_2024 = Teacher
           .joins(ect_at_school_periods: { training_periods: [:schedule, { school_partnership: { lead_provider_delivery_partnership: :framework_agreement } }] })
           .where(schedules: { contract_period_year: 2024 })
-          .where(active_lead_providers: { lead_provider_id: lead_provider.id })
+          .where(framework_agreements: { lead_provider_id: lead_provider.id })
           .select(:id)
 
         teachers_with_2025 = Teacher
           .joins(ect_at_school_periods: { training_periods: [:schedule, { school_partnership: { lead_provider_delivery_partnership: :framework_agreement } }] })
           .where(schedules: { contract_period_year: 2025 })
-          .where(active_lead_providers: { lead_provider_id: lead_provider.id })
+          .where(framework_agreements: { lead_provider_id: lead_provider.id })
           .select(:id)
 
         schools_with_rolled_over_participants = School
@@ -266,7 +266,7 @@ RSpec.describe APISeedData::SchoolScenarios do
       School
         .joins(school_partnerships: { lead_provider_delivery_partnership: :framework_agreement })
         .group("schools.id")
-        .having("COUNT(DISTINCT active_lead_providers.lead_provider_id) > 1")
+        .having("COUNT(DISTINCT framework_agreements.lead_provider_id) > 1")
     end
 
     it "creates schools with partnerships from multiple lead providers" do

--- a/spec/services/delivery_partners/add_lead_provider_pairings_spec.rb
+++ b/spec/services/delivery_partners/add_lead_provider_pairings_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe DeliveryPartners::AddLeadProviderPairings do
         expect { service.add! }.to change(LeadProviderDeliveryPartnership, :count).by(2)
 
         partnerships = delivery_partner.lead_provider_delivery_partnerships.reload
-        expect(partnerships.map(&:active_lead_provider_id)).to contain_exactly(framework_agreement_1.id, framework_agreement_2.id)
+        expect(partnerships.map(&:framework_agreement_id)).to contain_exactly(framework_agreement_1.id, framework_agreement_2.id)
       end
 
       it "records partnership added events" do
@@ -59,7 +59,7 @@ RSpec.describe DeliveryPartners::AddLeadProviderPairings do
           expect { service.add! }.to change(LeadProviderDeliveryPartnership, :count).by(2)
 
           partnerships = delivery_partner.lead_provider_delivery_partnerships.reload
-          expect(partnerships.map(&:active_lead_provider_id)).to contain_exactly(
+          expect(partnerships.map(&:framework_agreement_id)).to contain_exactly(
             framework_agreement_1.id, # existing - preserved
             framework_agreement_2.id, # new - added
             framework_agreement_3.id  # new - added

--- a/spec/services/delivery_partners/update_lead_provider_pairings_spec.rb
+++ b/spec/services/delivery_partners/update_lead_provider_pairings_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe DeliveryPartners::UpdateLeadProviderPairings do
         expect { service.update! }.to change(LeadProviderDeliveryPartnership, :count).by(2)
 
         partnerships = delivery_partner.lead_provider_delivery_partnerships.reload
-        expect(partnerships.map(&:active_lead_provider_id)).to contain_exactly(framework_agreement_1.id, framework_agreement_2.id)
+        expect(partnerships.map(&:framework_agreement_id)).to contain_exactly(framework_agreement_1.id, framework_agreement_2.id)
       end
 
       it "records partnership added events" do
@@ -59,7 +59,7 @@ RSpec.describe DeliveryPartners::UpdateLeadProviderPairings do
           expect { service.update! }.to change(LeadProviderDeliveryPartnership, :count).by(2)
 
           partnerships = delivery_partner.lead_provider_delivery_partnerships.reload
-          expect(partnerships.map(&:active_lead_provider_id)).to contain_exactly(
+          expect(partnerships.map(&:framework_agreement_id)).to contain_exactly(
             framework_agreement_1.id, # existing - kept because it's in the submitted list
             framework_agreement_2.id, # new - added
             framework_agreement_3.id  # new - added
@@ -74,7 +74,7 @@ RSpec.describe DeliveryPartners::UpdateLeadProviderPairings do
           expect { service.update! }.to change(LeadProviderDeliveryPartnership, :count).by(1) # -1 + 2 = 1
 
           partnerships = delivery_partner.lead_provider_delivery_partnerships.reload
-          expect(partnerships.map(&:active_lead_provider_id)).to contain_exactly(
+          expect(partnerships.map(&:framework_agreement_id)).to contain_exactly(
             framework_agreement_2.id,
             framework_agreement_3.id
           )
@@ -113,7 +113,7 @@ RSpec.describe DeliveryPartners::UpdateLeadProviderPairings do
           expect { service.update! }.to change(LeadProviderDeliveryPartnership, :count).by(-1)
 
           partnerships = delivery_partner.lead_provider_delivery_partnerships.reload
-          expect(partnerships.map(&:active_lead_provider_id)).to contain_exactly(framework_agreement_1.id)
+          expect(partnerships.map(&:framework_agreement_id)).to contain_exactly(framework_agreement_1.id)
         end
 
         it "records partnership removed events" do
@@ -147,7 +147,7 @@ RSpec.describe DeliveryPartners::UpdateLeadProviderPairings do
           expect { service.update! }.not_to change(LeadProviderDeliveryPartnership, :count) # -1 + 1 = 0
 
           partnerships = delivery_partner.lead_provider_delivery_partnerships.reload
-          expect(partnerships.map(&:active_lead_provider_id)).to contain_exactly(
+          expect(partnerships.map(&:framework_agreement_id)).to contain_exactly(
             framework_agreement_2.id,
             framework_agreement_3.id
           )

--- a/spec/support/seeds/reuse_choices_seed_helpers.rb
+++ b/spec/support/seeds/reuse_choices_seed_helpers.rb
@@ -63,7 +63,7 @@ module Seeds
         .joins(lead_provider_delivery_partnership: [{ framework_agreement: :contract_period }, :delivery_partner])
         .where(school:)
         .where(contract_periods: { year: contract_period_year })
-        .where(active_lead_providers: { lead_provider_id: lead_provider.id })
+        .where(framework_agreements: { lead_provider_id: lead_provider.id })
         .where(delivery_partners: { id: delivery_partner.id })
         .exists?
     end

--- a/spec/wizards/admin/schools/add_partnership_wizard/wizard_spec.rb
+++ b/spec/wizards/admin/schools/add_partnership_wizard/wizard_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Admin::Schools::AddPartnershipWizard::Wizard do
     context "when lead provider is set" do
       before do
         store.contract_period_year = 2026
-        store.active_lead_provider_id = 123
+        store.framework_agreement_id = 123
       end
 
       it { is_expected.to include(:select_delivery_partner) }
@@ -29,7 +29,7 @@ RSpec.describe Admin::Schools::AddPartnershipWizard::Wizard do
     context "when delivery partner is set" do
       before do
         store.contract_period_year = 2026
-        store.active_lead_provider_id = 123
+        store.framework_agreement_id = 123
         store.delivery_partner_id = 456
       end
 


### PR DESCRIPTION
### Context

Part of https://github.com/DFE-Digital/register-ects-project-board/issues/4334

### Changes proposed in this pull request

Following on from rename in the code, this renames the tables and columns from ActiveLeadProvider to FrameworkAgreement

### Guidance to review

* This change includes both database table renames and the code impact of these. This means that deployment will require a short quiet window.
