### PR TITLE
RIAB 5 - appropriate body period / lead school period- #2206

### DIFF
--- a/app/models/appropriate_body.rb
+++ b/app/models/appropriate_body.rb
@@ -18,9 +18,14 @@ class AppropriateBody < ApplicationRecord
 
   # Associations
   belongs_to :dfe_sign_in_organisation
-
   has_many :appropriate_body_periods # original AppropriateBody table
+  has_one :ongoing_appropriate_body_period, -> { ongoing }, class_name: "AppropriateBodyPeriod"
+
+  # Regions and Lead School Periods are only relevant to regional  Teaching School Hubs
   has_many :regions
+  has_many :lead_school_periods
+  has_one :ongoing_lead_school_period, -> { ongoing }, class_name: "LeadSchoolPeriod"
+  has_one :lead_school, through: :ongoing_lead_school_period, source: :school
 
   # Validations
   validates :name, presence: true, uniqueness: true
@@ -29,11 +34,21 @@ class AppropriateBody < ApplicationRecord
   # Normalizations
   normalizes :name, with: -> { it.squish }
 
+  # @return [Boolean]
+  def national?
+    name.in?(NATIONAL_BODIES)
+  end
+
+  # @return [Boolean]
+  def teaching_school_hub?
+    !national?
+  end
+
   # @return [Array<String>]
   def districts
     regions.collect(&:districts).flatten
   end
 
-  # @return [School]
-  delegate :school, to: :dfe_sign_in_organisation, prefix: :lead
+  # @return [School, nil]
+  delegate :school, to: :dfe_sign_in_organisation, prefix: :login
 end

--- a/app/models/appropriate_body_period.rb
+++ b/app/models/appropriate_body_period.rb
@@ -11,8 +11,7 @@ class AppropriateBodyPeriod < ApplicationRecord
     message: "Must be local authority, national or teaching school hub"
   }
 
-  # TODO: make this a period
-  # include Interval
+  include Interval
 
   # Associations
   has_one :legacy_appropriate_body, inverse_of: :appropriate_body_period
@@ -25,10 +24,6 @@ class AppropriateBodyPeriod < ApplicationRecord
   has_many :events
   has_many :unclaimed_ect_at_school_periods,
            -> { unclaimed_by_school_reported_appropriate_body },
-           class_name: "ECTAtSchoolPeriod",
-           foreign_key: :school_reported_appropriate_body_id
-  has_many :claimed_ect_at_school_periods,
-           -> { claimed_by_school_reported_appropriate_body },
            class_name: "ECTAtSchoolPeriod",
            foreign_key: :school_reported_appropriate_body_id
 
@@ -44,10 +39,17 @@ class AppropriateBodyPeriod < ApplicationRecord
   # Normalizations
   normalizes :name, with: -> { it.squish }
 
-  # TODO: consider removing once view components accept the new AB object not the ABP
-  # @return [School]
-  delegate :lead_school, to: :appropriate_body, allow_nil: true
+  # @return [LeadSchoolPeriod::ActiveRecord_AssociationRelation]
+  def lead_school_periods
+    return unless appropriate_body&.teaching_school_hub?
 
-  # Predicates
-  def active? = dfe_sign_in_organisation_id.present?
+    appropriate_body.lead_school_periods.containing_period(self)
+  end
+
+  # @return [School, nil]
+  def lead_school
+    return unless appropriate_body&.teaching_school_hub?
+
+    lead_school_periods.first&.school
+  end
 end

--- a/app/models/induction_period.rb
+++ b/app/models/induction_period.rb
@@ -77,6 +77,11 @@ class InductionPeriod < ApplicationRecord
     super
   end
 
+  # @return [School] AB's lead school at time of induction (not enforced at database level)
+  def lead_school
+    appropriate_body_period.lead_school_periods.containing_period(self).limit(1).first.school
+  end
+
 private
 
   # Ensure admin users inserting new induction periods include end dates.

--- a/app/models/lead_school_period.rb
+++ b/app/models/lead_school_period.rb
@@ -1,0 +1,7 @@
+class LeadSchoolPeriod < ApplicationRecord
+  include Interval
+
+  # Associations
+  belongs_to :school
+  belongs_to :appropriate_body
+end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -21,6 +21,15 @@
     - lead_school_id
     - created_at
     - updated_at
+  :lead_school_periods:
+    - id
+    - school_id
+    - appropriate_body_id
+    - started_on
+    - finished_on
+    - range
+    - created_at
+    - updated_at    
   :regions:
     - id
     - code
@@ -39,6 +48,9 @@
   :appropriate_body_periods:
     - body_type
     - appropriate_body_id
+    - started_on
+    - finished_on
+    - range
   :blazer_queries:
     - id
     - creator_id

--- a/db/migrate/20260209152247_create_lead_school_period.rb
+++ b/db/migrate/20260209152247_create_lead_school_period.rb
@@ -1,0 +1,13 @@
+class CreateLeadSchoolPeriod < ActiveRecord::Migration[8.0]
+  def change
+    create_table :lead_school_periods do |t|
+      t.references :school, foreign_key: true
+      t.references :appropriate_body, foreign_key: true
+      t.date :started_on, null: false
+      t.date :finished_on
+      t.virtual :range, type: :daterange, as: "daterange(started_on, finished_on)", stored: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260210123921_add_interval_to_appropriate_body_periods.rb
+++ b/db/migrate/20260210123921_add_interval_to_appropriate_body_periods.rb
@@ -1,0 +1,9 @@
+class AddIntervalToAppropriateBodyPeriods < ActiveRecord::Migration[8.0]
+  def change
+    change_table :appropriate_body_periods, bulk: true do |t|
+      t.date :started_on # TODO: add started_on values to appropriate_body_periods and enforce
+      t.date :finished_on
+      t.virtual :range, type: :daterange, as: "daterange(started_on, finished_on)", stored: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,17 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_06_113458) do
+ActiveRecord::Schema[8.0].define(version: 2026_02_12_124833) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
-  enable_extension "pgcrypto"
   enable_extension "unaccent"
 
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
-  create_enum "anonymisation_reasons", ["registered_in_error", "teacher_record_merged"]
   create_enum "appropriate_body_type", ["local_authority", "national", "teaching_school_hub"]
   create_enum "batch_status", ["pending", "processing", "processed", "completing", "completed", "failed"]
   create_enum "batch_type", ["action", "claim"]
@@ -29,7 +27,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_06_113458) do
   create_enum "declaration_payment_statuses", ["no_payment", "eligible", "payable", "paid", "voided"]
   create_enum "declaration_types", ["started", "retained-1", "retained-2", "retained-3", "retained-4", "completed", "extended-1", "extended-2", "extended-3"]
   create_enum "deferral_reasons", ["bereavement", "long_term_sickness", "parental_leave", "career_break", "other"]
-  create_enum "dfe_role_type", ["admin", "user_manager", "finance", "product_team"]
+  create_enum "dfe_role_type", ["admin", "user_manager", "finance"]
   create_enum "event_author_types", ["appropriate_body_user", "school_user", "dfe_staff_user", "system", "lead_provider_api"]
   create_enum "evidence_types", ["training-event-attended", "self-study-material-completed", "materials-engaged-with-offline", "75-percent-engagement-met", "75-percent-engagement-met-reduced-induction", "one-term-induction", "other"]
   create_enum "fee_types", ["output", "service"]
@@ -46,23 +44,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_06_113458) do
   create_enum "schedule_identifiers", ["ecf-extended-april", "ecf-extended-january", "ecf-extended-september", "ecf-reduced-april", "ecf-reduced-january", "ecf-reduced-september", "ecf-replacement-april", "ecf-replacement-january", "ecf-replacement-september", "ecf-standard-april", "ecf-standard-january", "ecf-standard-september"]
   create_enum "statement_statuses", ["open", "payable", "paid"]
   create_enum "training_programme", ["provider_led", "school_led"]
-  create_enum "withdrawal_reasons", ["left_teaching_profession", "moved_school", "mentor_no_longer_being_mentor", "switched_to_school_led", "other", "changed_lead_provider"]
+  create_enum "withdrawal_reasons", ["left_teaching_profession", "moved_school", "mentor_no_longer_being_mentor", "switched_to_school_led", "other"]
   create_enum "working_pattern", ["part_time", "full_time"]
 
-  create_table "active_lead_provider_bands", force: :cascade do |t|
-    t.bigint "active_lead_provider_id", null: false
-    t.integer "allocation_order", null: false
-    t.integer "capacity", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["active_lead_provider_id", "allocation_order"], name: "idx_on_active_lead_provider_id_allocation_order_3a1b864c94", unique: true
-    t.index ["active_lead_provider_id"], name: "index_active_lead_provider_bands_on_active_lead_provider_id"
-  end
-
   create_table "active_lead_providers", force: :cascade do |t|
+    t.bigint "lead_provider_id", null: false
     t.bigint "contract_period_year", null: false
     t.datetime "created_at", null: false
-    t.bigint "lead_provider_id", null: false
     t.datetime "updated_at", null: false
     t.index ["contract_period_year"], name: "index_active_lead_providers_on_contract_period_year"
     t.index ["lead_provider_id", "contract_period_year"], name: "idx_on_lead_provider_id_contract_period_year_e442ca2260", unique: true
@@ -70,224 +58,288 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_06_113458) do
   end
 
   create_table "api_tokens", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.string "description", null: false
-    t.datetime "last_used_at"
     t.bigint "lead_provider_id"
     t.string "token", null: false
+    t.string "description", null: false
+    t.datetime "last_used_at"
+    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["lead_provider_id"], name: "index_api_tokens_on_lead_provider_id"
     t.index ["token"], name: "index_api_tokens_on_token", unique: true
   end
 
   create_table "appropriate_bodies", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.bigint "dfe_sign_in_organisation_id", null: false
     t.string "name", null: false
+    t.bigint "dfe_sign_in_organisation_id", null: false
+    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["dfe_sign_in_organisation_id"], name: "index_appropriate_bodies_on_dfe_sign_in_organisation_id"
   end
 
   create_table "appropriate_body_periods", force: :cascade do |t|
-    t.bigint "appropriate_body_id"
-    t.enum "body_type", default: "teaching_school_hub", enum_type: "appropriate_body_type"
+    t.string "name", null: false
     t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.uuid "dfe_sign_in_organisation_id"
     t.uuid "dqt_id"
-    t.string "name", null: false
-    t.datetime "updated_at", null: false
+    t.enum "body_type", default: "teaching_school_hub", enum_type: "appropriate_body_type"
+    t.bigint "appropriate_body_id"
+    t.date "started_on"
+    t.date "finished_on"
+    t.virtual "range", type: :daterange, as: "daterange(started_on, finished_on)", stored: true
     t.index ["appropriate_body_id"], name: "index_appropriate_body_periods_on_appropriate_body_id"
     t.index ["dfe_sign_in_organisation_id"], name: "index_appropriate_body_periods_on_dfe_sign_in_organisation_id", unique: true
   end
 
   create_table "blazer_audits", force: :cascade do |t|
-    t.datetime "created_at"
-    t.string "data_source"
+    t.bigint "user_id"
     t.bigint "query_id"
     t.text "statement"
-    t.bigint "user_id"
+    t.string "data_source"
+    t.datetime "created_at"
     t.index ["query_id"], name: "index_blazer_audits_on_query_id"
     t.index ["user_id"], name: "index_blazer_audits_on_user_id"
   end
 
   create_table "blazer_checks", force: :cascade do |t|
-    t.string "check_type"
-    t.datetime "created_at", null: false
     t.bigint "creator_id"
-    t.text "emails"
-    t.datetime "last_run_at"
-    t.text "message"
     t.bigint "query_id"
-    t.string "schedule"
-    t.text "slack_channels"
     t.string "state"
+    t.string "schedule"
+    t.text "emails"
+    t.text "slack_channels"
+    t.string "check_type"
+    t.text "message"
+    t.datetime "last_run_at"
+    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["creator_id"], name: "index_blazer_checks_on_creator_id"
     t.index ["query_id"], name: "index_blazer_checks_on_query_id"
   end
 
   create_table "blazer_dashboard_queries", force: :cascade do |t|
-    t.datetime "created_at", null: false
     t.bigint "dashboard_id"
-    t.integer "position"
     t.bigint "query_id"
+    t.integer "position"
+    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["dashboard_id"], name: "index_blazer_dashboard_queries_on_dashboard_id"
     t.index ["query_id"], name: "index_blazer_dashboard_queries_on_query_id"
   end
 
   create_table "blazer_dashboards", force: :cascade do |t|
-    t.datetime "created_at", null: false
     t.bigint "creator_id"
     t.string "name"
+    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["creator_id"], name: "index_blazer_dashboards_on_creator_id"
   end
 
   create_table "blazer_queries", force: :cascade do |t|
-    t.datetime "created_at", null: false
     t.bigint "creator_id"
-    t.string "data_source"
-    t.text "description"
     t.string "name"
+    t.text "description"
     t.text "statement"
+    t.string "data_source"
     t.string "status"
+    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["creator_id"], name: "index_blazer_queries_on_creator_id"
   end
 
-  create_table "contract_banded_fee_structure_band_terms", force: :cascade do |t|
-    t.bigint "band_id", null: false
+  create_table "contract_banded_fee_structure_bands", force: :cascade do |t|
     t.bigint "banded_fee_structure_id", null: false
-    t.datetime "created_at", null: false
+    t.integer "min_declarations", default: 1, null: false
+    t.integer "max_declarations", null: false
     t.decimal "fee_per_declaration", precision: 12, scale: 2, null: false
     t.decimal "output_fee_ratio", precision: 3, scale: 2, null: false
     t.decimal "service_fee_ratio", precision: 3, scale: 2, null: false
+    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["band_id"], name: "index_contract_banded_fee_structure_band_terms_on_band_id"
-    t.index ["banded_fee_structure_id", "band_id"], name: "idx_on_banded_fee_structure_id_band_id_04f5837f9d", unique: true
-    t.index ["banded_fee_structure_id"], name: "idx_on_banded_fee_structure_id_f857ec5b02"
+    t.index ["banded_fee_structure_id"], name: "idx_on_banded_fee_structure_id_49a33a0bd5"
   end
 
   create_table "contract_banded_fee_structures", force: :cascade do |t|
-    t.bigint "contract_id", null: false
-    t.datetime "created_at", null: false
-    t.decimal "monthly_service_fee", precision: 12, scale: 2
     t.integer "recruitment_target", null: false
