### PR TITLE
[4318] Exclude upcoming mentors from the list of "eligible" mentors

### DIFF
--- a/app/services/schools/assign_mentor.rb
+++ b/app/services/schools/assign_mentor.rb
@@ -11,7 +11,7 @@ module Schools
 
     def assign!
       ActiveRecord::Base.transaction do
-        close_current_mentorship!
+        close_current_and_upcoming_mentorships!
         @mentorship_period = assign_new_mentor!
         record_events!
       end
@@ -19,29 +19,33 @@ module Schools
 
   private
 
-    def close_current_mentorship!
-      return unless current_ect_mentorship_period
-
-      if earliest_possible_start.after?(current_ect_mentorship_period.started_on)
-        finish_current_mentorship!
-      else
-        destroy_current_mentorship!
+    def close_current_and_upcoming_mentorships!
+      current_and_upcoming_mentorship_periods.each do |mentorship_period|
+        if started?(mentorship_period) && earliest_possible_start.after?(mentorship_period.started_on)
+          finish_mentorship!(mentorship_period)
+        else
+          destroy_mentorship!(mentorship_period)
+        end
       end
     end
 
-    def finish_current_mentorship!
+    def started?(mentorship_period) = !mentorship_period.started_on.future?
+
+    def finish_mentorship!(mentorship_period)
+      return if mentorship_period.finished_on&.before?(earliest_possible_start)
+
       # Since periods have inclusive range ends now, the "previous" period
       # must finish the day **before** the "new" period to avoid an overlap.
-      current_ect_mentorship_period.finish!(earliest_possible_start.yesterday)
+      mentorship_period.finish!(earliest_possible_start.yesterday)
     end
 
-    def destroy_current_mentorship!
-      Event.where(mentorship_period: current_ect_mentorship_period).delete_all
-      current_ect_mentorship_period.destroy!
+    def destroy_mentorship!(mentorship_period)
+      Event.where(mentorship_period:).delete_all
+      mentorship_period.destroy!
     end
 
-    def current_ect_mentorship_period
-      ect_at_school_period.current_or_next_mentorship_period
+    def current_and_upcoming_mentorship_periods
+      ect_at_school_period.mentorship_periods.current_or_future.earliest_first
     end
 
     def assign_new_mentor!
@@ -61,7 +65,7 @@ module Schools
       )
     end
 
-    def earliest_possible_start = dates_resolver.earliest_possible_start
+    def earliest_possible_start = @earliest_possible_start ||= dates_resolver.earliest_possible_start
     def latest_possible_finish = dates_resolver.latest_possible_finish
 
     def record_events!

--- a/spec/features/schools/ects/change/mentor_spec.rb
+++ b/spec/features/schools/ects/change/mentor_spec.rb
@@ -142,6 +142,25 @@ describe "School user can change early career teachers mentor" do
     end
   end
 
+  context "when the mentee has an upcoming mentor" do
+    it "replaces the upcoming mentorship with the newly reported mentor" do
+      and_the_mentee_is_on_school_led_training
+      and_the_mentee_has_an_assigned_mentor
+      and_the_mentee_has_an_upcoming_mentor
+      and_there_is_another_registered_mentor
+
+      when_i_visit_the_early_career_teacher_show_page
+      then_i_see_the_upcoming_mentor
+
+      when_i_change_the_mentor_to_another_registered_mentor_and_confirm
+      then_i_see_the_confirmation_message
+
+      when_i_visit_the_early_career_teacher_show_page
+      then_the_mentor_is_the_newly_reported_mentor
+      and_i_no_longer_see_the_upcoming_mentor
+    end
+  end
+
   context "when no mentor is selected" do
     it "re-renders the form with an error prefix in the page title" do
       and_the_mentee_is_on_school_led_training
@@ -229,12 +248,36 @@ private
       school: @school,
       started_on: @ect_at_school_period.started_on - 2.months
     )