-    t.decimal "setup_fee", precision: 12, scale: 2, null: false
-    t.datetime "updated_at", null: false
     t.decimal "uplift_fee_per_declaration", precision: 12, scale: 2, null: false
-    t.decimal "uplift_target_ratio", precision: 5, scale: 4
-    t.index ["contract_id"], name: "index_banded_fee_structures_on_contract_id_unique_not_null", unique: true, where: "(contract_id IS NOT NULL)"
-    t.index ["contract_id"], name: "index_contract_banded_fee_structures_on_contract_id"
+    t.decimal "monthly_service_fee", precision: 12, scale: 2
+    t.decimal "setup_fee", precision: 12, scale: 2, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "contract_flat_rate_fee_structures", force: :cascade do |t|
-    t.bigint "contract_id", null: false
-    t.datetime "created_at", null: false
-    t.decimal "fee_per_declaration", precision: 12, scale: 2, null: false
     t.integer "recruitment_target", null: false
+    t.decimal "fee_per_declaration", precision: 12, scale: 2, null: false
+    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["contract_id"], name: "index_contract_flat_rate_fee_structures_on_contract_id"
-    t.index ["contract_id"], name: "index_flat_rate_fee_structures_on_contract_id_unique_not_null", unique: true, where: "(contract_id IS NOT NULL)"
   end
 
   create_table "contract_periods", primary_key: "year", id: :serial, force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.boolean "detailed_evidence_types_enabled", default: false, null: false
-    t.boolean "enabled", default: false
-    t.date "finished_on"
-    t.boolean "mentor_funding_enabled", default: false, null: false
-    t.datetime "payments_frozen_at"
-    t.virtual "range", type: :daterange, as: "daterange(started_on, finished_on, '[]'::text)", stored: true
-    t.date "started_on"
     t.datetime "updated_at", null: false
-    t.boolean "uplift_fees_enabled", default: true, null: false
+    t.date "started_on"
+    t.date "finished_on"
+    t.boolean "enabled", default: false
+    t.virtual "range", type: :daterange, as: "daterange(started_on, finished_on)", stored: true
+    t.datetime "payments_frozen_at"
+    t.boolean "mentor_funding_enabled", default: false, null: false
+    t.boolean "detailed_evidence_types_enabled", default: false, null: false
     t.index ["year"], name: "index_contract_periods_on_year", unique: true
-    t.check_constraint "finished_on >= started_on", name: "finished_on_not_before_started_on"
+    t.check_constraint "finished_on > started_on", name: "period_length_greater_than_zero"
   end
 
   create_table "contracts", force: :cascade do |t|
-    t.bigint "active_lead_provider_id", null: false
     t.enum "contract_type", null: false, enum_type: "contract_types"
+    t.bigint "flat_rate_fee_structure_id"
+    t.bigint "banded_fee_structure_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.decimal "vat_rate", precision: 3, scale: 2, default: "0.2", null: false
-    t.index ["active_lead_provider_id"], name: "index_contracts_on_active_lead_provider_id"
+    t.index ["banded_fee_structure_id"], name: "index_contracts_on_banded_fee_structure_id", unique: true, where: "(banded_fee_structure_id IS NOT NULL)"
+    t.index ["flat_rate_fee_structure_id"], name: "index_contracts_on_flat_rate_fee_structure_id", unique: true, where: "(flat_rate_fee_structure_id IS NOT NULL)"
+  end
+
+  create_table "data_migration_failed_combinations", force: :cascade do |t|
+    t.string "trn"
+    t.uuid "profile_id"
+    t.string "profile_type"
+    t.uuid "induction_record_id"
+    t.string "training_programme"
+    t.string "school_urn"
+    t.integer "cohort_year"
+    t.string "lead_provider_name"
+    t.string "delivery_partner_name"
+    t.datetime "start_date"
+    t.datetime "end_date"
+    t.string "induction_status"
+    t.string "training_status"
+    t.uuid "mentor_profile_id"
+    t.uuid "schedule_id"
+    t.string "schedule_identifier"
+    t.string "schedule_name"
+    t.integer "schedule_cohort_year"
+    t.string "preferred_identity_email"
+    t.text "failure_message"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "data_migration_failed_mentorships", force: :cascade do |t|
+    t.uuid "ect_participant_profile_id"
+    t.uuid "mentor_participant_profile_id"
+    t.date "started_on"
+    t.date "finished_on"
+    t.uuid "ecf_start_induction_record_id"
+    t.uuid "ecf_end_induction_record_id"
+    t.text "failure_message"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "data_migration_teacher_combinations", force: :cascade do |t|
+    t.uuid "ecf1_ect_profile_id"
+    t.uuid "ecf1_mentor_profile_id"
+    t.jsonb "ecf1_ect_combinations", default: [], null: false
+    t.jsonb "ecf1_mentor_combinations", default: [], null: false
+    t.jsonb "ecf2_ect_combinations", default: [], null: false
+    t.jsonb "ecf2_mentor_combinations", default: [], null: false
+    t.virtual "ecf1_ect_combinations_count", type: :integer, as: "jsonb_array_length(ecf1_ect_combinations)", stored: true
+    t.virtual "ecf1_mentor_combinations_count", type: :integer, as: "jsonb_array_length(ecf1_mentor_combinations)", stored: true
+    t.virtual "ecf2_ect_combinations_count", type: :integer, as: "jsonb_array_length(ecf2_ect_combinations)", stored: true
+    t.virtual "ecf2_mentor_combinations_count", type: :integer, as: "jsonb_array_length(ecf2_mentor_combinations)", stored: true
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.jsonb "ecf1_mentorships", default: [], null: false
+    t.jsonb "ecf2_mentorships", default: [], null: false
+    t.virtual "ecf1_mentorships_count", type: :integer, as: "jsonb_array_length(ecf1_mentorships)", stored: true
+    t.virtual "ecf2_mentorships_count", type: :integer, as: "jsonb_array_length(ecf2_mentorships)", stored: true
+    t.uuid "api_id"
+  end
+
+  create_table "data_migrations", force: :cascade do |t|
+    t.string "model", null: false
+    t.integer "processed_count", default: 0, null: false
+    t.integer "failure_count", default: 0, null: false
+    t.datetime "started_at"
+    t.datetime "completed_at"
+    t.integer "total_count"
+    t.datetime "queued_at"
+    t.integer "worker"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.json "cache_stats"
   end
 
   create_table "declarations", force: :cascade do |t|
-    t.uuid "api_id", default: -> { "gen_random_uuid()" }, null: false
-    t.datetime "api_updated_at", default: -> { "CURRENT_TIMESTAMP" }
-    t.bigint "clawback_statement_id"
-    t.enum "clawback_status", default: "no_clawback", null: false, enum_type: "declaration_clawback_statuses"
+    t.bigint "training_period_id"
     t.datetime "created_at", null: false
-    t.datetime "declaration_date", default: -> { "CURRENT_TIMESTAMP" }, null: false
-    t.enum "declaration_type", default: "started", null: false, enum_type: "declaration_types"
-    t.bigint "delivery_partner_when_created_id", null: false
-    t.enum "evidence_type", enum_type: "evidence_types"
+    t.datetime "updated_at", null: false
+    t.bigint "voided_by_user_id"
     t.bigint "mentorship_period_id"
     t.bigint "payment_statement_id"
-    t.enum "payment_status", default: "no_payment", null: false, enum_type: "declaration_payment_statuses"
-    t.boolean "pupil_premium_uplift", default: false, null: false
-    t.boolean "sparsity_uplift", default: false, null: false
-    t.bigint "training_period_id"
-    t.datetime "updated_at", null: false
+    t.bigint "clawback_statement_id"
     t.datetime "voided_by_user_at"
-    t.bigint "voided_by_user_id"
+    t.uuid "api_id", default: -> { "gen_random_uuid()" }, null: false
+    t.datetime "declaration_date", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.enum "evidence_type", enum_type: "evidence_types"
+    t.enum "clawback_status", default: "no_clawback", null: false, enum_type: "declaration_clawback_statuses"
+    t.enum "declaration_type", default: "started", null: false, enum_type: "declaration_types"
+    t.boolean "sparsity_uplift", default: false, null: false
+    t.boolean "pupil_premium_uplift", default: false, null: false
+    t.datetime "api_updated_at", default: -> { "CURRENT_TIMESTAMP" }
+    t.enum "payment_status", default: "no_payment", null: false, enum_type: "declaration_payment_statuses"
     t.index ["api_id"], name: "index_declarations_on_api_id", unique: true
     t.index ["clawback_statement_id"], name: "index_declarations_on_clawback_statement_id"
-    t.index ["delivery_partner_when_created_id"], name: "index_declarations_on_delivery_partner_when_created_id"
     t.index ["mentorship_period_id"], name: "index_declarations_on_mentorship_period_id"
     t.index ["payment_statement_id"], name: "index_declarations_on_payment_statement_id"
     t.index ["training_period_id", "declaration_type", "payment_status"], name: "idx_unique_declarations", unique: true, where: "((payment_status = ANY (ARRAY['no_payment'::declaration_payment_statuses, 'eligible'::declaration_payment_statuses, 'payable'::declaration_payment_statuses, 'paid'::declaration_payment_statuses])) AND (clawback_status = 'no_clawback'::declaration_clawback_statuses))"
     t.index ["training_period_id"], name: "index_declarations_on_training_period_id"
-    t.index ["updated_at"], name: "index_declarations_on_updated_at"
     t.index ["voided_by_user_id"], name: "index_declarations_on_voided_by_user_id"
   end
 
   create_table "delivery_partners", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.uuid "api_id", default: -> { "gen_random_uuid()" }, null: false
     t.datetime "api_updated_at", default: -> { "CURRENT_TIMESTAMP" }
-    t.datetime "created_at", null: false
-    t.string "name", null: false
-    t.datetime "updated_at", null: false
     t.index ["api_id"], name: "index_delivery_partners_on_api_id", unique: true
     t.index ["name"], name: "index_delivery_partners_on_name", unique: true
   end
 
   create_table "dfe_sign_in_organisations", force: :cascade do |t|
-    t.string "address"
-    t.string "category"
-    t.string "company_registration_number"
-    t.datetime "created_at", null: false
-    t.datetime "first_authenticated_at"
-    t.datetime "last_authenticated_at"
     t.string "name", null: false
+    t.uuid "uuid", null: false
+    t.string "urn"
+    t.string "address"
+    t.string "company_registration_number"
+    t.string "category"
     t.string "organisation_type"
     t.string "status"
+    t.datetime "first_authenticated_at"
+    t.datetime "last_authenticated_at"
+    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "urn"
-    t.uuid "uuid", null: false
     t.index ["name"], name: "index_dfe_sign_in_organisations_on_name", unique: true
     t.index ["urn"], name: "index_dfe_sign_in_organisations_on_urn", unique: true
     t.index ["uuid"], name: "index_dfe_sign_in_organisations_on_uuid", unique: true
   end
 
   create_table "ect_at_school_periods", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.uuid "ecf_end_induction_record_id"
-    t.uuid "ecf_start_induction_record_id"
-    t.citext "email"
-    t.date "finished_on"
-    t.virtual "range", type: :daterange, as: "daterange(started_on, finished_on, '[]'::text)", stored: true
-    t.bigint "reported_leaving_by_school_id"
     t.bigint "school_id", null: false
-    t.bigint "school_reported_appropriate_body_id"
-    t.date "started_on", null: false
     t.bigint "teacher_id", null: false
+    t.date "started_on", null: false
+    t.date "finished_on"
+    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.virtual "range", type: :daterange, as: "daterange(started_on, finished_on)", stored: true
+    t.uuid "ecf_start_induction_record_id"
+    t.uuid "ecf_end_induction_record_id"
     t.enum "working_pattern", enum_type: "working_pattern"
+    t.citext "email"
+    t.bigint "school_reported_appropriate_body_id"
+    t.bigint "reported_leaving_by_school_id"
     t.index "teacher_id, ((finished_on IS NULL))", name: "index_ect_at_school_periods_on_teacher_id_finished_on_IS_NULL", unique: true, where: "(finished_on IS NULL)"
     t.index ["reported_leaving_by_school_id"], name: "index_ect_at_school_periods_on_reported_leaving_by_school_id"
     t.index ["school_id", "teacher_id", "started_on"], name: "index_ect_at_school_periods_on_school_id_teacher_id_started_on", unique: true
@@ -295,49 +347,47 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_06_113458) do
     t.index ["school_reported_appropriate_body_id"], name: "idx_on_school_reported_appropriate_body_id_01f5ffc90a"
     t.index ["teacher_id", "started_on"], name: "index_ect_at_school_periods_on_teacher_id_started_on", unique: true
     t.index ["teacher_id"], name: "index_ect_at_school_periods_on_teacher_id"
-    t.check_constraint "finished_on >= started_on", name: "finished_on_not_before_started_on"
+    t.check_constraint "finished_on > started_on", name: "period_length_greater_than_zero"
   end
 
   create_table "events", force: :cascade do |t|
-    t.bigint "active_lead_provider_id"
-    t.integer "appropriate_body_period_id"
-    t.citext "author_email"
-    t.integer "author_id"
-    t.text "author_name"
-    t.enum "author_type", null: false, enum_type: "event_author_types"
+    t.text "heading"
     t.text "body"
-    t.bigint "contract_period_id"
-    t.datetime "created_at", null: false
-    t.bigint "declaration_id"
-    t.integer "delivery_partner_id"
-    t.integer "ect_at_school_period_id"
     t.text "event_type"
     t.datetime "happened_at", default: -> { "CURRENT_TIMESTAMP" }
-    t.text "heading"
-    t.integer "induction_extension_id"
+    t.integer "teacher_id"
+    t.integer "appropriate_body_period_id"
     t.integer "induction_period_id"
-    t.bigint "lead_provider_delivery_partnership_id"
-    t.integer "lead_provider_id"
+    t.integer "induction_extension_id"
+    t.integer "school_id"
+    t.integer "ect_at_school_period_id"
     t.integer "mentor_at_school_period_id"
+    t.integer "training_period_id"
     t.integer "mentorship_period_id"
+    t.integer "school_partnership_id"
+    t.integer "lead_provider_id"
+    t.integer "delivery_partner_id"
+    t.integer "user_id"
+    t.enum "author_type", null: false, enum_type: "event_author_types"
+    t.integer "author_id"
+    t.text "author_name"
+    t.citext "author_email"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.jsonb "metadata"
     t.string "modifications", array: true
+    t.bigint "active_lead_provider_id"
+    t.bigint "lead_provider_delivery_partnership_id"
     t.bigint "pending_induction_submission_batch_id"
-    t.bigint "schedule_id"
-    t.integer "school_id"
-    t.integer "school_partnership_id"
-    t.bigint "statement_adjustment_id"
     t.bigint "statement_id"
-    t.integer "teacher_id"
-    t.integer "training_period_id"
-    t.datetime "updated_at", null: false
-    t.integer "user_id"
+    t.bigint "statement_adjustment_id"
     t.integer "zendesk_ticket_id"
+    t.bigint "schedule_id"
+    t.bigint "declaration_id"
     t.index ["active_lead_provider_id"], name: "index_events_on_active_lead_provider_id"
     t.index ["appropriate_body_period_id"], name: "index_events_on_appropriate_body_period_id"
     t.index ["author_email"], name: "index_events_on_author_email"
     t.index ["author_id"], name: "index_events_on_author_id"
-    t.index ["contract_period_id"], name: "index_events_on_contract_period_id"
     t.index ["declaration_id"], name: "index_events_on_declaration_id"
     t.index ["delivery_partner_id"], name: "index_events_on_delivery_partner_id"
     t.index ["ect_at_school_period_id"], name: "index_events_on_ect_at_school_period_id"
@@ -358,102 +408,111 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_06_113458) do
   end
 
   create_table "gias_school_links", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.date "link_date"
-    t.string "link_type", null: false
-    t.integer "link_urn", null: false
-    t.datetime "updated_at", null: false
     t.integer "urn", null: false
+    t.integer "link_urn", null: false
+    t.string "link_type", null: false
+    t.date "link_date"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["urn"], name: "index_gias_school_links_on_urn"
   end
 
   create_table "gias_schools", primary_key: "urn", force: :cascade do |t|
+    t.string "name", null: false
+    t.enum "status", default: "open", null: false, enum_type: "gias_school_statuses"
     t.string "address_line1"
     t.string "address_line2"
     t.string "address_line3"
-    t.string "administrative_district_name"
-    t.date "closed_on"
-    t.datetime "created_at", null: false
-    t.boolean "eligible", default: false, null: false
-    t.integer "establishment_number"
-    t.boolean "in_england", null: false
-    t.integer "local_authority_code", null: false
-    t.string "local_authority_name"
-    t.string "name", null: false
-    t.date "opened_on"
-    t.string "phase_name"
     t.string "postcode"
     t.string "primary_contact_email"
-    t.virtual "search", type: :tsvector, as: "to_tsvector('unaccented'::regconfig, ((((COALESCE((name)::text, ''::text) || ' '::text) || COALESCE((postcode)::text, ''::text)) || ' '::text) || COALESCE((urn)::text, ''::text)))", stored: true
     t.string "secondary_contact_email"
+    t.date "opened_on"
+    t.date "closed_on"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "administrative_district_name"
+    t.integer "local_authority_code", null: false
+    t.string "local_authority_name"
+    t.integer "establishment_number"
+    t.string "phase_name"
     t.boolean "section_41_approved", null: false
-    t.enum "status", default: "open", null: false, enum_type: "gias_school_statuses"
     t.string "type_name", null: false
     t.integer "ukprn"
-    t.datetime "updated_at", null: false
     t.string "website"
+    t.boolean "in_england", null: false
+    t.virtual "search", type: :tsvector, as: "to_tsvector('unaccented'::regconfig, ((((COALESCE((name)::text, ''::text) || ' '::text) || COALESCE((postcode)::text, ''::text)) || ' '::text) || COALESCE((urn)::text, ''::text)))", stored: true
+    t.boolean "eligible", default: false, null: false
     t.index ["name"], name: "index_gias_schools_on_name"
     t.index ["search"], name: "index_gias_schools_on_search", using: :gin
     t.index ["ukprn"], name: "index_gias_schools_on_ukprn", unique: true
   end
 
   create_table "induction_extensions", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.float "number_of_terms", null: false
     t.bigint "teacher_id", null: false
+    t.float "number_of_terms", null: false
+    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["teacher_id"], name: "index_induction_extensions_on_teacher_id"
   end
 
   create_table "induction_periods", force: :cascade do |t|
     t.bigint "appropriate_body_period_id", null: false
-    t.datetime "created_at", null: false
-    t.date "fail_confirmation_sent_on"
+    t.date "started_on", null: false
     t.date "finished_on"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.enum "induction_programme", null: false, enum_type: "induction_programme"
     t.float "number_of_terms"
-    t.enum "outcome", enum_type: "induction_outcomes"
-    t.virtual "range", type: :daterange, as: "daterange(started_on, finished_on, '[]'::text)", stored: true
-    t.date "started_on", null: false
+    t.virtual "range", type: :daterange, as: "daterange(started_on, finished_on)", stored: true
     t.bigint "teacher_id"
+    t.enum "outcome", enum_type: "induction_outcomes"
     t.enum "training_programme", enum_type: "training_programme"
-    t.datetime "updated_at", null: false
+    t.date "fail_confirmation_sent_on"
     t.index ["appropriate_body_period_id"], name: "index_induction_periods_on_appropriate_body_period_id"
     t.index ["teacher_id"], name: "index_induction_periods_on_teacher_id"
-    t.index ["teacher_id"], name: "index_induction_periods_one_outcome_per_teacher", unique: true, where: "(outcome IS NOT NULL)"
-    t.check_constraint "finished_on >= started_on", name: "finished_on_not_before_started_on"
+    t.check_constraint "finished_on > started_on", name: "period_length_greater_than_zero"
   end
 
   create_table "lead_provider_delivery_partnerships", force: :cascade do |t|
     t.bigint "active_lead_provider_id", null: false
-    t.datetime "created_at", null: false
     t.bigint "delivery_partner_id", null: false
-    t.uuid "ecf_id"
+    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "ecf_id"
     t.index ["active_lead_provider_id", "delivery_partner_id"], name: "idx_on_active_lead_provider_id_delivery_partner_id_3c66d9e812", unique: true
-    t.index ["active_lead_provider_id"], name: "idx_lpdps_active_lead_provider"
     t.index ["active_lead_provider_id"], name: "idx_on_active_lead_provider_id_2f96b67fbb"
     t.index ["delivery_partner_id"], name: "idx_on_delivery_partner_id_fcb95e8215"
     t.index ["ecf_id"], name: "index_lead_provider_delivery_partnerships_on_ecf_id", unique: true
   end
 
   create_table "lead_providers", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.uuid "ecf_cpd_lead_provider_id"
-    t.uuid "ecf_id"
     t.string "name", null: false
+    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "ecf_id"
     t.boolean "vat_registered", default: true, null: false
     t.index ["ecf_id"], name: "index_lead_providers_on_ecf_id", unique: true
     t.index ["name"], name: "index_lead_providers_on_name", unique: true
   end
 
-  create_table "legacy_appropriate_bodies", force: :cascade do |t|
-    t.bigint "appropriate_body_period_id", null: false
-    t.enum "body_type", null: false, enum_type: "appropriate_body_type"
+  create_table "lead_school_periods", force: :cascade do |t|
+    t.bigint "school_id"
+    t.bigint "appropriate_body_id"
+    t.date "started_on", null: false
+    t.date "finished_on"
+    t.virtual "range", type: :daterange, as: "daterange(started_on, finished_on)", stored: true
     t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["appropriate_body_id"], name: "index_lead_school_periods_on_appropriate_body_id"
+    t.index ["school_id"], name: "index_lead_school_periods_on_school_id"
+  end
+
+  create_table "legacy_appropriate_bodies", force: :cascade do |t|
     t.uuid "dqt_id", null: false
     t.string "name", null: false
+    t.enum "body_type", null: false, enum_type: "appropriate_body_type"
+    t.bigint "appropriate_body_period_id", null: false
+    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["appropriate_body_period_id"], name: "index_legacy_appropriate_bodies_on_appropriate_body_period_id", unique: true
     t.index ["dqt_id"], name: "index_legacy_appropriate_bodies_on_dqt_id", unique: true
@@ -461,50 +520,60 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_06_113458) do
   end
 
   create_table "mentor_at_school_periods", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.uuid "ecf_end_induction_record_id"
-    t.uuid "ecf_start_induction_record_id"
-    t.citext "email"
-    t.date "finished_on"
-    t.virtual "range", type: :daterange, as: "daterange(started_on, finished_on, '[]'::text)", stored: true
-    t.bigint "reported_leaving_by_school_id"
     t.bigint "school_id", null: false
-    t.date "started_on", null: false
     t.bigint "teacher_id", null: false
+    t.date "started_on", null: false
+    t.date "finished_on"
+    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.virtual "range", type: :daterange, as: "daterange(started_on, finished_on)", stored: true
+    t.uuid "ecf_start_induction_record_id"
+    t.uuid "ecf_end_induction_record_id"
+    t.citext "email"
+    t.bigint "reported_leaving_by_school_id"
     t.index "school_id, teacher_id, ((finished_on IS NULL))", name: "idx_on_school_id_teacher_id_finished_on_IS_NULL_dd7ee16a28", unique: true, where: "(finished_on IS NULL)"
     t.index ["reported_leaving_by_school_id"], name: "idx_on_reported_leaving_by_school_id_6c1d88c6d0"
     t.index ["school_id", "teacher_id", "started_on"], name: "idx_on_school_id_teacher_id_started_on_17d46e7783", unique: true
     t.index ["school_id"], name: "index_mentor_at_school_periods_on_school_id"
     t.index ["teacher_id"], name: "index_mentor_at_school_periods_on_teacher_id"
-    t.check_constraint "finished_on >= started_on", name: "finished_on_not_before_started_on"
+    t.check_constraint "finished_on > started_on", name: "period_length_greater_than_zero"
   end
 
   create_table "mentorship_periods", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.uuid "ecf_end_induction_record_id"
-    t.uuid "ecf_start_induction_record_id"
     t.bigint "ect_at_school_period_id", null: false
-    t.date "finished_on"
     t.bigint "mentor_at_school_period_id", null: false
-    t.virtual "range", type: :daterange, as: "daterange(started_on, finished_on, '[]'::text)", stored: true
     t.date "started_on", null: false
+    t.date "finished_on"
+    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.virtual "range", type: :daterange, as: "daterange(started_on, finished_on)", stored: true
+    t.uuid "ecf_start_induction_record_id"
+    t.uuid "ecf_end_induction_record_id"
     t.index "ect_at_school_period_id, ((finished_on IS NULL))", name: "idx_on_ect_at_school_period_id_finished_on_IS_NULL_afd5cf131d", unique: true, where: "(finished_on IS NULL)"
     t.index ["ect_at_school_period_id", "started_on"], name: "index_mentorship_periods_on_ect_at_school_period_id_started_on", unique: true
     t.index ["ect_at_school_period_id"], name: "index_mentorship_periods_on_ect_at_school_period_id"
     t.index ["mentor_at_school_period_id", "ect_at_school_period_id", "started_on"], name: "idx_on_mentor_at_school_period_id_ect_at_school_per_d69dffeecc", unique: true
     t.index ["mentor_at_school_period_id"], name: "index_mentorship_periods_on_mentor_at_school_period_id"
-    t.check_constraint "finished_on >= started_on", name: "finished_on_not_before_started_on"
+    t.check_constraint "finished_on > started_on", name: "period_length_greater_than_zero"
+  end
+
+  create_table "metadata_delivery_partners_lead_providers", force: :cascade do |t|
+    t.bigint "delivery_partner_id", null: false
+    t.bigint "lead_provider_id", null: false
+    t.integer "contract_period_years", default: [], null: false, array: true
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["delivery_partner_id", "lead_provider_id"], name: "idx_on_delivery_partner_id_lead_provider_id_a83df5ed0c", unique: true
+    t.index ["delivery_partner_id"], name: "idx_on_delivery_partner_id_d734fa500e"
+    t.index ["lead_provider_id"], name: "idx_on_lead_provider_id_b318746369"
   end
 
   create_table "metadata_schools_contract_periods", force: :cascade do |t|
-    t.datetime "api_updated_at", default: -> { "CURRENT_TIMESTAMP" }
-    t.integer "contract_period_year", null: false
-    t.datetime "created_at", null: false
+    t.bigint "school_id", null: false
+    t.integer "contract_period_year"
     t.boolean "in_partnership", null: false
     t.enum "induction_programme_choice", null: false, enum_type: "induction_programme_choice"
-    t.bigint "school_id", null: false
+    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["contract_period_year"], name: "idx_on_contract_period_year_e703aaa45a"
     t.index ["school_id", "contract_period_year"], name: "idx_on_school_id_contract_period_year_0dae2d65f6", unique: true
@@ -512,11 +581,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_06_113458) do
   end
 
   create_table "metadata_schools_lead_providers_contract_periods", force: :cascade do |t|
-    t.integer "contract_period_year"
-    t.datetime "created_at", null: false
-    t.boolean "expression_of_interest_or_school_partnership", null: false
-    t.bigint "lead_provider_id", null: false
     t.bigint "school_id", null: false
+    t.bigint "lead_provider_id", null: false
+    t.integer "contract_period_year"
+    t.boolean "expression_of_interest_or_school_partnership", null: false
+    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["contract_period_year"], name: "idx_on_contract_period_year_f5913b27f2"
     t.index ["lead_provider_id"], name: "idx_on_lead_provider_id_bb46a39503"
@@ -525,100 +594,160 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_06_113458) do
   end
 
   create_table "metadata_teachers_lead_providers", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.bigint "ect_assigned_mentor_latest_school_period_id"
-    t.boolean "involved_in_school_transfer"
-    t.integer "latest_ect_contract_period_year"
-    t.bigint "latest_ect_training_period_id"
-    t.integer "latest_mentor_contract_period_year"
-    t.bigint "latest_mentor_training_period_id"
-    t.bigint "lead_provider_id"
     t.bigint "teacher_id"
+    t.bigint "lead_provider_id"
+    t.bigint "latest_ect_training_period_id"
+    t.bigint "latest_mentor_training_period_id"
+    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["ect_assigned_mentor_latest_school_period_id"], name: "idx_on_ect_assigned_mentor_latest_school_period_id_7b494165a2"
+    t.uuid "api_mentor_id"
+    t.integer "latest_ect_contract_period_year"
+    t.integer "latest_mentor_contract_period_year"
+    t.boolean "involved_in_school_transfer"
     t.index ["latest_ect_training_period_id"], name: "idx_on_latest_ect_training_period_id_2d0632b258"
     t.index ["latest_mentor_training_period_id"], name: "idx_on_latest_mentor_training_period_id_862127afaf"