-    FactoryBot.create(
+    @current_mentorship_period = FactoryBot.create(
       :mentorship_period,
       :unfinished,
       mentee: @ect_at_school_period,
       mentor: mentor_at_school_period,
       started_on: @ect_at_school_period.started_on
+    )
+  end
+
+  def and_the_mentee_has_an_upcoming_mentor
+    teacher = FactoryBot.create(
+      :teacher,
+      trs_first_name: "Sally",
+      trs_last_name: "Successor"
+    )
+    mentor_at_school_period = FactoryBot.create(
+      :mentor_at_school_period,
+      :unfinished,
+      teacher:,
+      school: @school,
+      started_on: @ect_at_school_period.started_on - 2.months
+    )
+    @current_mentorship_period.update!(finished_on: 1.month.from_now)
+    @upcoming_mentorship_start_date = 1.month.from_now.next_day.to_date
+    FactoryBot.create(
+      :mentorship_period,
+      :unfinished,
+      mentee: @ect_at_school_period,
+      mentor: mentor_at_school_period,
+      started_on: @upcoming_mentorship_start_date
     )
   end
 
@@ -349,6 +392,32 @@ private
   def then_i_am_taken_back_to_the_early_career_teacher_show_page
     heading = page.locator("h1")
     expect(heading).to have_text("John Doe")
+  end
+
+  def then_i_see_the_upcoming_mentor
+    row = page.locator(".govuk-summary-list__row", hasText: "Mentor")
+    expect(row).to have_text(
+      "Sally Successor (from #{@upcoming_mentorship_start_date.to_fs(:govuk)})"
+    )
+  end
+
+  def when_i_change_the_mentor_to_another_registered_mentor_and_confirm
+    then_i_can_change_the_assigned_mentor
+    and_i_see_the_change_mentor_form
+    when_i_change_the_mentor_to_another_registered_mentor
+    and_i_click_continue
+    then_i_am_asked_to_check_and_confirm_the_change
+    and_i_confirm_the_change
+  end
+
+  def then_the_mentor_is_the_newly_reported_mentor
+    row = page.locator(".govuk-summary-list__row", hasText: "Mentor")
+    expect(row).to have_text("Jane Smith")
+  end
+
+  def and_i_no_longer_see_the_upcoming_mentor
+    row = page.locator(".govuk-summary-list__row", hasText: "Mentor")
+    expect(row).not_to have_text("Sally Successor")
   end
 
   def when_i_continue_without_selecting_a_mentor

--- a/spec/services/schools/assign_mentor_spec.rb
+++ b/spec/services/schools/assign_mentor_spec.rb
@@ -101,6 +101,94 @@ RSpec.describe Schools::AssignMentor do
       end
     end
 
+    describe "closing upcoming mentorships" do
+      let(:current_mentor) do
+        FactoryBot.create(
+          :mentor_at_school_period,
+          :unfinished,
+          started_on: 6.months.ago,
+          school: mentee.school
+        )
+      end
+      let(:upcoming_mentor) do
+        FactoryBot.create(
+          :mentor_at_school_period,
+          :unfinished,
+          started_on: 6.months.ago,
+          school: mentee.school
+        )
+      end
+      let!(:current_mentorship_period) do
+        FactoryBot.create(
+          :mentorship_period,
+          mentee:,
+          mentor: current_mentor,
+          started_on: 6.months.ago,
+          finished_on: 1.month.from_now
+        )
+      end
+      let!(:upcoming_mentorship_period) do
+        FactoryBot.create(
+          :mentorship_period,
+          :unfinished,
+          mentee:,
+          mentor: upcoming_mentor,
+          started_on: 1.month.from_now.next_day
+        )
+      end
+
+      it "destroys the upcoming mentorship period" do
+        assign!
+
+        expect { upcoming_mentorship_period.reload }
+          .to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it "destroys the events recorded against the upcoming mentorship period" do
+        FactoryBot.create(:event, mentorship_period: upcoming_mentorship_period)
+
+        expect { assign! }
+          .to change { Event.where(mentorship_period: upcoming_mentorship_period).count }
+          .from(1).to(0)
+      end
+
+      it "finishes the current mentorship period the day before the new one starts" do
+        expect { assign! }
+          .to change { current_mentorship_period.reload.finished_on }
+          .to(Date.yesterday)
+      end
+
+      it "leaves the new mentor as the only current or upcoming mentor" do
+        assign!
+
+        expect(mentee.reload.mentorship_periods.current_or_future.map(&:mentor))
+          .to contain_exactly(new_mentor)
+      end
+
+      context "when the new mentor starts in the future" do
+        let(:new_mentor_started_on) { 2.months.from_now }
+
+        it "destroys the upcoming mentorship period" do
+          assign!
+
+          expect { upcoming_mentorship_period.reload }
+            .to raise_error(ActiveRecord::RecordNotFound)
+        end
+
+        it "does not extend the current mentorship period" do
+          expect { assign! }
+            .not_to(change { current_mentorship_period.reload.finished_on })
+        end
+
+        it "starts the new mentorship when the new mentor starts" do
+          assign!
+
+          expect(mentee.reload.mentorship_periods.last)
+            .to have_attributes(mentor: new_mentor, started_on: new_mentor_started_on.to_date)
+        end
+      end
+    end
+
     describe "assigning the new mentor" do
       before do
         allow(Schools::MentorAssignment::MentorshipPeriods::DatesResolver)


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/4318

### Changes proposed in this pull request

`Schools::AssignMentor` now closes every current or upcoming mentorship period, rather than just the first one, so that changing an ECT's mentor overwrites a future mentorship if it exists, instead of failing with an overlap validation error. I put it in `AssignMentor` rather than the change mentor wizard because all the assignment paths (change mentor, register new mentor, assign existing mentor) go through it and hit the same bug.

A mentorship that's already started gets truncated to the day before the new one begins (not extended). One that hasn't started yet is deleted outright, which gives the desired "only ever one future mentor" behaviour.

n.b. The removed future mentor keeps their `TrainingPeriod`, which hangs off their own at-school period rather than the mentorship and can already carry declarations. This matches what already happens to an outgoing current mentor, so I think this is fine, just mentioning in case it's not what we want. If it's wrong, then we could change just in this case, or maybe tidying those up belongs in its own ticket covering both cases.

### Guidance to review

I'm a bit on the fence about the feature test, it is a bug that occurs as part of a wizard journey, but OTOH it's an edge case. Figured I'd add it so that we can see it, happy to revisit if there's a strong opinion against it.