-    t.index ["lead_provider_id", "teacher_id"], name: "idx_metadata_lead_provider_ect_active", where: "(latest_ect_training_period_id IS NOT NULL)"
-    t.index ["lead_provider_id", "teacher_id"], name: "idx_metadata_lead_provider_mentor_active", where: "(latest_mentor_training_period_id IS NOT NULL)"
     t.index ["lead_provider_id", "teacher_id"], name: "idx_on_lead_provider_id_teacher_id_74c7a13188", where: "((latest_ect_training_period_id IS NOT NULL) OR (latest_mentor_training_period_id IS NOT NULL))"
     t.index ["lead_provider_id"], name: "index_metadata_teachers_lead_providers_on_lead_provider_id"
     t.index ["teacher_id", "lead_provider_id"], name: "idx_on_teacher_id_lead_provider_id_23bbab847a", unique: true
     t.index ["teacher_id"], name: "index_metadata_teachers_lead_providers_on_teacher_id"
   end
 
-  create_table "milestones", force: :cascade do |t|
+  create_table "migration_failures", force: :cascade do |t|
+    t.bigint "data_migration_id", null: false
+    t.json "item", null: false
+    t.string "failure_message"
     t.datetime "created_at", null: false
-    t.enum "declaration_type", null: false, enum_type: "declaration_types"
-    t.date "milestone_date"
+    t.datetime "updated_at", null: false
+    t.integer "parent_id"
+    t.string "parent_type"
+    t.index ["data_migration_id"], name: "index_migration_failures_on_data_migration_id"
+    t.index ["parent_id"], name: "index_migration_failures_on_parent_id"
+  end
+
+  create_table "milestones", force: :cascade do |t|
     t.bigint "schedule_id"
+    t.enum "declaration_type", null: false, enum_type: "declaration_types"
     t.date "start_date", null: false
+    t.date "milestone_date"
+    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["schedule_id", "declaration_type"], name: "index_milestones_on_schedule_id_and_declaration_type", unique: true
     t.index ["schedule_id"], name: "index_milestones_on_schedule_id"
   end
 
+  create_table "parity_check_endpoints", force: :cascade do |t|
+    t.string "path", null: false
+    t.enum "method", null: false, enum_type: "request_method_types"
+    t.jsonb "options", default: {}, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "parity_check_requests", force: :cascade do |t|
+    t.bigint "run_id", null: false
+    t.bigint "lead_provider_id", null: false
+    t.datetime "started_at"
+    t.datetime "completed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "endpoint_id"
+    t.enum "state", default: "pending", null: false, enum_type: "parity_check_request_states"
+    t.index ["endpoint_id"], name: "index_parity_check_requests_on_endpoint_id"
+    t.index ["lead_provider_id"], name: "index_parity_check_requests_on_lead_provider_id"
+    t.index ["run_id"], name: "index_parity_check_requests_on_run_id"
+  end
+
+  create_table "parity_check_responses", force: :cascade do |t|
+    t.bigint "request_id", null: false
+    t.integer "ecf_status_code", null: false
+    t.integer "rect_status_code", null: false
+    t.string "ecf_body"
+    t.string "rect_body"
+    t.integer "ecf_time_ms", null: false
+    t.integer "rect_time_ms", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "page"
+    t.string "ecf_request_uri"
+    t.string "rect_request_uri"
+    t.jsonb "request_body"
+    t.integer "match_rate", default: 0, null: false
+    t.index ["request_id", "page"], name: "index_parity_check_responses_on_request_id_and_page", unique: true
+    t.index ["request_id"], name: "index_parity_check_responses_on_request_id"
+  end
+
+  create_table "parity_check_runs", force: :cascade do |t|
+    t.datetime "started_at"
+    t.datetime "completed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.enum "state", default: "pending", null: false, enum_type: "parity_check_run_states"
+    t.enum "mode", default: "concurrent", null: false, enum_type: "parity_check_run_modes"
+    t.index ["state"], name: "index_parity_check_runs_on_state", unique: true, where: "(state = 'in_progress'::parity_check_run_states)"
+  end
+
   create_table "pending_induction_submission_batches", force: :cascade do |t|
     t.bigint "appropriate_body_period_id", null: false
-    t.enum "batch_status", default: "pending", null: false, enum_type: "batch_status"
     t.enum "batch_type", null: false, enum_type: "batch_type"
-    t.integer "claimed_count"
-    t.datetime "created_at", null: false
-    t.jsonb "data"
+    t.enum "batch_status", default: "pending", null: false, enum_type: "batch_status"
     t.string "error_message"
-    t.integer "errored_count"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.jsonb "data"
     t.string "file_name"
+    t.integer "uploaded_count"
+    t.integer "processed_count"
+    t.integer "errored_count"
+    t.integer "released_count"
+    t.integer "passed_count"
+    t.integer "claimed_count"
     t.integer "file_size"
     t.string "file_type"
-    t.integer "passed_count"
-    t.integer "processed_count"
-    t.integer "released_count"
-    t.datetime "updated_at", null: false
-    t.integer "uploaded_count"
     t.index ["appropriate_body_period_id"], name: "idx_on_appropriate_body_period_id_6d39c36e05"
   end
 
   create_table "pending_induction_submissions", force: :cascade do |t|
     t.bigint "appropriate_body_period_id"
-    t.datetime "confirmed_at"
-    t.datetime "created_at", null: false
-    t.date "date_of_birth"
-    t.datetime "delete_at", precision: nil
-    t.string "error_messages", default: [], array: true
     t.string "establishment_id", limit: 8
-    t.date "fail_confirmation_sent_on"
-    t.date "finished_on"
-    t.enum "induction_programme", enum_type: "induction_programme"
-    t.float "number_of_terms"
-    t.enum "outcome", enum_type: "induction_outcomes"
-    t.bigint "pending_induction_submission_batch_id"
-    t.date "started_on"
-    t.enum "training_programme", enum_type: "training_programme"
     t.string "trn", limit: 7, null: false
-    t.jsonb "trs_alerts"
-    t.date "trs_date_of_birth"
-    t.citext "trs_email_address"
     t.string "trs_first_name", limit: 80
-    t.date "trs_induction_completed_date"
-    t.date "trs_induction_start_date"
+    t.string "trs_last_name", limit: 80
+    t.date "date_of_birth"
     t.string "trs_induction_status"
+    t.enum "induction_programme", enum_type: "induction_programme"
+    t.date "started_on"
+    t.date "finished_on"
+    t.float "number_of_terms"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "confirmed_at"
+    t.citext "trs_email_address"
+    t.jsonb "trs_alerts"
+    t.date "trs_induction_start_date"
+    t.string "trs_qts_status_description"
     t.date "trs_initial_teacher_training_end_date"
     t.string "trs_initial_teacher_training_provider_name"
-    t.string "trs_last_name", limit: 80
-    t.boolean "trs_prohibited_from_teaching"
+    t.enum "outcome", enum_type: "induction_outcomes"
     t.date "trs_qts_awarded_on"
-    t.string "trs_qts_status_description"
-    t.datetime "updated_at", null: false
+    t.datetime "delete_at", precision: nil
+    t.bigint "pending_induction_submission_batch_id"
+    t.string "error_messages", default: [], array: true
+    t.enum "training_programme", enum_type: "training_programme"
+    t.boolean "trs_prohibited_from_teaching"
+    t.date "trs_induction_completed_date"
+    t.date "trs_date_of_birth"
+    t.date "fail_confirmation_sent_on"
     t.index ["appropriate_body_period_id"], name: "idx_on_appropriate_body_period_id_b868757d9f"
     t.index ["pending_induction_submission_batch_id"], name: "idx_on_pending_induction_submission_batch_id_bb4509358d"
     t.index ["trn"], name: "index_pending_induction_submissions_on_trn"
   end
 
   create_table "regions", force: :cascade do |t|
-    t.bigint "appropriate_body_id"
     t.string "code", null: false
-    t.datetime "created_at", null: false
     t.string "districts", null: false, array: true
+    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "appropriate_body_id"
     t.index ["appropriate_body_id"], name: "index_regions_on_appropriate_body_id"
     t.index ["code"], name: "index_regions_on_code", unique: true
     t.index ["districts"], name: "index_regions_on_districts", using: :gin
@@ -626,91 +755,81 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_06_113458) do
 
   create_table "schedules", force: :cascade do |t|
     t.integer "contract_period_year", null: false
-    t.datetime "created_at", null: false
     t.enum "identifier", null: false, enum_type: "schedule_identifiers"
+    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["contract_period_year", "identifier"], name: "index_schedules_on_contract_period_year_and_identifier", unique: true
   end
 
-  create_table "school_funding_eligibilities", force: :cascade do |t|
-    t.integer "contract_period_year", null: false
-    t.datetime "created_at", null: false
-    t.bigint "gias_school_urn", null: false
-    t.boolean "pupil_premium_uplift", default: false, null: false
-    t.boolean "sparsity_uplift", default: false, null: false
-    t.datetime "updated_at", null: false
-    t.index ["contract_period_year"], name: "index_school_funding_eligibilities_on_contract_period_year"
-    t.index ["gias_school_urn"], name: "index_school_funding_eligibilities_on_gias_school_urn"
-  end
-
   create_table "school_partnerships", force: :cascade do |t|
-    t.uuid "api_id", default: -> { "gen_random_uuid()" }, null: false
-    t.datetime "api_updated_at", default: -> { "CURRENT_TIMESTAMP" }
     t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.bigint "lead_provider_delivery_partnership_id", null: false
     t.bigint "school_id", null: false
-    t.datetime "updated_at", null: false
+    t.uuid "api_id", default: -> { "gen_random_uuid()" }, null: false
+    t.datetime "api_updated_at", default: -> { "CURRENT_TIMESTAMP" }
     t.index ["api_id"], name: "index_school_partnerships_on_api_id", unique: true
     t.index ["lead_provider_delivery_partnership_id"], name: "idx_on_lead_provider_delivery_partnership_id_628487f752"
     t.index ["school_id", "lead_provider_delivery_partnership_id"], name: "idx_on_school_id_lead_provider_delivery_partnership_7b2d6a6684", unique: true
   end
 
   create_table "schools", force: :cascade do |t|
-    t.uuid "api_id", default: -> { "gen_random_uuid()" }, null: false
+    t.integer "urn", null: false
     t.datetime "created_at", null: false
-    t.citext "induction_tutor_email"
-    t.integer "induction_tutor_last_nominated_in"
-    t.string "induction_tutor_name"
+    t.datetime "updated_at", null: false
     t.bigint "last_chosen_appropriate_body_id"
     t.bigint "last_chosen_lead_provider_id"
     t.enum "last_chosen_training_programme", enum_type: "training_programme"
+    t.datetime "api_updated_at", default: -> { "CURRENT_TIMESTAMP" }
+    t.string "induction_tutor_name"
+    t.citext "induction_tutor_email"
+    t.uuid "api_id", default: -> { "gen_random_uuid()" }, null: false
+    t.integer "induction_tutor_last_nominated_in"
     t.boolean "marked_as_eligible", default: false, null: false
-    t.date "opted_out_of_reminder_emails_until"
-    t.datetime "updated_at", null: false
-    t.integer "urn", null: false
     t.index ["api_id"], name: "index_schools_on_api_id", unique: true
+    t.index ["api_updated_at"], name: "index_schools_on_api_updated_at"
     t.index ["last_chosen_appropriate_body_id"], name: "index_schools_on_last_chosen_appropriate_body_id"
     t.index ["last_chosen_lead_provider_id"], name: "index_schools_on_last_chosen_lead_provider_id"
     t.index ["urn"], name: "schools_unique_urn", unique: true
   end
 
   create_table "solid_queue_blocked_executions", force: :cascade do |t|
-    t.string "concurrency_key", null: false
-    t.datetime "created_at", null: false
-    t.datetime "expires_at", null: false
     t.bigint "job_id", null: false
-    t.integer "priority", default: 0, null: false
     t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "concurrency_key", null: false
+    t.datetime "expires_at", null: false
+    t.datetime "created_at", null: false
     t.index ["concurrency_key", "priority", "job_id"], name: "index_solid_queue_blocked_executions_for_release"
     t.index ["expires_at", "concurrency_key"], name: "index_solid_queue_blocked_executions_for_maintenance"
     t.index ["job_id"], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
   end
 
   create_table "solid_queue_claimed_executions", force: :cascade do |t|
-    t.datetime "created_at", null: false
     t.bigint "job_id", null: false
     t.bigint "process_id"
+    t.datetime "created_at", null: false
     t.index ["job_id"], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
     t.index ["process_id", "job_id"], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
   end
 
   create_table "solid_queue_failed_executions", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.text "error"
     t.bigint "job_id", null: false
+    t.text "error"
+    t.datetime "created_at", null: false
     t.index ["job_id"], name: "index_solid_queue_failed_executions_on_job_id", unique: true
   end
 
   create_table "solid_queue_jobs", force: :cascade do |t|
-    t.string "active_job_id"
-    t.text "arguments"
+    t.string "queue_name", null: false
     t.string "class_name", null: false
+    t.text "arguments"
+    t.integer "priority", default: 0, null: false
+    t.string "active_job_id"
+    t.datetime "scheduled_at"
+    t.datetime "finished_at"
     t.string "concurrency_key"
     t.datetime "created_at", null: false
-    t.datetime "finished_at"
-    t.integer "priority", default: 0, null: false
-    t.string "queue_name", null: false
-    t.datetime "scheduled_at"
     t.datetime "updated_at", null: false
     t.index ["active_job_id"], name: "index_solid_queue_jobs_on_active_job_id"
     t.index ["class_name"], name: "index_solid_queue_jobs_on_class_name"
@@ -720,135 +839,128 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_06_113458) do
   end
 
   create_table "solid_queue_pauses", force: :cascade do |t|
-    t.datetime "created_at", null: false
     t.string "queue_name", null: false
+    t.datetime "created_at", null: false
     t.index ["queue_name"], name: "index_solid_queue_pauses_on_queue_name", unique: true
   end
 
   create_table "solid_queue_processes", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.string "hostname"
     t.string "kind", null: false
     t.datetime "last_heartbeat_at", null: false
-    t.text "metadata"
-    t.string "name", null: false
-    t.integer "pid", null: false
     t.bigint "supervisor_id"
+    t.integer "pid", null: false
+    t.string "hostname"
+    t.text "metadata"
+    t.datetime "created_at", null: false
+    t.string "name", null: false
     t.index ["last_heartbeat_at"], name: "index_solid_queue_processes_on_last_heartbeat_at"
     t.index ["name", "supervisor_id"], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
     t.index ["supervisor_id"], name: "index_solid_queue_processes_on_supervisor_id"
   end
 
   create_table "solid_queue_ready_executions", force: :cascade do |t|
-    t.datetime "created_at", null: false
     t.bigint "job_id", null: false
-    t.integer "priority", default: 0, null: false
     t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.datetime "created_at", null: false
     t.index ["job_id"], name: "index_solid_queue_ready_executions_on_job_id", unique: true
     t.index ["priority", "job_id"], name: "index_solid_queue_poll_all"
     t.index ["queue_name", "priority", "job_id"], name: "index_solid_queue_poll_by_queue"
   end
 
   create_table "solid_queue_recurring_executions", force: :cascade do |t|
-    t.datetime "created_at", null: false
     t.bigint "job_id", null: false
-    t.datetime "run_at", null: false
     t.string "task_key", null: false
+    t.datetime "run_at", null: false
+    t.datetime "created_at", null: false
     t.index ["job_id"], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
     t.index ["task_key", "run_at"], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
   end
 
   create_table "solid_queue_recurring_tasks", force: :cascade do |t|
-    t.text "arguments"
-    t.string "class_name"
-    t.string "command", limit: 2048
-    t.datetime "created_at", null: false
-    t.text "description"
     t.string "key", null: false
-    t.integer "priority", default: 0
-    t.string "queue_name"
     t.string "schedule", null: false
+    t.string "command", limit: 2048
+    t.string "class_name"
+    t.text "arguments"
+    t.string "queue_name"
+    t.integer "priority", default: 0
     t.boolean "static", default: true, null: false
+    t.text "description"
+    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["key"], name: "index_solid_queue_recurring_tasks_on_key", unique: true
     t.index ["static"], name: "index_solid_queue_recurring_tasks_on_static"
   end
 
   create_table "solid_queue_scheduled_executions", force: :cascade do |t|
-    t.datetime "created_at", null: false
     t.bigint "job_id", null: false
-    t.integer "priority", default: 0, null: false
     t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
     t.datetime "scheduled_at", null: false
+    t.datetime "created_at", null: false
     t.index ["job_id"], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
     t.index ["scheduled_at", "priority", "job_id"], name: "index_solid_queue_dispatch_all"
   end
 
   create_table "solid_queue_semaphores", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "expires_at", null: false
     t.string "key", null: false
-    t.datetime "updated_at", null: false
     t.integer "value", default: 1, null: false
+    t.datetime "expires_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["expires_at"], name: "index_solid_queue_semaphores_on_expires_at"
     t.index ["key", "value"], name: "index_solid_queue_semaphores_on_key_and_value"
     t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
   end
 
   create_table "statement_adjustments", force: :cascade do |t|
-    t.decimal "amount", null: false
-    t.datetime "created_at", null: false
+    t.bigint "statement_id", null: false
     t.uuid "ecf_id"
     t.string "payment_type", null: false
-    t.bigint "statement_id", null: false
+    t.decimal "amount", null: false
+    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["ecf_id"], name: "index_statement_adjustments_on_ecf_id", unique: true
     t.index ["statement_id"], name: "index_statement_adjustments_on_statement_id"
   end
 
-  create_table "statement_audit_notes", force: :cascade do |t|
-    t.text "body", null: false
-    t.datetime "created_at", null: false
-    t.bigint "statement_id", null: false
-    t.datetime "updated_at", null: false
-    t.index ["statement_id"], name: "index_statement_audit_notes_on_statement_id"
-  end
-
   create_table "statements", force: :cascade do |t|
+    t.bigint "active_lead_provider_id", null: false
     t.uuid "api_id", default: -> { "gen_random_uuid()" }, null: false
-    t.datetime "api_updated_at", default: -> { "CURRENT_TIMESTAMP" }
-    t.bigint "contract_id", null: false
-    t.datetime "created_at", null: false
-    t.date "deadline_date", null: false
-    t.enum "fee_type", default: "output", null: false, enum_type: "fee_types"
-    t.datetime "marked_as_paid_at"
     t.integer "month", null: false
-    t.date "payment_date", null: false
-    t.enum "status", default: "open", null: false, enum_type: "statement_statuses"
-    t.datetime "updated_at", null: false
     t.integer "year", null: false
+    t.date "deadline_date", null: false
+    t.date "payment_date", null: false
+    t.datetime "marked_as_paid_at"
+    t.enum "status", default: "open", null: false, enum_type: "statement_statuses"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.enum "fee_type", default: "output", null: false, enum_type: "fee_types"
+    t.datetime "api_updated_at", default: -> { "CURRENT_TIMESTAMP" }
+    t.bigint "contract_id"
+    t.index ["active_lead_provider_id"], name: "index_statements_on_active_lead_provider_id"
     t.index ["contract_id"], name: "index_statements_on_contract_id"
-    t.index ["payment_date"], name: "index_statements_on_payment_date"
   end
 
   create_table "support_queries", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.string "email", null: false
-    t.text "message", null: false
+    t.string "state", default: "pending", null: false
+    t.integer "zendesk_id"
     t.string "name", null: false
+    t.string "email", null: false
     t.string "school_name", null: false
     t.integer "school_urn", null: false
-    t.string "state", default: "pending", null: false
+    t.text "message", null: false
+    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "zendesk_id"
   end
 
   create_table "teacher_id_changes", force: :cascade do |t|
+    t.bigint "teacher_id", null: false
     t.uuid "api_from_teacher_id", null: false
     t.uuid "api_to_teacher_id", null: false
-    t.datetime "created_at", null: false
     t.uuid "ecf_id"
-    t.bigint "teacher_id", null: false
+    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["api_from_teacher_id"], name: "index_teacher_id_changes_on_api_from_teacher_id"
     t.index ["api_to_teacher_id"], name: "index_teacher_id_changes_on_api_to_teacher_id"
@@ -856,40 +968,51 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_06_113458) do
     t.index ["teacher_id"], name: "index_teacher_id_changes_on_teacher_id"
   end
 
+  create_table "teacher_migration_failures", force: :cascade do |t|
+    t.bigint "teacher_id"
+    t.string "message", null: false
+    t.uuid "migration_item_id"
+    t.string "migration_item_type"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "model", default: "teacher", null: false
+    t.index ["model"], name: "index_teacher_migration_failures_on_model"
+    t.index ["teacher_id"], name: "index_teacher_migration_failures_on_teacher_id"
+  end
+
   create_table "teachers", force: :cascade do |t|
-    t.enum "anonymisation_reason", enum_type: "anonymisation_reasons"
-    t.datetime "anonymised_at"
-    t.uuid "api_ect_training_record_id", default: -> { "gen_random_uuid()" }, null: false
-    t.uuid "api_id", default: -> { "gen_random_uuid()" }, null: false
-    t.uuid "api_mentor_training_record_id", default: -> { "gen_random_uuid()" }, null: false
-    t.datetime "api_unfunded_mentor_updated_at", default: -> { "CURRENT_TIMESTAMP" }
-    t.datetime "api_updated_at", default: -> { "CURRENT_TIMESTAMP" }
     t.string "corrected_name"
     t.datetime "created_at", null: false
-    t.date "ect_became_ineligible_for_funding_on"
-    t.datetime "ect_first_became_eligible_for_training_at"
-    t.integer "ect_payments_frozen_year"
-    t.date "mentor_became_ineligible_for_funding_on"
-    t.enum "mentor_became_ineligible_for_funding_reason", enum_type: "mentor_became_ineligible_for_funding_reason"
-    t.datetime "mentor_first_became_eligible_for_training_at"
-    t.integer "mentor_payments_frozen_year"
-    t.enum "migration_mode", default: "not_migrated", enum_type: "participant_migration_mode"
-    t.virtual "search", type: :tsvector, as: "to_tsvector('unaccented'::regconfig, (((((COALESCE(trs_first_name, ''::character varying))::text || ' '::text) || (COALESCE(trs_last_name, ''::character varying))::text) || ' '::text) || (COALESCE(corrected_name, ''::character varying))::text))", stored: true
+    t.datetime "updated_at", null: false
     t.string "trn"
-    t.boolean "trnless", default: false, null: false
-    t.datetime "trs_data_last_refreshed_at", precision: nil
-    t.boolean "trs_deactivated", default: false
     t.string "trs_first_name"
-    t.date "trs_induction_completed_date"
-    t.date "trs_induction_start_date"
-    t.string "trs_induction_status", limit: 18
-    t.date "trs_initial_teacher_training_end_date"
-    t.string "trs_initial_teacher_training_provider_name"
     t.string "trs_last_name"
-    t.boolean "trs_not_found", default: false
     t.date "trs_qts_awarded_on"
     t.string "trs_qts_status_description"
-    t.datetime "updated_at", null: false
+    t.string "trs_induction_status", limit: 18
+    t.string "trs_initial_teacher_training_provider_name"
+    t.date "trs_initial_teacher_training_end_date"
+    t.datetime "trs_data_last_refreshed_at", precision: nil
+    t.date "mentor_became_ineligible_for_funding_on"
+    t.enum "mentor_became_ineligible_for_funding_reason", enum_type: "mentor_became_ineligible_for_funding_reason"
+    t.boolean "trs_deactivated", default: false
+    t.virtual "search", type: :tsvector, as: "to_tsvector('unaccented'::regconfig, (((((COALESCE(trs_first_name, ''::character varying))::text || ' '::text) || (COALESCE(trs_last_name, ''::character varying))::text) || ' '::text) || (COALESCE(corrected_name, ''::character varying))::text))", stored: true
+    t.uuid "api_id", default: -> { "gen_random_uuid()" }, null: false
+    t.uuid "api_ect_training_record_id"
+    t.uuid "api_mentor_training_record_id"
+    t.integer "ect_payments_frozen_year"
+    t.integer "mentor_payments_frozen_year"
+    t.boolean "ect_pupil_premium_uplift", default: false, null: false
+    t.boolean "ect_sparsity_uplift", default: false, null: false
+    t.date "trs_induction_start_date"
+    t.date "trs_induction_completed_date"
+    t.datetime "ect_first_became_eligible_for_training_at"
+    t.datetime "mentor_first_became_eligible_for_training_at"
+    t.boolean "trnless", default: false, null: false
+    t.datetime "api_updated_at", default: -> { "CURRENT_TIMESTAMP" }
+    t.datetime "api_unfunded_mentor_updated_at", default: -> { "CURRENT_TIMESTAMP" }
+    t.enum "migration_mode", default: "not_migrated", enum_type: "participant_migration_mode"
+    t.boolean "trs_not_found", default: false
     t.index ["api_ect_training_record_id"], name: "index_teachers_on_api_ect_training_record_id", unique: true
     t.index ["api_id"], name: "index_teachers_on_api_id", unique: true
     t.index ["api_mentor_training_record_id"], name: "index_teachers_on_api_mentor_training_record_id", unique: true
@@ -904,66 +1027,52 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_06_113458) do
   end
 
   create_table "training_periods", force: :cascade do |t|
-    t.datetime "api_transfer_updated_at", default: -> { "CURRENT_TIMESTAMP" }
-    t.datetime "created_at", null: false
-    t.enum "deferral_reason", enum_type: "deferral_reasons"
-    t.datetime "deferred_at"
-    t.uuid "ecf_end_induction_record_id"
-    t.uuid "ecf_start_induction_record_id"
-    t.bigint "ect_at_school_period_id"
-    t.bigint "expression_of_interest_id"
-    t.date "finished_on"
-    t.bigint "mentor_at_school_period_id"
-    t.virtual "range", type: :daterange, as: "daterange(started_on, finished_on, '[]'::text)", stored: true
-    t.bigint "schedule_id"
     t.bigint "school_partnership_id"
     t.date "started_on", null: false
-    t.enum "training_programme", null: false, enum_type: "training_programme"
+    t.date "finished_on"
+    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.enum "withdrawal_reason", enum_type: "withdrawal_reasons"
+    t.bigint "ect_at_school_period_id"
+    t.bigint "mentor_at_school_period_id"
+    t.virtual "range", type: :daterange, as: "daterange(started_on, finished_on)", stored: true
+    t.uuid "ecf_start_induction_record_id"
+    t.uuid "ecf_end_induction_record_id"
+    t.bigint "expression_of_interest_id"
+    t.enum "training_programme", null: false, enum_type: "training_programme"
+    t.datetime "deferred_at"
+    t.enum "deferral_reason", enum_type: "deferral_reasons"
     t.datetime "withdrawn_at"
+    t.enum "withdrawal_reason", enum_type: "withdrawal_reasons"
+    t.bigint "schedule_id"
+    t.datetime "api_transfer_updated_at", default: -> { "CURRENT_TIMESTAMP" }
     t.index "ect_at_school_period_id, mentor_at_school_period_id, ((finished_on IS NULL))", name: "idx_on_ect_at_school_period_id_mentor_at_school_per_42bce3bf48", unique: true, where: "(finished_on IS NULL)"
-    t.index ["api_transfer_updated_at", "ect_at_school_period_id"], name: "idx_training_periods_transfer_updated_ect", where: "(ect_at_school_period_id IS NOT NULL)"
-    t.index ["api_transfer_updated_at", "mentor_at_school_period_id"], name: "idx_training_periods_transfer_updated_mentor", where: "(mentor_at_school_period_id IS NOT NULL)"
-    t.index ["api_transfer_updated_at", "school_partnership_id"], name: "idx_training_periods_transfer_updated_partnership"
     t.index ["api_transfer_updated_at"], name: "index_training_periods_on_api_transfer_updated_at"
     t.index ["ect_at_school_period_id", "mentor_at_school_period_id", "started_on"], name: "idx_on_ect_at_school_period_id_mentor_at_school_per_70f2bb1a45", unique: true
-    t.index ["ect_at_school_period_id", "started_on"], name: "idx_training_periods_ect_started_on"
     t.index ["ect_at_school_period_id"], name: "index_training_periods_on_ect_at_school_period_id"
     t.index ["expression_of_interest_id"], name: "index_training_periods_on_expression_of_interest_id"
-    t.index ["mentor_at_school_period_id", "started_on"], name: "idx_training_periods_mentor_started_on"
     t.index ["mentor_at_school_period_id"], name: "index_training_periods_on_mentor_at_school_period_id"
     t.index ["schedule_id"], name: "index_training_periods_on_schedule_id"
     t.index ["school_partnership_id", "ect_at_school_period_id", "mentor_at_school_period_id", "started_on"], name: "provider_partnership_trainings", unique: true
     t.index ["school_partnership_id"], name: "index_training_periods_on_school_partnership_id"
-    t.check_constraint "finished_on >= started_on", name: "finished_on_not_before_started_on"
+    t.check_constraint "finished_on > started_on", name: "period_length_greater_than_zero"
   end
 
   create_table "users", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.citext "email", null: false
     t.string "name", null: false
-    t.integer "otp_failed_attempts", default: 0, null: false
-    t.datetime "otp_locked_at"
-    t.integer "otp_school_urn"
+    t.citext "email", null: false
     t.string "otp_secret"
     t.datetime "otp_verified_at"
-    t.enum "role", default: "admin", null: false, enum_type: "dfe_role_type"
+    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.enum "role", default: "admin", null: false, enum_type: "dfe_role_type"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
-  add_foreign_key "active_lead_provider_bands", "active_lead_providers"
   add_foreign_key "active_lead_providers", "contract_periods", column: "contract_period_year", primary_key: "year"
   add_foreign_key "active_lead_providers", "lead_providers"
   add_foreign_key "appropriate_bodies", "dfe_sign_in_organisations"
   add_foreign_key "appropriate_body_periods", "appropriate_bodies"
-  add_foreign_key "contract_banded_fee_structure_band_terms", "active_lead_provider_bands", column: "band_id"
-  add_foreign_key "contract_banded_fee_structure_band_terms", "contract_banded_fee_structures", column: "banded_fee_structure_id", on_delete: :cascade
-  add_foreign_key "contract_banded_fee_structures", "contracts"
-  add_foreign_key "contract_flat_rate_fee_structures", "contracts"
-  add_foreign_key "contracts", "active_lead_providers"
-  add_foreign_key "declarations", "delivery_partners", column: "delivery_partner_when_created_id"
+  add_foreign_key "contract_banded_fee_structure_bands", "contract_banded_fee_structures", column: "banded_fee_structure_id", on_delete: :cascade
   add_foreign_key "declarations", "statements", column: "clawback_statement_id"
   add_foreign_key "declarations", "statements", column: "payment_statement_id"
   add_foreign_key "declarations", "users", column: "voided_by_user_id"
@@ -973,7 +1082,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_06_113458) do
   add_foreign_key "ect_at_school_periods", "teachers"
   add_foreign_key "events", "active_lead_providers", on_delete: :nullify
   add_foreign_key "events", "appropriate_body_periods", on_delete: :nullify
-  add_foreign_key "events", "contract_periods", primary_key: "year", on_delete: :nullify
   add_foreign_key "events", "declarations", on_delete: :nullify
   add_foreign_key "events", "delivery_partners", on_delete: :nullify
   add_foreign_key "events", "ect_at_school_periods", on_delete: :nullify
@@ -996,12 +1104,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_06_113458) do
   add_foreign_key "induction_extensions", "teachers"
   add_foreign_key "induction_periods", "appropriate_body_periods"
   add_foreign_key "induction_periods", "teachers"
+  add_foreign_key "lead_school_periods", "appropriate_bodies"
+  add_foreign_key "lead_school_periods", "schools"
   add_foreign_key "legacy_appropriate_bodies", "appropriate_body_periods"
   add_foreign_key "mentor_at_school_periods", "schools"
   add_foreign_key "mentor_at_school_periods", "schools", column: "reported_leaving_by_school_id"
   add_foreign_key "mentor_at_school_periods", "teachers"
   add_foreign_key "mentorship_periods", "ect_at_school_periods"
   add_foreign_key "mentorship_periods", "mentor_at_school_periods"
+  add_foreign_key "metadata_delivery_partners_lead_providers", "delivery_partners"
+  add_foreign_key "metadata_delivery_partners_lead_providers", "lead_providers"
   add_foreign_key "metadata_schools_contract_periods", "contract_periods", column: "contract_period_year", primary_key: "year"
   add_foreign_key "metadata_schools_contract_periods", "schools"
   add_foreign_key "metadata_schools_lead_providers_contract_periods", "contract_periods", column: "contract_period_year", primary_key: "year"
@@ -1014,13 +1126,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_06_113458) do
   add_foreign_key "metadata_teachers_lead_providers", "training_periods", column: "latest_ect_training_period_id", on_delete: :nullify
   add_foreign_key "metadata_teachers_lead_providers", "training_periods", column: "latest_mentor_training_period_id", on_delete: :nullify
   add_foreign_key "milestones", "schedules"
+  add_foreign_key "parity_check_requests", "lead_providers"
+  add_foreign_key "parity_check_requests", "parity_check_endpoints", column: "endpoint_id"
+  add_foreign_key "parity_check_requests", "parity_check_runs", column: "run_id"
+  add_foreign_key "parity_check_responses", "parity_check_requests", column: "request_id"
   add_foreign_key "pending_induction_submission_batches", "appropriate_body_periods"
   add_foreign_key "pending_induction_submissions", "appropriate_body_periods"
   add_foreign_key "pending_induction_submissions", "pending_induction_submission_batches"
   add_foreign_key "regions", "appropriate_bodies"
   add_foreign_key "schedules", "contract_periods", column: "contract_period_year", primary_key: "year"
-  add_foreign_key "school_funding_eligibilities", "contract_periods", column: "contract_period_year", primary_key: "year"
-  add_foreign_key "school_funding_eligibilities", "gias_schools", column: "gias_school_urn", primary_key: "urn"
   add_foreign_key "school_partnerships", "schools"
   add_foreign_key "schools", "appropriate_body_periods", column: "last_chosen_appropriate_body_id"
   add_foreign_key "schools", "contract_periods", column: "induction_tutor_last_nominated_in", primary_key: "year"
@@ -1033,11 +1147,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_06_113458) do
   add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "statement_adjustments", "statements"
-  add_foreign_key "statement_audit_notes", "statements"
+  add_foreign_key "statements", "active_lead_providers"
   add_foreign_key "statements", "contracts"
   add_foreign_key "teacher_id_changes", "teachers"
   add_foreign_key "teacher_id_changes", "teachers", column: "api_from_teacher_id", primary_key: "api_id"
   add_foreign_key "teacher_id_changes", "teachers", column: "api_to_teacher_id", primary_key: "api_id"
+  add_foreign_key "teacher_migration_failures", "teachers"
   add_foreign_key "teachers", "contract_periods", column: "ect_payments_frozen_year", primary_key: "year"
   add_foreign_key "teachers", "contract_periods", column: "mentor_payments_frozen_year", primary_key: "year"
   add_foreign_key "training_periods", "active_lead_providers", column: "expression_of_interest_id"

--- a/db/seeds/appropriate_body_periods.rb
+++ b/db/seeds/appropriate_body_periods.rb
@@ -22,10 +22,6 @@ def dfe_sign_in_env
   Rails.application.config.dfe_sign_in_issuer.include?("test") ? :test : :pp
 end
 
-def seed_appropriate_body_with_dsi?
-  ActiveModel::Type::Boolean.new.cast(ENV.fetch("SEED_DFE_SIGN_IN_ORG", false))
-end
-
 appropriate_body_periods = [
   # National Organisations
   # ----------------------------------------------------------------------------
@@ -236,8 +232,14 @@ appropriate_body_periods.each do |data|
                                               dqt_id:,
                                               dfe_sign_in_organisation_id:)
 
+  # Skip seeding new Appropriate Body models
+  if ENV["SEED_NEW_APPROPRIATE_BODY_MODELS"] != "y"
+    describe_appropriate_body_period(appropriate_body_period)
+    next
+  end
+
   # Legacy Appropriate Body
-  if dfe_sign_in_organisation_id.present?
+  if dqt_id.present?
     FactoryBot.create(:legacy_appropriate_body,
                       appropriate_body_period:,
                       dqt_id:,
@@ -249,7 +251,7 @@ appropriate_body_periods.each do |data|
   next if dfe_sign_in_organisation_id.blank?
 
   # Teaching School Hubs
-  if appropriate_body_period.teaching_school_hub?
+  if appropriate_body_period.teaching_school_hub? && appropriate_body_period.appropriate_body.blank?
     school_name = data.dig(:lead_school, :name)
     urn = data.dig(:lead_school, :urn)
     regions = data[:regions]
@@ -258,30 +260,28 @@ appropriate_body_periods.each do |data|
                                     name: school_name,
                                     urn:)
 
-    if seed_appropriate_body_with_dsi?
-      school = FactoryBot.create(:school, :eligible, :with_dsi,
-                                 urn:,
-                                 gias_school:)
+    school = FactoryBot.create(:school, :eligible, :with_dsi,
+                               urn:,
+                               gias_school:)
 
-      appropriate_body = FactoryBot.create(:appropriate_body,
-                                           name:,
-                                           dfe_sign_in_organisation: school.dfe_sign_in_organisation)
+    appropriate_body = FactoryBot.create(:appropriate_body,
+                                         name:,
+                                         dfe_sign_in_organisation: school.dfe_sign_in_organisation)
 
-      regions.each do |region|
-        FactoryBot.create(:region,
-                          code: region[:code],
-                          districts: region[:districts].split(", "),
-                          appropriate_body:)
-      end
+    appropriate_body_period.update!(appropriate_body:)
 
-      appropriate_body_period.update!(appropriate_body:)
-
-    else
-      FactoryBot.create(:school, :eligible,
-                        urn:,
-                        gias_school:)
-
+    # Regions for TSH
+    regions.each do |region|
+      FactoryBot.create(:region,
+                        code: region[:code],
+                        districts: region[:districts].split(", "),
+                        appropriate_body:)
     end
+
+    # Lead School role for TSH
+    FactoryBot.create(:lead_school_period, :ongoing,
+                      school:,
+                      appropriate_body:)
 
     # Delivery Partner role for TSH
     FactoryBot.create(:delivery_partner,
@@ -289,7 +289,7 @@ appropriate_body_periods.each do |data|
   end
 
   # National Bodies
-  if appropriate_body_period.national? && seed_appropriate_body_with_dsi?
+  if appropriate_body_period.national? && appropriate_body_period.appropriate_body.blank?
     appropriate_body = FactoryBot.create(:appropriate_body, :with_dsi,
                                          name:)
     appropriate_body_period.update!(appropriate_body:)

--- a/documentation/domain-model.md
+++ b/documentation/domain-model.md
@@ -1,147 +1,133 @@
 ```mermaid
 erDiagram
-  Contract_BandedFeeStructure_BandTerm {
+  Contract_BandedFeeStructure_Band {
     integer id
-    integer band_id
     integer banded_fee_structure_id
-    datetime created_at
+    integer min_declarations
+    integer max_declarations
     decimal fee_per_declaration
     decimal output_fee_ratio
     decimal service_fee_ratio
+    datetime created_at
     datetime updated_at
   }
-  Contract_BandedFeeStructure_BandTerm }o--|| Contract_BandedFeeStructure : belongs_to
-  Contract_BandedFeeStructure_BandTerm }o--|| ActiveLeadProvider_Band : belongs_to
+  Contract_BandedFeeStructure_Band }o--|| Contract_BandedFeeStructure : belongs_to
   Contract_FlatRateFeeStructure {
     integer id
-    integer contract_id
-    datetime created_at
-    decimal fee_per_declaration
     integer recruitment_target
+    decimal fee_per_declaration
+    datetime created_at
     datetime updated_at
   }
-  Contract_FlatRateFeeStructure }o--|| Contract : belongs_to
   Contract_BandedFeeStructure {
     integer id
-    integer contract_id
-    datetime created_at
-    decimal monthly_service_fee
     integer recruitment_target
-    decimal setup_fee
-    datetime updated_at
     decimal uplift_fee_per_declaration
-    decimal uplift_target_ratio
-  }
-  Contract_BandedFeeStructure }o--|| Contract : belongs_to
-  ActiveLeadProvider_Band {
-    integer id
-    integer active_lead_provider_id
-    integer allocation_order
-    integer capacity
+    decimal monthly_service_fee
+    decimal setup_fee
     datetime created_at
     datetime updated_at
   }
-  ActiveLeadProvider_Band }o--|| ActiveLeadProvider : belongs_to
   User {
     integer id
-    datetime created_at
-    citext email
     string name
-    integer otp_failed_attempts
-    datetime otp_locked_at
-    integer otp_school_urn
+    citext email
     string otp_secret
     datetime otp_verified_at
-    enum role
+    datetime created_at
     datetime updated_at
+    enum role
   }
   TrainingPeriod {
     integer id
-    datetime api_transfer_updated_at
-    datetime created_at
-    enum deferral_reason
-    datetime deferred_at
-    uuid ecf_end_induction_record_id
-    uuid ecf_start_induction_record_id
-    integer ect_at_school_period_id
-    integer expression_of_interest_id
-    date finished_on
-    integer mentor_at_school_period_id
-    daterange range
-    integer schedule_id
     integer school_partnership_id
     date started_on
-    enum training_programme
+    date finished_on
+    datetime created_at
     datetime updated_at
-    enum withdrawal_reason
+    integer ect_at_school_period_id
+    integer mentor_at_school_period_id
+    daterange range
+    uuid ecf_start_induction_record_id
+    uuid ecf_end_induction_record_id
+    integer expression_of_interest_id
+    enum training_programme
+    datetime deferred_at
+    enum deferral_reason
     datetime withdrawn_at
+    enum withdrawal_reason
+    integer schedule_id
+    datetime api_transfer_updated_at
   }
   TrainingPeriod }o--|| ECTAtSchoolPeriod : belongs_to
   TrainingPeriod }o--|| MentorAtSchoolPeriod : belongs_to
   TrainingPeriod }o--|| SchoolPartnership : belongs_to
   TrainingPeriod }o--|| Schedule : belongs_to
   TrainingPeriod }o--|| ActiveLeadProvider : belongs_to
+  TeacherMigrationFailure {
+    integer id
+    integer teacher_id
+    string message
+    uuid migration_item_id
+    string migration_item_type
+    datetime created_at
+    datetime updated_at
+    string model
+  }
+  TeacherMigrationFailure }o--|| Teacher : belongs_to
   TeacherIdChange {
     integer id
+    integer teacher_id
     uuid api_from_teacher_id
     uuid api_to_teacher_id
-    datetime created_at
     uuid ecf_id
-    integer teacher_id
+    datetime created_at
     datetime updated_at
   }
   TeacherIdChange }o--|| Teacher : belongs_to
   Statement {
     integer id
+    integer active_lead_provider_id
     uuid api_id
+    integer month
+    integer year
+    date deadline_date
+    date payment_date
+    datetime marked_as_paid_at
+    enum status
+    datetime created_at
+    datetime updated_at
+    enum fee_type
     datetime api_updated_at
     integer contract_id
-    datetime created_at
-    date deadline_date
-    enum fee_type
-    datetime marked_as_paid_at
-    integer month
-    date payment_date
-    enum status
-    datetime updated_at
-    integer year
   }
+  Statement }o--|| ActiveLeadProvider : belongs_to
   Statement }o--|| Contract : belongs_to
   SchoolPartnership {
     integer id
-    uuid api_id
-    datetime api_updated_at
     datetime created_at
+    datetime updated_at
     integer lead_provider_delivery_partnership_id
     integer school_id
-    datetime updated_at
+    uuid api_id
+    datetime api_updated_at
   }
   SchoolPartnership }o--|| LeadProviderDeliveryPartnership : belongs_to
   SchoolPartnership }o--|| School : belongs_to
-  SchoolFundingEligibility {
-    integer id
-    integer contract_period_year
-    datetime created_at
-    integer gias_school_urn
-    boolean pupil_premium_uplift
-    boolean sparsity_uplift
-    datetime updated_at
-  }
-  SchoolFundingEligibility }o--|| ContractPeriod : belongs_to
   School {
     integer id
-    uuid api_id
+    integer urn
     datetime created_at
-    citext induction_tutor_email
-    integer induction_tutor_last_nominated_in
-    string induction_tutor_name
+    datetime updated_at
     integer last_chosen_appropriate_body_id
     integer last_chosen_lead_provider_id
     enum last_chosen_training_programme
+    datetime api_updated_at
+    string induction_tutor_name
+    citext induction_tutor_email
+    uuid api_id
+    integer induction_tutor_last_nominated_in
     boolean marked_as_eligible
-    date opted_out_of_reminder_emails_until
-    datetime updated_at
-    integer urn
   }
   School }o--|| DfESignInOrganisation : belongs_to
   School }o--|| AppropriateBodyPeriod : belongs_to
@@ -150,348 +136,417 @@ erDiagram
   Schedule {
     integer id
     integer contract_period_year
-    datetime created_at
     enum identifier
+    datetime created_at
     datetime updated_at
   }
   Schedule }o--|| ContractPeriod : belongs_to
   Region {
     integer id
-    integer appropriate_body_id
     string code
-    datetime created_at
     array[string] districts
+    datetime created_at
     datetime updated_at
+    integer appropriate_body_id
   }
   Region }o--|| AppropriateBody : belongs_to
   PendingInductionSubmissionBatch {
     integer id
     integer appropriate_body_period_id
-    enum batch_status
     enum batch_type
-    integer claimed_count
-    datetime created_at
-    jsonb data
+    enum batch_status
     string error_message
-    integer errored_count
+    datetime created_at
+    datetime updated_at
+    jsonb data
     string file_name
+    integer uploaded_count
+    integer processed_count
+    integer errored_count
+    integer released_count
+    integer passed_count
+    integer claimed_count
     integer file_size
     string file_type
-    integer passed_count
-    integer processed_count
-    integer released_count
-    datetime updated_at
-    integer uploaded_count
   }
   PendingInductionSubmissionBatch }o--|| AppropriateBodyPeriod : belongs_to
   Teacher {
     integer id
-    enum anonymisation_reason
-    datetime anonymised_at
-    uuid api_ect_training_record_id
-    uuid api_id
-    uuid api_mentor_training_record_id
-    datetime api_unfunded_mentor_updated_at
-    datetime api_updated_at
     string corrected_name
     datetime created_at
-    date ect_became_ineligible_for_funding_on
-    datetime ect_first_became_eligible_for_training_at
-    integer ect_payments_frozen_year
-    date mentor_became_ineligible_for_funding_on
-    enum mentor_became_ineligible_for_funding_reason
-    datetime mentor_first_became_eligible_for_training_at
-    integer mentor_payments_frozen_year
-    enum migration_mode
+    datetime updated_at
     string trn
-    boolean trnless
-    datetime trs_data_last_refreshed_at
-    boolean trs_deactivated
     string trs_first_name
-    date trs_induction_completed_date
-    date trs_induction_start_date
-    string trs_induction_status
-    date trs_initial_teacher_training_end_date
-    string trs_initial_teacher_training_provider_name
     string trs_last_name
-    boolean trs_not_found
     date trs_qts_awarded_on
     string trs_qts_status_description
-    datetime updated_at
+    string trs_induction_status
+    string trs_initial_teacher_training_provider_name
+    date trs_initial_teacher_training_end_date
+    datetime trs_data_last_refreshed_at
+    date mentor_became_ineligible_for_funding_on
+    enum mentor_became_ineligible_for_funding_reason
+    boolean trs_deactivated
+    uuid api_id
+    uuid api_ect_training_record_id
+    uuid api_mentor_training_record_id
+    integer ect_payments_frozen_year
+    integer mentor_payments_frozen_year
+    boolean ect_pupil_premium_uplift
+    boolean ect_sparsity_uplift
+    date trs_induction_start_date
+    date trs_induction_completed_date
+    datetime ect_first_became_eligible_for_training_at
+    datetime mentor_first_became_eligible_for_training_at
+    boolean trnless
+    datetime api_updated_at
+    datetime api_unfunded_mentor_updated_at
+    enum migration_mode
+    boolean trs_not_found
   }
   PendingInductionSubmission {
     integer id
     integer appropriate_body_period_id
-    datetime confirmed_at
-    datetime created_at
-    date date_of_birth
-    datetime delete_at
-    array[string] error_messages
     string establishment_id
-    date fail_confirmation_sent_on
-    date finished_on
-    enum induction_programme
-    float number_of_terms
-    enum outcome
-    integer pending_induction_submission_batch_id
-    date started_on
-    enum training_programme
     string trn
-    jsonb trs_alerts
-    date trs_date_of_birth
-    citext trs_email_address
     string trs_first_name
-    date trs_induction_completed_date
-    date trs_induction_start_date
+    string trs_last_name
+    date date_of_birth
     string trs_induction_status
+    enum induction_programme
+    date started_on
+    date finished_on
+    float number_of_terms
+    datetime created_at
+    datetime updated_at
+    datetime confirmed_at
+    citext trs_email_address
+    jsonb trs_alerts
+    date trs_induction_start_date
+    string trs_qts_status_description
     date trs_initial_teacher_training_end_date
     string trs_initial_teacher_training_provider_name
-    string trs_last_name
-    boolean trs_prohibited_from_teaching
+    enum outcome
     date trs_qts_awarded_on
-    string trs_qts_status_description
-    datetime updated_at
+    datetime delete_at
+    integer pending_induction_submission_batch_id
+    array[string] error_messages
+    enum training_programme
+    boolean trs_prohibited_from_teaching
+    date trs_induction_completed_date
+    date trs_date_of_birth
+    date fail_confirmation_sent_on
   }
   PendingInductionSubmission }o--|| AppropriateBodyPeriod : belongs_to
   PendingInductionSubmission }o--|| PendingInductionSubmissionBatch : belongs_to
   Milestone {
     integer id
-    datetime created_at
-    enum declaration_type
-    date milestone_date
     integer schedule_id
+    enum declaration_type
     date start_date
+    date milestone_date
+    datetime created_at
     datetime updated_at
   }
   Milestone }o--|| Schedule : belongs_to
   MentorshipPeriod {
     integer id
-    datetime created_at
-    uuid ecf_end_induction_record_id
-    uuid ecf_start_induction_record_id
     integer ect_at_school_period_id
-    date finished_on
     integer mentor_at_school_period_id
-    daterange range
     date started_on
+    date finished_on
+    datetime created_at
     datetime updated_at
+    daterange range
+    uuid ecf_start_induction_record_id
+    uuid ecf_end_induction_record_id
   }
   MentorshipPeriod }o--|| ECTAtSchoolPeriod : belongs_to
   MentorshipPeriod }o--|| MentorAtSchoolPeriod : belongs_to
   MentorAtSchoolPeriod {
     integer id
-    datetime created_at
-    uuid ecf_end_induction_record_id
-    uuid ecf_start_induction_record_id
-    citext email
-    date finished_on
-    daterange range
-    integer reported_leaving_by_school_id
     integer school_id
-    date started_on
     integer teacher_id
+    date started_on
+    date finished_on
+    datetime created_at
     datetime updated_at
+    daterange range
+    uuid ecf_start_induction_record_id
+    uuid ecf_end_induction_record_id
+    citext email
+    integer reported_leaving_by_school_id
   }
   MentorAtSchoolPeriod }o--|| School : belongs_to
   MentorAtSchoolPeriod }o--|| Teacher : belongs_to
   LegacyAppropriateBody {
     integer id
-    integer appropriate_body_period_id
-    enum body_type
-    datetime created_at
     uuid dqt_id
     string name
+    enum body_type
+    integer appropriate_body_period_id
+    datetime created_at
     datetime updated_at
   }
   LegacyAppropriateBody }o--|| AppropriateBodyPeriod : belongs_to
+  LeadSchoolPeriod {
+    integer id
+    integer school_id
+    integer appropriate_body_id
+    date started_on
+    date finished_on
+    daterange range
+    datetime created_at
+    datetime updated_at
+  }
+  LeadSchoolPeriod }o--|| School : belongs_to
+  LeadSchoolPeriod }o--|| AppropriateBody : belongs_to
   LeadProviderDeliveryPartnership {
     integer id
     integer active_lead_provider_id
-    datetime created_at
     integer delivery_partner_id
-    uuid ecf_id
+    datetime created_at
     datetime updated_at
+    uuid ecf_id
   }
   LeadProviderDeliveryPartnership }o--|| ActiveLeadProvider : belongs_to
   LeadProviderDeliveryPartnership }o--|| DeliveryPartner : belongs_to
   LeadProvider {
     integer id
-    datetime created_at
-    uuid ecf_cpd_lead_provider_id
-    uuid ecf_id
     string name
+    datetime created_at
     datetime updated_at
+    uuid ecf_id
     boolean vat_registered
   }
   InductionPeriod {
     integer id
     integer appropriate_body_period_id
-    datetime created_at
-    date fail_confirmation_sent_on
+    date started_on
     date finished_on
+    datetime created_at
+    datetime updated_at
     enum induction_programme
     float number_of_terms
-    enum outcome
     daterange range
-    date started_on
     integer teacher_id
+    enum outcome
     enum training_programme
-    datetime updated_at
+    date fail_confirmation_sent_on
   }
   InductionPeriod }o--|| AppropriateBodyPeriod : belongs_to
   InductionPeriod }o--|| Teacher : belongs_to
   InductionExtension {
     integer id
-    datetime created_at
-    float number_of_terms
     integer teacher_id
+    float number_of_terms
+    datetime created_at
     datetime updated_at
   }
   InductionExtension }o--|| Teacher : belongs_to
   ECTAtSchoolPeriod {
     integer id
-    datetime created_at
-    uuid ecf_end_induction_record_id
-    uuid ecf_start_induction_record_id
-    citext email
-    date finished_on
-    daterange range
-    integer reported_leaving_by_school_id
     integer school_id
-    integer school_reported_appropriate_body_id
-    date started_on
     integer teacher_id
+    date started_on
+    date finished_on
+    datetime created_at
     datetime updated_at
+    daterange range
+    uuid ecf_start_induction_record_id
+    uuid ecf_end_induction_record_id
     enum working_pattern
+    citext email
+    integer school_reported_appropriate_body_id
+    integer reported_leaving_by_school_id
   }
   ECTAtSchoolPeriod }o--|| School : belongs_to
   ECTAtSchoolPeriod }o--|| Teacher : belongs_to
   ECTAtSchoolPeriod }o--|| AppropriateBodyPeriod : belongs_to
   DfESignInOrganisation {
     integer id
-    string address
-    string category
-    string company_registration_number
-    datetime created_at
-    datetime first_authenticated_at
-    datetime last_authenticated_at
     string name
+    uuid uuid
+    string urn
+    string address
+    string company_registration_number
+    string category
     string organisation_type
     string status
+    datetime first_authenticated_at
+    datetime last_authenticated_at
+    datetime created_at
     datetime updated_at
-    string urn
-    uuid uuid
   }
   DeliveryPartner {
     integer id
+    string name
+    datetime created_at
+    datetime updated_at
     uuid api_id
     datetime api_updated_at
-    datetime created_at
-    string name
-    datetime updated_at
   }
   Declaration {
     integer id
-    uuid api_id
-    datetime api_updated_at
-    integer clawback_statement_id
-    enum clawback_status
+    integer training_period_id
     datetime created_at
-    datetime declaration_date
-    enum declaration_type
-    integer delivery_partner_when_created_id
-    enum evidence_type
+    datetime updated_at
+    integer voided_by_user_id
     integer mentorship_period_id
     integer payment_statement_id
-    enum payment_status
-    boolean pupil_premium_uplift
-    boolean sparsity_uplift
-    integer training_period_id
-    datetime updated_at
+    integer clawback_statement_id
     datetime voided_by_user_at
-    integer voided_by_user_id
+    uuid api_id
+    datetime declaration_date
+    enum evidence_type
+    enum clawback_status
+    enum declaration_type
+    boolean sparsity_uplift
+    boolean pupil_premium_uplift
+    datetime api_updated_at
+    enum payment_status
   }
   Declaration }o--|| TrainingPeriod : belongs_to
   Declaration }o--|| User : belongs_to
   Declaration }o--|| MentorshipPeriod : belongs_to
-  Declaration }o--|| DeliveryPartner : belongs_to
   Declaration }o--|| Statement : belongs_to
   Declaration }o--|| Statement : belongs_to
+  DataMigrationTeacherCombination {
+    integer id
+    uuid ecf1_ect_profile_id
+    uuid ecf1_mentor_profile_id
+    jsonb ecf1_ect_combinations
+    jsonb ecf1_mentor_combinations
+    jsonb ecf2_ect_combinations
+    jsonb ecf2_mentor_combinations
+    integer ecf1_ect_combinations_count
+    integer ecf1_mentor_combinations_count
+    integer ecf2_ect_combinations_count
+    integer ecf2_mentor_combinations_count
+    datetime created_at
+    datetime updated_at
+    jsonb ecf1_mentorships
+    jsonb ecf2_mentorships
+    integer ecf1_mentorships_count
+    integer ecf2_mentorships_count
+    uuid api_id
+  }
+  DataMigrationFailedMentorship {
+    integer id
+    uuid ect_participant_profile_id
+    uuid mentor_participant_profile_id
+    date started_on
+    date finished_on
+    uuid ecf_start_induction_record_id
+    uuid ecf_end_induction_record_id
+    text failure_message
+    datetime created_at
+    datetime updated_at
+  }
+  DataMigrationFailedCombination {
+    integer id
+    string trn
+    uuid profile_id
+    string profile_type
+    uuid induction_record_id
+    string training_programme
+    string school_urn
+    integer cohort_year
+    string lead_provider_name
+    string delivery_partner_name
+    datetime start_date
+    datetime end_date
+    string induction_status
+    string training_status
+    uuid mentor_profile_id
+    uuid schedule_id
+    string schedule_identifier
+    string schedule_name
+    integer schedule_cohort_year
+    string preferred_identity_email
+    text failure_message
+    datetime created_at
+    datetime updated_at
+  }
   ContractPeriod {
     integer year
     datetime created_at
-    boolean detailed_evidence_types_enabled
-    boolean enabled
-    date finished_on
-    boolean mentor_funding_enabled
-    datetime payments_frozen_at
-    daterange range
-    date started_on
     datetime updated_at
-    boolean uplift_fees_enabled
+    date started_on
+    date finished_on
+    boolean enabled
+    daterange range
+    datetime payments_frozen_at
+    boolean mentor_funding_enabled
+    boolean detailed_evidence_types_enabled
   }
   Contract {
     integer id
-    integer active_lead_provider_id
     enum contract_type
+    integer flat_rate_fee_structure_id
+    integer banded_fee_structure_id
     datetime created_at
     datetime updated_at
     decimal vat_rate
   }
-  Contract }o--|| ActiveLeadProvider : belongs_to
+  Contract }o--|| Contract_FlatRateFeeStructure : belongs_to
+  Contract }o--|| Contract_BandedFeeStructure : belongs_to
   AppropriateBodyPeriod {
     integer id
-    integer appropriate_body_id
-    enum body_type
+    string name
     datetime created_at
+    datetime updated_at
     uuid dfe_sign_in_organisation_id
     uuid dqt_id
-    string name
-    datetime updated_at
+    enum body_type
+    integer appropriate_body_id
+    date started_on
+    date finished_on
+    daterange range
   }
   AppropriateBodyPeriod }o--|| DfESignInOrganisation : belongs_to
   AppropriateBodyPeriod }o--|| AppropriateBody : belongs_to
   AppropriateBody {
     integer id
-    datetime created_at
-    integer dfe_sign_in_organisation_id
     string name
+    integer dfe_sign_in_organisation_id
+    datetime created_at
     datetime updated_at
   }
   AppropriateBody }o--|| DfESignInOrganisation : belongs_to
   ActiveLeadProvider {
     integer id
+    integer lead_provider_id
     integer contract_period_year
     datetime created_at
-    integer lead_provider_id
     datetime updated_at
   }
   ActiveLeadProvider }o--|| ContractPeriod : belongs_to
   ActiveLeadProvider }o--|| LeadProvider : belongs_to
   SupportQuery {
     integer id
-    datetime created_at
-    string email
-    text message
+    string state
+    integer zendesk_id
     string name
+    string email
     string school_name
     integer school_urn
-    string state
+    text message
+    datetime created_at
     datetime updated_at
-    integer zendesk_id
   }
   Metadata_TeacherLeadProvider {
     integer id
-    datetime created_at
-    integer ect_assigned_mentor_latest_school_period_id
-    boolean involved_in_school_transfer
-    integer latest_ect_contract_period_year
-    integer latest_ect_training_period_id
-    integer latest_mentor_contract_period_year
-    integer latest_mentor_training_period_id
-    integer lead_provider_id
     integer teacher_id
+    integer lead_provider_id
+    integer latest_ect_training_period_id
+    integer latest_mentor_training_period_id
+    datetime created_at
     datetime updated_at
+    uuid api_mentor_id
+    integer latest_ect_contract_period_year
+    integer latest_mentor_contract_period_year
+    boolean involved_in_school_transfer
   }
   Metadata_TeacherLeadProvider }o--|| Teacher : belongs_to
   Metadata_TeacherLeadProvider }o--|| LeadProvider : belongs_to
@@ -499,14 +554,13 @@ erDiagram
   Metadata_TeacherLeadProvider }o--|| TrainingPeriod : belongs_to
   Metadata_TeacherLeadProvider }o--|| ContractPeriod : belongs_to
   Metadata_TeacherLeadProvider }o--|| ContractPeriod : belongs_to
-  Metadata_TeacherLeadProvider }o--|| MentorAtSchoolPeriod : belongs_to
   Metadata_SchoolLeadProviderContractPeriod {
     integer id
-    integer contract_period_year
-    datetime created_at
-    boolean expression_of_interest_or_school_partnership
-    integer lead_provider_id
     integer school_id
+    integer lead_provider_id
+    integer contract_period_year
+    boolean expression_of_interest_or_school_partnership
+    datetime created_at
     datetime updated_at
   }
   Metadata_SchoolLeadProviderContractPeriod }o--|| School : belongs_to
@@ -514,14 +568,23 @@ erDiagram
   Metadata_SchoolLeadProviderContractPeriod }o--|| ContractPeriod : belongs_to
   Metadata_SchoolContractPeriod {
     integer id
-    datetime api_updated_at
+    integer school_id
     integer contract_period_year
-    datetime created_at
     boolean in_partnership
     enum induction_programme_choice
-    integer school_id
+    datetime created_at
     datetime updated_at
   }
   Metadata_SchoolContractPeriod }o--|| School : belongs_to
   Metadata_SchoolContractPeriod }o--|| ContractPeriod : belongs_to
+  Metadata_DeliveryPartnerLeadProvider {
+    integer id
+    integer delivery_partner_id
+    integer lead_provider_id
+    array[integer] contract_period_years
+    datetime created_at
+    datetime updated_at
+  }
+  Metadata_DeliveryPartnerLeadProvider }o--|| DeliveryPartner : belongs_to
+  Metadata_DeliveryPartnerLeadProvider }o--|| LeadProvider : belongs_to
 ```

--- a/spec/components/admin/appropriate_bodies/details_component_spec.rb
+++ b/spec/components/admin/appropriate_bodies/details_component_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Admin::AppropriateBodies::DetailsComponent, type: :component do
   subject(:component) { described_class.new(appropriate_body_period:) }
 
-  let(:appropriate_body_period) { FactoryBot.create(:appropriate_body_period) }
+  let(:appropriate_body_period) { FactoryBot.create(:appropriate_body_period, :with_lead_school) }
 
   before { render_inline(component) }
 

--- a/spec/factories/appropriate_body_period_factory.rb
+++ b/spec/factories/appropriate_body_period_factory.rb
@@ -41,5 +41,15 @@ FactoryBot.define do
       body_type { "local_authority" }
       dqt_id { Faker::Internet.uuid }
     end
+
+    trait :with_lead_school do
+      association :appropriate_body
+
+      after(:create) do |_period, evaluator|
+        FactoryBot.create(:lead_school_period, :ongoing,
+                          school: FactoryBot.create(:school),
+                          appropriate_body: evaluator.appropriate_body)
+      end
+    end
   end
 end

--- a/spec/factories/lead_school_period_factory.rb
+++ b/spec/factories/lead_school_period_factory.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory(:lead_school_period) do
+    association :appropriate_body
+    association :school
+
+    trait :ongoing do
+      started_on { 1.year.ago }
+      finished_on { nil }
+    end
+
+    trait :finished do
+      started_on { 2.years.ago }
+      finished_on { 1.year.ago }
+    end
+  end
+end

--- a/spec/features/appropriate_bodies/data_model_migration_spec.rb
+++ b/spec/features/appropriate_bodies/data_model_migration_spec.rb
@@ -62,14 +62,14 @@ RSpec.describe "Migrating authenticated Appropriate Body Period users" do
         end
         let(:school) { School.first }
 
-        it "links AppropriateBodyPeriod to AppropriateBody and to a leading School" do
+        it "links AppropriateBodyPeriod to AppropriateBody and to a login School (current lead school if not using a period)" do
           expect {
             sign_in_as_teaching_school_hub(appropriate_body: appropriate_body_period, school:)
           }.to change(AppropriateBody, :count).by(1)
 
           appropriate_body_period.reload
           expect(appropriate_body_period.appropriate_body.name).to eq(appropriate_body_period.name)
-          expect(appropriate_body_period.appropriate_body.lead_school).to eq(school)
+          expect(appropriate_body_period.appropriate_body.login_school).to eq(school)
         end
       end
     end

--- a/spec/models/appropriate_body_spec.rb
+++ b/spec/models/appropriate_body_spec.rb
@@ -8,6 +8,21 @@ RSpec.describe AppropriateBody, type: :model do
     it { is_expected.to have_many(:regions) }
   end
 
+  describe "scopes" do
+    let!(:istip) { FactoryBot.create(:appropriate_body, :istip) }
+    let!(:esp) { FactoryBot.create(:appropriate_body, :esp) }
+    let!(:tsh_1) { FactoryBot.create(:appropriate_body) }
+    let!(:tsh_2) { FactoryBot.create(:appropriate_body) }
+
+    describe ".national" do
+      it { expect(described_class.national).to contain_exactly(istip, esp) }
+    end
+
+    describe ".regional" do
+      it { expect(described_class.regional).to contain_exactly(tsh_1, tsh_2) }
+    end
+  end
+
   describe "validations" do
     subject { FactoryBot.build(:appropriate_body) }
 
@@ -33,14 +48,14 @@ RSpec.describe AppropriateBody, type: :model do
     it { expect(appropriate_body.districts).not_to be_empty }
   end
 
-  describe "#lead_school" do
+  describe "#login_school" do
     context "with a DfE Sign-In URN" do
       subject(:appropriate_body) { FactoryBot.create(:appropriate_body, dfe_sign_in_organisation:) }
 
       let(:school) { FactoryBot.create(:school) }
       let(:dfe_sign_in_organisation) { FactoryBot.create(:dfe_sign_in_organisation, urn: school.urn) }
 
-      it { expect(appropriate_body.lead_school.name).to eq(school.name) }
+      it { expect(appropriate_body.login_school.name).to eq(school.name) }
     end
 
     context "without a DfE Sign-In URN" do
@@ -48,7 +63,21 @@ RSpec.describe AppropriateBody, type: :model do
         FactoryBot.create(:dfe_sign_in_organisation, appropriate_body:)
       end
 
-      it { expect(appropriate_body.lead_school).to be_nil }
+      it { expect(appropriate_body.login_school).to be_nil }
     end
+  end
+
+  describe "#national?" do
+    subject { FactoryBot.build(:appropriate_body, :istip) }
+
+    it { is_expected.to be_national }
+    it { is_expected.not_to be_teaching_school_hub }
+  end
+
+  describe "#teaching_school_hub?" do
+    subject { FactoryBot.build(:appropriate_body) }
+
+    it { is_expected.to be_teaching_school_hub }
+    it { is_expected.not_to be_national }
   end
 end

--- a/spec/requests/admin/appropriate_bodies/show_spec.rb
+++ b/spec/requests/admin/appropriate_bodies/show_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "Viewing the appropriate bodies index", type: :request do
-  let!(:appropriate_body_period) { FactoryBot.create(:appropriate_body_period) }
+  let!(:appropriate_body_period) { FactoryBot.create(:appropriate_body_period, :with_lead_school) }
 
   describe "GET /admin/appropriate-bodies/:id" do
     it "redirects to sign in path" do

--- a/spec/views/admin/appropriate_bodies/show.html.erb_spec.rb
+++ b/spec/views/admin/appropriate_bodies/show.html.erb_spec.rb
@@ -1,6 +1,5 @@
 RSpec.describe "admin/appropriate_bodies/show.html.erb" do
-  let(:appropriate_body_period) { FactoryBot.create(:appropriate_body_period, name:) }
-  let(:name) { "Ancient County Council" }
+  let(:appropriate_body_period) { FactoryBot.create(:appropriate_body_period, :with_lead_school) }
 
   before do
     assign(:appropriate_body, appropriate_body_period)
@@ -12,19 +11,15 @@ RSpec.describe "admin/appropriate_bodies/show.html.erb" do
     expect(view.content_for(:page_header)).to have_css("h1", text: appropriate_body_period.name)
   end
 
-  context "when the appropriate body name contains ampersands" do
-    let(:name) { "Bright Futures Teaching School Hub (Salford & Trafford)" }
-
-    it "does not add the &amp; escape code in the title" do
-      expect(view.content_for(:page_title)).to eq name
-    end
-  end
-
   it "displays the DfE Sign In organisation ID" do
     expect(rendered).to have_css(".govuk-summary-list__value", text: appropriate_body_period.dfe_sign_in_organisation_id)
   end
 
   it "displays counts of current ECTs and bulk uploads" do
     expect(rendered).to have_css(".govuk-summary-list__value", exact_text: "0", count: 2)
+  end
+
+  it "links to appropriate body timeline", skip: "disabled for manual testing" do
+    expect(rendered).to have_link("Timeline of events", href: admin_appropriate_body_timeline_path(appropriate_body_period))
   end
 end


### PR DESCRIPTION
### Context

Rebase of https://github.com/DFE-Digital/register-early-career-teachers-public/pull/2206

Exploring the option of having `lead_school_period` which overlaps with `appropriate_body_period` depends on first finishing the implemention of `Interval` for ABPs.

### Changes proposed in this pull request

- make ABP behave like a period
- add LSP
- spike approach to have TSH's LS change without requiring ABP to end and IPs to be curtailed which was the intentional design of the first approach

### To Do

- [ ] what should the start dates be?
- [ ] what are the challenges of doing it this way?

### Guidance to review

Manual deployment due to conflicts... joy

https://cpd-ec2-review-2206-web.test.teacherservices.cloud/

```sh
$ kubectl exec -n cpd-development deployment/cpd-ec2-review-2206-web -- sh -c "DISABLE_DATABASE_ENVIRONMENT_CHECK=1 SEED_NEW_APPROPRIATE_BODY_MODELS=y rails db:seed:replant"
```